### PR TITLE
Fix part of #5: Abstraction on top of Oppia GAE for Subtopic Management System [Blocked: #78]

### DIFF
--- a/data/src/main/java/org/oppia/data/backends/gae/api/SubtopicService.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/api/SubtopicService.kt
@@ -1,0 +1,14 @@
+package org.oppia.data.backends.gae.api
+
+import org.oppia.data.backends.gae.model.GaeSubtopic
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+/** Service that provides access to subtopic endpoints. */
+interface SubtopicService {
+
+  @GET("subtopic_data_handler/{topic_name}/{subtopic_id}")
+  fun getSubtopic(@Path("topic_name") topic_name: String, @Path("subtopic_id") subtopic_id: String): Call<GaeSubtopic>
+
+}

--- a/data/src/main/java/org/oppia/data/backends/gae/api/SubtopicService.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/api/SubtopicService.kt
@@ -9,6 +9,6 @@ import retrofit2.http.Path
 interface SubtopicService {
 
   @GET("subtopic_data_handler/{topic_name}/{subtopic_id}")
-  fun getSubtopic(@Path("topic_name") topic_name: String, @Path("subtopic_id") subtopic_id: String): Call<GaeSubtopic>
+  fun getSubtopic(@Path("topic_name") topicName: String, @Path("subtopic_id") subtopicId: String): Call<GaeSubtopic>
 
 }

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeClassroom.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeClassroom.kt
@@ -10,6 +10,6 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class GaeClassroom(
 
-  @Json(name = "topic_summary_dicts") val topic_summary_dicts: List<GaeTopicSummary>?
+  @Json(name = "topic_summary_dicts") val topicSummaryDicts: List<GaeTopicSummary>?
 
 )

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeSubtopic.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeSubtopic.kt
@@ -1,0 +1,16 @@
+package org.oppia.data.backends.gae.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Data class for Subtopic model
+ * https://github.com/oppia/oppia/blob/b33aa9/core/controllers/subtopic_viewer.py#L31
+ */
+@JsonClass(generateAdapter = true)
+data class GaeSubtopic(
+
+  @Json(name = "subtopic_title") val subtopicTitle: String?,
+  @Json(name = "page_contents") val pageContents: GaeSubtopicPageContents?
+
+)

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeSubtopicPageContents.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeSubtopicPageContents.kt
@@ -1,0 +1,17 @@
+package org.oppia.data.backends.gae.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Data class for SubtopicPageContents model
+ * https://github.com/oppia/oppia/blob/b33aa9/core/domain/subtopic_page_domain.py#L112
+ */
+@JsonClass(generateAdapter = true)
+data class GaeSubtopicPageContents(
+
+  @Json(name = "subtitled_html") val content: GaeSubtitledHtml?,
+  @Json(name = "recorded_voiceovers") val recordedVoiceovers: GaeRecordedVoiceovers?,
+  @Json(name = "written_translations") val writtenTranslations: GaeWrittenTranslations?
+
+)

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeTopicSummary.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeTopicSummary.kt
@@ -14,11 +14,11 @@ data class GaeTopicSummary(
   @Json(name = "id") val id: String?,
   @Json(name = "name") val name: String?,
   @Json(name = "subtopic_count") val subtopic_count: Int?,
-  @Json(name = "canonical_story_count") val canonical_story_count: Int?,
-  @Json(name = "uncategorized_skill_count") val uncategorized_skill_count: Int?,
-  @Json(name = "additional_story_count") val additional_story_count: Int?,
-  @Json(name = "total_skill_count") val total_skill_count: Int?,
-  @Json(name = "topic_model_last_updated") val topic_model_last_updated: Double?,
-  @Json(name = "topic_model_created_on") val topic_model_created_on: Double?
+  @Json(name = "canonical_story_count") val canonicalStoryCount: Int?,
+  @Json(name = "uncategorized_skill_count") val uncategorizedSkillCount: Int?,
+  @Json(name = "additional_story_count") val additionalStoryCount: Int?,
+  @Json(name = "total_skill_count") val totalSkillCount: Int?,
+  @Json(name = "topic_model_last_updated") val topicModelLastUpdated: Double?,
+  @Json(name = "topic_model_created_on") val topicModelCreatedOn: Double?
 
 )

