### PR TITLE
Fix broken proto build

### DIFF
--- a/model/build.gradle
+++ b/model/build.gradle
@@ -23,7 +23,9 @@ protobuf {
 }
 
 dependencies {
-  implementation 'com.google.protobuf:protobuf-lite:3.0.0'
+  // This must use compile in order for lite protobufs to generate correctly.
+  // TODO(#59): Move to Bazel to avoid relying on a deprecated Gradle directive.
+  compile 'com.google.protobuf:protobuf-lite:3.0.0'
 }
 
 sourceCompatibility = "8"


### PR DESCRIPTION
Update build.gradle proto directive to use 'compile' instead of 'implementation'. It's not clear to me why this is needed, and #59 will eventually render this unnecessary, but in the meantime we need to ensure that we continue using 'compile' instead of 'implementation'.