### PR TITLE
Fix part of #10: Hifi continue playing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,9 @@
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"
     android:theme="@style/OppiaTheme">
-    <activity android:name=".home.continueplaying.ContinuePlayingActivity" />
+    <activity
+      android:name=".home.continueplaying.ContinuePlayingActivity"
+      android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity android:name=".testing.ContinuePlayingFragmentTestActivity" />
     <activity android:name=".home.HomeActivity" />
     <activity android:name=".player.audio.testing.AudioFragmentTestActivity" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
     <activity
       android:name=".home.continueplaying.ContinuePlayingActivity"
       android:theme="@style/OppiaThemeWithoutActionBar" />
-    <activity android:name=".testing.ContinuePlayingFragmentTestActivity" />
     <activity android:name=".home.HomeActivity" />
     <activity android:name=".player.audio.testing.AudioFragmentTestActivity" />
     <activity
@@ -38,6 +37,7 @@
     <activity android:name=".story.testing.StoryFragmentTestActivity" />
     <activity android:name=".testing.BindableAdapterTestActivity" />
     <activity android:name=".testing.ContentCardTestActivity" />
+    <activity android:name=".testing.ContinuePlayingFragmentTestActivity" />
     <activity android:name=".testing.HtmlParserTestActivity" />
     <activity android:name=".testing.InputInteractionViewTestActivity" />
     <activity
@@ -46,10 +46,10 @@
     <activity
       android:name=".testing.TopicTestActivityForStory"
       android:theme="@style/OppiaThemeWithoutActionBar" />
+    <activity android:name=".topic.conceptcard.testing.ConceptCardFragmentTestActivity" />
+    <activity android:name=".topic.questionplayer.QuestionPlayerActivity" />
     <activity
       android:name=".topic.TopicActivity"
       android:theme="@style/OppiaThemeWithoutActionBar" />
-    <activity android:name=".topic.conceptcard.testing.ConceptCardFragmentTestActivity" />
-    <activity android:name=".topic.questionplayer.QuestionPlayerActivity" />
   </application>
 </manifest>