--- a/data/src/test/assets/api_mocks/subtopic.json
+++ b/data/src/test/assets/api_mocks/subtopic.json
@@ -1,0 +1,37 @@
+{
+  "page_contents": {
+    "subtitled_html": {
+      "html": "<p>test</p>",
+      "content_id": "content"
+    },
+    "recorded_voiceovers": {
+      "voiceovers_mapping": {
+        "content": {
+          "en": {
+            "filename": "test.mp3",
+            "file_size_bytes": 100,
+            "needs_update": false
+          }
+        }
+      }
+    },
+    "written_translations": {
+      "translations_mapping": {
+        "content": {
+          "en": {
+            "html": "Translation.",
+            "needs_update": false
+          }
+        }
+      }
+    }
+  },
+  "is_admin": true,
+  "username": "rt4914",
+  "user_email": "test@example.com",
+  "iframed": false,
+  "additional_angular_modules": [],
+  "is_topic_manager": false,
+  "subtopic_title": "Subtopic 1",
+  "is_super_admin": true
+}

--- a/data/src/test/java/org/oppia/data/backends/api/MockSubtopicService.kt
+++ b/data/src/test/java/org/oppia/data/backends/api/MockSubtopicService.kt
@@ -1,0 +1,42 @@
+package org.oppia.data.backends.api
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import org.oppia.data.backends.ApiUtils
+import org.oppia.data.backends.gae.NetworkInterceptor
+import org.oppia.data.backends.gae.NetworkSettings
+import org.oppia.data.backends.gae.api.SubtopicService
+import org.oppia.data.backends.gae.model.GaeSubtopic
+import retrofit2.Call
+import retrofit2.mock.BehaviorDelegate
+
+/**
+ * Mock SubtopicService with dummy data from [subtopic.json]
+ */
+class MockSubtopicService(private val delegate: BehaviorDelegate<SubtopicService>) :
+  SubtopicService {
+  override fun getSubtopic(topic_name: String, subtopic_id: String): Call<GaeSubtopic> {
+    val subtopic = createMockGaeSubtopic()
+    return delegate.returningResponse(subtopic).getSubtopic(topic_name, subtopic_id)
+  }
+
+  /**
+   * This function creates a mock GaeSubtopic with data from dummy json.
+   * This function also tests the removeXSSIPrefix function from [NetworkInterceptor]
+   * @return GaeSubtopic: GaeSubtopic with mock data
+   */
+  private fun createMockGaeSubtopic(): GaeSubtopic {
+    val networkInterceptor = NetworkInterceptor()
+    var subtopicResponseWithXssiPrefix =
+      NetworkSettings.XSSI_PREFIX + ApiUtils.getFakeJson("subtopic.json")
+
+    subtopicResponseWithXssiPrefix =
+      networkInterceptor.removeXSSIPrefix(subtopicResponseWithXssiPrefix)
+
+    val moshi = Moshi.Builder().build()
+    val adapter: JsonAdapter<GaeSubtopic> = moshi.adapter(GaeSubtopic::class.java)
+    val mockGaeSubtopic = adapter.fromJson(subtopicResponseWithXssiPrefix)
+
+    return mockGaeSubtopic!!
+  }
+}

