### PR TITLE
Add missing Logger dependencies in tests.

### DIFF
--- a/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
@@ -35,6 +35,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.app.R
 import org.oppia.domain.UserAppHistoryController
+import org.oppia.util.logging.EnableConsoleLog
+import org.oppia.util.logging.EnableFileLog
+import org.oppia.util.logging.GlobalLogLevel
+import org.oppia.util.logging.LogLevel
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import java.util.concurrent.AbstractExecutorService
@@ -165,6 +169,20 @@ class HomeActivityTest {
     fun provideBlockingDispatcher(): CoroutineDispatcher {
       return MainThreadExecutor.asCoroutineDispatcher()
     }
+
+    // TODO(#59): Either isolate these to their own shared test module, or use the real logging
+    // module in tests to avoid needing to specify these settings for tests.
+    @EnableConsoleLog
+    @Provides
+    fun provideEnableConsoleLog(): Boolean = true
+
+    @EnableFileLog
+    @Provides
+    fun provideEnableFileLog(): Boolean = false
+
+    @GlobalLogLevel
+    @Provides
+    fun provideGlobalLogLevel(): LogLevel = LogLevel.VERBOSE
   }
 
   @Singleton

--- a/domain/src/test/java/org/oppia/domain/UserAppHistoryControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/UserAppHistoryControllerTest.kt
@@ -34,6 +34,10 @@ import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoRule
 import org.oppia.app.model.UserAppHistory
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.logging.EnableConsoleLog
+import org.oppia.util.logging.EnableFileLog
+import org.oppia.util.logging.GlobalLogLevel
+import org.oppia.util.logging.LogLevel
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import org.robolectric.annotation.Config
@@ -197,6 +201,20 @@ class UserAppHistoryControllerTest {
     fun provideBlockingDispatcher(@TestDispatcher testDispatcher: CoroutineDispatcher): CoroutineDispatcher {
       return testDispatcher
     }
+
+    // TODO(#59): Either isolate these to their own shared test module, or use the real logging
+    // module in tests to avoid needing to specify these settings for tests.
+    @EnableConsoleLog
+    @Provides
+    fun provideEnableConsoleLog(): Boolean = true
+
+    @EnableFileLog
+    @Provides
+    fun provideEnableFileLog(): Boolean = false
+
+    @GlobalLogLevel
+    @Provides
+    fun provideGlobalLogLevel(): LogLevel = LogLevel.VERBOSE
   }
 
   // TODO(#89): Move this to a common test application component.

--- a/utility/src/main/java/org/oppia/util/logging/Logger.kt
+++ b/utility/src/main/java/org/oppia/util/logging/Logger.kt
@@ -15,7 +15,8 @@ import javax.inject.Singleton
 @Singleton
 class Logger @Inject constructor(
   context: Context, @BlockingDispatcher private val blockingDispatcher: CoroutineDispatcher,
-  @EnableConsoleLog private val enableConsoleLog: Boolean, @EnableConsoleLog private val enableFileLog: Boolean,
+  @EnableConsoleLog private val enableConsoleLog: Boolean,
+  @EnableFileLog private val enableFileLog: Boolean,
   @GlobalLogLevel private val globalLogLevel: LogLevel
 ) {
   private val blockingScope = CoroutineScope(blockingDispatcher)

--- a/utility/src/main/java/org/oppia/util/logging/LoggingAnnotations.kt
+++ b/utility/src/main/java/org/oppia/util/logging/LoggingAnnotations.kt
@@ -3,10 +3,10 @@ package org.oppia.util.logging
 import javax.inject.Qualifier
 
 /** Corresponds to a singleton boolean of whether console (logcat) logging is enabled. */
-@Qualifier internal annotation class EnableConsoleLog
+@Qualifier annotation class EnableConsoleLog
 
 /** Corresponds to a singleton boolean of whether logs are saved to a file. */
-@Qualifier internal annotation class EnableFileLog
+@Qualifier annotation class EnableFileLog
 
 /** Corresponds to a singleton [LogLevel] determining the minimum severity of logs that should be kept. */
-@Qualifier internal annotation class GlobalLogLevel
+@Qualifier annotation class GlobalLogLevel


### PR DESCRIPTION
This fixes a breakage in develop for all tests that depend on Logger. The new Logger dependencies added in #104 also needed to be added to those tests, and this was missed. I verified that all relevant tests are now passing after this fix.

This also fixes one injection mistake in Logger itself--we weren't injecting the correct qualified value. I caught this when making sure each of the three values were present, as expected, in HomeActivityTest's TestModule.