### PR TITLE
Fix #156 & #157: Continue/End Exploration player buttons- low-fi

### DIFF
--- a/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
@@ -12,11 +12,12 @@ import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.UserAppHistoryController
 import org.oppia.domain.exploration.ExplorationDataController
 import org.oppia.domain.exploration.TEST_EXPLORATION_ID_5
+import org.oppia.domain.exploration.TEST_EXPLORATION_ID_6
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.logging.Logger
 import javax.inject.Inject
 
-private const val EXPLORATION_ID = TEST_EXPLORATION_ID_5
+private const val EXPLORATION_ID = TEST_EXPLORATION_ID_6
 
 /** The controller for [HomeFragment]. */
 @FragmentScope

--- a/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
@@ -12,12 +12,11 @@ import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.UserAppHistoryController
 import org.oppia.domain.exploration.ExplorationDataController
 import org.oppia.domain.exploration.TEST_EXPLORATION_ID_5
-import org.oppia.domain.exploration.TEST_EXPLORATION_ID_6
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.logging.Logger
 import javax.inject.Inject
 
-private const val EXPLORATION_ID = TEST_EXPLORATION_ID_6
+private const val EXPLORATION_ID = TEST_EXPLORATION_ID_5
 
 /** The controller for [HomeFragment]. */
 @FragmentScope

--- a/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
@@ -9,8 +9,10 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.Transformations
 import org.oppia.app.databinding.StateFragmentBinding
 import org.oppia.app.fragment.FragmentScope
+import org.oppia.app.model.AnswerOutcome
 import org.oppia.app.model.CellularDataPreference
 import org.oppia.app.model.EphemeralState
+import org.oppia.app.model.InteractionObject
 import org.oppia.app.player.audio.CellularDataDialogFragment
 import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.audio.CellularDialogController
@@ -19,7 +21,15 @@ import org.oppia.util.data.AsyncResult
 import org.oppia.util.logging.Logger
 import javax.inject.Inject
 
-private const val TAG_CELLULAR_DATA_DIALOG = "CELLULAR_DATA_DIALOG"
+private const val CONTINUE = "Continue"
+private const val END_EXPLORATION = "EndExploration"
+private const val MULTIPLE_CHOICE_INPUT = "MultipleChoiceInput"
+private const val ITEM_SELECT_INPUT = "ItemSelectionInput"
+private const val TEXT_INPUT = "TextInput"
+private const val FRACTION_INPUT = "FractionInput"
+private const val NUMERIC_INPUT = "NumericInput"
+private const val NUMERIC_WITH_UNITS = "NumberWithUnits"
+private const val StateFragment_CELLULAR_DATA_DIALOG = "CELLULAR_DATA_DIALOG"
 
 /** The presenter for [StateFragment]. */
 @FragmentScope
