### PR TITLE
Fix #136: Topic overview download preference save (part 3) [ON HOLD]

### DIFF
--- a/app/src/sharedTest/java/org/oppia/app/topic/overview/TopicOverviewFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/overview/TopicOverviewFragmentTest.kt
@@ -21,6 +21,7 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineDispatcher
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.Matchers.not
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -76,8 +77,7 @@ class TopicOverviewFragmentTest {
   fun testTopicOverviewFragment_clickDownloadStatusIcon_clickPositive_changesIconStatusToDownloaded() {
     ActivityScenario.launch(TopicActivity::class.java).use {
       onView(withId(R.id.download_status_image_view)).perform(click())
-      onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog())
-        .check(matches(isDisplayed())).perform(click())
+      onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog()).perform(click())
       onView(withId(R.id.download_status_image_view)).check(matches(withTagValue(equalTo(R.drawable.ic_check_circle_primary_24dp))))
     }
   }
@@ -86,8 +86,7 @@ class TopicOverviewFragmentTest {
   fun testTopicOverviewFragment_clickDownloadStatusIcon_clickNegative_doesNotChangeIconStatus() {
     ActivityScenario.launch(TopicActivity::class.java).use {
       onView(withId(R.id.download_status_image_view)).perform(click())
-      onView(withText(R.string.topic_download_alert_dialog_cancel_button)).inRoot(isDialog())
-        .check(matches(isDisplayed())).perform(click())
+      onView(withText(R.string.topic_download_alert_dialog_cancel_button)).inRoot(isDialog()).perform(click())
       onView(withId(R.id.download_status_image_view)).check(matches(withTagValue(equalTo(R.drawable.ic_file_download_primary_24dp))))
     }
   }
@@ -96,8 +95,7 @@ class TopicOverviewFragmentTest {
   fun testTopicOverviewFragment_clickDownloadStatusIcon_clickPositive_clickDownloadStatusIcon_showsDeleteDialog() {
     ActivityScenario.launch(TopicActivity::class.java).use {
       onView(withId(R.id.download_status_image_view)).perform(click())
-      onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog())
-        .check(matches(isDisplayed())).perform(click())
+      onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog()).perform(click())
       onView(withId(R.id.download_status_image_view)).perform(click())
       onView(withText(R.string.topic_delete_alert_dialog_description)).check(matches(isDisplayed()))
     }
@@ -107,11 +105,9 @@ class TopicOverviewFragmentTest {
   fun testTopicOverviewFragment_clickDownloadStatusIcon_clickPositive_clickDownloadStatusIcon_clickPositive_changesBackToNotDownloadedStatusIcon() {
     ActivityScenario.launch(TopicActivity::class.java).use {
       onView(withId(R.id.download_status_image_view)).perform(click())
-      onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog())
-        .check(matches(isDisplayed())).perform(click())
+      onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog()).perform(click())
       onView(withId(R.id.download_status_image_view)).perform(click())
-      onView(withText(R.string.topic_delete_alert_dialog_delete_button)).inRoot(isDialog())
-        .check(matches(isDisplayed())).perform(click())
+      onView(withText(R.string.topic_delete_alert_dialog_delete_button)).inRoot(isDialog()).perform(click())
       onView(withId(R.id.download_status_image_view)).check(matches(withTagValue(equalTo(R.drawable.ic_file_download_primary_24dp))))
     }
   }
@@ -120,11 +116,9 @@ class TopicOverviewFragmentTest {
   fun testTopicOverviewFragment_clickDownloadStatusIcon_clickPositive_clickDownloadStatusIcon_clickNegative_statusIconIsDownloaded() {
     ActivityScenario.launch(TopicActivity::class.java).use {
       onView(withId(R.id.download_status_image_view)).perform(click())
-      onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog())
-        .check(matches(isDisplayed())).perform(click())
+      onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog()).perform(click())
       onView(withId(R.id.download_status_image_view)).perform(click())
-      onView(withText(R.string.topic_delete_alert_dialog_delete_button)).inRoot(isDialog())
-        .check(matches(isDisplayed())).perform(click())
+      onView(withText(R.string.topic_delete_alert_dialog_delete_button)).inRoot(isDialog()).perform(click())
       onView(withId(R.id.download_status_image_view)).check(matches(withTagValue(equalTo(R.drawable.ic_file_download_primary_24dp))))
     }
   }
