### PR TITLE
Fix #302: Start SplashActivity upon opening the app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,17 +12,14 @@
     android:supportsRtl="true"
     android:theme="@style/OppiaTheme">
     <activity android:name=".home.ContinuePlayingActivity" />
-    <activity android:name=".topic.conceptcard.testing.ConceptCardFragmentTestActivity" />
-    <activity android:name=".testing.ContentCardTestActivity" />
-    <activity android:name=".player.state.testing.StateFragmentTestActivity" />
-    <activity android:name=".player.exploration.ExplorationActivity" />
-    <activity android:name=".topic.questionplayer.QuestionPlayerActivity" />
-    <activity android:name=".topic.TopicActivity" />
+    <activity android:name=".home.HomeActivity" />
     <activity android:name=".player.audio.testing.AudioFragmentTestActivity" />
-    <activity android:name=".testing.InputInteractionViewTestActivity" />
+    <activity android:name=".player.exploration.ExplorationActivity" />
+    <activity android:name=".player.state.testing.StateFragmentTestActivity" />
     <activity android:name=".profile.ProfileActivity" />
-    <activity android:name=".story.StoryActivity" />
-    <activity android:name=".home.HomeActivity">
+    <activity
+      android:name=".splash.SplashActivity"
+      android:theme="@style/SplashScreenTheme">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
@@ -32,10 +29,13 @@
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
     </activity>
-    <activity
-      android:name=".splash.SplashActivity"
-      android:theme="@style/SplashScreenTheme" />
-    <activity android:name=".testing.HtmlParserTestActivity" />
+    <activity android:name=".story.StoryActivity" />
     <activity android:name=".testing.BindableAdapterTestActivity" />
+    <activity android:name=".testing.ContentCardTestActivity" />
+    <activity android:name=".testing.HtmlParserTestActivity" />
+    <activity android:name=".testing.InputInteractionViewTestActivity" />
+    <activity android:name=".topic.TopicActivity" />
+    <activity android:name=".topic.conceptcard.testing.ConceptCardFragmentTestActivity" />
+    <activity android:name=".topic.questionplayer.QuestionPlayerActivity" />
   </application>
 </manifest>


### PR DESCRIPTION
Fixes #302: start SplashActivity upon opening the app. Also, alphabetize activities in the main app manifest.