### PR TITLE
Fix #161: Exploration player contentcard supports rich-text part -3

### DIFF
--- a/app/src/sharedTest/java/org/oppia/app/player/content/ContentListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/content/ContentListFragmentTest.kt
@@ -4,50 +4,34 @@ import android.app.Application
 import android.content.Context
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
 import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineDispatcher
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.oppia.app.R
+import org.oppia.app.home.HomeActivity
 import org.oppia.app.player.exploration.ExplorationActivity
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import javax.inject.Singleton
-import android.app.Activity
-import android.content.Intent
-import androidx.databinding.Observable
-import org.junit.Before
-import androidx.databinding.Observable.OnPropertyChangedCallback
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.intent.Intents
-
-import androidx.test.rule.ActivityTestRule
-import org.junit.After
-import org.junit.Rule
-import org.oppia.app.R
-import org.oppia.app.home.HomeActivity
 
 /** Tests for [ContentListFragment]. */
 @RunWith(AndroidJUnit4::class)
 class ContentListFragmentTest {
-  private lateinit var launchedActivity: Activity
   @get:Rule
   var activityTestRule: ActivityTestRule<ExplorationActivity> = ActivityTestRule(
     ExplorationActivity::class.java, /* initialTouchMode= */ true, /* launchActivity= */ false
   )
-
-//  @Before
-//  fun setUp() {
-//    Intents.init()
-//    val intent = Intent(Intent.ACTION_PICK)
-////    launchedActivity = activityTestRule.launchActivity(intent)
-//  }
 
   @Test
   fun testContentListFragment_loadHtmlContent_isDisplayed() {
@@ -56,11 +40,6 @@ class ContentListFragmentTest {
       onView(withId(R.id.recyclerview)).check(matches(isDisplayed()))
     }
   }
-
-//  @After
-//  fun tearDown() {
-//    Intents.release()
-//  }
 
   @Module
   class TestModule {

--- a/app/src/sharedTest/java/org/oppia/app/player/content/ContentListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/content/ContentListFragmentTest.kt
@@ -19,14 +19,29 @@ import org.oppia.app.player.exploration.ExplorationActivity
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import javax.inject.Singleton
+import android.app.Activity
+import androidx.databinding.Observable
+import org.junit.Before
+import androidx.databinding.Observable.OnPropertyChangedCallback
+
+
+
+
 
 /** Tests for [ContentListFragment]. */
 @RunWith(AndroidJUnit4::class)
 class ContentListFragmentTest {
 
+  private var viewModel: ContentViewModel? = null
+
+  @Before
+  fun setup() {
+    viewModel = ContentViewModel()
+  }
   @Test
   fun testContentListFragment_loadHtmlContent_isDisplayed() {
     ActivityScenario.launch(ExplorationActivity::class.java).use {
+      viewModel!!.setHtmlContent("hkjhkjd")
       onView(withId(org.oppia.app.R.id.recyclerview)).check(matches(isDisplayed()))
       pauseTestFor(3000)
     }

--- a/app/src/sharedTest/java/org/oppia/app/player/content/ContentListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/content/ContentListFragmentTest.kt
@@ -20,40 +20,47 @@ import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import javax.inject.Singleton
 import android.app.Activity
+import android.content.Intent
 import androidx.databinding.Observable
 import org.junit.Before
 import androidx.databinding.Observable.OnPropertyChangedCallback
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.intent.Intents
 
-
-
-
+import androidx.test.rule.ActivityTestRule
+import org.junit.After
+import org.junit.Rule
+import org.oppia.app.R
+import org.oppia.app.home.HomeActivity
 
 /** Tests for [ContentListFragment]. */
 @RunWith(AndroidJUnit4::class)
 class ContentListFragmentTest {
+  private lateinit var launchedActivity: Activity
+  @get:Rule
+  var activityTestRule: ActivityTestRule<ExplorationActivity> = ActivityTestRule(
+    ExplorationActivity::class.java, /* initialTouchMode= */ true, /* launchActivity= */ false
+  )
 
-  private var viewModel: ContentViewModel? = null
+//  @Before
+//  fun setUp() {
+//    Intents.init()
+//    val intent = Intent(Intent.ACTION_PICK)
+////    launchedActivity = activityTestRule.launchActivity(intent)
+//  }
 
-  @Before
-  fun setup() {
-    viewModel = ContentViewModel()
-  }
   @Test
   fun testContentListFragment_loadHtmlContent_isDisplayed() {
-    ActivityScenario.launch(ExplorationActivity::class.java).use {
-      viewModel!!.setHtmlContent("hkjhkjd")
-      onView(withId(org.oppia.app.R.id.recyclerview)).check(matches(isDisplayed()))
-      pauseTestFor(3000)
+    ActivityScenario.launch(HomeActivity::class.java).use {
+      onView(withId(R.id.play_exploration_button)).perform(click())
+      onView(withId(R.id.recyclerview)).check(matches(isDisplayed()))
     }
   }
 
-  fun pauseTestFor(milliseconds: Long) {
-    try {
-      Thread.sleep(milliseconds)
-    } catch (e: InterruptedException) {
-      e.printStackTrace();
-    }
-  }
+//  @After
+//  fun tearDown() {
+//    Intents.release()
+//  }
 
   @Module
   class TestModule {

--- a/app/src/sharedTest/java/org/oppia/app/player/content/ContentListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/content/ContentListFragmentTest.kt
@@ -1,0 +1,74 @@
+package org.oppia.app.player.content
+
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.BindsInstance
+import dagger.Component
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.CoroutineDispatcher
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.oppia.app.player.exploration.ExplorationActivity
+import org.oppia.util.threading.BackgroundDispatcher
+import org.oppia.util.threading.BlockingDispatcher
+import javax.inject.Singleton
+
+/** Tests for [ContentListFragment]. */
+@RunWith(AndroidJUnit4::class)
+class ContentListFragmentTest {
+
+  @Test
+  fun testContentListFragment_loadHtmlContent_isDisplayed() {
+    ActivityScenario.launch(ExplorationActivity::class.java).use {
+      onView(withId(org.oppia.app.R.id.recyclerview)).check(matches(isDisplayed()))
+      pauseTestFor(3000)
+    }
+  }
+
+  fun pauseTestFor(milliseconds: Long) {
+    try {
+      Thread.sleep(milliseconds)
+    } catch (e: InterruptedException) {
+      e.printStackTrace();
+    }
+  }
+
+  @Module
+  class TestModule {
+    @Provides
+    @Singleton
+    fun provideContext(application: Application): Context {
+      return application
+    }
+
+    // TODO(#89): Introduce a proper IdlingResource for background dispatchers to ensure they all complete before
+    //  proceeding in an Espresso test. This solution should also be interoperative with Robolectric contexts by using a
+    //  test coroutine dispatcher.
+
+    @Singleton
+    @Provides
+    @BackgroundDispatcher
+    fun provideBackgroundDispatcher(@BlockingDispatcher blockingDispatcher: CoroutineDispatcher): CoroutineDispatcher {
+      return blockingDispatcher
+    }
+  }
+
+  @Singleton
+  @Component(modules = [TestModule::class])
+  interface TestApplicationComponent {
+    @Component.Builder
+    interface Builder {
+      @BindsInstance
+      fun setApplication(application: Application): Builder
+
+      fun build(): TestApplicationComponent
+    }
+  }
+}


### PR DESCRIPTION
## Explanation
This PR is replica of #189 . It includes rich-text component that parses HTML content. This PR also extracts image from the HTML content.

Exploration Content card is divided in 3 PR's

#228 It includes resources drawable files
#229 Contains Kotlin and layout files
[#232](https://github.com/oppia/oppia-android/pull/232) Contains Testcase