### PR TITLE
Fix part of #5: Abstraction on top of Oppia GAE for QuestionPlayer [Blocked: #66]

### DIFF
--- a/data/src/main/java/org/oppia/data/backends/gae/api/QuestionPlayerService.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/api/QuestionPlayerService.kt
@@ -1,0 +1,17 @@
+package org.oppia.data.backends.gae.api
+
+import org.oppia.data.backends.gae.model.GaeQuestionPlayer
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+/** Service that provides access to question-player endpoints. */
+interface QuestionPlayerService {
+
+  @GET("question_player_handler")
+  fun getQuestionPlayerBySkillIds(
+    @Query("skill_ids") skillIds: String,
+    @Query("question_count") questionCount: Int
+  ): Call<GaeQuestionPlayer>
+
+}

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeQuestion.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeQuestion.kt
@@ -1,0 +1,18 @@
+package org.oppia.data.backends.gae.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Data class for Question model
+ * https://github.com/oppia/oppia/blob/b33aa9/core/domain/question_domain.py#L144
+ */
+@JsonClass(generateAdapter = true)
+data class GaeQuestion(
+
+  @Json(name = "id") val id: String?,
+  @Json(name = "question_state_data") val state: GaeState?,
+  @Json(name = "version") val version: Int?,
+  @Json(name = "linked_skill_ids") val linkedSkillIds: List<String>?
+
+)

--- a/data/src/main/java/org/oppia/data/backends/gae/model/GaeQuestionPlayer.kt
+++ b/data/src/main/java/org/oppia/data/backends/gae/model/GaeQuestionPlayer.kt
@@ -1,0 +1,15 @@
+package org.oppia.data.backends.gae.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Data class model for Questions List
+ * https://github.com/oppia/oppia/blob/b33aa9/core/controllers/reader.py#L1008
+ */
+@JsonClass(generateAdapter = true)
+data class GaeQuestionPlayer(
+
+  @Json(name = "question_dicts") val questions: List<GaeQuestion>?
+
+)

--- a/data/src/test/assets/api_mocks/question_player.json
+++ b/data/src/test/assets/api_mocks/question_player.json
@@ -1,0 +1,128 @@
+{
+  "is_moderator": true,
+  "is_admin": true,
+  "username": "rt4914",
+  "question_dicts": [
+    {
+      "version": 3,
+      "linked_skill_ids": [
+        "A9j9taXAqqkV"
+      ],
+      "language_code": "en",
+      "question_state_data_schema_version": 30,
+      "question_state_data": {
+        "interaction": {
+          "default_outcome": {
+            "dest": null,
+            "labelled_as_correct": false,
+            "missing_prerequisite_skill_id": null,
+            "param_changes": [],
+            "feedback": {
+              "content_id": "default_outcome",
+              "html": ""
+            },
+            "refresher_exploration_id": null
+          },
+          "answer_groups": [
+            {
+              "outcome": {
+                "dest": null,
+                "labelled_as_correct": true,
+                "missing_prerequisite_skill_id": null,
+                "param_changes": [],
+                "feedback": {
+                  "content_id": "feedback_1",
+                  "html": "\u003cp\u003ecorrect\u003c/p\u003e"
+                },
+                "refresher_exploration_id": null
+              },
+              "tagged_skill_misconception_id": null,
+              "rule_specs": [
+                {
+                  "inputs": {
+                    "x": 0
+                  },
+                  "rule_type": "Equals"
+                }
+              ],
+              "training_data": []
+            },
+            {
+              "outcome": {
+                "dest": null,
+                "labelled_as_correct": false,
+                "missing_prerequisite_skill_id": null,
+                "param_changes": [],
+                "feedback": {
+                  "content_id": "feedback_2",
+                  "html": "\u003cp\u003edefault feedback\u003c/p\u003e"
+                },
+                "refresher_exploration_id": null
+              },
+              "tagged_skill_misconception_id": "A9j9taXAqqkV-0",
+              "rule_specs": [
+                {
+                  "inputs": {
+                    "x": 1
+                  },
+                  "rule_type": "Equals"
+                }
+              ],
+              "training_data": []
+            }
+          ],
+          "id": "MultipleChoiceInput",
+          "solution": null,
+          "customization_args": {
+            "choices": {
+              "value": [
+                "\u003cp\u003e1\u003c/p\u003e",
+                "\u003cp\u003e2\u003c/p\u003e"
+              ]
+            }
+          },
+          "hints": [
+            {
+              "hint_content": {
+                "content_id": "hint_1",
+                "html": "\u003cp\u003eHint 1\u003c/p\u003e"
+              }
+            }
+          ],
+          "confirmed_unclassified_answers": []
+        },
+        "content": {
+          "content_id": "content",
+          "html": "\u003cp\u003e\u003cstrong\u003eQuestion Editor\u003c/strong\u003e\u003c/p\u003e"
+        },
+        "written_translations": {
+          "translations_mapping": {
+            "feedback_1": {},
+            "default_outcome": {},
+            "feedback_2": {},
+            "hint_1": {},
+            "content": {}
+          }
+        },
+        "classifier_model_id": null,
+        "solicit_answer_details": false,
+        "param_changes": [],
+        "recorded_voiceovers": {
+          "voiceovers_mapping": {
+            "feedback_1": {},
+            "default_outcome": {},
+            "feedback_2": {},
+            "hint_1": {},
+            "content": {}
+          }
+        }
+      },
+      "id": "NoUdS5FVV0eV"
+    }
+  ],
+  "user_email": "test@example.com",
+  "iframed": false,
+  "additional_angular_modules": [],
+  "is_topic_manager": false,
+  "is_super_admin": true
+}

