### PR TITLE
Fix part of #5: Abstraction on top of Oppia GAE for StoryPage [Blocked: #66]

### DIFF
--- a/data/src/main/java/org/oppia/data/backends/gae/api/StoryService.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/api/StoryService.kt
@@ -1,0 +1,19 @@
+package org.oppia.data.backends.gae.api
+
+import org.oppia.data.backends.gae.model.GaeStory
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/** Service that provides access to story endpoints. */
+interface StoryService {
+
+  @GET("story_data_handler/{story_id}")
+  fun getStory(
+    @Path("story_id") storyId: String,
+    @Query("user_id") userId: String?,
+    @Query("user") user: String?
+  ): Call<GaeStory>
+
+}

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeExpSummary.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeExpSummary.kt
@@ -1,0 +1,25 @@
+package org.oppia.data.backends.gae.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Data class for ExpSummary model
+ * https://github.com/oppia/oppia/blob/b56a20/core/domain/summary_services.py#L340
+ */
+@JsonClass(generateAdapter = true)
+data class GaeExpSummary(
+
+  @Json(name = "title") val title: String?,
+  @Json(name = "status") val status: String?,
+  @Json(name = "category") val category: String?,
+  @Json(name = "objective") val objective: String?,
+  @Json(name = "num_views") val numViews: Int?,
+  @Json(name = "activity_type") val activityType: String?,
+  @Json(name = "id") val id: String?,
+  @Json(name = "created_on_msec") val createdOnMsec: Double?,
+  @Json(name = "last_updated_msec") val lastUpdatedMsec: Double?,
+  @Json(name = "ratings") val ratings: Map<String, Float>?,
+  @Json(name = "tags") val tags: List<String>?
+
+)

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeStory.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeStory.kt
@@ -1,0 +1,17 @@
+package org.oppia.data.backends.gae.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Data class for Story model
+ * https://github.com/oppia/oppia/blob/b56a20/core/controllers/story_viewer.py#L47
+ */
+@JsonClass(generateAdapter = true)
+data class GaeStory(
+
+  @Json(name = "story_title") val storyTitle: String?,
+  @Json(name = "story_description") val storyDescription: String?,
+  @Json(name = "story_nodes") val storyNodes: List<GaeStoryNode>?
+
+)

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeStoryNode.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeStoryNode.kt
@@ -1,0 +1,24 @@
+package org.oppia.data.backends.gae.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Data class for StoryNode model
+ * https://github.com/oppia/oppia/blob/b56a20/core/domain/story_domain.py#L226
+ */
+@JsonClass(generateAdapter = true)
+data class GaeStoryNode(
+
+  @Json(name = "id") val id: String?,
+  @Json(name = "title") val title: String?,
+  @Json(name = "destination_node_ids") val destinationNodeIds: List<String>?,
+  @Json(name = "acquired_skill_ids") val acquiredSkillIds: List<String>?,
+  @Json(name = "prerequisite_skill_ids") val prerequisiteSkillIds: List<String>?,
+  @Json(name = "outline") val outline: String?,
+  @Json(name = "outline_is_finalized") val isOutlineFinalized: Boolean?,
+  @Json(name = "exploration_id") val explorationId: String?,
+  @Json(name = "exp_summary_dict") val explorationSummaryDict: GaeExpSummary?,
+  @Json(name = "completed") val isCompleted: Boolean?
+
+)

