### PR TITLE
Fix #257: Add support for tracking the upcoming state for past states in ExplorationProgressController

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,6 @@ utility/build
 /build
 /captures
 .externalNativeBuild
-./gradle
-./gradlew
-./gradlew.bat
+gradle
+gradlew
+gradlew.bat

--- a/domain/src/main/java/org/oppia/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/domain/exploration/ExplorationProgressController.kt
@@ -401,6 +401,7 @@ class ExplorationProgressController @Inject constructor(
       val answerOutcomeBuilder = AnswerOutcome.newBuilder()
         .setFeedback(outcome.feedback)
         .setLabelledAsCorrectAnswer(outcome.labelledAsCorrect)
+        .setState(currentState)
       when {
         outcome.refresherExplorationId.isNotEmpty() ->
           answerOutcomeBuilder.refresherExplorationId = outcome.refresherExplorationId
@@ -436,7 +437,13 @@ class ExplorationProgressController @Inject constructor(
     /** Navigates to the next State in the deck, or fails if this isn't possible. */
     internal fun navigateToNextState() {
       check(!isCurrentStateTopOfDeck()) { "Cannot navigate to next state; at most recent state." }
+      val previousState = previousStates[stateIndex]
       stateIndex++
+      if (!previousState.hasNextState) {
+        // Update the previous state to indicate that it has a next state now that its next state has actually been
+        // 'created' by navigating to it.
+        previousStates[stateIndex - 1] = previousState.toBuilder().setHasNextState(true).build()
+      }
     }
 
     /**
@@ -470,6 +477,8 @@ class ExplorationProgressController @Inject constructor(
       check(!isCurrentStateTerminal()) { "Cannot push another state after reaching a terminal state." }
       check(currentDialogInteractions.size != 0) { "Cannot push another state without an answer." }
       check(state.name != pendingTopState.name) { "Cannot route from the same state to itself as a new card." }
+      // NB: This technically has a 'next' state, but it's not marked until it's first navigated away since the new
+      // state doesn't become fully realized until navigated to.
       previousStates += EphemeralState.newBuilder()
         .setState(pendingTopState)
         .setHasPreviousState(!isCurrentStateInitial())

--- a/model/src/main/proto/exploration.proto
+++ b/model/src/main/proto/exploration.proto
@@ -151,18 +151,22 @@ message EphemeralState {
   // of the exploration.
   bool has_previous_state = 2;
 
+  // Whether this specific state has an upcoming state that the learner can navigate to (indicating that this is not
+  // the state at the top of the current state deck).
+  bool has_next_state = 3;
+
   // Different types this state can take depending on whether the learner needs to finish an existing card, has
   // navigated to a previous card, or has reached the end of the exploration.
   oneof state_type {
     // A pending state that requires a correct answer to continue.
-    PendingState pending_state = 3;
+    PendingState pending_state = 4;
 
     // A previous state completed by the learner.
-    CompletedState completed_state = 4;
+    CompletedState completed_state = 5;
 
     // This value is always true in the case where the state type is terminal. This type may change in the future to a
     // message structure if additional data needs to be passed along to the terminal state card.
-    bool terminal_state = 5;
+    bool terminal_state = 6;
   }
 }
 
@@ -196,21 +200,25 @@ message AnswerOutcome {
   // correctness, and not all correct answers are guaranteed to be labelled as correct.
   bool labelled_as_correct_answer = 2;
 
+  // The State the answer was submitted in (to help downstream observers make decisions based on the State without
+  // needing to synchronize with other data providers).
+  State state = 3;
+
   // One of several destinations the learner should be routed to as a result of submitting this answer.
   oneof destination {
     // Indicates that the learner should not progress past the current state.
-    bool same_state = 3;
+    bool same_state = 4;
 
     // Indicates that the learner should move to the next state. This contains the name of that state, but this isn't
     // meant to be used by the UI directly beyond for logging purposes.
-    string state_name = 4;
+    string state_name = 5;
 
     // Indicates that the learner should be shown a concept card corresponding to the specified skill ID to refresh the
     // concept before proceeding.
-    string missing_prerequisite_skill_id = 5;
+    string missing_prerequisite_skill_id = 6;
 
     // Indicates that the learner needs to play the specified exploration ID to refresh missing topics and then return
     // to restart the current exploration.
-    string refresher_exploration_id = 6;
+    string refresher_exploration_id = 7;
   }
 }


### PR DESCRIPTION
This PR fixes  #257 by reporting in ``EphemeralState`` whether that state has another after it to avoid downstream code needing to track this for back-and-forth navigation. This PR includes tests to verify various cases around when next state is set (for example, submitting an answer triggers the availability of a next state, but no next state actually exists until ``moveToNextState()`` is called since the UI itself shouldn't need to display the navigate next button until after the submit button is pressed to proceed).

This also includes passing along the ``State`` object for submitted answers, and a small update to .gitignore.

This PR was split out of #270.