--- a/data/src/test/java/org/oppia/data/backends/api/MockQuestionPlayerService.kt
+++ b/data/src/test/java/org/oppia/data/backends/api/MockQuestionPlayerService.kt
@@ -1,0 +1,45 @@
+package org.oppia.data.backends.api
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import org.oppia.data.backends.ApiUtils
+import org.oppia.data.backends.gae.NetworkInterceptor
+import org.oppia.data.backends.gae.NetworkSettings
+import org.oppia.data.backends.gae.api.QuestionPlayerService
+import org.oppia.data.backends.gae.model.GaeQuestionPlayer
+import retrofit2.Call
+import retrofit2.mock.BehaviorDelegate
+
+/**
+ * Mock QuestionPlayerService with dummy data from [question_player.json]
+ */
+class MockQuestionPlayerService(private val delegate: BehaviorDelegate<QuestionPlayerService>) :
+  QuestionPlayerService {
+  override fun getQuestionPlayerBySkillIds(
+    skillIds: String,
+    questionCount: Int
+  ): Call<GaeQuestionPlayer> {
+    val questionPlayer = createMockGaeQuestionPlayer()
+    return delegate.returningResponse(questionPlayer)
+      .getQuestionPlayerBySkillIds(skillIds, questionCount)
+  }
+
+  /**
+   * This function creates a mock GaeQuestionPlayer with data from dummy json.
+   * @return GaeQuestionPlayer: GaeQuestionPlayer with mock data
+   */
+  private fun createMockGaeQuestionPlayer(): GaeQuestionPlayer {
+    val networkInterceptor = NetworkInterceptor()
+    var questionPlayerResponseWithXssiPrefix =
+      NetworkSettings.XSSI_PREFIX + ApiUtils.getFakeJson("question_player.json")
+
+    questionPlayerResponseWithXssiPrefix =
+      networkInterceptor.removeXSSIPrefix(questionPlayerResponseWithXssiPrefix)
+
+    val moshi = Moshi.Builder().build()
+    val adapter: JsonAdapter<GaeQuestionPlayer> = moshi.adapter(GaeQuestionPlayer::class.java)
+    val mockGaeQuestionPlayer = adapter.fromJson(questionPlayerResponseWithXssiPrefix)
+
+    return mockGaeQuestionPlayer!!
+  }
+}

--- a/data/src/test/java/org/oppia/data/backends/test/MockQuestionPlayerTest.kt
+++ b/data/src/test/java/org/oppia/data/backends/test/MockQuestionPlayerTest.kt
@@ -1,0 +1,59 @@
+package org.oppia.data.backends.test
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import okhttp3.OkHttpClient
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.oppia.data.backends.api.MockQuestionPlayerService
+import org.oppia.data.backends.gae.NetworkInterceptor
+import org.oppia.data.backends.gae.NetworkSettings
+import org.oppia.data.backends.gae.api.QuestionPlayerService
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.mock.MockRetrofit
+import retrofit2.mock.NetworkBehavior
+
+/**
+ * Test for [QuestionPlayerService] retrofit instance using [MockQuestionPlayerService]
+ */
+@RunWith(AndroidJUnit4::class)
+class MockQuestionPlayerTest {
+  private lateinit var mockRetrofit: MockRetrofit
+  private lateinit var retrofit: Retrofit
+
+  @Before
+  fun setUp() {
+    val client = OkHttpClient.Builder()
+    client.addInterceptor(NetworkInterceptor())
+
+    retrofit = retrofit2.Retrofit.Builder()
+      .baseUrl(NetworkSettings.getBaseUrl())
+      .addConverterFactory(MoshiConverterFactory.create())
+      .client(client.build())
+      .build()
+
+    val behavior = NetworkBehavior.create()
+    mockRetrofit = MockRetrofit.Builder(retrofit)
+      .networkBehavior(behavior)
+      .build()
+  }
+
+  @Test
+  fun testQuestionPlayerService_usingFakeJson_deserializationSuccessful() {
+    val delegate = mockRetrofit.create(QuestionPlayerService::class.java)
+    val mockQuestionPlayerService = MockQuestionPlayerService(delegate)
+
+    val skillIdList = ArrayList<String>()
+    skillIdList.add("1")
+    skillIdList.add("2")
+    skillIdList.add("3")
+    val skillIds = skillIdList.joinToString(separator = ", ")
+    val questionPlayer = mockQuestionPlayerService.getQuestionPlayerBySkillIds(skillIds, 10)
+    val questionPlayerResponse = questionPlayer.execute()
+
+    assertThat(questionPlayerResponse.isSuccessful).isTrue()
+    assertThat(questionPlayerResponse.body()!!.questions!!.size).isEqualTo(1)
+  }
+}


### PR DESCRIPTION
## Explanation
PR contains question player service, models and test-cases
This PR was earlier on #68 

## Checklist
Work items:

- [x] Identify among all existing GAE endpoints (get/post), which we can use during the prototype
- [x] Loosely identify data missing from the above endpoints (this bucket is expected to be small/non-existent), and identify which endpoints have data which needs to be changed for the Android app
- [x] Specify the Retrofit interfaces to represent all of the identified endpoints (simple interfaces/no annotations or return types needed beyond pseudocode)
- [x] Identify** what data (via pseudocode data structures/YAML/JSON/etc) we will be passing along from the backend through these endpoints
- [x] Identify how error handling will work (e.g. what Retrofit does), whether RPC retry is supported & how it is/can be configured, etc.
- [x] Determine the testing strategy for the GAE endpoints for downstream app components

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is **assigned** to an appropriate reviewer.
