### PR TITLE
Move Logger to the utility module

### DIFF
--- a/app/src/main/java/org/oppia/app/application/ApplicationComponent.kt
+++ b/app/src/main/java/org/oppia/app/application/ApplicationComponent.kt
@@ -5,13 +5,14 @@ import dagger.BindsInstance
 import dagger.Component
 import org.oppia.app.activity.ActivityComponent
 import org.oppia.data.backends.gae.NetworkModule
+import org.oppia.util.logging.LoggerModule
 import org.oppia.util.threading.DispatcherModule
 import javax.inject.Provider
 import javax.inject.Singleton
 
 /** Root Dagger component for the application. All application-scoped modules should be included in this component. */
 @Singleton
-@Component(modules = [ApplicationModule::class, DispatcherModule::class, NetworkModule::class])
+@Component(modules = [ApplicationModule::class, DispatcherModule::class, NetworkModule::class, LoggerModule::class])
 interface ApplicationComponent {
   @Component.Builder
   interface Builder {

--- a/app/src/main/java/org/oppia/app/home/UserAppHistoryViewModel.kt
+++ b/app/src/main/java/org/oppia/app/home/UserAppHistoryViewModel.kt
@@ -1,12 +1,11 @@
 package org.oppia.app.home
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import org.oppia.app.fragment.FragmentScope
 import org.oppia.app.model.UserAppHistory
-import org.oppia.app.utility.Logger
+import org.oppia.util.logging.Logger
 import org.oppia.domain.UserAppHistoryController
 import org.oppia.util.data.AsyncResult
 import javax.inject.Inject

--- a/domain/src/main/java/org/oppia/domain/UserAppHistoryController.kt
+++ b/domain/src/main/java/org/oppia/domain/UserAppHistoryController.kt
@@ -1,18 +1,19 @@
 package org.oppia.domain
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import org.oppia.app.model.UserAppHistory
 import org.oppia.data.persistence.PersistentCacheStore
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders
+import org.oppia.util.logging.Logger
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /** Controller for persisting and retrieving the previous user history of using the app. */
 @Singleton
 class UserAppHistoryController @Inject constructor(
-  cacheStoreFactory: PersistentCacheStore.Factory, private val dataProviders: DataProviders
+  cacheStoreFactory: PersistentCacheStore.Factory, private val dataProviders: DataProviders,
+  private val logger: Logger
 ) {
   private val appHistoryStore = cacheStoreFactory.create("user_app_history", UserAppHistory.getDefaultInstance())
 
@@ -20,7 +21,7 @@ class UserAppHistoryController @Inject constructor(
     // Prime the cache ahead of time so that any existing history is read prior to any calls to markUserOpenedApp().
     appHistoryStore.primeCacheAsync().invokeOnCompletion {
       it?.let {
-        Log.e("DOMAIN", "Failed to prime cache ahead of LiveData conversion for user app open history.", it)
+        logger.e("DOMAIN", "Failed to prime cache ahead of LiveData conversion for user app open history.", it)
       }
     }
   }
@@ -34,7 +35,7 @@ class UserAppHistoryController @Inject constructor(
       it.toBuilder().setAlreadyOpenedApp(true).build()
     }.invokeOnCompletion {
       it?.let {
-        Log.e("DOMAIN", "Failed when storing that the user already opened the app.", it)
+        logger.e("DOMAIN", "Failed when storing that the user already opened the app.", it)
       }
     }
   }
@@ -43,7 +44,7 @@ class UserAppHistoryController @Inject constructor(
   fun clearUserAppHistory() {
     appHistoryStore.clearCacheAsync().invokeOnCompletion {
       it?.let {
-        Log.e("DOMAIN", "Failed to clear user app history.", it)
+        logger.e("DOMAIN", "Failed to clear user app history.", it)
       }
     }
   }

--- a/utility/src/main/java/org/oppia/util/logging/LogLevel.kt
+++ b/utility/src/main/java/org/oppia/util/logging/LogLevel.kt
@@ -1,0 +1,12 @@
+package org.oppia.util.logging
+
+import android.util.Log
+
+/** Corresponds to different severities of logs. */
+enum class LogLevel constructor(internal val logLevel: Int) {
+  VERBOSE(Log.VERBOSE),
+  DEBUG(Log.DEBUG),
+  INFO(Log.INFO),
+  WARNING(Log.WARN),
+  ERROR(Log.ERROR)
+}

--- a/utility/src/main/java/org/oppia/util/logging/LoggerModule.kt
+++ b/utility/src/main/java/org/oppia/util/logging/LoggerModule.kt
@@ -1,0 +1,33 @@
+package org.oppia.util.logging
+
+import dagger.Module
+import dagger.Provides
+import javax.inject.Singleton
+
+// TODO(#59): Introduce flavor-specific modules that configure logging settings based on what's reasonable (e.g. prod
+// builds ought to not include verbose logging).
+/** Provides logging-based dependencies. */
+@Module
+class LoggerModule {
+  @Provides
+  @EnableConsoleLog
+  @Singleton
+  fun provideEnableConsoleLog(): Boolean {
+    return true
+  }
+
+  @Provides
+  @EnableFileLog
+  @Singleton
+  fun provideEnableFileLog(): Boolean {
+    return true
+  }
+
+  @Provides
+  @GlobalLogLevel
+  @Singleton
+  fun provideGlobalLogLevel(): LogLevel {
+    // By default, log everything.
+    return LogLevel.VERBOSE
+  }
+}

--- a/utility/src/main/java/org/oppia/util/logging/LoggingAnnotations.kt
+++ b/utility/src/main/java/org/oppia/util/logging/LoggingAnnotations.kt
@@ -1,0 +1,12 @@
+package org.oppia.util.logging
+
+import javax.inject.Qualifier
+
+/** Corresponds to a singleton boolean of whether console (logcat) logging is enabled. */
+@Qualifier internal annotation class EnableConsoleLog
+
+/** Corresponds to a singleton boolean of whether logs are saved to a file. */
+@Qualifier internal annotation class EnableFileLog
+
+/** Corresponds to a singleton [LogLevel] determining the minimum severity of logs that should be kept. */
+@Qualifier internal annotation class GlobalLogLevel


### PR DESCRIPTION
I missed some parts in #63. This PR:
- Moves ``Logger`` to the utility module so that the whole app can use it
- Cleans up ``Logger`` a bit by extracting configuration constants to a Dagger module for later build-time replacement once #59 is done
- Migrates all existing Android ``Log`` uses to using ``Logger``

Reviewers: I just need 1 approval to check this in. Please don't wait on others to review it.