### PR TITLE
Fix part of #5: Abstraction on top of Oppia GAE for ConceptCard [Blocked: #66]

### DIFF
--- a/data/src/main/java/org/oppia/data/backends/gae/api/ClassroomService.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/api/ClassroomService.kt
@@ -10,4 +10,5 @@ interface ClassroomService {
 
   @GET("classroom_data_handler/{classroom_name}")
   fun getClassroom(@Path("classroom_name") classRoomName: String): Call<GaeClassroom>
+
 }

--- a/data/src/main/java/org/oppia/data/backends/gae/api/ConceptCardService.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/api/ConceptCardService.kt
@@ -1,0 +1,14 @@
+package org.oppia.data.backends.gae.api
+
+import org.oppia.data.backends.gae.model.GaeConceptCard
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+/** Service that provides access to concept-card endpoints. */
+interface ConceptCardService {
+
+  @GET("concept_card_handler/{comma_separated_skill_ids}")
+  fun getSkillContents(@Query("comma_separated_skill_ids") skillIds: String): Call<GaeConceptCard>
+
+}

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeConceptCard.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeConceptCard.kt
@@ -1,0 +1,15 @@
+package org.oppia.data.backends.gae.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Data class for ConceptCard model
+ *
+ */
+@JsonClass(generateAdapter = true)
+data class GaeConceptCard(
+
+  @Json(name = "concept_card_dicts") val conceptCardDicts: List<GaeSkillContents>
+
+)

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeConceptCard.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeConceptCard.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonClass
 
 /**
  * Data class for ConceptCard model
- *
+ * https://github.com/oppia/oppia/blob/b33aa9/core/controllers/concept_card_viewer.py#L30
  */
 @JsonClass(generateAdapter = true)
 data class GaeConceptCard(

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeConceptCard.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeConceptCard.kt
@@ -10,6 +10,6 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class GaeConceptCard(
 
-  @Json(name = "concept_card_dicts") val conceptCardDicts: List<GaeSkillContents>
+  @Json(name = "concept_card_dicts") val conceptCardDicts: List<GaeSkillContents>?
 
 )

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeSkillContents.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeSkillContents.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonClass
 
 /**
  * Data class for SkillContents model
- *
+ * https://github.com/oppia/oppia/blob/b33aa9/core/domain/skill_domain.py#L285
  */
 @JsonClass(generateAdapter = true)
 data class GaeSkillContents(

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeSkillContents.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeSkillContents.kt
@@ -1,0 +1,18 @@
+package org.oppia.data.backends.gae.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Data class for SkillContents model
+ *
+ */
+@JsonClass(generateAdapter = true)
+data class GaeSkillContents(
+
+  @Json(name = "explanation") val explanation: GaeSubtitledHtml,
+  @Json(name = "worked_examples") val workedExamples: List<GaeSubtitledHtml>,
+  @Json(name = "recorded_voiceovers") val recordedVoiceovers: GaeRecordedVoiceovers,
+  @Json(name = "written_translations") val writtenTranslations: GaeWrittenTranslations
+
+)

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeSkillContents.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeSkillContents.kt
@@ -10,9 +10,9 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class GaeSkillContents(
 
-  @Json(name = "explanation") val explanation: GaeSubtitledHtml,
-  @Json(name = "worked_examples") val workedExamples: List<GaeSubtitledHtml>,
-  @Json(name = "recorded_voiceovers") val recordedVoiceovers: GaeRecordedVoiceovers,
-  @Json(name = "written_translations") val writtenTranslations: GaeWrittenTranslations
+  @Json(name = "explanation") val explanation: GaeSubtitledHtml?,
+  @Json(name = "worked_examples") val workedExamples: List<GaeSubtitledHtml>?,
+  @Json(name = "recorded_voiceovers") val recordedVoiceovers: GaeRecordedVoiceovers?,
+  @Json(name = "written_translations") val writtenTranslations: GaeWrittenTranslations?
 
 )

--- a/data/src/test/assets/api_mocks/concept_card.json
+++ b/data/src/test/assets/api_mocks/concept_card.json
@@ -1,0 +1,36 @@
+{
+  "is_moderator": true,
+  "is_admin": true,
+  "username": "rt4914",
+  "user_email": "test@example.com",
+  "concept_card_dicts": [
+    {
+      "explanation": {
+        "content_id": "explanation",
+        "html": "\u003cp\u003eReview Material\u003c/p\u003e"
+      },
+      "worked_examples": [
+        {
+          "content_id": "worked_example_1",
+          "html": "\u003cp\u003e\u003cem\u003eExample 1\u003c/em\u003e\u003c/p\u003e"
+        }
+      ],
+      "recorded_voiceovers": {
+        "voiceovers_mapping": {
+          "explanation": {},
+          "worked_example_1": {}
+        }
+      },
+      "written_translations": {
+        "translations_mapping": {
+          "explanation": {},
+          "worked_example_1": {}
+        }
+      }
+    }
+  ],
+  "iframed": false,
+  "additional_angular_modules": [],
+  "is_topic_manager": false,
+  "is_super_admin": true
+}

--- a/data/src/test/java/org/oppia/data/backends/api/MockConceptCardService.kt
+++ b/data/src/test/java/org/oppia/data/backends/api/MockConceptCardService.kt
@@ -1,0 +1,41 @@
+package org.oppia.data.backends.api
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import org.oppia.data.backends.ApiUtils
+import org.oppia.data.backends.gae.NetworkInterceptor
+import org.oppia.data.backends.gae.NetworkSettings
+import org.oppia.data.backends.gae.api.ConceptCardService
+import org.oppia.data.backends.gae.model.GaeConceptCard
+import retrofit2.Call
+import retrofit2.mock.BehaviorDelegate
+
+/**
+ * Mock ConceptCardService with dummy data from [concept_card.json]
+ */
+class MockConceptCardService(private val delegate: BehaviorDelegate<ConceptCardService>) :
+  ConceptCardService {
+  override fun getSkillContents(skillIds: String): Call<GaeConceptCard> {
+    val conceptCard = createMockGaeConceptCard()
+    return delegate.returningResponse(conceptCard).getSkillContents(skillIds)
+  }
+
+  /**
+   * This function creates a mock GaeConceptCard with data from dummy json.
+   * @return GaeConceptCard: GaeConceptCard with mock data
+   */
+  private fun createMockGaeConceptCard(): GaeConceptCard {
+    val networkInterceptor = NetworkInterceptor()
+    var conceptCardResponseWithXssiPrefix =
+      NetworkSettings.XSSI_PREFIX + ApiUtils.getFakeJson("concept_card.json")
+
+    conceptCardResponseWithXssiPrefix =
+      networkInterceptor.removeXSSIPrefix(conceptCardResponseWithXssiPrefix)
+
+    val moshi = Moshi.Builder().build()
+    val adapter: JsonAdapter<GaeConceptCard> = moshi.adapter(GaeConceptCard::class.java)
+    val mockGaeConceptCard = adapter.fromJson(conceptCardResponseWithXssiPrefix)
+
+    return mockGaeConceptCard!!
+  }
+}

--- a/data/src/test/java/org/oppia/data/backends/test/MockConceptCardTest.kt
+++ b/data/src/test/java/org/oppia/data/backends/test/MockConceptCardTest.kt
@@ -1,0 +1,60 @@
+package org.oppia.data.backends.test
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import okhttp3.OkHttpClient
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.oppia.data.backends.api.MockConceptCardService
+import org.oppia.data.backends.gae.NetworkInterceptor
+import org.oppia.data.backends.gae.NetworkSettings
+import org.oppia.data.backends.gae.api.ConceptCardService
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.mock.MockRetrofit
+import retrofit2.mock.NetworkBehavior
+
+/**
+ * Test for [ConceptCardService] retrofit instance using [MockConceptCardService]
+ */
+@RunWith(AndroidJUnit4::class)
+class MockConceptCardTest {
+  private lateinit var mockRetrofit: MockRetrofit
+  private lateinit var retrofit: Retrofit
+
+  @Before
+  fun setUp() {
+    val client = OkHttpClient.Builder()
+    client.addInterceptor(NetworkInterceptor())
+
+    retrofit = retrofit2.Retrofit.Builder()
+      .baseUrl(NetworkSettings.getBaseUrl())
+      .addConverterFactory(MoshiConverterFactory.create())
+      .client(client.build())
+      .build()
+
+    val behavior = NetworkBehavior.create()
+    mockRetrofit = MockRetrofit.Builder(retrofit)
+      .networkBehavior(behavior)
+      .build()
+  }
+
+  @Test
+  fun testConceptCardService_usingFakeJson_deserializationSuccessful() {
+    val delegate = mockRetrofit.create(ConceptCardService::class.java)
+    val mockConceptCardService = MockConceptCardService(delegate)
+
+    val skillIdList = ArrayList<String>()
+    skillIdList.add("1")
+    skillIdList.add("2")
+    skillIdList.add("3")
+
+    val skillIds = skillIdList.joinToString(separator = ", ")
+    val conceptCard = mockConceptCardService.getSkillContents(skillIds)
+    val conceptCardResponse = conceptCard.execute()
+
+    assertThat(conceptCardResponse.isSuccessful).isTrue()
+    assertThat(conceptCardResponse.body()!!.conceptCardDicts.size).isEqualTo(1)
+  }
+}


### PR DESCRIPTION
## Explanation
PR contains concept card service, models and test cases.
This PR was earlier on #67 

## Checklist
Work items:

- [x] Identify among all existing GAE endpoints (get/post), which we can use during the prototype
- [x] Loosely identify data missing from the above endpoints (this bucket is expected to be small/non-existent), and identify which endpoints have data which needs to be changed for the Android app
- [x] Specify the Retrofit interfaces to represent all of the identified endpoints (simple interfaces/no annotations or return types needed beyond pseudocode)
- [x] Identify** what data (via pseudocode data structures/YAML/JSON/etc) we will be passing along from the backend through these endpoints
- [x] Identify how error handling will work (e.g. what Retrofit does), whether RPC retry is supported & how it is/can be configured, etc.
- [x] Determine the testing strategy for the GAE endpoints for downstream app components

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is **assigned** to an appropriate reviewer.
