### PR TITLE
Fix #348: Fixed story fragment exploration routing

### DIFF
--- a/app/src/main/java/org/oppia/app/story/StoryViewModel.kt
+++ b/app/src/main/java/org/oppia/app/story/StoryViewModel.kt
@@ -12,6 +12,7 @@ import org.oppia.app.model.StorySummary
 import org.oppia.app.story.storyitemviewmodel.StoryChapterSummaryViewModel
 import org.oppia.app.story.storyitemviewmodel.StoryHeaderViewModel
 import org.oppia.app.story.storyitemviewmodel.StoryItemViewModel
+import org.oppia.domain.exploration.ExplorationDataController
 import org.oppia.domain.topic.TopicController
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.logging.Logger
@@ -22,6 +23,7 @@ import javax.inject.Inject
 class StoryViewModel @Inject constructor(
   private val fragment: Fragment,
   private val topicController: TopicController,
+  private val explorationDataController: ExplorationDataController,
   private val logger: Logger
 ) : ViewModel() {
   /** [storyId] needs to be set before any of the live data members can be accessed. */
@@ -77,7 +79,9 @@ class StoryViewModel @Inject constructor(
 
     // Add the rest of the list
     itemViewModelList.addAll(chapterList.mapIndexed { index, chapter ->
-      StoryChapterSummaryViewModel(index, explorationSelectionListener, chapter) as StoryItemViewModel
+      StoryChapterSummaryViewModel(
+        index, fragment, explorationSelectionListener, explorationDataController, logger, chapter
+      )
     })
 
     return itemViewModelList

--- a/app/src/main/java/org/oppia/app/story/storyitemviewmodel/StoryChapterSummaryViewModel.kt
+++ b/app/src/main/java/org/oppia/app/story/storyitemviewmodel/StoryChapterSummaryViewModel.kt
@@ -1,23 +1,45 @@
 package org.oppia.app.story.storyitemviewmodel
 
 import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
 import org.oppia.app.model.ChapterSummary
 import org.oppia.app.model.LessonThumbnail
 import org.oppia.app.story.ExplorationSelectionListener
 import org.oppia.app.story.StoryFragment
+import org.oppia.domain.exploration.ExplorationDataController
+import org.oppia.util.data.AsyncResult
+import org.oppia.util.logging.Logger
+
+private const val STORY_VIEWER_TAG = "StoryViewer"
 
 /** Chapter summary view model for the recycler view in [StoryFragment]. */
 class StoryChapterSummaryViewModel(
   val index: Int,
+  private val fragment: Fragment,
   private val explorationSelectionListener: ExplorationSelectionListener,
+  private val explorationDataController: ExplorationDataController,
+  private val logger: Logger,
   val chapterSummary: ChapterSummary
 ) : StoryItemViewModel() {
-  val id: String = chapterSummary.explorationId
+  val explorationId: String = chapterSummary.explorationId
   val name: String = chapterSummary.name
   val summary: String = chapterSummary.summary
   val chapterThumbnail: LessonThumbnail = chapterSummary.chapterThumbnail
 
   fun onExplorationClicked(v: View) {
-    explorationSelectionListener.selectExploration(id)
+    explorationDataController.stopPlayingExploration()
+    explorationDataController.startPlayingExploration(
+      explorationId
+    ).observe(fragment, Observer<AsyncResult<Any?>> { result ->
+      when {
+        result.isPending() -> logger.d(STORY_VIEWER_TAG, "Loading exploration")
+        result.isFailure() -> logger.e(STORY_VIEWER_TAG, "Failed to load exploration", result.getErrorOrNull()!!)
+        else -> {
+          logger.d(STORY_VIEWER_TAG, "Successfully loaded exploration: " + explorationId)
+          explorationSelectionListener.selectExploration(explorationId)
+        }
+      }
+    })
   }
 }

--- a/app/src/sharedTest/java/org/oppia/app/topic/play/TopicPlayFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/play/TopicPlayFragmentTest.kt
@@ -155,7 +155,7 @@ class TopicPlayFragmentTest {
   @Test
   fun testTopicPlayFragment_loadFragmentWithTopicTestId0_default_arrowDown() {
     activityTestRule.launchActivity(null)
-    onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.chapter_list_view_control)).check(
+    onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.expand_list_icon)).check(
       matches(
         withDrawable(R.drawable.ic_keyboard_arrow_down_black_24dp)
       )
@@ -165,8 +165,8 @@ class TopicPlayFragmentTest {
   @Test
   fun testTopicPlayFragment_loadFragmentWithTopicTestId0_clickExpandListIcon_iconChanges() {
     activityTestRule.launchActivity(null)
-    onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.chapter_list_view_control)).perform(click())
-    onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.chapter_list_view_control)).check(
+    onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.expand_list_icon)).perform(click())
+    onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.expand_list_icon)).check(
       matches(
         withDrawable(R.drawable.ic_keyboard_arrow_up_black_24dp)
       )
@@ -176,7 +176,7 @@ class TopicPlayFragmentTest {
   @Test
   fun testTopicPlayFragment_loadFragmentWithTopicTestId0_clickExpandListIcon_chapterListIsVisible() {
     activityTestRule.launchActivity(null)
-    onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.chapter_list_view_control)).perform(click())
+    onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.expand_list_icon)).perform(click())
     onView(
       atPositionOnView(
         R.id.story_summary_recycler_view,
@@ -189,7 +189,7 @@ class TopicPlayFragmentTest {
   @Test
   fun testTopicPlayFragment_loadFragmentWithTopicTestId0_clickChapter_opensExplorationActivity() {
     activityTestRule.launchActivity(null)
-    onView(atPositionOnView(R.id.story_summary_recycler_view, 1, R.id.chapter_list_view_control)).perform(click())
+    onView(atPositionOnView(R.id.story_summary_recycler_view, 1, R.id.expand_list_icon)).perform(click())
     onView(
       allOf(
         withId(R.id.chapter_recycler_view),
@@ -204,8 +204,8 @@ class TopicPlayFragmentTest {
   @Test
   fun testTopicPlayFragment_loadFragmentWithTopicTestId0_clickExpandListIconIndex0_clickExpandListIconIndex1_chapterListForIndex0IsNotDisplayed() {
     activityTestRule.launchActivity(null)
-    onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.chapter_list_view_control)).perform(click())
-    onView(atPositionOnView(R.id.story_summary_recycler_view, 1, R.id.chapter_list_view_control)).perform(click())
+    onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.expand_list_icon)).perform(click())
+    onView(atPositionOnView(R.id.story_summary_recycler_view, 1, R.id.expand_list_icon)).perform(click())
     onView(
       atPositionOnView(
         R.id.story_summary_recycler_view,
@@ -218,8 +218,8 @@ class TopicPlayFragmentTest {
   @Test
   fun testTopicPlayFragment_loadFragmentWithTopicTestId0_clickExpandListIconIndex1_clickExpandListIconIndex0_chapterListForIndex0IsNotDisplayed() {
     activityTestRule.launchActivity(null)
-    onView(atPositionOnView(R.id.story_summary_recycler_view, 1, R.id.chapter_list_view_control)).perform(click())
-    onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.chapter_list_view_control)).perform(click())
+    onView(atPositionOnView(R.id.story_summary_recycler_view, 1, R.id.expand_list_icon)).perform(click())
+    onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.expand_list_icon)).perform(click())
     onView(
       atPositionOnView(
         R.id.story_summary_recycler_view,
@@ -232,7 +232,7 @@ class TopicPlayFragmentTest {
   @Test
   fun testTopicPlayFragment_loadFragmentWithTopicTestId0_clickExpandListIconIndex0_configurationChange_chapterListIsVisible() {
     ActivityScenario.launch(TopicActivity::class.java).use {
-      onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.chapter_list_view_control)).perform(click())
+      onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.expand_list_icon)).perform(click())
       it.onActivity { activity ->
         activity.requestedOrientation = Configuration.ORIENTATION_LANDSCAPE
       }


### PR DESCRIPTION
This PR ensures that we're properly starting an exploration before routing to it. Verified that StoryActivityTest still passes.

This also fixes TopicPlayFragmentTest build which broke after a recent change. The test isn't passing, but it's at least building now.

One test in StoryFragmentTest appears to fail, but I think this is due to the wrong data being loaded and not this change.