### PR TITLE
Fix #281: Broken AudioFragmentTest build when built for Espresso

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,6 +87,7 @@ dependencies {
       'androidx.test.ext:junit:1.1.1',
       'androidx.test:runner:1.2.0',
       'com.google.truth:truth:0.43',
+      'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.2'
   )
   androidTestUtil(
       'androidx.test:orchestrator:1.2.0',

--- a/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
@@ -67,6 +67,7 @@ class HomeActivityTest {
   @After
   fun tearDown() {
     IdlingRegistry.getInstance().unregister(MainThreadExecutor.countingResource)
+    Intents.release()
   }
 
   @Test

--- a/app/src/sharedTest/java/org/oppia/app/player/audio/AudioFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/audio/AudioFragmentTest.kt
@@ -3,6 +3,7 @@ package org.oppia.app.player.audio
 import android.app.Application
 import android.content.Context
 import android.content.res.Configuration
+import android.media.MediaPlayer
 import android.net.Uri
 import android.view.View
 import android.widget.ImageView
@@ -43,10 +44,7 @@ import org.oppia.util.logging.GlobalLogLevel
 import org.oppia.util.logging.LogLevel
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
-import org.robolectric.Shadows
 import javax.inject.Singleton
-import org.robolectric.shadows.ShadowMediaPlayer
-import org.robolectric.shadows.util.DataSource
 import javax.inject.Inject
 import javax.inject.Qualifier
 
@@ -65,7 +63,7 @@ class AudioFragmentTest {
 
   @Inject
   lateinit var audioPlayerController: AudioPlayerController
-  private lateinit var shadowMediaPlayer: ShadowMediaPlayer
+  private lateinit var shadowMediaPlayer: Any
 
   private val TEST_URL = "https://storage.googleapis.com/oppiaserver-resources/exploration/DIWZiVgs0km-/assets/audio/content-hi-en-u0rzwuys9s7ur1kg3b5zsemi.mp3"
   private val TEST_URL2 = "https://storage.googleapis.com/oppiaserver-resources/exploration/DIWZiVgs0km-/assets/audio/content-es-4lbxy0bwo4g.mp3"
@@ -74,8 +72,8 @@ class AudioFragmentTest {
   fun setUp() {
     setUpTestApplicationComponent()
     addMediaInfo()
-    shadowMediaPlayer = Shadows.shadowOf(audioPlayerController.getTestMediaPlayer())
-    shadowMediaPlayer.dataSource = DataSource.toDataSource(context, Uri.parse(TEST_URL))
+    shadowMediaPlayer = shadowOf(audioPlayerController.getTestMediaPlayer())
+    setDataSource(shadowMediaPlayer, toDataSource(context, Uri.parse(TEST_URL)))
     activityScenario = ActivityScenario.launch(AudioFragmentTestActivity::class.java)
   }
 
@@ -87,7 +85,7 @@ class AudioFragmentTest {
 
   @Test
   fun testAudioFragment_invokePrepared_clickPlayButton_showsPauseButton() {
-    shadowMediaPlayer.invokePreparedListener()
+    invokePreparedListener(shadowMediaPlayer)
 
     onView(withId(R.id.ivPlayPauseAudio)).perform(click())
 
@@ -96,7 +94,7 @@ class AudioFragmentTest {
 
   @Test
   fun testAudioFragment_invokePrepared_touchSeekBar_checkStillPaused() {
-    shadowMediaPlayer.invokePreparedListener()
+    invokePreparedListener(shadowMediaPlayer)
 
     onView(withId(R.id.sbAudioProgress)).perform(clickSeekBar(100))
 
@@ -105,7 +103,7 @@ class AudioFragmentTest {
 
   @Test
   fun testAudioFragment_invokePrepared_clickPlay_touchSeekBar_checkStillPlaying() {
-    shadowMediaPlayer.invokePreparedListener()
+    invokePreparedListener(shadowMediaPlayer)
 
     onView(withId(R.id.ivPlayPauseAudio)).perform(click())
     onView(withId(R.id.sbAudioProgress)).perform(clickSeekBar(100))
@@ -116,7 +114,7 @@ class AudioFragmentTest {
 
   @Test
   fun testAudioFragment_invokePrepared_playAudio_configurationChange_checkStillPlaying() {
-    shadowMediaPlayer.invokePreparedListener()
+    invokePreparedListener(shadowMediaPlayer)
     onView(withId(R.id.ivPlayPauseAudio)).perform(click())
     onView(withId(R.id.sbAudioProgress)).perform(clickSeekBar(100))
 
@@ -129,7 +127,7 @@ class AudioFragmentTest {
 
   @Test
   fun testAudioFragment_invokePrepared_changeDifferentLanguage_checkResetSeekBarAndPaused() {
-    shadowMediaPlayer.invokePreparedListener()
+    invokePreparedListener(shadowMediaPlayer)
     onView(withId(R.id.ivPlayPauseAudio)).perform(click())
     onView(withId(R.id.sbAudioProgress)).perform(clickSeekBar(100))
 
@@ -190,11 +188,57 @@ class AudioFragmentTest {
   }
 
   private fun addMediaInfo() {
-    val dataSource = DataSource.toDataSource(context , Uri.parse(TEST_URL))
-    val dataSource2 = DataSource.toDataSource(context , Uri.parse(TEST_URL2))
-    val mediaInfo = ShadowMediaPlayer.MediaInfo(/* duration= */ 1000,/* preparationDelay= */ 0)
-    ShadowMediaPlayer.addMediaInfo(dataSource, mediaInfo)
-    ShadowMediaPlayer.addMediaInfo(dataSource2, mediaInfo)
+    val dataSource = toDataSource(context , Uri.parse(TEST_URL))
+    val dataSource2 = toDataSource(context , Uri.parse(TEST_URL2))
+    val mediaInfo = createMediaInfo(/* duration= */ 1000,/* preparationDelay= */ 0)
+    addMediaInfo(dataSource, mediaInfo)
+    addMediaInfo(dataSource2, mediaInfo)
+  }
+
+  // TODO(#59): Replace the reflection code below with direct calls to Robolectric once this test can be made to run
+  //  only on Robolectric (or properly on Espresso without relying on Robolectric shadows, e.g. by using compile-time
+  //  replaceable fakes).
+
+  // NOTE TO DEVELOPERS: DO NOT REPLICATE THE REFLECTION CODE BELOW ANYWHERE. THIS IS A STOP-GAP MEASURE UNTIL WE CAN
+  // USE BAZEL TO PROPERLY BUILD THIS TEST SPECIFICALLY FOR ROBOLECTRIC AND NOT FOR ESPRESSO.
+
+  /** Calls Robolectric's Shadows.shadowOf() using reflection. */
+  private fun shadowOf(mediaPlayer: MediaPlayer): Any {
+    val shadowsClass = Class.forName("org.robolectric.Shadows")
+    return shadowsClass.getMethod("shadowOf", MediaPlayer::class.java).invoke(/* obj= */ null, mediaPlayer)
+  }
+
+  /** Calls ShadowMediaPlayer.setDataSource() using reflection. */
+  private fun setDataSource(shadowMediaPlayer: Any, dataSource: Any) {
+    val dataSourceClass = Class.forName("org.robolectric.shadows.util.DataSource")
+    shadowMediaPlayer.javaClass.getMethod("setDataSource", dataSourceClass).invoke(shadowMediaPlayer, dataSource)
+  }
+
+  /** Calls ShadowMediaPlayer.invokePreparedListener() using reflection. */
+  private fun invokePreparedListener(shadowMediaPlayer: Any) {
+    shadowMediaPlayer.javaClass.getMethod("invokePreparedListener").invoke(shadowMediaPlayer)
+  }
+
+  /** Returns a new ShadowMediaPlayer.MediaInfo using reflection. */
+  private fun createMediaInfo(duration: Int, preparationDelay: Int): Any {
+    val mediaInfoClass = Class.forName("org.robolectric.shadows.ShadowMediaPlayer\$MediaInfo")
+    return mediaInfoClass.getConstructor(Int::class.java, Int::class.java).newInstance(duration, preparationDelay)
+  }
+
+  /** Calls ShadowMediaPlayer.addMediaInfo() using reflection. */
+  private fun addMediaInfo(dataSource: Any, mediaInfo: Any) {
+    val shadowMediaPlayerClass = Class.forName("org.robolectric.shadows.ShadowMediaPlayer")
+    val dataSourceClass = Class.forName("org.robolectric.shadows.util.DataSource")
+    val mediaInfoClass = Class.forName("org.robolectric.shadows.ShadowMediaPlayer\$MediaInfo")
+    val addMediaInfoMethod = shadowMediaPlayerClass.getMethod("addMediaInfo", dataSourceClass, mediaInfoClass)
+    addMediaInfoMethod.invoke(/* obj= */ null, dataSource, mediaInfo)
+  }
+
+  /** Calls DataSource.toDataSource() using reflection. */
+  private fun toDataSource(context: Context, uri: Uri): Any {
+    val dataSourceClass = Class.forName("org.robolectric.shadows.util.DataSource")
+    val toDataSourceMethod = dataSourceClass.getMethod("toDataSource", Context::class.java, Uri::class.java)
+    return toDataSourceMethod.invoke(/* obj= */ null, context, uri)
   }
 
   @Qualifier


### PR DESCRIPTION
Fixes #281 by relying on reflection for interacting with Robolectric instead of direct references until #59 is resolved and we can avoid building AudioFragmentTest on Espresso, or until we have a way to properly test the audio fragment on both.

This pattern should NOT be replicated for any other test. It's a stop-gap solution.

I verified that all Espresso tests now build and run, and the output for AudioFragmentTest via Robolectric matches its current output (which appears to be broken--FYI @jamesxu0 ).

Many of our tests are broken on both Robolectric and Espresso, but this at least unblocks building Espresso tests without needing to comment out the file. #73 appears a lot more important now. We should look into setting that up before #59 is resolved at this point.

NB: This includes one fix in HomeActivityTest that I noticed was missing when testing.