--- a/data/src/test/assets/api_mocks/story.json
+++ b/data/src/test/assets/api_mocks/story.json
@@ -1,0 +1,49 @@
+{
+  "story_title": "Story 1",
+  "story_description": "Story Description",
+  "is_moderator": true,
+  "is_admin": true,
+  "username": "rt4914",
+  "user_email": "test@example.com",
+  "iframed": false,
+  "story_nodes": [
+    {
+      "exp_summary_dict": {
+        "community_owned": true,
+        "human_readable_contributors_summary": {},
+        "category": "Algebra",
+        "title": "Root Linear Coefficient Theorem",
+        "status": "public",
+        "num_views": 4,
+        "objective": "discover the Root Linear Coefficient Theorem",
+        "activity_type": "exploration",
+        "ratings": {
+          "2": 0,
+          "3": 0,
+          "1": 0,
+          "4": 0,
+          "5": 0
+        },
+        "id": "3",
+        "thumbnail_bg_color": "#cd672b",
+        "created_on_msec": 1566278940160.576,
+        "tags": [],
+        "thumbnail_icon_url": "/subjects/Algebra.svg",
+        "language_code": "en",
+        "last_updated_msec": 1566278940160.279
+      },
+      "completed": false,
+      "title": "Chapter 1",
+      "outline": "\u003cp\u003eChapter 1 Outline\u003c/p\u003e",
+      "prerequisite_skill_ids": [],
+      "destination_node_ids": [],
+      "outline_is_finalized": false,
+      "acquired_skill_ids": [],
+      "id": "node_1",
+      "exploration_id": "3"
+    }
+  ],
+  "additional_angular_modules": [],
+  "is_topic_manager": false,
+  "is_super_admin": true
+}

