### PR TITLE
Fix part of #134: Home fragment text fix

### DIFF
--- a/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.Transformations
 import androidx.recyclerview.widget.GridLayoutManager
 import org.oppia.app.databinding.HomeFragmentBinding
 import org.oppia.app.fragment.FragmentScope
+import org.oppia.app.home.topiclist.AllTopicsViewModel
 import org.oppia.app.home.topiclist.PromotedStoryViewModel
 import org.oppia.app.home.topiclist.TopicListAdapter
 import org.oppia.app.home.topiclist.TopicSummaryClickListener
@@ -58,7 +59,7 @@ class HomeFragmentPresenter @Inject constructor(
     val homeLayoutManager = GridLayoutManager(activity.applicationContext, 2)
     homeLayoutManager.spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {
       override fun getSpanSize(position: Int): Int {
-        return if (position == 0 || position == 1) {
+        return if (position == 0 || position == 1 || position == 2) {
           /* number of spaces this item should occupy = */ 2
         } else {
           /* number of spaces this item should occupy = */ 1
@@ -109,6 +110,10 @@ class HomeFragmentPresenter @Inject constructor(
       val promotedStoryViewModel = PromotedStoryViewModel(activity)
       promotedStoryViewModel.setPromotedStory(result.promotedStory)
       itemList.add(promotedStoryViewModel)
+      if(result.topicSummaryList.isNotEmpty()){
+        val allTopicsViewModel = AllTopicsViewModel()
+        itemList.add(allTopicsViewModel)
+      }
       for (topicSummary in result.topicSummaryList) {
         val topicSummaryViewModel = TopicSummaryViewModel(topicSummary, fragment as TopicSummaryClickListener)
         itemList.add(topicSummaryViewModel)

--- a/app/src/main/java/org/oppia/app/home/topiclist/AllTopicsViewModel.kt
+++ b/app/src/main/java/org/oppia/app/home/topiclist/AllTopicsViewModel.kt
@@ -3,5 +3,5 @@ package org.oppia.app.home.topiclist
 import androidx.lifecycle.ViewModel
 import org.oppia.app.home.HomeItemViewModel
 
-/** [ViewModel] all topic text in [HomeFragment]. */
+/** [ViewModel] all topics text in [HomeFragment]. */
 class AllTopicsViewModel : HomeItemViewModel()

--- a/app/src/main/java/org/oppia/app/home/topiclist/AllTopicsViewModel.kt
+++ b/app/src/main/java/org/oppia/app/home/topiclist/AllTopicsViewModel.kt
@@ -1,0 +1,7 @@
+package org.oppia.app.home.topiclist
+
+import androidx.lifecycle.ViewModel
+import org.oppia.app.home.HomeItemViewModel
+
+/** [ViewModel] all topic text in [HomeFragment]. */
+class AllTopicsViewModel : HomeItemViewModel()

--- a/app/src/main/java/org/oppia/app/home/topiclist/TopicListAdapter.kt
+++ b/app/src/main/java/org/oppia/app/home/topiclist/TopicListAdapter.kt
@@ -3,6 +3,7 @@ package org.oppia.app.home.topiclist
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import org.oppia.app.databinding.AllTopicsBinding
 import org.oppia.app.databinding.PromotedStoryCardBinding
 import org.oppia.app.databinding.TopicSummaryViewBinding
 import org.oppia.app.databinding.WelcomeBinding
@@ -11,7 +12,8 @@ import org.oppia.app.home.UserAppHistoryViewModel
 
 private const val VIEW_TYPE_WELCOME_MESSAGE = 1
 private const val VIEW_TYPE_PROMOTED_STORY = 2
-private const val VIEW_TYPE_TOPIC_LIST = 3
+private const val VIEW_TYPE_ALL_TOPICS = 3
+private const val VIEW_TYPE_TOPIC_LIST = 4
 
 /** Adapter to inflate different items/views inside [RecyclerView]. The itemList consists of various ViewModels. */
 class TopicListAdapter(
@@ -42,6 +44,16 @@ class TopicListAdapter(
           )
         PromotedStoryViewHolder(binding)
       }
+      VIEW_TYPE_ALL_TOPICS -> {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding =
+          AllTopicsBinding.inflate(
+            inflater,
+            parent,
+            /* attachToParent= */ false
+          )
+        AllTopicsViewHolder(binding)
+      }
       VIEW_TYPE_TOPIC_LIST -> {
         val inflater = LayoutInflater.from(parent.context)
         val binding =
@@ -64,6 +76,9 @@ class TopicListAdapter(
       VIEW_TYPE_PROMOTED_STORY -> {
         (holder as PromotedStoryViewHolder).bind(itemList[position] as PromotedStoryViewModel)
       }
+      VIEW_TYPE_ALL_TOPICS -> {
+        (holder as AllTopicsViewHolder).bind()
+      }
       VIEW_TYPE_TOPIC_LIST -> {
         (holder as TopicListViewHolder).bind(itemList[position] as TopicSummaryViewModel)
       }
@@ -77,6 +92,9 @@ class TopicListAdapter(
       }
       is PromotedStoryViewModel -> {
         VIEW_TYPE_PROMOTED_STORY
+      }
+      is AllTopicsViewModel -> {
+        VIEW_TYPE_ALL_TOPICS
       }
       is TopicSummaryViewModel -> {
         VIEW_TYPE_TOPIC_LIST
@@ -102,6 +120,13 @@ class TopicListAdapter(
   ) : RecyclerView.ViewHolder(binding.root) {
     internal fun bind(promotedStoryViewModel: PromotedStoryViewModel) {
       binding.viewModel = promotedStoryViewModel
+    }
+  }
+
+  private class AllTopicsViewHolder(
+    val binding: AllTopicsBinding
+  ) : RecyclerView.ViewHolder(binding.root) {
+    internal fun bind() {
     }
   }
 

--- a/app/src/main/res/layout/all_topics.xml
+++ b/app/src/main/res/layout/all_topics.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <data>
+
+    <import type="android.view.View" />
+
+    <variable
+      name="viewModel"
+      type="org.oppia.app.home.topiclist.PromotedStoryViewModel" />
+  </data>
+
+  <FrameLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+      android:id="@+id/all_topics_text_view"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="24dp"
+      android:layout_marginTop="16dp"
+      android:layout_marginEnd="24dp"
+      android:layout_marginBottom="16dp"
+      android:text="@string/all_topics"
+      android:textColor="@color/oppiaPrimaryText"
+      android:textSize="18sp"
+      android:textStyle="bold" />
+  </FrameLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
   <string name="view_all">View All</string>
   <string name="ongoing_story_last_week">Played within the Last Week</string>
   <string name="ongoing_story_last_month">Played within the Last Month</string>
+  <string name="all_topics">All Topics</string>
   <plurals name="chapter_count">
     <item quantity="one">
       1 Chapter

--- a/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
@@ -214,36 +214,12 @@ class HomeActivityTest {
   }
 
   @Test
-  fun testHomeActivity_recyclerViewIndex2_topicSummary_topicNameIsCorrect() {
-    launch(HomeActivity::class.java).use {
-      onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(2))
-      onView(atPositionOnView(R.id.home_recycler_view, 2, R.id.topic_name_text_view)).check(
-        matches(
-          withText(containsString("First Topic"))
-        )
-      )
-    }
-  }
-
-  @Test
-  fun testHomeActivity_recyclerViewIndex2_topicSummary_lessonCountIsCorrect() {
-    launch(HomeActivity::class.java).use {
-      onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(2))
-      onView(atPositionOnView(R.id.home_recycler_view, 2, R.id.lesson_count_text_view)).check(
-        matches(
-          withText(containsString("2 Lessons"))
-        )
-      )
-    }
-  }
-
-  @Test
   fun testHomeActivity_recyclerViewIndex3_topicSummary_topicNameIsCorrect() {
     launch(HomeActivity::class.java).use {
       onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(3))
       onView(atPositionOnView(R.id.home_recycler_view, 3, R.id.topic_name_text_view)).check(
         matches(
-          withText(containsString("Second Topic"))
+          withText(containsString("First Topic"))
         )
       )
     }
@@ -255,18 +231,29 @@ class HomeActivityTest {
       onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(3))
       onView(atPositionOnView(R.id.home_recycler_view, 3, R.id.lesson_count_text_view)).check(
         matches(
-          withText(containsString("1 Lesson"))
+          withText(containsString("2 Lessons"))
         )
       )
     }
   }
 
   @Test
-  fun testHomeActivity_recyclerViewIndex3_topicSummary_configurationChange_lessonCountIsCorrect() {
+  fun testHomeActivity_recyclerViewIndex4_topicSummary_topicNameIsCorrect() {
     launch(HomeActivity::class.java).use {
-      onView(isRoot()).perform(orientationLandscape())
-      onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(3))
-      onView(atPositionOnView(R.id.home_recycler_view, 3, R.id.lesson_count_text_view)).check(
+      onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(4))
+      onView(atPositionOnView(R.id.home_recycler_view, 4, R.id.topic_name_text_view)).check(
+        matches(
+          withText(containsString("Second Topic"))
+        )
+      )
+    }
+  }
+
+  @Test
+  fun testHomeActivity_recyclerViewIndex4_topicSummary_lessonCountIsCorrect() {
+    launch(HomeActivity::class.java).use {
+      onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(4))
+      onView(atPositionOnView(R.id.home_recycler_view, 4, R.id.lesson_count_text_view)).check(
         matches(
           withText(containsString("1 Lesson"))
         )
@@ -275,10 +262,23 @@ class HomeActivityTest {
   }
 
   @Test
-  fun testHomeActivity_recyclerViewIndex1_clickTopicSummary_opensTopicActivity() {
+  fun testHomeActivity_recyclerViewIndex4_topicSummary_configurationChange_lessonCountIsCorrect() {
     launch(HomeActivity::class.java).use {
-      onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(2))
-      onView(atPosition(R.id.home_recycler_view, 2)).perform(click())
+      onView(isRoot()).perform(orientationLandscape())
+      onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(4))
+      onView(atPositionOnView(R.id.home_recycler_view, 4, R.id.lesson_count_text_view)).check(
+        matches(
+          withText(containsString("1 Lesson"))
+        )
+      )
+    }
+  }
+
+  @Test
+  fun testHomeActivity_recyclerViewIndex3_clickTopicSummary_opensTopicActivity() {
+    launch(HomeActivity::class.java).use {
+      onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(3))
+      onView(atPosition(R.id.home_recycler_view, 3)).perform(click())
       intended(hasComponent(TopicActivity::class.java.name))
       intended(hasExtra(TopicActivity.TOPIC_ACTIVITY_TOPIC_ID_ARGUMENT_KEY, "test_topic_id_0"))
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

"All Topics" text was missing from HomeFragment just above Topic list.

I have added that as a item now.

Mock: https://xd.adobe.com/spec/e2239cf4-9cde-4c08-5296-25316c1f0a14-9412/screen/d47aa8de-a7a8-4d25-b011-5baefc7b7098/HP-Home-Page-


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
