### PR TITLE
Fix #324: Fixed crash on enter button on soft keyboard

### DIFF
--- a/app/src/main/res/layout/fraction_interaction_item.xml
+++ b/app/src/main/res/layout/fraction_interaction_item.xml
@@ -35,6 +35,7 @@
         android:hint="@string/fractions_hint_text"
         android:inputType="text"
         android:longClickable="false"
+        android:imeOptions="actionDone"
         android:maxLength="200"
         android:padding="8dp"
         android:singleLine="true"

--- a/app/src/main/res/layout/numeric_input_interaction_item.xml
+++ b/app/src/main/res/layout/numeric_input_interaction_item.xml
@@ -27,6 +27,7 @@
       android:hint="@string/number_input_hint_text"
       android:inputType="numberDecimal"
       android:longClickable="false"
+      android:imeOptions="actionDone"
       android:maxLength="200"
       android:padding="8dp"
       android:singleLine="true"

--- a/app/src/main/res/layout/text_input_interaction_item.xml
+++ b/app/src/main/res/layout/text_input_interaction_item.xml
@@ -27,6 +27,7 @@
       android:inputType="text"
       android:longClickable="false"
       android:maxLength="200"
+      android:imeOptions="actionDone"
       android:padding="8dp"
       android:singleLine="true"
       android:text="@={viewModel.answerText}"


### PR DESCRIPTION

## Explanation
Hide Soft keyboard on return key press by adding imeOptions as Done in all edit_text input interactions.