--- a/data/src/test/java/org/oppia/data/backends/api/MockClassroomService.kt
+++ b/data/src/test/java/org/oppia/data/backends/api/MockClassroomService.kt
@@ -22,7 +22,6 @@ class MockClassroomService(private val delegate: BehaviorDelegate<ClassroomServi
 
   /**
    * This function creates a mock GaeClassroom with data from dummy json.
-   * This function also tests the removeXSSIPrefix function from [NetworkInterceptor]
    * @return GaeClassroom: GaeClassroom with mock data
    */
   private fun createMockGaeClassroom(): GaeClassroom {

--- a/data/src/test/java/org/oppia/data/backends/api/MockExplorationService.kt
+++ b/data/src/test/java/org/oppia/data/backends/api/MockExplorationService.kt
@@ -22,7 +22,6 @@ class MockExplorationService(private val delegate: BehaviorDelegate<ExplorationS
 
   /**
    * This function creates a mock GaeExplorationContainer with data from dummy json.
-   * This function also tests the removeXSSIPrefix function from [NetworkInterceptor]
    * @return GaeExplorationContainer: GaeExplorationContainer with mock data
    */
   private fun createMockGaeExplorationContainer(): GaeExplorationContainer {

--- a/data/src/test/java/org/oppia/data/backends/api/MockStoryService.kt
+++ b/data/src/test/java/org/oppia/data/backends/api/MockStoryService.kt
@@ -1,0 +1,40 @@
+package org.oppia.data.backends.api
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import org.oppia.data.backends.ApiUtils
+import org.oppia.data.backends.gae.NetworkInterceptor
+import org.oppia.data.backends.gae.NetworkSettings
+import org.oppia.data.backends.gae.api.StoryService
+import org.oppia.data.backends.gae.model.GaeStory
+import retrofit2.Call
+import retrofit2.mock.BehaviorDelegate
+
+/**
+ * Mock StoryService with dummy data from [story.json]
+ */
+class MockStoryService(private val delegate: BehaviorDelegate<StoryService>) : StoryService {
+  override fun getStory(storyId: String, userId: String?, user: String?): Call<GaeStory> {
+    val story = createMockGaeStory()
+    return delegate.returningResponse(story).getStory(storyId, userId, user)
+  }
+
+  /**
+   * This function creates a mock GaeStory with data from dummy json.
+   * This function also tests the removeXSSIPrefix function from [NetworkInterceptor]
+   * @return GaeStory: GaeStory with mock data
+   */
+  private fun createMockGaeStory(): GaeStory {
+    val networkInterceptor = NetworkInterceptor()
+    var storyResponseWithXssiPrefix =
+      NetworkSettings.XSSI_PREFIX + ApiUtils.getFakeJson("story.json")
+
+    storyResponseWithXssiPrefix = networkInterceptor.removeXSSIPrefix(storyResponseWithXssiPrefix)
+
+    val moshi = Moshi.Builder().build()
+    val adapter: JsonAdapter<GaeStory> = moshi.adapter(GaeStory::class.java)
+    val mockGaeStory = adapter.fromJson(storyResponseWithXssiPrefix)
+
+    return mockGaeStory!!
+  }
+}

--- a/data/src/test/java/org/oppia/data/backends/api/MockStoryService.kt
+++ b/data/src/test/java/org/oppia/data/backends/api/MockStoryService.kt
@@ -21,7 +21,6 @@ class MockStoryService(private val delegate: BehaviorDelegate<StoryService>) : S
 
   /**
    * This function creates a mock GaeStory with data from dummy json.
-   * This function also tests the removeXSSIPrefix function from [NetworkInterceptor]
    * @return GaeStory: GaeStory with mock data
    */
   private fun createMockGaeStory(): GaeStory {

--- a/data/src/test/java/org/oppia/data/backends/api/MockTopicService.kt
+++ b/data/src/test/java/org/oppia/data/backends/api/MockTopicService.kt
@@ -21,7 +21,6 @@ class MockTopicService(private val delegate: BehaviorDelegate<TopicService>) : T
 
   /**
    * This function creates a mock GaeTopic with data from dummy json.
-   * This function also tests the removeXSSIPrefix function from [NetworkInterceptor]
    * @return GaeTopic: GaeTopic with mock data
    */
   private fun createMockGaeTopic(): GaeTopic {

--- a/data/src/test/java/org/oppia/data/backends/test/MockStoryTest.kt
+++ b/data/src/test/java/org/oppia/data/backends/test/MockStoryTest.kt
@@ -1,0 +1,54 @@
+package org.oppia.data.backends.test
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import okhttp3.OkHttpClient
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.oppia.data.backends.api.MockStoryService
+import org.oppia.data.backends.gae.NetworkInterceptor
+import org.oppia.data.backends.gae.NetworkSettings
+import org.oppia.data.backends.gae.api.StoryService
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.mock.MockRetrofit
+import retrofit2.mock.NetworkBehavior
+
+/**
+ * Test for [StoryService] retrofit instance using [MockStoryService]
+ */
+@RunWith(AndroidJUnit4::class)
+class MockStoryTest {
+  private lateinit var mockRetrofit: MockRetrofit
+  private lateinit var retrofit: Retrofit
+
+  @Before
+  fun setUp() {
+    val client = OkHttpClient.Builder()
+    client.addInterceptor(NetworkInterceptor())
+
+    retrofit = retrofit2.Retrofit.Builder()
+      .baseUrl(NetworkSettings.getBaseUrl())
+      .addConverterFactory(MoshiConverterFactory.create())
+      .client(client.build())
+      .build()
+
+    val behavior = NetworkBehavior.create()
+    mockRetrofit = MockRetrofit.Builder(retrofit)
+      .networkBehavior(behavior)
+      .build()
+  }
+
+  @Test
+  fun testStoryService_usingFakeJson_deserializationSuccessful() {
+    val delegate = mockRetrofit.create(StoryService::class.java)
+    val mockStoryService = MockStoryService(delegate)
+
+    val story = mockStoryService.getStory("1", "randomUserId", "rt4914")
+    val storyResponse = story.execute()
+
+    assertThat(storyResponse.isSuccessful).isTrue()
+    assertThat(storyResponse.body()!!.storyTitle).isEqualTo("Story 1")
+  }
+}


### PR DESCRIPTION
## Explanation
PR contains story page retrofit instance, story page models and test-cases
This PR was earlier on #69 

## Checklist 1
Work items:

- [x] Identify among all existing GAE endpoints (get/post), which we can use during the prototype
- [x] Loosely identify data missing from the above endpoints (this bucket is expected to be small/non-existent), and identify which endpoints have data which needs to be changed for the Android app
- [x] Specify the Retrofit interfaces to represent all of the identified endpoints (simple interfaces/no annotations or return types needed beyond pseudocode)
- [x] Identify** what data (via pseudocode data structures/YAML/JSON/etc) we will be passing along from the backend through these endpoints
- [x] Identify how error handling will work (e.g. what Retrofit does), whether RPC retry is supported & how it is/can be configured, etc.
- [x] Determine the testing strategy for the GAE endpoints for downstream app components


## Checklist 2
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is **assigned** to an appropriate reviewer.
