### PR TITLE
Fix #161: Exploration player contentcard supports rich-text part -1

### DIFF
--- a/app/src/main/res/drawable/bg_blue_card.xml
+++ b/app/src/main/res/drawable/bg_blue_card.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-       android:padding="16dp"
-       android:shape="rectangle">
+<shape
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:padding="16dp"
+  android:shape="rectangle">
   <stroke
     android:width="2dp"
     android:color="@color/blue_shade_200"/>

--- a/app/src/main/res/drawable/bg_blue_card.xml
+++ b/app/src/main/res/drawable/bg_blue_card.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:padding="16dp"
+       android:shape="rectangle">
+  <stroke
+    android:width="2dp"
+    android:color="@color/blue_shade_200"/>
+  <corners android:radius="8dp"/>
+  <solid
+    android:color="@color/blue_shade_100"/>
+</shape>

--- a/app/src/main/res/drawable/bg_white_card.xml
+++ b/app/src/main/res/drawable/bg_white_card.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:padding="16dp"
+       android:shape="rectangle">
+  <stroke
+    android:width="2dp"
+    android:color="@color/black"/>
+  <corners android:radius="8dp"/>
+  <solid
+    android:color="@color/white"/>
+</shape>

--- a/app/src/main/res/drawable/bg_white_card.xml
+++ b/app/src/main/res/drawable/bg_white_card.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-       android:padding="16dp"
-       android:shape="rectangle">
+<shape
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:padding="16dp"
+  android:shape="rectangle">
   <stroke
     android:width="2dp"
     android:color="@color/black"/>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -27,7 +27,6 @@
   <color name="blue_shade_20">#202D4A9D</color>
   <color name="blue_shade_60">#602D4A9D</color>
   <color name="grey_shade_10">#102D4A9D</color>
-
   <color name="blue_shade_100">#0F0086FB</color>
   <color name="blue_shade_200">#6B0086FB</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -27,4 +27,7 @@
   <color name="blue_shade_20">#202D4A9D</color>
   <color name="blue_shade_60">#602D4A9D</color>
   <color name="grey_shade_10">#102D4A9D</color>
+
+  <color name="blue_shade_100">#0F0086FB</color>
+  <color name="blue_shade_200">#6B0086FB</color>
 </resources>


### PR DESCRIPTION
##  Explanation
This PR is replica of [#189](https://github.com/oppia/oppia-android/pull/189) . It includes rich-text component that parses HTML content. This PR also extracts image from the HTML content.

Exploration Content card is divided in 3 PR's
1)  [#228](https://github.com/oppia/oppia-android/pull/228) It includes resources drawable files
2) [#229](https://github.com/oppia/oppia-android/pull/229) Contains Kotlin and layout files
3) Contains Testcase