--- a/app/src/main/java/org/oppia/app/home/continueplaying/ContinuePlayingFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/continueplaying/ContinuePlayingFragmentPresenter.kt
@@ -37,6 +37,10 @@ class ContinuePlayingFragmentPresenter @Inject constructor(
   fun handleCreateView(inflater: LayoutInflater, container: ViewGroup?): View? {
     binding = ContinuePlayingFragmentBinding.inflate(inflater, container, /* attachToRoot= */ false)
 
+    binding.toolbar.setNavigationOnClickListener {
+      (activity as ContinuePlayingActivity).finish()
+    }
+
     ongoingListAdapter = OngoingListAdapter(itemList)
 
     binding.ongoingStoryRecyclerView.apply {

--- a/app/src/main/res/layout/continue_playing_fragment.xml
+++ b/app/src/main/res/layout/continue_playing_fragment.xml
@@ -36,6 +36,7 @@
       android:layout_height="0dp"
       android:clipToPadding="false"
       android:overScrollMode="never"
+      android:paddingTop="8dp"
       android:paddingBottom="128dp"
       android:scrollbars="none"
       app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"

--- a/app/src/main/res/layout/continue_playing_fragment.xml
+++ b/app/src/main/res/layout/continue_playing_fragment.xml
@@ -2,17 +2,46 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
-  <LinearLayout
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/white"
-    android:orientation="vertical">
+    android:background="@color/white">
+
+    <com.google.android.material.appbar.AppBarLayout
+      android:id="@+id/topic_app_bar_layout"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent">
+
+      <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:fontFamily="sans-serif"
+        android:minHeight="?attr/actionBarSize"
+        android:textSize="20sp"
+        app:navigationContentDescription="@string/go_to_previous_page"
+        app:navigationIcon="?attr/homeAsUpIndicator"
+        app:title="@string/continue_playing_activity"
+        app:titleTextColor="@color/white" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.recyclerview.widget.RecyclerView
       android:id="@+id/ongoing_story_recycler_view"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
+      android:layout_width="0dp"
+      android:layout_height="0dp"
+      android:clipToPadding="false"
       android:overScrollMode="never"
-      app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
-  </LinearLayout>
+      android:paddingBottom="128dp"
+      android:scrollbars="none"
+      app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/topic_app_bar_layout" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/ongoing_story_card.xml
+++ b/app/src/main/res/layout/ongoing_story_card.xml
@@ -17,6 +17,7 @@
     android:layout_marginStart="28dp"
     android:layout_marginTop="28dp"
     android:layout_marginEnd="28dp"
+    app:cardBackgroundColor="@color/white"
     app:cardCornerRadius="4dp"
     app:cardElevation="4dp">
 
@@ -28,10 +29,11 @@
       <ImageView
         android:id="@+id/lesson_thumbnail"
         android:layout_width="80dp"
-        android:layout_height="45dp"
+        android:layout_height="44dp"
         android:layout_marginStart="8dp"
         android:importantForAccessibility="no"
         android:paddingStart="40dp"
+        android:paddingTop="4dp"
         android:paddingEnd="40dp"
         android:scaleType="centerCrop"
         android:src="@{viewModel.ongoingStory.lessonThumbnail.thumbnailGraphic}"
@@ -56,14 +58,14 @@
 
         <TextView
           android:id="@+id/chapter_name_text_view"
-          android:textSize="18sp"
-          android:textColor="@color/oppiaPrimaryText"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:ellipsize="end"
-          android:maxLines="1"
           android:fontFamily="sans-serif-medium"
-          android:text="@{viewModel.ongoingStory.nextChapterName}" />
+          android:maxLines="1"
+          android:text="@{viewModel.ongoingStory.nextChapterName}"
+          android:textColor="@color/oppiaPrimaryText"
+          android:textSize="18sp" />
 
         <TextView
           android:id="@+id/story_name_text_view"
@@ -72,8 +74,8 @@
           android:layout_marginTop="4dp"
           android:layout_marginBottom="4dp"
           android:ellipsize="end"
-          android:maxLines="1"
           android:fontFamily="sans-serif"
+          android:maxLines="1"
           android:text="@{viewModel.ongoingStory.storyName}"
           android:textColor="@color/oppiaPrimaryText"
           android:textSize="16sp" />
@@ -83,12 +85,12 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:ellipsize="end"
-          android:maxLines="1"
-          android:textSize="14sp"
-          android:textColor="@color/oppiaPrimaryText"
           android:fontFamily="sans-serif-light"
+          android:maxLines="1"
           android:text="@{viewModel.ongoingStory.topicName}"
-          android:textAllCaps="true" />
+          android:textAllCaps="true"
+          android:textColor="@color/oppiaPrimaryText"
+          android:textSize="14sp" />
       </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
   </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/ongoing_story_card.xml
+++ b/app/src/main/res/layout/ongoing_story_card.xml
@@ -14,23 +14,22 @@
   <com.google.android.material.card.MaterialCardView
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginStart="24dp"
-    android:layout_marginTop="8dp"
-    android:layout_marginEnd="24dp"
-    android:layout_marginBottom="8dp"
-    app:cardCornerRadius="2dp"
+    android:layout_marginStart="28dp"
+    android:layout_marginTop="28dp"
+    android:layout_marginEnd="28dp"
+    app:cardCornerRadius="4dp"
     app:cardElevation="4dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:onClick="@{viewModel::clickOnOngoingStoryTile}"
-      android:padding="8dp">
+      android:onClick="@{viewModel::clickOnOngoingStoryTile}">
 
       <ImageView
         android:id="@+id/lesson_thumbnail"
         android:layout_width="80dp"
         android:layout_height="45dp"
+        android:layout_marginStart="8dp"
         android:importantForAccessibility="no"
         android:paddingStart="40dp"
         android:paddingEnd="40dp"
@@ -44,6 +43,10 @@
       <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginEnd="12dp"
+        android:layout_marginBottom="12dp"
         android:background="@color/white"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -53,40 +56,37 @@
 
         <TextView
           android:id="@+id/chapter_name_text_view"
-          style="@style/TextAppearance.AppCompat.Subhead"
+          android:textSize="18sp"
+          android:textColor="@color/oppiaPrimaryText"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginStart="16dp"
-          android:layout_marginTop="8dp"
-          android:layout_marginEnd="16dp"
           android:ellipsize="end"
           android:maxLines="1"
+          android:fontFamily="sans-serif-medium"
           android:text="@{viewModel.ongoingStory.nextChapterName}" />
 
         <TextView
           android:id="@+id/story_name_text_view"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginStart="16dp"
-          android:layout_marginTop="8dp"
-          android:layout_marginEnd="16dp"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="4dp"
           android:ellipsize="end"
           android:maxLines="1"
+          android:fontFamily="sans-serif"
           android:text="@{viewModel.ongoingStory.storyName}"
           android:textColor="@color/oppiaPrimaryText"
           android:textSize="16sp" />
 
         <TextView
           android:id="@+id/topic_name_text_view"
-          style="@style/TextAppearance.AppCompat.Caption"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginStart="16dp"
-          android:layout_marginTop="8dp"
-          android:layout_marginEnd="16dp"
-          android:layout_marginBottom="8dp"
           android:ellipsize="end"
           android:maxLines="1"
+          android:textSize="14sp"
+          android:textColor="@color/oppiaPrimaryText"
+          android:fontFamily="sans-serif-light"
           android:text="@{viewModel.ongoingStory.topicName}"
           android:textAllCaps="true" />
       </LinearLayout>

--- a/app/src/main/res/layout/section_title.xml
+++ b/app/src/main/res/layout/section_title.xml
@@ -19,22 +19,20 @@
       android:id="@+id/divider_view"
       android:layout_width="match_parent"
       android:layout_height="1dp"
-      android:layout_marginTop="8dp"
-      android:layout_marginBottom="8dp"
-      android:background="@color/grey"
+      android:layout_marginTop="28dp"
+      android:background="@color/divider"
       android:visibility="@{viewModel.isDividerVisible? View.VISIBLE : View.GONE}" />
 
     <TextView
       android:id="@+id/section_title_text_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginStart="24dp"
-      android:layout_marginTop="16dp"
-      android:layout_marginEnd="24dp"
-      android:layout_marginBottom="16dp"
+      android:layout_marginStart="28dp"
+      android:layout_marginTop="28dp"
+      android:layout_marginEnd="28dp"
+      android:fontFamily="sans-serif-medium"
       android:text="@{viewModel.sectionTitleText}"
       android:textColor="@color/oppiaPrimaryText"
-      android:textSize="20sp"
-      android:textStyle="bold" />
+      android:textSize="18sp" />
   </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/section_title.xml
+++ b/app/src/main/res/layout/section_title.xml
@@ -25,7 +25,7 @@
 
     <TextView
       android:id="@+id/section_title_text_view"
-      android:layout_width="match_parent"
+      android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginStart="28dp"
       android:layout_marginTop="28dp"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -37,4 +37,5 @@
   <color name="grey_shade_40">#0000003D</color>
   <color name="blue_shade_100">#0F0086FB</color>
   <color name="blue_shade_200">#6B0086FB</color>
+  <color name="divider">#AFAFAF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,8 @@
   <string name="ongoing_story_last_week">Played within the Last Week</string>
   <string name="ongoing_story_last_month">Played within the Last Month</string>
   <string name="all_topics">All Topics</string>
+  <string name="go_to_previous_page">Go to previous page.</string>
+  <string name="continue_playing_activity">Continue playing</string>
   <plurals name="chapter_count">
     <item quantity="one">
       1 Chapter


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Mock Link: https://xd.adobe.com/spec/e2239cf4-9cde-4c08-5296-25316c1f0a14-9412/screen/2b6c8e95-5ac7-4472-bc2b-1c318a3f7e5c/HP-Continue-Playing-

Known Issues which needs discussion:
 - Issue: Divider line has color code `#00000061` in mocks but in android this is a transparent color or a blue color if we remove first two digits.
Current Implementation: Changed this color code to `#AFAFAF`
 - Issue: Card shadow is on all sides and is different from the default android code. Generally shadow is on three sides excluding the top.
Current Implementation: Keeping default android shadow.
- Issue: Toolbar has a shadow at bottom
Not solved currently.


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.

![Screenshot_1573545966](https://user-images.githubusercontent.com/9396084/68653289-68fb2200-0551-11ea-999a-cfee42f660c4.png)
