### PR TITLE
Fix topic-play-expanded-list

### DIFF
--- a/app/src/main/java/org/oppia/app/topic/play/TopicPlayFragment.kt
+++ b/app/src/main/java/org/oppia/app/topic/play/TopicPlayFragment.kt
@@ -24,7 +24,10 @@ class TopicPlayFragment : InjectableFragment(), ExpandedChapterListIndexListener
 
   override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
     if (savedInstanceState != null) {
-      currentExpandedChapterListIndex = savedInstanceState.getInt(KEY_CURRENT_EXPANDED_LIST_INDEX)
+      currentExpandedChapterListIndex = savedInstanceState.getInt(KEY_CURRENT_EXPANDED_LIST_INDEX, -1)
+      if (currentExpandedChapterListIndex == -1) {
+        currentExpandedChapterListIndex = null
+      }
     }
     return topicPlayFragmentPresenter.handleCreateView(
       inflater,
@@ -36,7 +39,7 @@ class TopicPlayFragment : InjectableFragment(), ExpandedChapterListIndexListener
 
   override fun onSaveInstanceState(outState: Bundle) {
     super.onSaveInstanceState(outState)
-    if(currentExpandedChapterListIndex!=null) {
+    if (currentExpandedChapterListIndex != null) {
       outState.putInt(KEY_CURRENT_EXPANDED_LIST_INDEX, currentExpandedChapterListIndex!!)
     }
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

By default `savedInstanceState.getInt(KEY_CURRENT_EXPANDED_LIST_INDEX)` was giving 0 value and because of which the first index was getting opened on Topic-Play unexpectedly. So made sure that the default value is -1 which will then be changed to `null`

Testing:
Switch between TopicPlayTab and TopicReviewTab and note that no item should expand in TopicPlayTab or if there is an expanded item, that should remain intact.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
