### PR TITLE
Fix part of #5: Abstraction on top of Oppia GAE for Topic Management System

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 android {
   compileSdkVersion 28

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
 
 android {
   compileSdkVersion 28
@@ -11,6 +12,7 @@ android {
     targetSdkVersion 28
     versionCode 1
     versionName "1.0"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
   compileOptions {
@@ -35,10 +37,19 @@ dependencies {
   implementation(
       'androidx.appcompat:appcompat:1.0.2',
       'com.google.protobuf:protobuf-lite:3.0.0',
+      'com.squareup.moshi:moshi-kotlin:1.8.0',
+      'com.squareup.retrofit2:converter-moshi:2.5.0',
+      'com.squareup.retrofit2:retrofit:2.5.0',
       'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.2',
   )
   testImplementation(
+      'android.arch.core:core-testing:1.1.1',
+      'androidx.test.ext:junit:1.1.1',
+      'com.google.truth:truth:0.43',
       'junit:junit:4.12',
+      'org.robolectric:robolectric:4.3',
   )
+  androidTestImplementation('androidx.test:runner:1.2.0',
+      'androidx.test.espresso:espresso-core:3.2.0')
   implementation project(":utility")
 }

--- a/data/src/main/java/org/oppia/data/Constants.kt
+++ b/data/src/main/java/org/oppia/data/Constants.kt
@@ -1,0 +1,8 @@
+package org.oppia.data
+
+/** Constant values for data module will be defined here */
+object Constants {
+
+  const val RESPONSE_SUCCESS = 200
+
+}

--- a/data/src/main/java/org/oppia/data/backends/gae/NetworkInterceptor.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/NetworkInterceptor.kt
@@ -1,0 +1,38 @@
+package org.oppia.data.backends.gae
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import okhttp3.ResponseBody
+import org.oppia.data.Constants
+import java.io.IOException
+
+/** Interceptor on top of Retrofit to modify requests and response */
+class NetworkInterceptor : Interceptor {
+
+  @Throws(IOException::class)
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val request = chain.request()
+    val response = chain.proceed(request)
+
+    if (response.code() == Constants.RESPONSE_SUCCESS) {
+      if (response.body() != null) {
+        var rawJson = response.body()!!.string()
+        rawJson = removeXSSIPrefixFromResponse(rawJson)
+        val contentType = response.body()!!.contentType()
+        val body = ResponseBody.create(contentType, rawJson)
+        return response.newBuilder().body(body).build()
+      }
+    }
+    return response
+  }
+
+  /**
+   * This method accepts a non-null string which is a JSON response and
+   * removes XSSI_PREFIX from response before deserialization
+   * @param rawJson: This is the string that we get in body of our response
+   * @return String: rawJson without XSSI_PREFIX
+   */
+  fun removeXSSIPrefixFromResponse(rawJson: String): String {
+    return rawJson.removePrefix(NetworkSettings.XSSI_PREFIX).trimStart()
+  }
+}

--- a/data/src/main/java/org/oppia/data/backends/gae/NetworkInterceptor.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/NetworkInterceptor.kt
@@ -6,7 +6,11 @@ import okhttp3.ResponseBody
 import org.oppia.data.Constants
 import java.io.IOException
 
-/** Interceptor on top of Retrofit to modify requests and response */
+/**
+ * Interceptor on top of Retrofit to modify requests and response
+ * The Interceptor intercepts requests and response and in every response
+ * it checks for XSSI_PREFIX and removes it to make a valid Json
+ */
 class NetworkInterceptor : Interceptor {
 
   @Throws(IOException::class)

--- a/data/src/main/java/org/oppia/data/backends/gae/NetworkSettings.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/NetworkSettings.kt
@@ -1,0 +1,10 @@
+package org.oppia.data.backends.gae
+
+/** NetworkSettings contains functions and constants specifically related to network only. */
+object NetworkSettings {
+
+  // TODO(#74): Move this to DI graph
+  const val BASE_URL = "https://oppia.org"
+  const val XSSI_PREFIX = ")]}\'"
+
+}

--- a/data/src/main/java/org/oppia/data/backends/gae/OppiaGaeClient.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/OppiaGaeClient.kt
@@ -1,0 +1,26 @@
+package org.oppia.data.backends.gae
+
+import okhttp3.OkHttpClient
+
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+/** This file manages Retrofit configuration and connection with Oppia backend */
+object OppiaGaeClient {
+
+  private var retrofit: Retrofit? = null
+
+  val retrofitInstance: Retrofit? by lazy {
+    if (retrofit == null) {
+      val client = OkHttpClient.Builder()
+      client.addInterceptor(NetworkInterceptor())
+
+      retrofit = retrofit2.Retrofit.Builder()
+        .baseUrl(NetworkSettings.BASE_URL)
+        .addConverterFactory(MoshiConverterFactory.create())
+        .client(client.build())
+        .build()
+    }
+    return@lazy retrofit
+  }
+}

--- a/data/src/main/java/org/oppia/data/backends/gae/api/TopicService.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/api/TopicService.kt
@@ -1,0 +1,14 @@
+package org.oppia.data.backends.gae.api
+
+import org.oppia.data.backends.gae.model.Topic
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+/** Retrofit instance for managing topic-handler */
+interface TopicService {
+
+  @GET("topic_data_handler/{topic_name}")
+  fun getTopicByTopicName(@Path("topic_name") topicName: String): Call<Topic>
+
+}

--- a/data/src/main/java/org/oppia/data/backends/gae/model/StorySummary.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/StorySummary.kt
@@ -3,7 +3,8 @@ package org.oppia.data.backends.gae.model
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
-/** Model for serialization/deserialization using Moshi with Retrofit
+/**
+ * Model for serialization/deserialization using Moshi with Retrofit
  * @see <a href="https://github.com/oppia/oppia/blob/b33aa9cf1aa6372e12d0b35f95cceb44efe5320f/core/domain/story_domain.py#L1118">Oppia-Web StorySummary structure</a>
  */
 @JsonClass(generateAdapter = true)

--- a/data/src/main/java/org/oppia/data/backends/gae/model/StorySummary.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/StorySummary.kt
@@ -1,0 +1,16 @@
+package org.oppia.data.backends.gae.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/** Model for serialization/deserialization using Moshi with Retrofit
+ * @see <a href="https://github.com/oppia/oppia/blob/b33aa9cf1aa6372e12d0b35f95cceb44efe5320f/core/domain/story_domain.py#L1118">Oppia-Web StorySummary structure</a>
+ */
+@JsonClass(generateAdapter = true)
+data class StorySummary(
+
+  @Json(name = "id") val storyId: String?,
+  @Json(name = "title") val title: String?,
+  @Json(name = "description") val description: String?
+
+)

--- a/data/src/main/java/org/oppia/data/backends/gae/model/SubtopicSummary.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/SubtopicSummary.kt
@@ -1,0 +1,16 @@
+package org.oppia.data.backends.gae.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/** Model for serialization/deserialization using Moshi with Retrofit
+ * @see <a href="https://github.com/oppia/oppia/blob/b33aa9cf1aa6372e12d0b35f95cceb44efe5320f/core/domain/topic_domain.py#L297">Oppia-Web SubtopicSummary structure</a>
+ */
+@JsonClass(generateAdapter = true)
+data class SubtopicSummary(
+
+  @Json(name = "id") val subtopicId: String?,
+  @Json(name = "title") val title: String?,
+  @Json(name = "skill_ids") val skillIds: List<String?>?
+
+)

--- a/data/src/main/java/org/oppia/data/backends/gae/model/SubtopicSummary.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/SubtopicSummary.kt
@@ -3,7 +3,8 @@ package org.oppia.data.backends.gae.model
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
-/** Model for serialization/deserialization using Moshi with Retrofit
+/**
+ * Model for serialization/deserialization using Moshi with Retrofit
  * @see <a href="https://github.com/oppia/oppia/blob/b33aa9cf1aa6372e12d0b35f95cceb44efe5320f/core/domain/topic_domain.py#L297">Oppia-Web SubtopicSummary structure</a>
  */
 @JsonClass(generateAdapter = true)

--- a/data/src/main/java/org/oppia/data/backends/gae/model/Topic.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/Topic.kt
@@ -1,0 +1,23 @@
+package org.oppia.data.backends.gae.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/** Model for serialization/deserialization using Moshi with Retrofit *
+ * @see <a href="https://github.com/oppia/oppia/blob/b33aa9cf1aa6372e12d0b35f95cceb44efe5320f/core/controllers/topic_viewer.py#L45">Oppia-Web Topic structure</a>
+ */
+@JsonClass(generateAdapter = true)
+data class Topic(
+
+  @Json(name = "topic_id") val topicId: String?,
+  @Json(name = "topic_name") val topicName: String?,
+  @Json(name = "canonical_story_dicts") val canonicalStoryDicts: List<StorySummary?>?,
+  @Json(name = "additional_story_dicts") val additionalStoryDicts: List<StorySummary?>?,
+  /** skill_descriptions map has skill id as key and skill name as value */
+  @Json(name = "skill_descriptions") val skillDescriptions: Map<String, String?>?,
+  /** degrees_of_mastery map has skill id as key and a float value */
+  @Json(name = "degrees_of_mastery") val degreesOfMastery: Map<String, Float?>?,
+  @Json(name = "uncategorized_skill_ids") val uncategorizedSkillIds: List<String?>?,
+  @Json(name = "subtopics") val subtopics: List<SubtopicSummary?>?
+
+)

--- a/data/src/main/java/org/oppia/data/backends/gae/model/Topic.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/Topic.kt
@@ -3,7 +3,8 @@ package org.oppia.data.backends.gae.model
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
-/** Model for serialization/deserialization using Moshi with Retrofit *
+/**
+ * Model for serialization/deserialization using Moshi with Retrofit *
  * @see <a href="https://github.com/oppia/oppia/blob/b33aa9cf1aa6372e12d0b35f95cceb44efe5320f/core/controllers/topic_viewer.py#L45">Oppia-Web Topic structure</a>
  */
 @JsonClass(generateAdapter = true)

--- a/data/src/test/java/org/oppia/data/NetworkInterceptorTest.kt
+++ b/data/src/test/java/org/oppia/data/NetworkInterceptorTest.kt
@@ -1,0 +1,33 @@
+package org.oppia.data
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.oppia.data.backends.gae.NetworkInterceptor
+import org.oppia.data.backends.gae.NetworkSettings
+
+private const val FAKE_RESPONSE_WITHOUT_XSSI_PREFIX: String = "{\"is_valid_response\": true}"
+private const val FAKE_RESPONSE_WITH_XSSI_PREFIX: String =
+  NetworkSettings.XSSI_PREFIX + "\n" + "{\"is_valid_response\": true}"
+
+/** Tests for [NetworkInterceptor] */
+@RunWith(AndroidJUnit4::class)
+class NetworkInterceptorTest {
+
+  @Test
+  fun testNetworkInterceptor_removeXSSIPrefixFromResponse_withXSSIPREFIX() {
+    val networkInterceptor = NetworkInterceptor()
+    val rawJson: String = networkInterceptor.removeXSSIPrefixFromResponse(FAKE_RESPONSE_WITH_XSSI_PREFIX)
+
+    assertThat(rawJson).isEqualTo(FAKE_RESPONSE_WITHOUT_XSSI_PREFIX)
+  }
+
+  @Test
+  fun testNetworkInterceptor_removeXSSIPrefixFromResponse_withoutXSSIPREFIX() {
+    val networkInterceptor = NetworkInterceptor()
+    val rawJson: String = networkInterceptor.removeXSSIPrefixFromResponse(FAKE_RESPONSE_WITHOUT_XSSI_PREFIX)
+
+    assertThat(rawJson).isEqualTo(FAKE_RESPONSE_WITHOUT_XSSI_PREFIX)
+  }
+}


### PR DESCRIPTION
## Explanation
The PR contains data module, necessary libraries for API calls and Topic Management System models, retrofit instance and interceptor.

Also this PR was earlier on #61 but because of merge conflicts I have introduced this new PR.

## Libraries Used
1. **Retrofit:** implementation 'com.squareup.retrofit2:retrofit:2.5.0'
This library is responsible for making API calls to Oppia backend
2. **Retrofit Moshi Converter:** implementation 'com.squareup.retrofit2:converter-moshi:2.5.0'
This library is the actual deserializer that we are using over GSON.
3. **Moshi Kotlin Support:** implementation"com.squareup.moshi:moshi-kotlin:1.8.0"
Moshi Kotlin support library for using Moshi in Kotlin.

## Issues
The models in this PR does not have custom field names because @Json in Moshi which is similar to @SerializedName in GSON is not working with Kotlin Moshi.

## Checklist
Work items:

- [x] Identify among all existing GAE endpoints (get/post), which we can use during the prototype
- [x] Loosely identify data missing from the above endpoints (this bucket is expected to be small/non-existent), and identify which endpoints have data which needs to be changed for the Android app
- [x] Specify the Retrofit interfaces to represent all of the identified endpoints (simple interfaces/no annotations or return types needed beyond pseudocode)
- [x] Identify** what data (via pseudocode data structures/YAML/JSON/etc) we will be passing along from the backend through these endpoints
- [ ] Identify how error handling will work (e.g. what Retrofit does), whether RPC retry is supported & how it is/can be configured, etc.
- [ ] Determine the testing strategy for the GAE endpoints for downstream app components