@@ -134,8 +128,7 @@ class TopicOverviewFragmentTest {
     ActivityScenario.launch(TopicActivity::class.java).use {
       onView(withId(R.id.download_status_image_view)).perform(click())
       onView(withId(R.id.topic_download_dialog_checkbox)).perform(click())
-      onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog())
-        .check(matches(isDisplayed())).perform(click())
+      onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog()).perform(click())
       onView(withId(R.id.download_status_image_view)).check(matches(withTagValue(equalTo(R.drawable.ic_check_circle_primary_24dp))))
     }
   }
@@ -145,8 +138,7 @@ class TopicOverviewFragmentTest {
     ActivityScenario.launch(TopicActivity::class.java).use {
       onView(withId(R.id.download_status_image_view)).perform(click())
       onView(withId(R.id.topic_download_dialog_checkbox)).perform(click())
-      onView(withText(R.string.topic_download_alert_dialog_cancel_button)).inRoot(isDialog())
-        .check(matches(isDisplayed())).perform(click())
+      onView(withText(R.string.topic_download_alert_dialog_cancel_button)).inRoot(isDialog()).perform(click())
       onView(withId(R.id.download_status_image_view)).check(matches(withTagValue(equalTo(R.drawable.ic_file_download_primary_24dp))))
     }
   }
@@ -163,19 +155,17 @@ class TopicOverviewFragmentTest {
   fun testTopicOverviewFragment_clickDownloadStatusIcon_clickPositive_configurationChange_changesIconStatusToDownloaded() {
     activityTestRule.launchActivity(null)
     onView(withId(R.id.download_status_image_view)).perform(click())
-    onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog())
-      .check(matches(isDisplayed())).perform(click())
+    onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog()).perform(click())
     activityTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
     onView(withId(R.id.download_status_image_view)).check(matches(withTagValue(equalTo(R.drawable.ic_check_circle_primary_24dp))))
 
   }
 
   @Test
-  fun testTopicOverviewFragment_clickDownloadStatusIcon_clickNegative_configurationChange_doesNotChangeIconStatus() {
+  fun testTopicOverviewFragment_clickDownloadStatusIcon_clickNegative_configurationChange_doesNotChangeStatusIcon() {
     activityTestRule.launchActivity(null)
     onView(withId(R.id.download_status_image_view)).perform(click())
-    onView(withText(R.string.topic_download_alert_dialog_cancel_button)).inRoot(isDialog())
-      .check(matches(isDisplayed())).perform(click())
+    onView(withText(R.string.topic_download_alert_dialog_cancel_button)).inRoot(isDialog()).perform(click())
     activityTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
     onView(withId(R.id.download_status_image_view)).check(matches(withTagValue(equalTo(R.drawable.ic_file_download_primary_24dp))))
   }
@@ -184,11 +174,34 @@ class TopicOverviewFragmentTest {
   fun testTopicOverviewFragment_clickDownloadStatusIcon_clickPositive_clickDownloadStatusIcon_configurationChange_showsDeleteDialog() {
     activityTestRule.launchActivity(null)
     onView(withId(R.id.download_status_image_view)).perform(click())
-    onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog())
-      .check(matches(isDisplayed())).perform(click())
+    onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog()).perform(click())
     onView(withId(R.id.download_status_image_view)).perform(click())
     activityTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
     onView(withText(R.string.topic_delete_alert_dialog_description)).check(matches(isDisplayed()))
+  }
+
+  @Test
+  fun testTopicOverviewFragment_clickDownloadStatusIcon_selectCheckbox_clickNegative_clickDownloadStatusIcon_cellularDialogDoesNotAppear_doesNotChangeStatusIcon() {
+    ActivityScenario.launch(TopicActivity::class.java).use {
+      onView(withId(R.id.download_status_image_view)).perform(click())
+      onView(withId(R.id.topic_download_dialog_checkbox)).perform(click())
+      onView(withText(R.string.topic_download_alert_dialog_cancel_button)).inRoot(isDialog()).perform(click())
+      onView(withId(R.id.download_status_image_view)).check(matches(withTagValue(equalTo(R.drawable.ic_file_download_primary_24dp))))
+      onView(withId(R.id.download_status_image_view)).check(matches(withTagValue(equalTo(R.drawable.ic_file_download_primary_24dp))))
+    }
+  }
+
+  @Test
+  fun testTopicOverviewFragment_clickDownloadStatusIcon_selectCheckbox_clickPositive_deleteDownload_clickDownloadStatusIcon_cellularDialogDoesNotAppear_changesIconStatusToDownloaded() {
+    ActivityScenario.launch(TopicActivity::class.java).use {
+      onView(withId(R.id.download_status_image_view)).perform(click())
+      onView(withId(R.id.topic_download_dialog_checkbox)).perform(click())
+      onView(withText(R.string.topic_download_alert_dialog_download_button)).inRoot(isDialog()).perform(click())
+      onView(withId(R.id.download_status_image_view)).perform(click())
+      onView(withText(R.string.topic_delete_alert_dialog_delete_button)).inRoot(isDialog()).perform(click())
+      onView(withId(R.id.download_status_image_view)).perform(click())
+      onView(withId(R.id.download_status_image_view)).check(matches(withTagValue(equalTo(R.drawable.ic_check_circle_primary_24dp))))
+    }
   }
 
   @Module