--- a/data/src/test/java/org/oppia/data/backends/api/MockSubtopicService.kt
+++ b/data/src/test/java/org/oppia/data/backends/api/MockSubtopicService.kt
@@ -15,14 +15,13 @@ import retrofit2.mock.BehaviorDelegate
  */
 class MockSubtopicService(private val delegate: BehaviorDelegate<SubtopicService>) :
   SubtopicService {
-  override fun getSubtopic(topic_name: String, subtopic_id: String): Call<GaeSubtopic> {
+  override fun getSubtopic(topicName: String, subtopicId: String): Call<GaeSubtopic> {
     val subtopic = createMockGaeSubtopic()
-    return delegate.returningResponse(subtopic).getSubtopic(topic_name, subtopic_id)
+    return delegate.returningResponse(subtopic).getSubtopic(topicName, subtopicId)
   }
 
   /**
    * This function creates a mock GaeSubtopic with data from dummy json.
-   * This function also tests the removeXSSIPrefix function from [NetworkInterceptor]
    * @return GaeSubtopic: GaeSubtopic with mock data
    */
   private fun createMockGaeSubtopic(): GaeSubtopic {

--- a/data/src/test/java/org/oppia/data/backends/test/MockClassroomTest.kt
+++ b/data/src/test/java/org/oppia/data/backends/test/MockClassroomTest.kt
@@ -49,6 +49,6 @@ class MockClassroomTest {
     val classroomResponse = classroom.execute()
 
     assertThat(classroomResponse.isSuccessful).isTrue()
-    assertThat(classroomResponse.body()!!.topic_summary_dicts?.get(0)?.name).isEqualTo("Math")
+    assertThat(classroomResponse.body()!!.topicSummaryDicts?.get(0)?.name).isEqualTo("Math")
   }
 }

--- a/data/src/test/java/org/oppia/data/backends/test/MockSubtopicTest.kt
+++ b/data/src/test/java/org/oppia/data/backends/test/MockSubtopicTest.kt
@@ -1,0 +1,54 @@
+package org.oppia.data.backends.test
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import okhttp3.OkHttpClient
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.oppia.data.backends.api.MockSubtopicService
+import org.oppia.data.backends.gae.NetworkInterceptor
+import org.oppia.data.backends.gae.NetworkSettings
+import org.oppia.data.backends.gae.api.SubtopicService
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.mock.MockRetrofit
+import retrofit2.mock.NetworkBehavior
+
+/**
+ * Test for [SubtopicService] retrofit instance using [MockSubtopicService]
+ */
+@RunWith(AndroidJUnit4::class)
+class MockSubtopicTest {
+  private lateinit var mockRetrofit: MockRetrofit
+  private lateinit var retrofit: Retrofit
+
+  @Before
+  fun setUp() {
+    val client = OkHttpClient.Builder()
+    client.addInterceptor(NetworkInterceptor())
+
+    retrofit = retrofit2.Retrofit.Builder()
+      .baseUrl(NetworkSettings.getBaseUrl())
+      .addConverterFactory(MoshiConverterFactory.create())
+      .client(client.build())
+      .build()
+
+    val behavior = NetworkBehavior.create()
+    mockRetrofit = MockRetrofit.Builder(retrofit)
+      .networkBehavior(behavior)
+      .build()
+  }
+
+  @Test
+  fun testSubtopicService_usingFakeJson_deserializationSuccessful() {
+    val delegate = mockRetrofit.create(SubtopicService::class.java)
+    val mockSubtopicService = MockSubtopicService(delegate)
+
+    val subtopic = mockSubtopicService.getSubtopic("Subtopic 1", "randomId")
+    val subtopicResponse = subtopic.execute()
+
+    assertThat(subtopicResponse.isSuccessful).isTrue()
+    assertThat(subtopicResponse.body()!!.subtopicTitle).isEqualTo("Subtopic 1")
+  }
+}


### PR DESCRIPTION
## Explanation
PR contains subtopic retrofit instance, subtopic models and test-cases.
This PR was earlier on #62 which has been closed now.

## Checklist
Work items:

- [x] Identify among all existing GAE endpoints (get/post), which we can use during the prototype
- [x] Loosely identify data missing from the above endpoints (this bucket is expected to be small/non-existent), and identify which endpoints have data which needs to be changed for the Android app
- [x] Specify the Retrofit interfaces to represent all of the identified endpoints (simple interfaces/no annotations or return types needed beyond pseudocode)
- [x] Identify** what data (via pseudocode data structures/YAML/JSON/etc) we will be passing along from the backend through these endpoints
- [x] Identify how error handling will work (e.g. what Retrofit does), whether RPC retry is supported & how it is/can be configured, etc.
- [x] Determine the testing strategy for the GAE endpoints for downstream app components
