### PR TITLE
Add .github folder with code of conduct, contributing instructions, and a PR template.

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment where everyone gets a chance to learn, we as
+contributors and maintainers pledge to making participation in our project, Oppia and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Being available to help other contributors.
+* Being respectful of differing viewpoints and experiences.
+* Focusing on teaching-oriented communication so that each contributor gets a chance to learn and grow.
+* Focusing on what is best for the Oppia community.
+* Gracefully accepting constructive criticism.
+* Showing empathy towards other community members.
+* Using welcoming and inclusive language.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances.
+* Trolling, insulting/derogatory comments, and personal or political attacks.
+* Public or private harassment.
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission.
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting.
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [admin@oppia.org](mailto:admin@oppia.org). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please see [this link](https://github.com/oppia/oppia-android/wiki) for instructions on how to contribute code to the Oppia Android project. Thanks!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--
+  - Thanks for submitting code to Oppia! Please fill out the following as part of
+  - your pull request so we can review your code more easily.
+  -->
+
+## Explanation
+<!--
+  - Explain what your PR does. If this PR fixes an existing bug, please include
+  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
+  - when this PR is merged.
+  -->
+
+## Checklist
+<!-- Please tick the relevant boxes by putting an "x" in them. -->
+- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
+- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
+- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
+- [ ] The PR does not contain any unnecessary auto-generated code from Android Studio.
+- [ ] The PR is made from a branch that's **not** called "develop".
+- [ ] The PR is **assigned** to an appropriate reviewer.


### PR DESCRIPTION
This PR adds a .github folder which includes:

- A code of conduct (the same one as in the oppia/oppia repo)
- A CONTRIBUTING file that links to our main wiki page
- A PR template with some quick checks that should be done by developers prior to submitting a PR.