--- a/domain/src/main/java/org/oppia/domain/topic/TopicDownloadDialogController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicDownloadDialogController.kt
@@ -1,0 +1,56 @@
+package org.oppia.domain.topic
+
+import androidx.lifecycle.LiveData
+import org.oppia.app.model.TopicDownloadPreference
+import org.oppia.data.persistence.PersistentCacheStore
+import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders
+import org.oppia.util.logging.Logger
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Controller for persisting and retrieving the topic download preference. */
+@Singleton
+class TopicDownloadDialogController @Inject constructor(
+  cacheStoreFactory: PersistentCacheStore.Factory, private val dataProviders: DataProviders,
+  private val logger: Logger
+) {
+  private val topicDownloadStore = cacheStoreFactory.create("topic_download_preference", TopicDownloadPreference.getDefaultInstance())
+
+  fun setNeverUseCellularDataPreference() {
+    setHideDialogPreference(true)
+    setUseCellularDataPreference(false)
+  }
+
+  fun setAlwaysUseCellularDataPreference() {
+    setHideDialogPreference(true)
+    setUseCellularDataPreference(true)
+  }
+
+  /** Saves that the user's preference on whether to hide the dialog. */
+  private fun setHideDialogPreference(hideDialog: Boolean) {
+    topicDownloadStore.storeDataAsync(updateInMemoryCache = true) {
+      it.toBuilder().setHideDialog(hideDialog).build()
+    }.invokeOnCompletion {
+      it?.let {
+        logger.e("DOMAIN", "Failed when storing the user's preference to hide topic download dialog.", it)
+      }
+    }
+  }
+
+  /** Saves that the user's preference on whether to use cellular data. */
+  private fun setUseCellularDataPreference(useData: Boolean) {
+    topicDownloadStore.storeDataAsync(updateInMemoryCache = true) {
+      it.toBuilder().setUseCellularData(useData).build()
+    }.invokeOnCompletion {
+      it?.let {
+        logger.e("DOMAIN", "Failed when storing the user's preference to use cellular data to download topic.", it)
+      }
+    }
+  }
+
+  /** Returns a [LiveData] result indicating the user's topic download preferences. */
+  fun getTopicDownloadPreference(): LiveData<AsyncResult<TopicDownloadPreference>> {
+    return dataProviders.convertToLiveData(topicDownloadStore)
+  }
+}

--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -237,3 +237,12 @@ message CellularDataPreference {
   // Preference on whether to use cellular data
   bool use_cellular_data = 2;
 }
+
+// Represents user's preference for downloading topic to device
+message TopicDownloadPreference {
+  // Preference on whether to hide TopicDownloadDialogFragment
+  bool hide_dialog = 1;
+
+  // Preference on whether to download topic on cellular data
+  bool use_cellular_data = 2;
+}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

This PR is based on #236 

Mock: https://xd.adobe.com/spec/e2239cf4-9cde-4c08-5296-25316c1f0a14-9412/screen/b98da363-bac6-4f7d-b1d2-ee0f9aa048c4/Topic-w-o-Play-8

This PR mainly introduces the TopicDownloadDialogController which saves user preference related to topic download.

Download topic and delete topic low-fi part finished in this PR.

For testing purpose make following change in code:
1. Launcher activity should be `TopicActivity`
2. Inside `TopicActivityPresenter` change `TopicFragment` to `TopicOverviewFragment`

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is **assigned** to an appropriate reviewer.