@@ -30,6 +40,7 @@ class StateFragmentPresenter @Inject constructor(
   private val explorationProgressController: ExplorationProgressController,
   private val logger: Logger
 ) {
+  private val stateViewModel = viewModelProvider.getForFragment(fragment, StateViewModel::class.java)
 
   private var showCellularDataDialog = true
   private var useCellularData = false
@@ -47,7 +58,8 @@ class StateFragmentPresenter @Inject constructor(
     val binding = StateFragmentBinding.inflate(inflater, container, /* attachToRoot= */ false)
     binding.let {
       it.stateFragment = fragment as StateFragment
-      it.viewModel = getStateViewModel()
+      it.presenter = this
+      it.viewModel = stateViewModel
     }
 
     subscribeToCurrentState()
@@ -76,40 +88,122 @@ class StateFragmentPresenter @Inject constructor(
   }
 
   private fun showCellularDataDialogFragment() {
-    val previousFragment = fragment.childFragmentManager.findFragmentByTag(TAG_CELLULAR_DATA_DIALOG)
+    val previousFragment = fragment.childFragmentManager.findFragmentByTag(StateFragment_CELLULAR_DATA_DIALOG)
     if (previousFragment != null) {
       fragment.childFragmentManager.beginTransaction().remove(previousFragment).commitNow()
     }
     val dialogFragment = CellularDataDialogFragment.newInstance()
-    dialogFragment.showNow(fragment.childFragmentManager, TAG_CELLULAR_DATA_DIALOG)
-  }
-
-  private fun getStateViewModel(): StateViewModel {
-    return viewModelProvider.getForFragment(fragment, StateViewModel::class.java)
+    dialogFragment.showNow(fragment.childFragmentManager, StateFragment_CELLULAR_DATA_DIALOG)
   }
 
   fun setAudioFragmentVisible(isVisible: Boolean) {
-    getStateViewModel().setAudioFragmentVisible(isVisible)
+    stateViewModel.setAudioFragmentVisible(isVisible)
   }
 
+  private fun controlButtonVisibility(interactionId: String, hasPreviousState: Boolean, hasNextState: Boolean) {
+    logger.d("StateFragment", "interactionId: $interactionId")
+    logger.d("StateFragment", "hasPreviousState: $hasPreviousState")
+    logger.d("StateFragment", "hasNextState: $hasNextState")
+    stateViewModel.hideAllButtons()
+    stateViewModel.setPreviousButtonVisible(hasPreviousState)
+    if (!hasNextState) {
+      when (interactionId) {
+        CONTINUE -> stateViewModel.setContinueButtonVisible(true)
+        END_EXPLORATION -> stateViewModel.setEndExplorationButtonVisible(true)
+        FRACTION_INPUT -> stateViewModel.setSubmitButtonVisible(true)
+        ITEM_SELECT_INPUT -> stateViewModel.setSubmitButtonVisible(true)
+        MULTIPLE_CHOICE_INPUT -> stateViewModel.setSubmitButtonVisible(true)
+        NUMERIC_INPUT -> stateViewModel.setSubmitButtonVisible(true)
+        NUMERIC_WITH_UNITS -> stateViewModel.setSubmitButtonVisible(true)
+        TEXT_INPUT -> stateViewModel.setSubmitButtonVisible(true)
+      }
+    } else {
+      stateViewModel.setNextButtonVisible(hasNextState)
+    }
+  }
+
+  /**
+   * This function subscribes to current state of the exploration.
+   * Whenever the current state changes it will automatically get called and therefore their is no need to call this separately.
+   * This function currently provides important information to decide which button we should display.
+   */
   private fun subscribeToCurrentState() {
     ephemeralStateLiveData.observe(fragment, Observer<EphemeralState> { result ->
-      logger.d("StateFragment", "getCurrentState: ${result.state.name}")
+      logger.d("StateFragment", "stateName: ${result.state.name}")
+      val interactionId = result.state.interaction.id
+      val hasPreviousState = result.hasPreviousState
+      val hasNextState = result.completedState.answerCount > 0
+
+      controlButtonVisibility(interactionId, hasPreviousState, hasNextState)
     })
   }
 
+  /** Helper for subscribeToCurrentState. */
   private val ephemeralStateLiveData: LiveData<EphemeralState> by lazy {
     getEphemeralState()
   }
 
+  /** Helper for subscribeToCurrentState. */
   private fun getEphemeralState(): LiveData<EphemeralState> {
     return Transformations.map(explorationProgressController.getCurrentState(), ::processCurrentState)
   }
 
+  /** Helper for subscribeToCurrentState. */
   private fun processCurrentState(ephemeralStateResult: AsyncResult<EphemeralState>): EphemeralState {
     if (ephemeralStateResult.isFailure()) {
       logger.e("StateFragment", "Failed to retrieve ephemeral state", ephemeralStateResult.getErrorOrNull()!!)
     }
     return ephemeralStateResult.getOrDefault(EphemeralState.getDefaultInstance())
+  }
+
+  /**
+   * This function listens to the result of submitAnswer.
+   * Whenever an answer is submitted using ExplorationProgressController.submitAnswer function,
+   *  this function will wait for the response from that function and based on which we can move to next state.
+   */
+  private fun subscribeToAnswerOutcome(answerOutcomeLiveData: LiveData<AnswerOutcome>) {
+    answerOutcomeLiveData.observe(fragment, Observer<AnswerOutcome> { result ->
+      logger.d("StateFragment", "subscribeToAnswerOutcome: ${result.stateName}")
+      explorationProgressController.moveToNextState()
+    })
+  }
+
+  /** Helper for subscribeToAnswerOutcome. */
+  private fun getAnswerOutcome(answerOutcome: LiveData<AsyncResult<AnswerOutcome>>): LiveData<AnswerOutcome> {
+    return Transformations.map(answerOutcome, ::processAnswerOutcome)
+  }
+
+  /** Helper for subscribeToAnswerOutcome. */
+  private fun processAnswerOutcome(ephemeralStateResult: AsyncResult<AnswerOutcome>): AnswerOutcome {
+    if (ephemeralStateResult.isFailure()) {
+      logger.e("StateFragment", "Failed to retrieve answer outcome", ephemeralStateResult.getErrorOrNull()!!)
+    }
+    return ephemeralStateResult.getOrDefault(AnswerOutcome.getDefaultInstance())
+  }
+
+  // NB: Any interaction will lead to answer submission,
+  //  meaning we have to submit answer even when user clicks on "Continue".
+  fun continueButtonClicked(v: View) {
+    val interactionObject = InteractionObject.newBuilder().setNormalizedString("Please continue.").build()
+    val answerOutcomeLiveData = getAnswerOutcome(explorationProgressController.submitAnswer(interactionObject))
+    subscribeToAnswerOutcome(answerOutcomeLiveData)
+
+    explorationProgressController.moveToNextState()
+  }
+
+  fun submitButtonClicked(v: View) {
+    // NB: This value needs to be fetched from other interactions in #150, #151, #152, #153, #154, #155.
+    val learnerResponse = 0
+    val interactionObject = InteractionObject.newBuilder().setNonNegativeInt(learnerResponse).build()
+    val answerOutcomeLiveData = getAnswerOutcome(explorationProgressController.submitAnswer(interactionObject))
+    subscribeToAnswerOutcome(answerOutcomeLiveData)
+  }
+
+  fun nextButtonClicked(v: View) {
+    explorationProgressController.moveToNextState()
+  }
+
+  fun previousButtonClicked(v: View) {
+    explorationProgressController.moveToPreviousState()
   }
 }

--- a/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
@@ -116,24 +116,20 @@ class StateFragmentPresenter @Inject constructor(
     stateViewModel.setAudioFragmentVisible(isVisible)
   }
 
-  private fun updateNavigationButtonVisibility(interactionId: String, hasPreviousState: Boolean, hasNextState: Boolean) {
+  private fun updateNavigationButtonVisibility(
+    interactionId: String,
+    hasPreviousState: Boolean,
+    hasNextState: Boolean
+  ) {
     logger.d("StateFragment", "interactionId: $interactionId")
     logger.d("StateFragment", "hasPreviousState: $hasPreviousState")
     logger.d("StateFragment", "hasNextState: $hasNextState")
-    stateViewModel.hideAllButtons()
     stateViewModel.setPreviousButtonVisible(hasPreviousState)
     if (!hasNextState) {
-      when (interactionId) {
-        CONTINUE -> stateViewModel.setContinueButtonVisible(true)
-        END_EXPLORATION -> stateViewModel.setEndExplorationButtonVisible(true)
-        FRACTION_INPUT -> stateViewModel.setSubmitButtonVisible(true)
-        ITEM_SELECT_INPUT -> stateViewModel.setSubmitButtonVisible(true)
-        MULTIPLE_CHOICE_INPUT -> stateViewModel.setSubmitButtonVisible(true)
-        NUMERIC_INPUT -> stateViewModel.setSubmitButtonVisible(true)
-        NUMERIC_WITH_UNITS -> stateViewModel.setSubmitButtonVisible(true)
-        TEXT_INPUT -> stateViewModel.setSubmitButtonVisible(true)
-      }
+      stateViewModel.setObservableInteractionId(interactionId)
+      stateViewModel.optionSelected(true)
     } else {
+      stateViewModel.clearObservableInteractionId()
       stateViewModel.setNextButtonVisible(hasNextState)
     }
   }
@@ -204,6 +200,10 @@ class StateFragmentPresenter @Inject constructor(
   }
 
   fun submitButtonClicked(v: View) {
+
+  }
+
+  fun interactionButtonClicked(v: View) {
     // TODO(#163): Remove these dummy answers and fetch answers from different interaction views.
     // NB: This sample data will work only with TEST_EXPLORATION_ID_5
     // 0 -> What Language

--- a/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
@@ -41,6 +41,8 @@ private const val TAG_CELLULAR_DATA_DIALOG = "CELLULAR_DATA_DIALOG"
 // https://github.com/oppia/oppia/blob/37285a/extensions/interactions/Continue/directives/oppia-interactive-continue.directive.ts.
 private const val DEFAULT_CONTINUE_INTERACTION_TEXT_ANSWER = "Please continue."
 
+// TODO(163): Remove all loggers.
+
 /** The presenter for [StateFragment]. */
 @FragmentScope
 class StateFragmentPresenter @Inject constructor(
@@ -204,6 +206,7 @@ class StateFragmentPresenter @Inject constructor(
 
   fun submitButtonClicked(v: View) {
     // TODO(163): Remove these dummy answers and fetch answers from different interaction views.
+    // NB: This sample data will work only with TEST_EXPLORATION_ID_5
     // 0 -> What Language
     // 2 -> Welcome!
     // XX -> What Language

--- a/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
@@ -29,7 +29,7 @@ private const val TEXT_INPUT = "TextInput"
 private const val FRACTION_INPUT = "FractionInput"
 private const val NUMERIC_INPUT = "NumericInput"
 private const val NUMERIC_WITH_UNITS = "NumberWithUnits"
-private const val StateFragment_CELLULAR_DATA_DIALOG = "CELLULAR_DATA_DIALOG"
+private const val TAG_CELLULAR_DATA_DIALOG = "CELLULAR_DATA_DIALOG"
 
 /** The presenter for [StateFragment]. */
 @FragmentScope
@@ -88,12 +88,12 @@ class StateFragmentPresenter @Inject constructor(
   }
 
   private fun showCellularDataDialogFragment() {
-    val previousFragment = fragment.childFragmentManager.findFragmentByTag(StateFragment_CELLULAR_DATA_DIALOG)
+    val previousFragment = fragment.childFragmentManager.findFragmentByTag(TAG_CELLULAR_DATA_DIALOG)
     if (previousFragment != null) {
       fragment.childFragmentManager.beginTransaction().remove(previousFragment).commitNow()
     }
     val dialogFragment = CellularDataDialogFragment.newInstance()
-    dialogFragment.showNow(fragment.childFragmentManager, StateFragment_CELLULAR_DATA_DIALOG)
+    dialogFragment.showNow(fragment.childFragmentManager, TAG_CELLULAR_DATA_DIALOG)
   }
 
   fun setAudioFragmentVisible(isVisible: Boolean) {

--- a/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
@@ -47,12 +47,12 @@ private const val DEFAULT_CONTINUE_INTERACTION_TEXT_ANSWER = "Please continue."
 @FragmentScope
 class StateFragmentPresenter @Inject constructor(
   private val activity: AppCompatActivity,
-  private val fragment: Fragment,
   private val cellularDialogController: CellularDialogController,
   private val explorationDataController: ExplorationDataController,
   private val explorationProgressController: ExplorationProgressController,
+  private val fragment: Fragment,
   private val logger: Logger,
-  viewModelProvider: ViewModelProvider<StateViewModel>
+  private val viewModelProvider: ViewModelProvider<StateViewModel>
 ) {
   private val stateViewModel = viewModelProvider.getForFragment(fragment, StateViewModel::class.java)
 

--- a/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
@@ -230,11 +230,11 @@ class StateFragmentPresenter @Inject constructor(
   }
 
   fun nextButtonClicked(v: View) {
-    moveToNextState()
+    explorationProgressController.moveToNextState()
   }
 
   fun previousButtonClicked(v: View) {
-    moveToPreviousState()
+    explorationProgressController.moveToPreviousState()
   }
 
   private fun submitContinueButtonAnswer() {
@@ -287,14 +287,6 @@ class StateFragmentPresenter @Inject constructor(
 
   private fun createTextInputAnswer(textAnswer: String): InteractionObject {
     return InteractionObject.newBuilder().setNormalizedString(textAnswer).build()
-  }
-
-  private fun moveToNextState() {
-    explorationProgressController.moveToNextState()
-  }
-
-  private fun moveToPreviousState() {
-    explorationProgressController.moveToPreviousState()
   }
 
   private fun endExploration() {

--- a/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
@@ -41,7 +41,7 @@ private const val TAG_CELLULAR_DATA_DIALOG = "CELLULAR_DATA_DIALOG"
 // https://github.com/oppia/oppia/blob/37285a/extensions/interactions/Continue/directives/oppia-interactive-continue.directive.ts.
 private const val DEFAULT_CONTINUE_INTERACTION_TEXT_ANSWER = "Please continue."
 
-// TODO(163): Remove all loggers.
+// TODO(#163): Remove all loggers.
 
 /** The presenter for [StateFragment]. */
 @FragmentScope
@@ -56,7 +56,7 @@ class StateFragmentPresenter @Inject constructor(
 ) {
   private val stateViewModel = viewModelProvider.getForFragment(fragment, StateViewModel::class.java)
 
-  private val resultEphemeralState = ObservableField<EphemeralState>()
+  private val currentEphemeralState = ObservableField<EphemeralState>()
 
   private var showCellularDataDialog = true
   private var useCellularData = false
@@ -116,7 +116,7 @@ class StateFragmentPresenter @Inject constructor(
     stateViewModel.setAudioFragmentVisible(isVisible)
   }
 
-  private fun controlButtonVisibility(interactionId: String, hasPreviousState: Boolean, hasNextState: Boolean) {
+  private fun updateNavigationButtonVisibility(interactionId: String, hasPreviousState: Boolean, hasNextState: Boolean) {
     logger.d("StateFragment", "interactionId: $interactionId")
     logger.d("StateFragment", "hasPreviousState: $hasPreviousState")
     logger.d("StateFragment", "hasNextState: $hasNextState")
@@ -140,17 +140,17 @@ class StateFragmentPresenter @Inject constructor(
 
   /**
    * This function subscribes to current state of the exploration.
-   * Whenever the current state changes it will automatically get called and therefore their is no need to call this separately.
-   * This function currently provides important information to decide which button we should display.
+   * Whenever the current state changes it will automatically get called and therefore there is no need to call this separately.
+   * this function currently provides important information to decide which button we should display.
    */
   private fun subscribeToCurrentState() {
     ephemeralStateLiveData.observe(fragment, Observer<EphemeralState> { it ->
-      resultEphemeralState.set(it)
+      currentEphemeralState.set(it)
       logger.d("StateFragment", "stateName: ${it.state.name}")
       val interactionId = it.state.interaction.id
       val hasPreviousState = it.hasPreviousState
       val hasNextState = it.completedState.answerCount > 0
-      controlButtonVisibility(interactionId, hasPreviousState, hasNextState)
+      updateNavigationButtonVisibility(interactionId, hasPreviousState, hasNextState)
     })
   }
 
@@ -175,7 +175,7 @@ class StateFragmentPresenter @Inject constructor(
   /**
    * This function listens to the result of submitAnswer.
    * Whenever an answer is submitted using ExplorationProgressController.submitAnswer function,
-   *  this function will wait for the response from that function and based on which we can move to next state.
+   * this function will wait for the response from that function and based on which we can move to next state.
    */
   private fun subscribeToAnswerOutcome(answerOutcomeResultLiveData: LiveData<AsyncResult<AnswerOutcome>>) {
     val answerOutcomeLiveData = getAnswerOutcome(answerOutcomeResultLiveData)
@@ -204,7 +204,7 @@ class StateFragmentPresenter @Inject constructor(
   }
 
   fun submitButtonClicked(v: View) {
-    // TODO(163): Remove these dummy answers and fetch answers from different interaction views.
+    // TODO(#163): Remove these dummy answers and fetch answers from different interaction views.
     // NB: This sample data will work only with TEST_EXPLORATION_ID_5
     // 0 -> What Language
     // 2 -> Welcome!
@@ -220,7 +220,7 @@ class StateFragmentPresenter @Inject constructor(
     // XX -> Numeric Input
     val stateNumericInputAnswer = 121
 
-    when (resultEphemeralState.get()!!.state.interaction.id) {
+    when (currentEphemeralState.get()!!.state.interaction.id) {
       FRACTION_INPUT -> submitFractionInputAnswer(Fraction.getDefaultInstance())
       ITEM_SELECT_INPUT -> submitMultipleChoiceAnswer(0)
       MULTIPLE_CHOICE_INPUT -> submitMultipleChoiceAnswer(stateWelcomeAnswer)

--- a/app/src/main/java/org/oppia/app/player/state/StateViewModel.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateViewModel.kt
@@ -1,11 +1,14 @@
 package org.oppia.app.player.state
 
 import android.content.Context
+import android.widget.Button
+import androidx.databinding.BindingAdapter
 import androidx.databinding.ObservableField
 import androidx.lifecycle.ViewModel
-import org.oppia.app.R
 import org.oppia.app.fragment.FragmentScope
 import javax.inject.Inject
+import org.oppia.app.R
+import org.oppia.app.viewmodel.ObservableViewModel
 
 private const val CONTINUE = "Continue"
 private const val END_EXPLORATION = "EndExploration"
@@ -19,7 +22,16 @@ private const val NUMERIC_WITH_UNITS = "NumberWithUnits"
 
 /** [ViewModel] for state-fragment. */
 @FragmentScope
-class StateViewModel @Inject constructor(val context: Context) : ViewModel() {
+class StateViewModel @Inject constructor(val context: Context) : ObservableViewModel() {
+
+  companion object{
+    @JvmStatic
+    @BindingAdapter("xyz")
+    fun setBackgroundResource(button: Button, resource: Int) {
+      button.setBackgroundResource(resource)
+    }
+  }
+
   var isAudioFragmentVisible = ObservableField<Boolean>(false)
 
   var isNextButtonVisible = ObservableField<Boolean>(false)
@@ -28,31 +40,43 @@ class StateViewModel @Inject constructor(val context: Context) : ViewModel() {
   var observableInteractionId = ObservableField<String>()
   var isInteractionButtonActive = ObservableField<Boolean>(false)
   var isInteractionButtonVisible = ObservableField<Boolean>(false)
+  var drawableResourceValue = ObservableField<Int>(R.drawable.state_button_primary_background)
 
   var name = ObservableField<String>()
 
   fun setObservableInteractionId(interactionId: String) {
+    setNextButtonVisible(false)
     observableInteractionId.set(interactionId)
     when (interactionId) {
       CONTINUE -> {
         isInteractionButtonActive.set(true)
+        isInteractionButtonVisible.set(true)
         name.set(context.getString(R.string.state_continue_button))
+        drawableResourceValue.set(R.drawable.state_button_primary_background)
       }
       END_EXPLORATION -> {
         isInteractionButtonActive.set(true)
+        isInteractionButtonVisible.set(true)
         name.set(context.getString(R.string.state_end_exploration_button))
+        drawableResourceValue.set(R.drawable.state_button_primary_background)
       }
       LEARN_AGAIN -> {
         isInteractionButtonActive.set(true)
+        isInteractionButtonVisible.set(true)
         name.set(context.getString(R.string.state_learn_again_button))
+        drawableResourceValue.set(R.drawable.state_button_blue_background)
       }
       ITEM_SELECT_INPUT, MULTIPLE_CHOICE_INPUT -> {
         isInteractionButtonActive.set(true)
+        isInteractionButtonVisible.set(false)
         name.set(context.getString(R.string.state_submit_button))
+        drawableResourceValue.set(R.drawable.state_button_primary_background)
       }
       FRACTION_INPUT, NUMERIC_INPUT, NUMERIC_WITH_UNITS, TEXT_INPUT -> {
         isInteractionButtonActive.set(false)
+        isInteractionButtonVisible.set(true)
         name.set(context.getString(R.string.state_submit_button))
+        drawableResourceValue.set(R.drawable.state_button_transparent_background)
       }
     }
   }
@@ -78,8 +102,10 @@ class StateViewModel @Inject constructor(val context: Context) : ViewModel() {
   fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
     if (s.isNotEmpty()) {
       isInteractionButtonActive.set(true)
+      drawableResourceValue.set(R.drawable.state_button_primary_background)
     } else {
       isInteractionButtonActive.set(false)
+      drawableResourceValue.set(R.drawable.state_button_transparent_background)
     }
   }
 

--- a/app/src/main/java/org/oppia/app/player/state/StateViewModel.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateViewModel.kt
@@ -1,46 +1,70 @@
 package org.oppia.app.player.state
 
-import android.view.View
+import android.content.Context
 import androidx.databinding.ObservableField
 import androidx.lifecycle.ViewModel
+import org.oppia.app.R
 import org.oppia.app.fragment.FragmentScope
 import javax.inject.Inject
 
+private const val CONTINUE = "Continue"
+private const val END_EXPLORATION = "EndExploration"
+private const val LEARN_AGAIN = "LearnAgain"
+private const val MULTIPLE_CHOICE_INPUT = "MultipleChoiceInput"
+private const val ITEM_SELECT_INPUT = "ItemSelectionInput"
+private const val TEXT_INPUT = "TextInput"
+private const val FRACTION_INPUT = "FractionInput"
+private const val NUMERIC_INPUT = "NumericInput"
+private const val NUMERIC_WITH_UNITS = "NumberWithUnits"
+
 /** [ViewModel] for state-fragment. */
 @FragmentScope
-class StateViewModel @Inject constructor() : ViewModel() {
+class StateViewModel @Inject constructor(val context: Context) : ViewModel() {
   var isAudioFragmentVisible = ObservableField<Boolean>(false)
-  var isContinueButtonVisible = ObservableField<Boolean>(false)
-  var isEndExplorationButtonVisible = ObservableField<Boolean>(false)
-  var isLearnAgainButtonVisible = ObservableField<Boolean>(false)
+
   var isNextButtonVisible = ObservableField<Boolean>(false)
   var isPreviousButtonVisible = ObservableField<Boolean>(false)
-  var isSubmitButtonVisible = ObservableField<Boolean>(false)
-  var isSubmitButtonActive = ObservableField<Boolean>(false)
 
-  fun hideAllButtons() {
-    isContinueButtonVisible.set(false)
-    isEndExplorationButtonVisible.set(false)
-    isLearnAgainButtonVisible.set(false)
-    isNextButtonVisible.set(false)
-    isPreviousButtonVisible.set(false)
-    isSubmitButtonVisible.set(false)
+  var observableInteractionId = ObservableField<String>()
+  var isInteractionButtonActive = ObservableField<Boolean>(false)
+  var isInteractionButtonVisible = ObservableField<Boolean>(false)
+
+  var name = ObservableField<String>()
+
+  fun setObservableInteractionId(interactionId: String) {
+    observableInteractionId.set(interactionId)
+    when (interactionId) {
+      CONTINUE -> {
+        isInteractionButtonActive.set(true)
+        name.set(context.getString(R.string.state_continue_button))
+      }
+      END_EXPLORATION -> {
+        isInteractionButtonActive.set(true)
+        name.set(context.getString(R.string.state_end_exploration_button))
+      }
+      LEARN_AGAIN -> {
+        isInteractionButtonActive.set(true)
+        name.set(context.getString(R.string.state_learn_again_button))
+      }
+      ITEM_SELECT_INPUT, MULTIPLE_CHOICE_INPUT -> {
+        isInteractionButtonActive.set(true)
+        name.set(context.getString(R.string.state_submit_button))
+      }
+      FRACTION_INPUT, NUMERIC_INPUT, NUMERIC_WITH_UNITS, TEXT_INPUT -> {
+        isInteractionButtonActive.set(false)
+        name.set(context.getString(R.string.state_submit_button))
+      }
+    }
+  }
+
+  fun clearObservableInteractionId() {
+    observableInteractionId.set("")
+    isInteractionButtonVisible.set(false)
+    isInteractionButtonActive.set(false)
   }
 
   fun setAudioFragmentVisible(isVisible: Boolean) {
     isAudioFragmentVisible.set(isVisible)
-  }
-
-  fun setContinueButtonVisible(isVisible: Boolean) {
-    isContinueButtonVisible.set(isVisible)
-  }
-
-  fun setEndExplorationButtonVisible(isVisible: Boolean) {
-    isEndExplorationButtonVisible.set(isVisible)
-  }
-
-  fun setLearnAgainButtonVisible(isVisible: Boolean) {
-    isLearnAgainButtonVisible.set(isVisible)
   }
 
   fun setNextButtonVisible(isVisible: Boolean) {
@@ -51,15 +75,15 @@ class StateViewModel @Inject constructor() : ViewModel() {
     isPreviousButtonVisible.set(isVisible)
   }
 
-  fun setSubmitButtonVisible(isVisible: Boolean) {
-    isSubmitButtonVisible.set(isVisible)
-  }
-
   fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
     if (s.isNotEmpty()) {
-      isSubmitButtonActive.set(true)
+      isInteractionButtonActive.set(true)
     } else {
-      isSubmitButtonActive.set(false)
+      isInteractionButtonActive.set(false)
     }
+  }
+
+  fun optionSelected(isOptionSelected: Boolean) {
+    isInteractionButtonVisible.set(isOptionSelected)
   }
 }

--- a/app/src/main/java/org/oppia/app/player/state/StateViewModel.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateViewModel.kt
@@ -62,19 +62,4 @@ class StateViewModel @Inject constructor() : ViewModel() {
       isSubmitButtonActive.set(false)
     }
   }
-
-  fun continueButtonClicked(v: View) {
-  }
-
-  fun endExplorationButtonClicked(v: View) {
-  }
-
-  fun learnAgainButtonClicked(v: View) {
-  }
-
-  fun nextButtonClicked(v: View) {
-  }
-
-  fun previousButtonClicked(v: View) {
-  }
 }

--- a/app/src/main/java/org/oppia/app/player/state/StateViewModel.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateViewModel.kt
@@ -8,9 +8,7 @@ import javax.inject.Inject
 
 /** [ViewModel] for state-fragment. */
 @FragmentScope
-class StateViewModel @Inject constructor(
-
-  ) : ViewModel() {
+class StateViewModel @Inject constructor() : ViewModel() {
   var isAudioFragmentVisible = ObservableField<Boolean>(false)
   var isContinueButtonVisible = ObservableField<Boolean>(false)
   var isEndExplorationButtonVisible = ObservableField<Boolean>(false)

--- a/app/src/main/java/org/oppia/app/player/state/StateViewModel.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateViewModel.kt
@@ -23,10 +23,9 @@ private const val NUMERIC_WITH_UNITS = "NumberWithUnits"
 /** [ViewModel] for state-fragment. */
 @FragmentScope
 class StateViewModel @Inject constructor(val context: Context) : ObservableViewModel() {
-
-  companion object{
+  companion object {
     @JvmStatic
-    @BindingAdapter("xyz")
+    @BindingAdapter("buttonDrawable")
     fun setBackgroundResource(button: Button, resource: Int) {
       button.setBackgroundResource(resource)
     }

--- a/app/src/main/java/org/oppia/app/player/state/StateViewModel.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateViewModel.kt
@@ -1,5 +1,6 @@
 package org.oppia.app.player.state
 
+import android.view.View
 import androidx.databinding.ObservableField
 import androidx.lifecycle.ViewModel
 import org.oppia.app.fragment.FragmentScope
@@ -7,10 +8,75 @@ import javax.inject.Inject
 
 /** [ViewModel] for state-fragment. */
 @FragmentScope
-class StateViewModel @Inject constructor() : ViewModel() {
+class StateViewModel @Inject constructor(
+
+  ) : ViewModel() {
   var isAudioFragmentVisible = ObservableField<Boolean>(false)
+  var isContinueButtonVisible = ObservableField<Boolean>(false)
+  var isEndExplorationButtonVisible = ObservableField<Boolean>(false)
+  var isLearnAgainButtonVisible = ObservableField<Boolean>(false)
+  var isNextButtonVisible = ObservableField<Boolean>(false)
+  var isPreviousButtonVisible = ObservableField<Boolean>(false)
+  var isSubmitButtonVisible = ObservableField<Boolean>(false)
+  var isSubmitButtonActive = ObservableField<Boolean>(false)
+
+  fun hideAllButtons() {
+    isContinueButtonVisible.set(false)
+    isEndExplorationButtonVisible.set(false)
+    isLearnAgainButtonVisible.set(false)
+    isNextButtonVisible.set(false)
+    isPreviousButtonVisible.set(false)
+    isSubmitButtonVisible.set(false)
+  }
 
   fun setAudioFragmentVisible(isVisible: Boolean) {
     isAudioFragmentVisible.set(isVisible)
+  }
+
+  fun setContinueButtonVisible(isVisible: Boolean) {
+    isContinueButtonVisible.set(isVisible)
+  }
+
+  fun setEndExplorationButtonVisible(isVisible: Boolean) {
+    isEndExplorationButtonVisible.set(isVisible)
+  }
+
+  fun setLearnAgainButtonVisible(isVisible: Boolean) {
+    isLearnAgainButtonVisible.set(isVisible)
+  }
+
+  fun setNextButtonVisible(isVisible: Boolean) {
+    isNextButtonVisible.set(isVisible)
+  }
+
+  fun setPreviousButtonVisible(isVisible: Boolean) {
+    isPreviousButtonVisible.set(isVisible)
+  }
+
+  fun setSubmitButtonVisible(isVisible: Boolean) {
+    isSubmitButtonVisible.set(isVisible)
+  }
+
+  fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
+    if (s.isNotEmpty()) {
+      isSubmitButtonActive.set(true)
+    } else {
+      isSubmitButtonActive.set(false)
+    }
+  }
+
+  fun continueButtonClicked(v: View) {
+  }
+
+  fun endExplorationButtonClicked(v: View) {
+  }
+
+  fun learnAgainButtonClicked(v: View) {
+  }
+
+  fun nextButtonClicked(v: View) {
+  }
+
+  fun previousButtonClicked(v: View) {
   }
 }

--- a/app/src/main/res/layout/state_fragment.xml
+++ b/app/src/main/res/layout/state_fragment.xml
@@ -32,6 +32,15 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
     </LinearLayout>
+    <TextView
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="16dp"
+      android:gravity="center"
+      android:text="@{`State name: ` + presenter.currentEphemeralState.get().state.name + `\n` + `NB: If button does not work, try typing something.`}"
+      app:layout_constraintBottom_toTopOf="@id/dummy_audio_button"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"/>
     <Button
       android:id="@+id/dummy_audio_button"
       android:layout_width="wrap_content"
@@ -95,12 +104,13 @@
         android:id="@+id/interaction_button"
         style="@style/StateButtonActive"
         android:layout_alignParentEnd="true"
-        android:background="@{viewModel.name.get().equals(@string/state_learn_again_button)? @drawable/state_button_blue_background : @drawable/state_button_primary_background}"
         android:clickable="@{viewModel.isInteractionButtonActive()}"
         android:drawableEnd="@{viewModel.name.get().equals(@string/state_learn_again_button)? @drawable/ic_refresh_white_24dp : null}"
         android:onClick="@{presenter::interactionButtonClicked}"
         android:text="@{viewModel.name}"
-        android:visibility="@{viewModel.isInteractionButtonVisible()? View.VISIBLE: View.GONE}"/>
+        android:textColor="@{viewModel.isInteractionButtonActive()? @color/white : @color/oppiaSecondaryText}"
+        android:visibility="@{viewModel.isInteractionButtonVisible()? View.VISIBLE: View.GONE}"
+        xyz="@{viewModel.drawableResourceValue.get(), default=@drawable/state_button_primary_background}"/>
     </RelativeLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/state_fragment.xml
+++ b/app/src/main/res/layout/state_fragment.xml
@@ -112,7 +112,7 @@
         android:id="@+id/end_exploration_state_button"
         style="@style/StateButtonActive"
         android:layout_alignParentEnd="true"
-        android:onClick="@{viewModel::endExplorationButtonClicked}"
+        android:onClick="@{presenter::endExplorationButtonClicked}"
         android:text="@string/state_end_exploration_button"
         android:visibility="@{viewModel.isEndExplorationButtonVisible()? View.VISIBLE: View.GONE}"/>
       <Button
@@ -122,7 +122,7 @@
         android:background="@drawable/state_button_blue_background"
         android:drawableEnd="@drawable/ic_refresh_white_24dp"
         android:drawablePadding="4dp"
-        android:onClick="@{viewModel::learnAgainButtonClicked}"
+        android:onClick="@{presenter::learnAgainButtonClicked}"
         android:text="@string/state_learn_again_button"
         android:visibility="@{viewModel.isLearnAgainButtonVisible()? View.VISIBLE: View.GONE}"/>
     </RelativeLayout>

--- a/app/src/main/res/layout/state_fragment.xml
+++ b/app/src/main/res/layout/state_fragment.xml
@@ -92,39 +92,15 @@
         android:src="@drawable/ic_arrow_forward_oppia_dark_blue_24dp"
         android:visibility="@{viewModel.isNextButtonVisible()? View.VISIBLE: View.GONE}"/>
       <Button
-        android:id="@+id/continue_state_button"
+        android:id="@+id/interaction_button"
         style="@style/StateButtonActive"
         android:layout_alignParentEnd="true"
-        android:onClick="@{presenter::continueButtonClicked}"
-        android:text="@string/state_continue_button"
-        android:visibility="@{viewModel.isContinueButtonVisible()? View.VISIBLE: View.GONE}"/>
-      <Button
-        android:id="@+id/submit_state_button"
-        style="@style/StateButtonInactive"
-        android:layout_alignParentEnd="true"
-        android:background="@{viewModel.isSubmitButtonActive() ? @drawable/state_button_primary_background :@drawable/state_button_transparent_background}"
-        android:clickable="@{viewModel.isSubmitButtonActive()}"
-        android:onClick="@{presenter::submitButtonClicked}"
-        android:text="@string/state_submit_button"
-        android:textColor="@{viewModel.isSubmitButtonActive()? @color/white : @color/submitButtonInactive}"
-        android:visibility="@{viewModel.isSubmitButtonVisible()? View.VISIBLE: View.GONE}"/>
-      <Button
-        android:id="@+id/end_exploration_state_button"
-        style="@style/StateButtonActive"
-        android:layout_alignParentEnd="true"
-        android:onClick="@{presenter::endExplorationButtonClicked}"
-        android:text="@string/state_end_exploration_button"
-        android:visibility="@{viewModel.isEndExplorationButtonVisible()? View.VISIBLE: View.GONE}"/>
-      <Button
-        android:id="@+id/learn_again_state_button"
-        style="@style/StateButtonActive"
-        android:layout_alignParentEnd="true"
-        android:background="@drawable/state_button_blue_background"
-        android:drawableEnd="@drawable/ic_refresh_white_24dp"
-        android:drawablePadding="4dp"
-        android:onClick="@{presenter::learnAgainButtonClicked}"
-        android:text="@string/state_learn_again_button"
-        android:visibility="@{viewModel.isLearnAgainButtonVisible()? View.VISIBLE: View.GONE}"/>
+        android:background="@{viewModel.name.get().equals(@string/state_learn_again_button)? @drawable/state_button_blue_background : @drawable/state_button_primary_background}"
+        android:clickable="@{viewModel.isInteractionButtonActive()}"
+        android:drawableEnd="@{viewModel.name.get().equals(@string/state_learn_again_button)? @drawable/ic_refresh_white_24dp : null}"
+        android:onClick="@{presenter::interactionButtonClicked}"
+        android:text="@{viewModel.name}"
+        android:visibility="@{viewModel.isInteractionButtonVisible()? View.VISIBLE: View.GONE}"/>
     </RelativeLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/state_fragment.xml
+++ b/app/src/main/res/layout/state_fragment.xml
@@ -110,7 +110,7 @@
         android:text="@{viewModel.name}"
         android:textColor="@{viewModel.isInteractionButtonActive()? @color/white : @color/oppiaSecondaryText}"
         android:visibility="@{viewModel.isInteractionButtonVisible()? View.VISIBLE: View.GONE}"
-        xyz="@{viewModel.drawableResourceValue.get(), default=@drawable/state_button_primary_background}"/>
+        buttonDrawable="@{viewModel.drawableResourceValue.get(), default=@drawable/state_button_primary_background}"/>
     </RelativeLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/state_fragment.xml
+++ b/app/src/main/res/layout/state_fragment.xml
@@ -8,6 +8,9 @@
       name="stateFragment"
       type="org.oppia.app.player.state.StateFragment"/>
     <variable
+      name="presenter"
+      type="org.oppia.app.player.state.StateFragmentPresenter"/>
+    <variable
       name="viewModel"
       type="org.oppia.app.player.state.StateViewModel"/>
   </data>
@@ -43,5 +46,85 @@
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"/>
+    <EditText
+      android:id="@+id/dummy_interaction_edit_text"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="8dp"
+      android:layout_marginTop="16dp"
+      android:layout_marginEnd="8dp"
+      android:layout_marginBottom="8dp"
+      android:onTextChanged="@{viewModel.onTextChanged}"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/dummy_audio_button"/>
+    <RelativeLayout
+      android:id="@+id/button_container_relative_layout"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="16dp"
+      android:gravity="center_vertical"
+      android:padding="16dp"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintHorizontal_bias="0.0"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/dummy_interaction_edit_text">
+      <ImageView
+        android:id="@+id/previous_state_image_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:background="@drawable/previous_next_state_image_view_background"
+        android:contentDescription="@string/previous_state_description"
+        android:onClick="@{presenter::previousButtonClicked}"
+        android:padding="8dp"
+        android:src="@drawable/ic_arrow_back_oppia_dark_blue_24dp"
+        android:visibility="@{viewModel.isPreviousButtonVisible()? View.VISIBLE: View.GONE}"/>
+      <ImageView
+        android:id="@+id/next_state_image_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:background="@drawable/previous_next_state_image_view_background"
+        android:contentDescription="@string/next_state_description"
+        android:onClick="@{presenter::nextButtonClicked}"
+        android:padding="8dp"
+        android:src="@drawable/ic_arrow_forward_oppia_dark_blue_24dp"
+        android:visibility="@{viewModel.isNextButtonVisible()? View.VISIBLE: View.GONE}"/>
+      <Button
+        android:id="@+id/continue_state_button"
+        style="@style/StateButtonActive"
+        android:layout_alignParentEnd="true"
+        android:onClick="@{presenter::continueButtonClicked}"
+        android:text="@string/state_continue_button"
+        android:visibility="@{viewModel.isContinueButtonVisible()? View.VISIBLE: View.GONE}"/>
+      <Button
+        android:id="@+id/submit_state_button"
+        style="@style/StateButtonInactive"
+        android:layout_alignParentEnd="true"
+        android:background="@{viewModel.isSubmitButtonActive() ? @drawable/state_button_primary_background :@drawable/state_button_transparent_background}"
+        android:clickable="@{viewModel.isSubmitButtonActive()}"
+        android:onClick="@{presenter::submitButtonClicked}"
+        android:text="@string/state_submit_button"
+        android:textColor="@{viewModel.isSubmitButtonActive()? @color/white : @color/submitButtonInactive}"
+        android:visibility="@{viewModel.isSubmitButtonVisible()? View.VISIBLE: View.GONE}"/>
+      <Button
+        android:id="@+id/end_exploration_state_button"
+        style="@style/StateButtonActive"
+        android:layout_alignParentEnd="true"
+        android:onClick="@{viewModel::endExplorationButtonClicked}"
+        android:text="@string/state_end_exploration_button"
+        android:visibility="@{viewModel.isEndExplorationButtonVisible()? View.VISIBLE: View.GONE}"/>
+      <Button
+        android:id="@+id/learn_again_state_button"
+        style="@style/StateButtonActive"
+        android:layout_alignParentEnd="true"
+        android:background="@drawable/state_button_blue_background"
+        android:drawableEnd="@drawable/ic_refresh_white_24dp"
+        android:drawablePadding="4dp"
+        android:onClick="@{viewModel::learnAgainButtonClicked}"
+        android:text="@string/state_learn_again_button"
+        android:visibility="@{viewModel.isLearnAgainButtonVisible()? View.VISIBLE: View.GONE}"/>
+    </RelativeLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
@@ -188,113 +188,113 @@ class StateFragmentTest {
     }
   }
 
-  @Test
-  fun testStateFragmentButtons_loadExplorationTest5_startState_submitButtonIsInactive() {
-    ActivityScenario.launch(HomeActivity::class.java).use {
-      onView(withId(R.id.play_exploration_button)).perform(click())
-      intended(hasComponent(ExplorationActivity::class.java.name))
-      onView(withId(R.id.continue_state_button)).check(matches(not(isDisplayed())))
-      onView(withId(R.id.end_exploration_state_button)).check(matches(not(isDisplayed())))
-      onView(withId(R.id.learn_again_state_button)).check(matches(not(isDisplayed())))
-      onView(withId(R.id.next_state_image_view)).check(matches(not(isDisplayed())))
-      onView(withId(R.id.previous_state_image_view)).check(matches(not(isDisplayed())))
-      onView(withId(R.id.submit_state_button)).check(matches(isDisplayed()))
-      onView(withId(R.id.submit_state_button)).check(matches(not(isClickable())))
-    }
-  }
-
-  @Test
-  fun testStateFragmentButtons_loadExplorationTest5_startState_typeAnswer_submitButtonIsActive() {
-    ActivityScenario.launch(HomeActivity::class.java).use {
-      onView(withId(R.id.play_exploration_button)).perform(click())
-      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
-      onView(withId(R.id.submit_state_button)).check(matches(isClickable()))
-    }
-  }
-
-  @Test
-  fun testStateFragmentButtons_loadExplorationTest5_startState_typeAnswer_clearAnswer_submitButtonIsInactive() {
-    ActivityScenario.launch(HomeActivity::class.java).use {
-      onView(withId(R.id.play_exploration_button)).perform(click())
-      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
-      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
-      onView(withId(R.id.submit_state_button)).check(matches(not(isClickable())))
-    }
-  }
-
-  @Test
-  fun testStateFragmentButtons_loadExplorationTest5_secondState_previousButtonWorks_nextButtonWorks() {
-    ActivityScenario.launch(HomeActivity::class.java).use {
-      onView(withId(R.id.play_exploration_button)).perform(click())
-
-      // State 0
-      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
-      onView(withId(R.id.submit_state_button)).perform(click())
-
-      // State 1
-      onView(withId(R.id.previous_state_image_view)).check(matches(isDisplayed()))
-      onView(withId(R.id.previous_state_image_view)).perform(click())
-
-      // State 0
-      onView(withId(R.id.previous_state_image_view)).check(matches(not(isDisplayed())))
-      onView(withId(R.id.submit_state_button)).check(matches(not(isDisplayed())))
-      onView(withId(R.id.next_state_image_view)).check(matches(isDisplayed()))
-      onView(withId(R.id.next_state_image_view)).perform(click())
-
-      //State 1
-      onView(withId(R.id.previous_state_image_view)).check(matches(isDisplayed()))
-    }
-  }
-
-  @Test
-  fun testStateFragmentButtons_loadExplorationTest5_startToEndTraversal_isSuccessful() {
-    ActivityScenario.launch(HomeActivity::class.java).use {
-      onView(withId(R.id.play_exploration_button)).perform(click())
-
-      // State 0
-      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 1"), closeSoftKeyboard())
-      onView(withId(R.id.submit_state_button)).perform(click())
-
-      // State 1
-      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
-      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 2"), closeSoftKeyboard())
-      onView(withId(R.id.submit_state_button)).perform(click())
-
-      // State 2
-      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
-      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 3"), closeSoftKeyboard())
-      onView(withId(R.id.submit_state_button)).perform(click())
-
-      //State 4
-      onView(withId(R.id.continue_state_button)).check(matches(isDisplayed()))
-      onView(withId(R.id.continue_state_button)).perform(click())
-
-      //State 5
-      onView(withId(R.id.end_exploration_state_button)).check(matches(isDisplayed()))
-      onView(withId(R.id.end_exploration_state_button)).perform(click())
-
-      assertTrue(activityTestRule.activity.isFinishing)
-    }
-  }
-
-  @Test
-  fun testStateFragmentButtons_loadExplorationTest5_configurationChange_submitButtonIsInactive() {
-    ActivityScenario.launch(HomeActivity::class.java).use {
-      onView(withId(R.id.play_exploration_button)).perform(click())
-      activityTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-      onView(withId(R.id.submit_state_button)).check(matches(not(isClickable())))
-    }
-  }
-
-  @Test
-  fun testStateFragmentButtons_loadExplorationTest5_typeAnswer_configurationChange_submitButtonIsInactive() {
-    ActivityScenario.launch(HomeActivity::class.java).use {
-      onView(withId(R.id.play_exploration_button)).perform(click())
-      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
-      activityTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-      onView(withId(R.id.submit_state_button)).check(matches(isClickable()))
-    }
-  }
+//  @Test
+//  fun testStateFragmentButtons_loadExplorationTest5_startState_submitButtonIsInactive() {
+//    ActivityScenario.launch(HomeActivity::class.java).use {
+//      onView(withId(R.id.play_exploration_button)).perform(click())
+//      intended(hasComponent(ExplorationActivity::class.java.name))
+//      onView(withId(R.id.interaction_button)).check(matches(isDisplayed()))
+//      onView(withId(R.id.end_exploration_state_button)).check(matches(not(isDisplayed())))
+//      onView(withId(R.id.learn_again_state_button)).check(matches(not(isDisplayed())))
+//      onView(withId(R.id.next_state_image_view)).check(matches(not(isDisplayed())))
+//      onView(withId(R.id.previous_state_image_view)).check(matches(not(isDisplayed())))
+//      onView(withId(R.id.submit_state_button)).check(matches(isDisplayed()))
+//      onView(withId(R.id.submit_state_button)).check(matches(not(isClickable())))
+//    }
+//  }
+//
+//  @Test
+//  fun testStateFragmentButtons_loadExplorationTest5_startState_typeAnswer_submitButtonIsActive() {
+//    ActivityScenario.launch(HomeActivity::class.java).use {
+//      onView(withId(R.id.play_exploration_button)).perform(click())
+//      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
+//      onView(withId(R.id.submit_state_button)).check(matches(isClickable()))
+//    }
+//  }
+//
+//  @Test
+//  fun testStateFragmentButtons_loadExplorationTest5_startState_typeAnswer_clearAnswer_submitButtonIsInactive() {
+//    ActivityScenario.launch(HomeActivity::class.java).use {
+//      onView(withId(R.id.play_exploration_button)).perform(click())
+//      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
+//      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
+//      onView(withId(R.id.submit_state_button)).check(matches(not(isClickable())))
+//    }
+//  }
+//
+//  @Test
+//  fun testStateFragmentButtons_loadExplorationTest5_secondState_previousButtonWorks_nextButtonWorks() {
+//    ActivityScenario.launch(HomeActivity::class.java).use {
+//      onView(withId(R.id.play_exploration_button)).perform(click())
+//
+//      // State 0
+//      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
+//      onView(withId(R.id.submit_state_button)).perform(click())
+//
+//      // State 1
+//      onView(withId(R.id.previous_state_image_view)).check(matches(isDisplayed()))
+//      onView(withId(R.id.previous_state_image_view)).perform(click())
+//
+//      // State 0
+//      onView(withId(R.id.previous_state_image_view)).check(matches(not(isDisplayed())))
+//      onView(withId(R.id.submit_state_button)).check(matches(not(isDisplayed())))
+//      onView(withId(R.id.next_state_image_view)).check(matches(isDisplayed()))
+//      onView(withId(R.id.next_state_image_view)).perform(click())
+//
+//      //State 1
+//      onView(withId(R.id.previous_state_image_view)).check(matches(isDisplayed()))
+//    }
+//  }
+//
+//  @Test
+//  fun testStateFragmentButtons_loadExplorationTest5_startToEndTraversal_isSuccessful() {
+//    ActivityScenario.launch(HomeActivity::class.java).use {
+//      onView(withId(R.id.play_exploration_button)).perform(click())
+//
+//      // State 0
+//      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 1"), closeSoftKeyboard())
+//      onView(withId(R.id.submit_state_button)).perform(click())
+//
+//      // State 1
+//      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
+//      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 2"), closeSoftKeyboard())
+//      onView(withId(R.id.submit_state_button)).perform(click())
+//
+//      // State 2
+//      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
+//      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 3"), closeSoftKeyboard())
+//      onView(withId(R.id.submit_state_button)).perform(click())
+//
+//      //State 4
+//      onView(withId(R.id.continue_state_button)).check(matches(isDisplayed()))
+//      onView(withId(R.id.continue_state_button)).perform(click())
+//
+//      //State 5
+//      onView(withId(R.id.end_exploration_state_button)).check(matches(isDisplayed()))
+//      onView(withId(R.id.end_exploration_state_button)).perform(click())
+//
+//      assertTrue(activityTestRule.activity.isFinishing)
+//    }
+//  }
+//
+//  @Test
+//  fun testStateFragmentButtons_loadExplorationTest5_configurationChange_submitButtonIsInactive() {
+//    ActivityScenario.launch(HomeActivity::class.java).use {
+//      onView(withId(R.id.play_exploration_button)).perform(click())
+//      activityTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+//      onView(withId(R.id.submit_state_button)).check(matches(not(isClickable())))
+//    }
+//  }
+//
+//  @Test
+//  fun testStateFragmentButtons_loadExplorationTest5_typeAnswer_configurationChange_submitButtonIsInactive() {
+//    ActivityScenario.launch(HomeActivity::class.java).use {
+//      onView(withId(R.id.play_exploration_button)).perform(click())
+//      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
+//      activityTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+//      onView(withId(R.id.submit_state_button)).check(matches(isClickable()))
+//    }
+//  }
 
   @Module
   class TestModule {

--- a/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
@@ -2,6 +2,7 @@ package org.oppia.app.player.state
 
 import android.app.Application
 import android.content.Context
+import android.content.pm.ActivityInfo
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
@@ -32,13 +33,15 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.oppia.app.R
 import org.oppia.app.home.HomeActivity
 import org.oppia.app.player.exploration.ExplorationActivity
 import org.oppia.app.player.state.testing.StateFragmentTestActivity
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import javax.inject.Singleton
+import android.content.Intent
+import android.app.Activity
+import org.oppia.app.R
 
 /** Tests for [StateFragment]. */
 @RunWith(AndroidJUnit4::class)
@@ -46,12 +49,16 @@ class StateFragmentTest {
 
   @get:Rule
   var activityTestRule: ActivityTestRule<ExplorationActivity> = ActivityTestRule(
-    ExplorationActivity::class.java, /* initialTouchMode= */ true, /* launchActivity= */ false
+    ExplorationActivity::class.java, /* initialTouchMode= */ false, /* launchActivity= */ false
   )
+
+  private lateinit var launchedActivity: Activity
 
   @Before
   fun setUp() {
     Intents.init()
+    val intent = Intent(Intent.ACTION_PICK)
+    launchedActivity = activityTestRule.launchActivity(intent)
   }
 
   @Test
@@ -200,7 +207,6 @@ class StateFragmentTest {
   fun testStateFragmentButtons_loadExplorationTest5_startState_typeAnswer_submitButtonIsActive() {
     ActivityScenario.launch(HomeActivity::class.java).use {
       onView(withId(R.id.play_exploration_button)).perform(click())
-      intended(hasComponent(ExplorationActivity::class.java.name))
       onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
       onView(withId(R.id.submit_state_button)).check(matches(isClickable()))
     }
@@ -210,7 +216,6 @@ class StateFragmentTest {
   fun testStateFragmentButtons_loadExplorationTest5_startState_typeAnswer_clearAnswer_submitButtonIsInactive() {
     ActivityScenario.launch(HomeActivity::class.java).use {
       onView(withId(R.id.play_exploration_button)).perform(click())
-      intended(hasComponent(ExplorationActivity::class.java.name))
       onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
       onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
       onView(withId(R.id.submit_state_button)).check(matches(not(isClickable())))
@@ -221,7 +226,6 @@ class StateFragmentTest {
   fun testStateFragmentButtons_loadExplorationTest5_secondState_previousButtonWorks_nextButtonWorks() {
     ActivityScenario.launch(HomeActivity::class.java).use {
       onView(withId(R.id.play_exploration_button)).perform(click())
-      intended(hasComponent(ExplorationActivity::class.java.name))
 
       // State 0
       onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
@@ -246,7 +250,6 @@ class StateFragmentTest {
   fun testStateFragmentButtons_loadExplorationTest5_startToEndTraversal_isSuccessful() {
     ActivityScenario.launch(HomeActivity::class.java).use {
       onView(withId(R.id.play_exploration_button)).perform(click())
-      intended(hasComponent(ExplorationActivity::class.java.name))
 
       // State 0
       onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 1"), closeSoftKeyboard())
@@ -270,7 +273,26 @@ class StateFragmentTest {
       onView(withId(R.id.end_exploration_state_button)).check(matches(isDisplayed()))
       onView(withId(R.id.end_exploration_state_button)).perform(click())
 
-      assertTrue(activityTestRule.activity == null)
+      assertTrue(activityTestRule.activity.isFinishing)
+    }
+  }
+
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_configurationChange_submitButtonIsInactive() {
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+      activityTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+      onView(withId(R.id.submit_state_button)).check(matches(not(isClickable())))
+    }
+  }
+
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_typeAnswer_configurationChange_submitButtonIsInactive() {
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
+      activityTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+      onView(withId(R.id.submit_state_button)).check(matches(isClickable()))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
@@ -65,8 +65,7 @@ class StateFragmentTest {
   fun testStateFragment_clickDummyButton_showsCellularDialog() {
     ActivityScenario.launch(StateFragmentTestActivity::class.java).use {
       Espresso.onView(withId(R.id.dummy_audio_button)).perform(click())
-      Espresso.onView(withId(R.id.cellular_data_dialog_checkbox))
-        .check(matches(withText("Don\'t show this message again")))
+      Espresso.onView(withId(R.id.cellular_data_dialog_checkbox)).check(matches(withText("Don\'t show this message again")))
     }
   }
 
@@ -94,8 +93,7 @@ class StateFragmentTest {
       Espresso.onView(withId(R.id.dummy_audio_button)).perform(click())
       Espresso.onView(withText("OK")).inRoot(isDialog()).check(matches(isDisplayed())).perform(click())
       Espresso.onView(withId(R.id.dummy_audio_button)).perform(click())
-      Espresso.onView(withId(R.id.cellular_data_dialog_checkbox))
-        .check(matches(withText("Don\'t show this message again")))
+      Espresso.onView(withId(R.id.cellular_data_dialog_checkbox)).check(matches(withText("Don\'t show this message again")))
     }
   }
 
@@ -105,8 +103,7 @@ class StateFragmentTest {
       Espresso.onView(withId(R.id.dummy_audio_button)).perform(click())
       Espresso.onView(withText("CANCEL")).inRoot(isDialog()).check(matches(isDisplayed())).perform(click())
       Espresso.onView(withId(R.id.dummy_audio_button)).perform(click())
-      Espresso.onView(withId(R.id.cellular_data_dialog_checkbox))
-        .check(matches(withText("Don\'t show this message again")))
+      Espresso.onView(withId(R.id.cellular_data_dialog_checkbox)).check(matches(withText("Don\'t show this message again")))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
@@ -26,7 +26,6 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
-import junit.framework.Assert.assertTrue
 import kotlinx.coroutines.CoroutineDispatcher
 import org.hamcrest.CoreMatchers.not
 import org.junit.Before
@@ -39,8 +38,6 @@ import org.oppia.app.player.state.testing.StateFragmentTestActivity
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import javax.inject.Singleton
-import android.content.Intent
-import android.app.Activity
 import org.oppia.app.R
 
 /** Tests for [StateFragment]. */
@@ -52,13 +49,9 @@ class StateFragmentTest {
     ExplorationActivity::class.java, /* initialTouchMode= */ false, /* launchActivity= */ false
   )
 
-  private lateinit var launchedActivity: Activity
-
   @Before
   fun setUp() {
     Intents.init()
-    val intent = Intent(Intent.ACTION_PICK)
-    launchedActivity = activityTestRule.launchActivity(intent)
   }
 
   @Test
@@ -188,113 +181,129 @@ class StateFragmentTest {
     }
   }
 
-//  @Test
-//  fun testStateFragmentButtons_loadExplorationTest5_startState_submitButtonIsInactive() {
-//    ActivityScenario.launch(HomeActivity::class.java).use {
-//      onView(withId(R.id.play_exploration_button)).perform(click())
-//      intended(hasComponent(ExplorationActivity::class.java.name))
-//      onView(withId(R.id.interaction_button)).check(matches(isDisplayed()))
-//      onView(withId(R.id.end_exploration_state_button)).check(matches(not(isDisplayed())))
-//      onView(withId(R.id.learn_again_state_button)).check(matches(not(isDisplayed())))
-//      onView(withId(R.id.next_state_image_view)).check(matches(not(isDisplayed())))
-//      onView(withId(R.id.previous_state_image_view)).check(matches(not(isDisplayed())))
-//      onView(withId(R.id.submit_state_button)).check(matches(isDisplayed()))
-//      onView(withId(R.id.submit_state_button)).check(matches(not(isClickable())))
-//    }
-//  }
-//
-//  @Test
-//  fun testStateFragmentButtons_loadExplorationTest5_startState_typeAnswer_submitButtonIsActive() {
-//    ActivityScenario.launch(HomeActivity::class.java).use {
-//      onView(withId(R.id.play_exploration_button)).perform(click())
-//      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
-//      onView(withId(R.id.submit_state_button)).check(matches(isClickable()))
-//    }
-//  }
-//
-//  @Test
-//  fun testStateFragmentButtons_loadExplorationTest5_startState_typeAnswer_clearAnswer_submitButtonIsInactive() {
-//    ActivityScenario.launch(HomeActivity::class.java).use {
-//      onView(withId(R.id.play_exploration_button)).perform(click())
-//      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
-//      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
-//      onView(withId(R.id.submit_state_button)).check(matches(not(isClickable())))
-//    }
-//  }
-//
-//  @Test
-//  fun testStateFragmentButtons_loadExplorationTest5_secondState_previousButtonWorks_nextButtonWorks() {
-//    ActivityScenario.launch(HomeActivity::class.java).use {
-//      onView(withId(R.id.play_exploration_button)).perform(click())
-//
-//      // State 0
-//      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
-//      onView(withId(R.id.submit_state_button)).perform(click())
-//
-//      // State 1
-//      onView(withId(R.id.previous_state_image_view)).check(matches(isDisplayed()))
-//      onView(withId(R.id.previous_state_image_view)).perform(click())
-//
-//      // State 0
-//      onView(withId(R.id.previous_state_image_view)).check(matches(not(isDisplayed())))
-//      onView(withId(R.id.submit_state_button)).check(matches(not(isDisplayed())))
-//      onView(withId(R.id.next_state_image_view)).check(matches(isDisplayed()))
-//      onView(withId(R.id.next_state_image_view)).perform(click())
-//
-//      //State 1
-//      onView(withId(R.id.previous_state_image_view)).check(matches(isDisplayed()))
-//    }
-//  }
-//
-//  @Test
-//  fun testStateFragmentButtons_loadExplorationTest5_startToEndTraversal_isSuccessful() {
-//    ActivityScenario.launch(HomeActivity::class.java).use {
-//      onView(withId(R.id.play_exploration_button)).perform(click())
-//
-//      // State 0
-//      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 1"), closeSoftKeyboard())
-//      onView(withId(R.id.submit_state_button)).perform(click())
-//
-//      // State 1
-//      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
-//      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 2"), closeSoftKeyboard())
-//      onView(withId(R.id.submit_state_button)).perform(click())
-//
-//      // State 2
-//      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
-//      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 3"), closeSoftKeyboard())
-//      onView(withId(R.id.submit_state_button)).perform(click())
-//
-//      //State 4
-//      onView(withId(R.id.continue_state_button)).check(matches(isDisplayed()))
-//      onView(withId(R.id.continue_state_button)).perform(click())
-//
-//      //State 5
-//      onView(withId(R.id.end_exploration_state_button)).check(matches(isDisplayed()))
-//      onView(withId(R.id.end_exploration_state_button)).perform(click())
-//
-//      assertTrue(activityTestRule.activity.isFinishing)
-//    }
-//  }
-//
-//  @Test
-//  fun testStateFragmentButtons_loadExplorationTest5_configurationChange_submitButtonIsInactive() {
-//    ActivityScenario.launch(HomeActivity::class.java).use {
-//      onView(withId(R.id.play_exploration_button)).perform(click())
-//      activityTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-//      onView(withId(R.id.submit_state_button)).check(matches(not(isClickable())))
-//    }
-//  }
-//
-//  @Test
-//  fun testStateFragmentButtons_loadExplorationTest5_typeAnswer_configurationChange_submitButtonIsInactive() {
-//    ActivityScenario.launch(HomeActivity::class.java).use {
-//      onView(withId(R.id.play_exploration_button)).perform(click())
-//      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
-//      activityTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-//      onView(withId(R.id.submit_state_button)).check(matches(isClickable()))
-//    }
-//  }
+  // TODO(#163): Update these test cases once MultipleChoiceInput and TextInput is merged.
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_startState_submitButtonIsActive() {
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+      intended(hasComponent(ExplorationActivity::class.java.name))
+      // State 0: MultipleChoiceInput
+      onView(withId(R.id.next_state_image_view)).check(matches(not(isDisplayed())))
+      onView(withId(R.id.previous_state_image_view)).check(matches(not(isDisplayed())))
+      onView(withId(R.id.interaction_button)).check(matches(isDisplayed()))
+      onView(withId(R.id.interaction_button)).check(matches(withText(R.string.state_submit_button)))
+      onView(withId(R.id.interaction_button)).check(matches(isClickable()))
+    }
+  }
+
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_startState_typeAnswer_submitButtonIsInactive() {
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+      onView(withId(R.id.interaction_button)).perform(click())
+      // State 1: TextInput
+      onView(withId(R.id.interaction_button)).check(matches(not(isClickable())))
+    }
+  }
+
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_startState_typeAnswer_submitButtonIsActive() {
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+      onView(withId(R.id.interaction_button)).perform(click())
+      // State 1: TextInput
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
+      onView(withId(R.id.interaction_button)).check(matches(isClickable()))
+    }
+  }
+
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_startState_typeAnswer_clearAnswer_submitButtonIsInactive() {
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+      onView(withId(R.id.interaction_button)).perform(click())
+      // State 1: TextInput
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
+      onView(withId(R.id.interaction_button)).check(matches(not(isClickable())))
+    }
+  }
+
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_secondState_previousButtonWorks_nextButtonWorks() {
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+
+      // State 0
+      onView(withId(R.id.interaction_button)).perform(click())
+
+      // State 1
+      onView(withId(R.id.previous_state_image_view)).check(matches(isDisplayed()))
+      onView(withId(R.id.previous_state_image_view)).perform(click())
+
+      // State 0
+      onView(withId(R.id.previous_state_image_view)).check(matches(not(isDisplayed())))
+      onView(withId(R.id.next_state_image_view)).check(matches(isDisplayed()))
+      onView(withId(R.id.next_state_image_view)).perform(click())
+
+      //State 1
+      onView(withId(R.id.previous_state_image_view)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_startToEndTraversal_isSuccessful() {
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+
+      // State 0
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 1"), closeSoftKeyboard())
+      onView(withId(R.id.interaction_button)).perform(click())
+
+      // State 1
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 2"), closeSoftKeyboard())
+      onView(withId(R.id.interaction_button)).perform(click())
+
+      // State 2
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 3"), closeSoftKeyboard())
+      onView(withId(R.id.interaction_button)).perform(click())
+
+      //State 4
+      onView(withId(R.id.interaction_button)).check(matches(isDisplayed()))
+      onView(withId(R.id.interaction_button)).check(matches(withText(R.string.state_continue_button)))
+      onView(withId(R.id.interaction_button)).perform(click())
+
+      //State 5
+      onView(withId(R.id.interaction_button)).check(matches(isDisplayed()))
+      onView(withId(R.id.interaction_button)).check(matches(withText(R.string.state_end_exploration_button)))
+      onView(withId(R.id.interaction_button)).perform(click())
+    }
+  }
+
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_configurationChange_submitButtonIsInactive() {
+    activityTestRule.launchActivity(null)
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+      onView(withId(R.id.interaction_button)).perform(click())
+      activityTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+      onView(withId(R.id.interaction_button)).check(matches(not(isClickable())))
+    }
+  }
+
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_typeAnswer_configurationChange_submitButtonIsInactive() {
+    activityTestRule.launchActivity(null)
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+      onView(withId(R.id.interaction_button)).perform(click())
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
+      activityTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+      onView(withId(R.id.interaction_button)).check(matches(isClickable()))
+    }
+  }
 
   @Module
   class TestModule {

--- a/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
@@ -4,23 +4,37 @@ import android.app.Application
 import android.content.Context
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
+import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isClickable
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.rule.ActivityTestRule
 import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
+import junit.framework.Assert.assertTrue
 import kotlinx.coroutines.CoroutineDispatcher
 import org.hamcrest.CoreMatchers.not
+import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.app.R
+import org.oppia.app.home.HomeActivity
+import org.oppia.app.player.exploration.ExplorationActivity
 import org.oppia.app.player.state.testing.StateFragmentTestActivity
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
@@ -29,6 +43,16 @@ import javax.inject.Singleton
 /** Tests for [StateFragment]. */
 @RunWith(AndroidJUnit4::class)
 class StateFragmentTest {
+
+  @get:Rule
+  var activityTestRule: ActivityTestRule<ExplorationActivity> = ActivityTestRule(
+    ExplorationActivity::class.java, /* initialTouchMode= */ true, /* launchActivity= */ false
+  )
+
+  @Before
+  fun setUp() {
+    Intents.init()
+  }
 
   @Test
   fun testStateFragmentTestActivity_loadStateFragment_hasDummyButton() {
@@ -41,7 +65,8 @@ class StateFragmentTest {
   fun testStateFragment_clickDummyButton_showsCellularDialog() {
     ActivityScenario.launch(StateFragmentTestActivity::class.java).use {
       Espresso.onView(withId(R.id.dummy_audio_button)).perform(click())
-      Espresso.onView(withId(R.id.cellular_data_dialog_checkbox)).check(matches(withText("Don\'t show this message again")))
+      Espresso.onView(withId(R.id.cellular_data_dialog_checkbox))
+        .check(matches(withText("Don\'t show this message again")))
     }
   }
 
@@ -69,7 +94,8 @@ class StateFragmentTest {
       Espresso.onView(withId(R.id.dummy_audio_button)).perform(click())
       Espresso.onView(withText("OK")).inRoot(isDialog()).check(matches(isDisplayed())).perform(click())
       Espresso.onView(withId(R.id.dummy_audio_button)).perform(click())
-      Espresso.onView(withId(R.id.cellular_data_dialog_checkbox)).check(matches(withText("Don\'t show this message again")))
+      Espresso.onView(withId(R.id.cellular_data_dialog_checkbox))
+        .check(matches(withText("Don\'t show this message again")))
     }
   }
 
@@ -79,7 +105,8 @@ class StateFragmentTest {
       Espresso.onView(withId(R.id.dummy_audio_button)).perform(click())
       Espresso.onView(withText("CANCEL")).inRoot(isDialog()).check(matches(isDisplayed())).perform(click())
       Espresso.onView(withId(R.id.dummy_audio_button)).perform(click())
-      Espresso.onView(withId(R.id.cellular_data_dialog_checkbox)).check(matches(withText("Don\'t show this message again")))
+      Espresso.onView(withId(R.id.cellular_data_dialog_checkbox))
+        .check(matches(withText("Don\'t show this message again")))
     }
   }
 
@@ -129,8 +156,6 @@ class StateFragmentTest {
     }
   }
 
-
-
   @Test
   fun testStateFragment_clickCheckBoxAndPositive_restartActivity_clickDummyButton_doesNotShowCellularDialogAndShowsAudioFragment() {
     ActivityScenario.launch(StateFragmentTestActivity::class.java).use {
@@ -156,6 +181,99 @@ class StateFragmentTest {
       Espresso.onView(withId(R.id.dummy_audio_button)).perform(click())
       Espresso.onView(withId(R.id.cellular_data_dialog_checkbox)).check(doesNotExist())
       Espresso.onView(withId(R.id.audio_fragment)).check(matches(not(isDisplayed())))
+    }
+  }
+
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_startState_submitButtonIsInactive() {
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+      intended(hasComponent(ExplorationActivity::class.java.name))
+      onView(withId(R.id.continue_state_button)).check(matches(not(isDisplayed())))
+      onView(withId(R.id.end_exploration_state_button)).check(matches(not(isDisplayed())))
+      onView(withId(R.id.learn_again_state_button)).check(matches(not(isDisplayed())))
+      onView(withId(R.id.next_state_image_view)).check(matches(not(isDisplayed())))
+      onView(withId(R.id.previous_state_image_view)).check(matches(not(isDisplayed())))
+      onView(withId(R.id.submit_state_button)).check(matches(isDisplayed()))
+      onView(withId(R.id.submit_state_button)).check(matches(not(isClickable())))
+    }
+  }
+
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_startState_typeAnswer_submitButtonIsActive() {
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+      intended(hasComponent(ExplorationActivity::class.java.name))
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
+      onView(withId(R.id.submit_state_button)).check(matches(isClickable()))
+    }
+  }
+
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_startState_typeAnswer_clearAnswer_submitButtonIsInactive() {
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+      intended(hasComponent(ExplorationActivity::class.java.name))
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
+      onView(withId(R.id.submit_state_button)).check(matches(not(isClickable())))
+    }
+  }
+
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_secondState_previousButtonWorks_nextButtonWorks() {
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+      intended(hasComponent(ExplorationActivity::class.java.name))
+
+      // State 0
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text"), closeSoftKeyboard())
+      onView(withId(R.id.submit_state_button)).perform(click())
+
+      // State 1
+      onView(withId(R.id.previous_state_image_view)).check(matches(isDisplayed()))
+      onView(withId(R.id.previous_state_image_view)).perform(click())
+
+      // State 0
+      onView(withId(R.id.previous_state_image_view)).check(matches(not(isDisplayed())))
+      onView(withId(R.id.submit_state_button)).check(matches(not(isDisplayed())))
+      onView(withId(R.id.next_state_image_view)).check(matches(isDisplayed()))
+      onView(withId(R.id.next_state_image_view)).perform(click())
+
+      //State 1
+      onView(withId(R.id.previous_state_image_view)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testStateFragmentButtons_loadExplorationTest5_startToEndTraversal_isSuccessful() {
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+      intended(hasComponent(ExplorationActivity::class.java.name))
+
+      // State 0
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 1"), closeSoftKeyboard())
+      onView(withId(R.id.submit_state_button)).perform(click())
+
+      // State 1
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 2"), closeSoftKeyboard())
+      onView(withId(R.id.submit_state_button)).perform(click())
+
+      // State 2
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(clearText())
+      onView(withId(R.id.dummy_interaction_edit_text)).perform(typeText("Sample text 3"), closeSoftKeyboard())
+      onView(withId(R.id.submit_state_button)).perform(click())
+
+      //State 4
+      onView(withId(R.id.continue_state_button)).check(matches(isDisplayed()))
+      onView(withId(R.id.continue_state_button)).perform(click())
+
+      //State 5
+      onView(withId(R.id.end_exploration_state_button)).check(matches(isDisplayed()))
+      onView(withId(R.id.end_exploration_state_button)).perform(click())
+
+      assertTrue(activityTestRule.activity == null)
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

This fixes #156 and #157 and introduces following buttons which will be used in state:
1. Continue
2. Return to Topic
3. Learn Again
4. Submit
5. Previous Arrow Button
6. Next Arrow Button

Reference Design Doc: https://docs.google.com/document/d/1iD4sY_hWmWRu4eC8jGoolKQ5hsqpIV5sG1NA4YB2HL4/edit?usp=sharing

This PR was earlier on #185  

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is **assigned** to an appropriate reviewer.
