### PR TITLE
Fix #370: Remove all temporary topic, skill, exploration, story, and question data

### DIFF
--- a/app/src/main/java/org/oppia/app/testing/TopicTestActivity.kt
+++ b/app/src/main/java/org/oppia/app/testing/TopicTestActivity.kt
@@ -15,7 +15,7 @@ import org.oppia.app.topic.TopicFragment
 import org.oppia.app.topic.TopicTab
 import org.oppia.app.topic.conceptcard.ConceptCardFragment
 import org.oppia.app.topic.questionplayer.QuestionPlayerActivity
-import org.oppia.domain.topic.TEST_TOPIC_ID_0
+import org.oppia.domain.topic.FRACTIONS_TOPIC_ID
 import javax.inject.Inject
 
 /** The activity for testing [TopicFragment]. */
@@ -27,7 +27,7 @@ class TopicTestActivity : InjectableAppCompatActivity(), RouteToQuestionPlayerLi
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     activityComponent.inject(this)
-    topicActivityPresenter.handleOnCreate(topicId = TEST_TOPIC_ID_0, storyId = "")
+    topicActivityPresenter.handleOnCreate(topicId = FRACTIONS_TOPIC_ID, storyId = "")
   }
 
   override fun routeToQuestionPlayer(skillIdList: ArrayList<String>) {

--- a/app/src/main/java/org/oppia/app/testing/TopicTestActivityForStory.kt
+++ b/app/src/main/java/org/oppia/app/testing/TopicTestActivityForStory.kt
@@ -15,8 +15,8 @@ import org.oppia.app.topic.TopicFragment
 import org.oppia.app.topic.TopicTab
 import org.oppia.app.topic.conceptcard.ConceptCardFragment
 import org.oppia.app.topic.questionplayer.QuestionPlayerActivity
-import org.oppia.domain.topic.TEST_STORY_ID_1
-import org.oppia.domain.topic.TEST_TOPIC_ID_0
+import org.oppia.domain.topic.FRACTIONS_STORY_ID_0
+import org.oppia.domain.topic.FRACTIONS_TOPIC_ID
 import javax.inject.Inject
 
 /** The test activity for [TopicFragment] to test displaying story by storyId. */
@@ -29,7 +29,7 @@ class TopicTestActivityForStory : InjectableAppCompatActivity(), RouteToQuestion
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     activityComponent.inject(this)
-    topicActivityPresenter.handleOnCreate(topicId = TEST_TOPIC_ID_0, storyId = TEST_STORY_ID_1)
+    topicActivityPresenter.handleOnCreate(topicId = FRACTIONS_TOPIC_ID, storyId = FRACTIONS_STORY_ID_0)
   }
 
   override fun routeToQuestionPlayer(skillIdList: ArrayList<String>) {

--- a/app/src/main/java/org/oppia/app/topic/TopicFragment.kt
+++ b/app/src/main/java/org/oppia/app/topic/TopicFragment.kt
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import org.oppia.app.fragment.InjectableFragment
-import org.oppia.domain.topic.TEST_TOPIC_ID_0
+import org.oppia.domain.topic.FRACTIONS_TOPIC_ID
 import javax.inject.Inject
 
 /** Fragment that contains tabs for Topic. */
@@ -21,7 +21,7 @@ class TopicFragment : InjectableFragment() {
   }
 
   override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-    topicId = arguments?.getString(TOPIC_ID_ARGUMENT_KEY) ?: TEST_TOPIC_ID_0
+    topicId = arguments?.getString(TOPIC_ID_ARGUMENT_KEY) ?: FRACTIONS_TOPIC_ID
     return topicFragmentPresenter.handleCreateView(inflater, container, topicId)
   }
 }

--- a/app/src/main/java/org/oppia/app/topic/conceptcard/testing/ConceptCardFragmentTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/topic/conceptcard/testing/ConceptCardFragmentTestActivityPresenter.kt
@@ -4,8 +4,8 @@ import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.concept_card_fragment_test_activity.*
 import org.oppia.app.R
 import org.oppia.app.topic.conceptcard.ConceptCardFragment
-import org.oppia.domain.topic.TEST_SKILL_ID_1
-import org.oppia.domain.topic.TEST_SKILL_ID_2
+import org.oppia.domain.topic.FRACTIONS_SKILL_ID_0
+import org.oppia.domain.topic.FRACTIONS_SKILL_ID_1
 import javax.inject.Inject
 
 private const val TAG_CONCEPT_CARD_DIALOG = "CONCEPT_CARD_DIALOG"
@@ -15,11 +15,11 @@ class ConceptCardFragmentTestActivityPresenter @Inject constructor(private val a
   fun handleOnCreate() {
     activity.setContentView(R.layout.concept_card_fragment_test_activity)
     activity.open_dialog_1.setOnClickListener {
-      val frag = ConceptCardFragment.newInstance(TEST_SKILL_ID_1)
+      val frag = ConceptCardFragment.newInstance(FRACTIONS_SKILL_ID_0)
       frag.showNow(activity.supportFragmentManager, TAG_CONCEPT_CARD_DIALOG)
     }
     activity.open_dialog_2.setOnClickListener {
-      val frag = ConceptCardFragment.newInstance(TEST_SKILL_ID_2)
+      val frag = ConceptCardFragment.newInstance(FRACTIONS_SKILL_ID_1)
       frag.showNow(activity.supportFragmentManager, TAG_CONCEPT_CARD_DIALOG)
     }
   }

--- a/domain/src/main/java/org/oppia/domain/topic/StoryProgressController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/StoryProgressController.kt
@@ -11,17 +11,9 @@ import org.oppia.util.data.AsyncResult
 import javax.inject.Inject
 import javax.inject.Singleton
 
-const val TEST_STORY_ID_0 = "test_story_id_0"
-const val TEST_STORY_ID_1 = "test_story_id_1"
-const val TEST_STORY_ID_2 = "test_story_id_2"
 const val FRACTIONS_STORY_ID_0 = "wANbh4oOClga"
 const val RATIOS_STORY_ID_0 = "wAMdg4oOClga"
 const val RATIOS_STORY_ID_1 = "xBSdg4oOClga"
-const val TEST_EXPLORATION_ID_0 = "test_exp_id_0"
-const val TEST_EXPLORATION_ID_1 = "test_exp_id_1"
-const val TEST_EXPLORATION_ID_2 = "test_exp_id_2"
-const val TEST_EXPLORATION_ID_3 = "test_exp_id_3"
-const val TEST_EXPLORATION_ID_4 = "test_exp_id_4"
 const val FRACTIONS_EXPLORATION_ID_0 = "0"
 const val FRACTIONS_EXPLORATION_ID_1 = "16"
 const val RATIOS_EXPLORATION_ID_0 = "2mzzFVDLuAj8"
@@ -80,9 +72,6 @@ class StoryProgressController @Inject constructor(
 
   private fun createInitialStoryProgressState(): Map<String, TrackedStoryProgress> {
     return mapOf(
-      TEST_STORY_ID_0 to createStoryProgress0(),
-      TEST_STORY_ID_1 to createStoryProgress1(),
-      TEST_STORY_ID_2 to createStoryProgress2(),
       FRACTIONS_STORY_ID_0 to createStoryProgressForJsonStory("fractions_stories.json", /* index= */ 0),
       RATIOS_STORY_ID_0 to createStoryProgressForJsonStory("ratios_stories.json", /* index= */ 0),
       RATIOS_STORY_ID_1 to createStoryProgressForJsonStory("ratios_stories.json", /* index= */ 1)
@@ -114,27 +103,6 @@ class StoryProgressController @Inject constructor(
       explorationIdList.add(chapter.getString("exploration_id"))
     }
     return explorationIdList
-  }
-
-  private fun createStoryProgress0(): TrackedStoryProgress {
-    return TrackedStoryProgress(
-      chapterList = listOf(TEST_EXPLORATION_ID_0),
-      completedChapters = setOf(TEST_EXPLORATION_ID_0)
-    )
-  }
-
-  private fun createStoryProgress1(): TrackedStoryProgress {
-    return TrackedStoryProgress(
-      chapterList = listOf(TEST_EXPLORATION_ID_1, TEST_EXPLORATION_ID_2, TEST_EXPLORATION_ID_3),
-      completedChapters = setOf(TEST_EXPLORATION_ID_1)
-    )
-  }
-
-  private fun createStoryProgress2(): TrackedStoryProgress {
-    return TrackedStoryProgress(
-      chapterList = listOf(TEST_EXPLORATION_ID_4),
-      completedChapters = setOf()
-    )
   }
 
   /**

--- a/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
@@ -27,21 +27,10 @@ import org.oppia.util.data.DataProviders
 import javax.inject.Inject
 import javax.inject.Singleton
 
-const val TEST_SKILL_ID_0 = "test_skill_id_0"
-const val TEST_SKILL_ID_1 = "test_skill_id_1"
-const val TEST_SKILL_ID_2 = "test_skill_id_2"
 const val FRACTIONS_SKILL_ID_0 = "5RM9KPfQxobH"
 const val FRACTIONS_SKILL_ID_1 = "UxTGIJqaHMLa"
 const val FRACTIONS_SKILL_ID_2 = "B39yK4cbHZYI"
 const val RATIOS_SKILL_ID_0 = "NGZ89uMw0IGV"
-const val TEST_SKILL_CONTENT_ID_0 = "test_skill_content_id_0"
-const val TEST_SKILL_CONTENT_ID_1 = "test_skill_content_id_1"
-const val TEST_QUESTION_ID_0 = "question_id_0"
-const val TEST_QUESTION_ID_1 = "question_id_1"
-const val TEST_QUESTION_ID_2 = "question_id_2"
-const val TEST_QUESTION_ID_3 = "question_id_3"
-const val TEST_QUESTION_ID_4 = "question_id_4"
-const val TEST_QUESTION_ID_5 = "question_id_5"
 const val FRACTIONS_QUESTION_ID_0 = "dobbibJorU9T"
 const val FRACTIONS_QUESTION_ID_1 = "EwbUb5oITtUX"
 const val FRACTIONS_QUESTION_ID_2 = "ryIPWUmts8rN"
@@ -68,8 +57,6 @@ class TopicController @Inject constructor(
   fun getTopic(topicId: String): LiveData<AsyncResult<Topic>> {
     return MutableLiveData(
       when (topicId) {
-        TEST_TOPIC_ID_0 -> AsyncResult.success(createTestTopic0())
-        TEST_TOPIC_ID_1 -> AsyncResult.success(createTestTopic1())
         FRACTIONS_TOPIC_ID -> AsyncResult.success(createTopicFromJson(
           "fractions_topic.json", "fractions_skills.json", "fractions_stories.json"))
         RATIOS_TOPIC_ID -> AsyncResult.success(createTopicFromJson(
@@ -85,9 +72,6 @@ class TopicController @Inject constructor(
   fun getStory(storyId: String): LiveData<AsyncResult<StorySummary>> {
     return MutableLiveData(
       when (storyId) {
-        TEST_STORY_ID_0 -> AsyncResult.success(createTestTopic0Story0())
-        TEST_STORY_ID_1 -> AsyncResult.success(createTestTopic0Story1())
-        TEST_STORY_ID_2 -> AsyncResult.success(createTestTopic1Story2())
         FRACTIONS_STORY_ID_0 -> AsyncResult.success(
           createStoryFromJsonFile(
             "fractions_stories.json", /* index= */ 0
@@ -112,9 +96,6 @@ class TopicController @Inject constructor(
   fun getConceptCard(skillId: String): LiveData<AsyncResult<ConceptCard>> {
     return MutableLiveData(
       when (skillId) {
-        TEST_SKILL_ID_0 -> AsyncResult.success(createTestConceptCardForSkill0())
-        TEST_SKILL_ID_1 -> AsyncResult.success(createTestConceptCardForSkill1())
-        TEST_SKILL_ID_2 -> AsyncResult.success(createTestConceptCardForSkill2())
         FRACTIONS_SKILL_ID_0 -> AsyncResult.success(
           createConceptCardFromJson(
             "fractions_skills.json", /* index= */ 0
@@ -164,26 +145,6 @@ class TopicController @Inject constructor(
     )?.getJSONArray("questions")!!
     for (skillId in skillIdsList) {
       when (skillId) {
-        TEST_SKILL_ID_0 -> questionsList.addAll(
-          mutableListOf(
-            createTestQuestion0(questionsJSON),
-            createTestQuestion1(questionsJSON),
-            createTestQuestion2(questionsJSON)
-          )
-        )
-        TEST_SKILL_ID_1 -> questionsList.addAll(
-          mutableListOf(
-            createTestQuestion0(questionsJSON),
-            createTestQuestion3(questionsJSON)
-          )
-        )
-        TEST_SKILL_ID_2 -> questionsList.addAll(
-          mutableListOf(
-            createTestQuestion2(questionsJSON),
-            createTestQuestion4(questionsJSON),
-            createTestQuestion5(questionsJSON)
-          )
-        )
         FRACTIONS_SKILL_ID_0 -> questionsList.addAll(
           mutableListOf(
             createQuestionFromJsonObject(fractionQuestionsJSON.getJSONObject(0)),
@@ -228,116 +189,6 @@ class TopicController @Inject constructor(
         )
       )
       .addAllLinkedSkillIds(jsonAssetRetriever.getStringsFromJSONArray(questionJson.getJSONArray("linked_skill_ids")))
-      .build()
-  }
-
-  private fun createTestQuestion0(questionsJson: JSONArray?): Question {
-    return Question.newBuilder()
-      .setQuestionId(TEST_QUESTION_ID_0)
-      .setQuestionState(
-        stateRetriever.createStateFromJson(
-          "question", questionsJson?.getJSONObject(0)
-        )
-      )
-      .addAllLinkedSkillIds(mutableListOf(TEST_SKILL_ID_0, TEST_SKILL_ID_1))
-      .build()
-  }
-
-  private fun createTestQuestion1(questionsJson: JSONArray?): Question {
-    return Question.newBuilder()
-      .setQuestionId(TEST_QUESTION_ID_1)
-      .setQuestionState(
-        stateRetriever.createStateFromJson(
-          "question", questionsJson?.getJSONObject(1)
-        )
-      )
-      .addAllLinkedSkillIds(mutableListOf(TEST_SKILL_ID_0))
-      .build()
-  }
-
-  private fun createTestQuestion2(questionsJson: JSONArray?): Question {
-    return Question.newBuilder()
-      .setQuestionId(TEST_QUESTION_ID_2)
-      .setQuestionState(
-        stateRetriever.createStateFromJson(
-          "question", questionsJson?.getJSONObject(2)
-        )
-      )
-      .addAllLinkedSkillIds(mutableListOf(TEST_SKILL_ID_0, TEST_SKILL_ID_2))
-      .build()
-  }
-
-  private fun createTestQuestion3(questionsJson: JSONArray?): Question {
-    return Question.newBuilder()
-      .setQuestionId(TEST_QUESTION_ID_3)
-      .setQuestionState(
-        stateRetriever.createStateFromJson(
-          "question", questionsJson?.getJSONObject(0)
-        )
-      )
-      .addAllLinkedSkillIds(mutableListOf(TEST_SKILL_ID_1))
-      .build()
-  }
-
-  private fun createTestQuestion4(questionsJson: JSONArray?): Question {
-    return Question.newBuilder()
-      .setQuestionId(TEST_QUESTION_ID_4)
-      .setQuestionState(
-        stateRetriever.createStateFromJson(
-          "question", questionsJson?.getJSONObject(1)
-        )
-      )
-      .addAllLinkedSkillIds(mutableListOf(TEST_SKILL_ID_2))
-      .build()
-  }
-
-  private fun createTestQuestion5(questionsJson: JSONArray?): Question {
-    return Question.newBuilder()
-      .setQuestionId(TEST_QUESTION_ID_5)
-      .setQuestionState(
-        stateRetriever.createStateFromJson(
-          "question", questionsJson?.getJSONObject(2)
-        )
-      )
-      .addAllLinkedSkillIds(mutableListOf(TEST_SKILL_ID_2))
-      .build()
-  }
-
-  private fun createTestTopic0(): Topic {
-    return Topic.newBuilder()
-      .setTopicId(TEST_TOPIC_ID_0)
-      .setName("First Test Topic")
-      .setDescription("A topic investigating the interesting aspects of the Oppia Android app.")
-      .addStory(createTestTopic0Story0())
-      .addSkill(createTestTopic0Skill0())
-      .addStory(createTestTopic0Story1())
-      .addSkill(createTestTopic0Skill1())
-      .addSkill(createTestTopic0Skill2())
-      .addSkill(createTestTopic0Skill3())
-      .setTopicThumbnail(createTestTopic0Thumbnail())
-      .build()
-  }
-
-  private fun createTestTopic0Thumbnail(): LessonThumbnail {
-    return LessonThumbnail.newBuilder()
-      .setThumbnailGraphic(LessonThumbnailGraphic.CHILD_WITH_BOOK)
-      .setBackgroundColorRgb(0xd5836f)
-      .build()
-  }
-
-  private fun createTestTopic1(): Topic {
-    return Topic.newBuilder()
-      .setTopicId(TEST_TOPIC_ID_1)
-      .setName("Second Test Topic")
-      .setDescription(
-        "A topic considering the various implications of having especially long topic descriptions. " +
-            "These descriptions almost certainly need to wrap, which should be interesting in the UI (especially on " +
-            "small screens). Consider also that there may even be multiple points pertaining to a topic, some of which " +
-            "may require expanding the description section in order to read the whole topic description."
-      )
-      .addStory(createTestTopic1Story2())
-      .addSkill(createTestTopic1Skill0())
-      .setTopicThumbnail(createTestTopic1Thumbnail())
       .build()
   }
 
@@ -436,163 +287,6 @@ class TopicController @Inject constructor(
     }
   }
 
-  private fun createTestTopic1Thumbnail(): LessonThumbnail {
-    return LessonThumbnail.newBuilder()
-      .setThumbnailGraphic(LessonThumbnailGraphic.CHILD_WITH_CUPCAKES)
-      .setBackgroundColorRgb(0xf7bf73)
-      .build()
-  }
-
-  private fun createTestTopic0Story0(): StorySummary {
-    return StorySummary.newBuilder()
-      .setStoryId(TEST_STORY_ID_0)
-      .setStoryName("First Story")
-      .addChapter(createTestTopic0Story0Chapter0())
-      .build()
-  }
-
-  private fun createTestTopic0Story0Chapter0(): ChapterSummary {
-    return ChapterSummary.newBuilder()
-      .setExplorationId(TEST_EXPLORATION_ID_30)
-      .setName("Prototype Exploration")
-      .setSummary("This is the prototype exploration to verify interaction functionality.")
-      .setChapterPlayState(ChapterPlayState.COMPLETED)
-      .setChapterThumbnail(createTestTopic0Story0Chapter0Thumbnail())
-      .build()
-  }
-
-  private fun createTestTopic0Story0Chapter0Thumbnail(): LessonThumbnail {
-    return LessonThumbnail.newBuilder()
-      .setThumbnailGraphic(LessonThumbnailGraphic.CHILD_WITH_FRACTIONS_HOMEWORK)
-      .setBackgroundColorRgb(0x494276)
-      .build()
-  }
-
-  private fun createTestTopic0Story1(): StorySummary {
-    return StorySummary.newBuilder()
-      .setStoryId(TEST_STORY_ID_1)
-      .setStoryName("Second Story")
-      .addChapter(createTestTopic0Story1Chapter0())
-      .addChapter(createTestTopic0Story1Chapter1())
-      .addChapter(createTestTopic0Story1Chapter2())
-      .build()
-  }
-
-  private fun createTestTopic0Story1Chapter0(): ChapterSummary {
-    return ChapterSummary.newBuilder()
-      .setExplorationId(TEST_EXPLORATION_ID_1)
-      .setName("Second Exploration")
-      .setSummary("This is the second exploration summary")
-      .setChapterPlayState(ChapterPlayState.COMPLETED)
-      .setChapterThumbnail(createTestTopic0Story1ChapterThumbnail1())
-      .build()
-  }
-
-  private fun createTestTopic0Story1Chapter1(): ChapterSummary {
-    return ChapterSummary.newBuilder()
-      .setExplorationId(TEST_EXPLORATION_ID_2)
-      .setName("Third Exploration")
-      .setSummary("This is the third exploration summary")
-      .setChapterPlayState(ChapterPlayState.NOT_STARTED)
-      .setChapterThumbnail(createTestTopic0Story1ChapterThumbnail2())
-      .build()
-  }
-
-  private fun createTestTopic0Story1Chapter2(): ChapterSummary {
-    return ChapterSummary.newBuilder()
-      .setExplorationId(TEST_EXPLORATION_ID_3)
-      .setName("Fourth Exploration")
-      .setSummary("This is the fourth exploration summary")
-      .setChapterPlayState(ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES)
-      .setChapterThumbnail(createTestTopic0Story1ChapterThumbnail3())
-      .build()
-  }
-
-  /** Returns the [LessonThumbnail] associated for each chapter in story 1. */
-  private fun createTestTopic0Story1ChapterThumbnail1(): LessonThumbnail {
-    return LessonThumbnail.newBuilder()
-      .setThumbnailGraphic(LessonThumbnailGraphic.DUCK_AND_CHICKEN)
-      .setBackgroundColorRgb(0xa5d3ec)
-      .build()
-  }
-
-  /** Returns the [LessonThumbnail] associated for each chapter in story 1. */
-  private fun createTestTopic0Story1ChapterThumbnail2(): LessonThumbnail {
-    return LessonThumbnail.newBuilder()
-      .setThumbnailGraphic(LessonThumbnailGraphic.CHILD_WITH_FRACTIONS_HOMEWORK)
-      .setBackgroundColorRgb(0xffeebe)
-      .build()
-  }
-
-  /** Returns the [LessonThumbnail] associated for each chapter in story 1. */
-  private fun createTestTopic0Story1ChapterThumbnail3(): LessonThumbnail {
-    return LessonThumbnail.newBuilder()
-      .setThumbnailGraphic(LessonThumbnailGraphic.PERSON_WITH_PIE_CHART)
-      .setBackgroundColorRgb(0x76d1ca)
-      .build()
-  }
-
-  private fun createTestTopic1Story2(): StorySummary {
-    return StorySummary.newBuilder()
-      .setStoryId(TEST_STORY_ID_2)
-      .setStoryName("Other Interesting Story")
-      .addChapter(createTestTopic1Story2Chapter0())
-      .build()
-  }
-
-  private fun createTestTopic1Story2Chapter0(): ChapterSummary {
-    return ChapterSummary.newBuilder()
-      .setExplorationId(TEST_EXPLORATION_ID_4)
-      .setName("Fifth Exploration")
-      .setChapterPlayState(ChapterPlayState.NOT_STARTED)
-      .setChapterThumbnail(createTestTopic1Story2Chapter0Thumbnail())
-      .build()
-  }
-
-  private fun createTestTopic1Story2Chapter0Thumbnail(): LessonThumbnail {
-    return LessonThumbnail.newBuilder()
-      .setThumbnailGraphic(LessonThumbnailGraphic.PERSON_WITH_PIE_CHART)
-      .setBackgroundColorRgb(0x7eb3ad)
-      .build()
-  }
-
-  private fun createTestTopic0Skill0(): SkillSummary {
-    return SkillSummary.newBuilder()
-      .setSkillId(TEST_SKILL_ID_0)
-      .setDescription("An important skill")
-      .build()
-  }
-
-  private fun createTestTopic0Skill1(): SkillSummary {
-    return SkillSummary.newBuilder()
-      .setSkillId(TEST_SKILL_ID_1)
-      .setDescription("Another important skill")
-      .build()
-  }
-
-
-  private fun createTestTopic0Skill2(): SkillSummary {
-    return SkillSummary.newBuilder()
-      .setSkillId(TEST_SKILL_ID_1)
-      .setDescription("A different skill in a different topic Another important skill")
-      .build()
-  }
-
-
-  private fun createTestTopic0Skill3(): SkillSummary {
-    return SkillSummary.newBuilder()
-      .setSkillId(TEST_SKILL_ID_1)
-      .setDescription("Another important skill")
-      .build()
-  }
-
-  private fun createTestTopic1Skill0(): SkillSummary {
-    return SkillSummary.newBuilder()
-      .setSkillId(TEST_SKILL_ID_2)
-      .setDescription("A different skill in a different topic")
-      .build()
-  }
-
   private fun createConceptCardFromJson(fileName: String, index: Int): ConceptCard {
     val skillList = jsonAssetRetriever.loadJsonFromAsset(fileName)?.getJSONArray("skill_list")!!
     if (skillList.length() < index) {
@@ -623,57 +317,5 @@ class TopicController @Inject constructor(
       )
     }
     return workedExampleList
-  }
-
-  private fun createTestConceptCardForSkill0(): ConceptCard {
-    return ConceptCard.newBuilder()
-      .setSkillId(TEST_SKILL_ID_0)
-      .setSkillDescription(createTestTopic0Skill0().description)
-      .setExplanation(
-        SubtitledHtml.newBuilder().setHtml("Hello. Welcome to Oppia.").setContentId(TEST_SKILL_CONTENT_ID_0).build()
-      )
-      .addWorkedExample(
-        SubtitledHtml.newBuilder().setHtml("This is the first example.").setContentId(TEST_SKILL_CONTENT_ID_1).build()
-      )
-      .putRecordedVoiceover(
-        TEST_SKILL_CONTENT_ID_0, VoiceoverMapping.newBuilder().putVoiceoverMapping(
-          "es", Voiceover.newBuilder().setFileName("fake_spanish_xlated_explanation.mp3").setFileSizeBytes(456).build()
-        ).build()
-      )
-      .putRecordedVoiceover(
-        TEST_SKILL_CONTENT_ID_1, VoiceoverMapping.newBuilder().putVoiceoverMapping(
-          "es", Voiceover.newBuilder().setFileName("fake_spanish_xlated_example.mp3").setFileSizeBytes(123).build()
-        ).build()
-      )
-      .putWrittenTranslation(
-        TEST_SKILL_CONTENT_ID_0, TranslationMapping.newBuilder().putTranslationMapping(
-          "es", Translation.newBuilder().setHtml("Hola. Bienvenidos a Oppia.").build()
-        ).build()
-      )
-      .putWrittenTranslation(
-        TEST_SKILL_CONTENT_ID_1, TranslationMapping.newBuilder().putTranslationMapping(
-          "es", Translation.newBuilder().setHtml("Este es el primer ejemplo trabajado.").build()
-        ).build()
-      )
-      .build()
-  }
-
-  private fun createTestConceptCardForSkill1(): ConceptCard {
-    return ConceptCard.newBuilder()
-      .setSkillId(TEST_SKILL_ID_1)
-      .setSkillDescription(createTestTopic0Skill1().description)
-      .setExplanation(SubtitledHtml.newBuilder().setHtml("Explanation with <b>rich text</b>.").build())
-      .addWorkedExample(SubtitledHtml.newBuilder().setHtml("Worked example with <i>rich text</i>.").build())
-      .build()
-  }
-
-  private fun createTestConceptCardForSkill2(): ConceptCard {
-    return ConceptCard.newBuilder()
-      .setSkillId(TEST_SKILL_ID_2)
-      .setSkillDescription(createTestTopic1Skill0().description)
-      .setExplanation(SubtitledHtml.newBuilder().setHtml("Explanation without rich text.").build())
-      .addWorkedExample(SubtitledHtml.newBuilder().setHtml("Worked example without rich text.").build())
-      .addWorkedExample(SubtitledHtml.newBuilder().setHtml("Second worked example.").build())
-      .build()
   }
 }

--- a/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
@@ -14,8 +14,6 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
-const val TEST_TOPIC_ID_0 = "test_topic_id_0"
-const val TEST_TOPIC_ID_1 = "test_topic_id_1"
 const val FRACTIONS_TOPIC_ID = "GJ2rLXRKD5hw"
 const val RATIOS_TOPIC_ID = "omzF4oqgeTXd"
 
@@ -45,8 +43,6 @@ class TopicListController @Inject constructor(
   private fun createTopicList(): TopicList {
     return TopicList.newBuilder()
       .setPromotedStory(createPromotedStory1())
-      .addTopicSummary(createTopicSummary0())
-      .addTopicSummary(createTopicSummary1())
       .addTopicSummary(createFractionsTopicSummary())
       .addTopicSummary(createRatiosTopicSummary())
       .setOngoingStoryCount(2)
@@ -85,94 +81,22 @@ class TopicListController @Inject constructor(
       .build()
   }
 
-  private fun createTopicSummary0(): TopicSummary {
-    return TopicSummary.newBuilder()
-      .setTopicId(TEST_TOPIC_ID_0)
-      .setName("First Topic")
-      .setVersion(1)
-      .setSubtopicCount(0)
-      .setCanonicalStoryCount(2)
-      .setUncategorizedSkillCount(0)
-      .setAdditionalStoryCount(0)
-      .setTotalSkillCount(2)
-      .setTotalChapterCount(4)
-      .setTopicThumbnail(createTopicThumbnail0())
-      .build()
-  }
-
-  private fun createTopicSummary1(): TopicSummary {
-    return TopicSummary.newBuilder()
-      .setTopicId(TEST_TOPIC_ID_1)
-      .setName("Second Topic")
-      .setVersion(3)
-      .setSubtopicCount(0)
-      .setCanonicalStoryCount(1)
-      .setUncategorizedSkillCount(0)
-      .setAdditionalStoryCount(0)
-      .setTotalSkillCount(1)
-      .setTotalChapterCount(1)
-      .setTopicThumbnail(createTopicThumbnail1())
-      .build()
-  }
-
   private fun createOngoingStoryList(): OngoingStoryList {
     return OngoingStoryList.newBuilder()
       .addRecentStory(createPromotedStory1())
-      .addRecentStory(createPromotedStory2())
-      .addOlderStory(createPromotedStory3())
       .build()
   }
 
   private fun createPromotedStory1(): PromotedStory {
     return PromotedStory.newBuilder()
-      .setStoryId(TEST_STORY_ID_1)
+      .setStoryId(FRACTIONS_STORY_ID_0)
       .setStoryName("Second Story")
-      .setTopicId(TEST_TOPIC_ID_0)
+      .setTopicId(FRACTIONS_TOPIC_ID)
       .setTopicName("First Topic")
       .setNextChapterName("The Meaning of Equal Parts")
       .setCompletedChapterCount(1)
       .setTotalChapterCount(3)
       .setLessonThumbnail(createStoryThumbnail())
-      .build()
-  }
-
-  private fun createPromotedStory2(): PromotedStory {
-    return PromotedStory.newBuilder()
-      .setStoryId(TEST_STORY_ID_0)
-      .setStoryName("Equal Ratios")
-      .setTopicId(TEST_TOPIC_ID_1)
-      .setTopicName("Ratios and Proportions")
-      .setNextChapterName("Matthew Goes to the Bakery")
-      .setCompletedChapterCount(1)
-      .setTotalChapterCount(3)
-      .setLessonThumbnail(createStoryThumbnail1())
-      .build()
-  }
-
-  private fun createPromotedStory3(): PromotedStory {
-    return PromotedStory.newBuilder()
-      .setStoryId(TEST_STORY_ID_0)
-      .setStoryName("Types of Angles")
-      .setTopicId(TEST_TOPIC_ID_1)
-      .setTopicName("Geometrical Figures")
-      .setNextChapterName("Miguel Reads a Book")
-      .setCompletedChapterCount(1)
-      .setTotalChapterCount(3)
-      .setLessonThumbnail(createStoryThumbnail2())
-      .build()
-  }
-
-  private fun createTopicThumbnail0(): LessonThumbnail {
-    return LessonThumbnail.newBuilder()
-      .setThumbnailGraphic(LessonThumbnailGraphic.CHILD_WITH_BOOK)
-      .setBackgroundColorRgb(0xd5836f)
-      .build()
-  }
-
-  private fun createTopicThumbnail1(): LessonThumbnail {
-    return LessonThumbnail.newBuilder()
-      .setThumbnailGraphic(LessonThumbnailGraphic.CHILD_WITH_CUPCAKES)
-      .setBackgroundColorRgb(0xf7bf73)
       .build()
   }
 
@@ -194,20 +118,6 @@ class TopicListController @Inject constructor(
     return LessonThumbnail.newBuilder()
       .setThumbnailGraphic(LessonThumbnailGraphic.DUCK_AND_CHICKEN)
       .setBackgroundColorRgb(0xa5d3ec)
-      .build()
-  }
-
-  private fun createStoryThumbnail1(): LessonThumbnail {
-    return LessonThumbnail.newBuilder()
-      .setThumbnailGraphic(LessonThumbnailGraphic.CHILD_WITH_FRACTIONS_HOMEWORK)
-      .setBackgroundColorRgb(0xd3a5ec)
-      .build()
-  }
-
-  private fun createStoryThumbnail2(): LessonThumbnail {
-    return LessonThumbnail.newBuilder()
-      .setThumbnailGraphic(LessonThumbnailGraphic.CHILD_WITH_CUPCAKES)
-      .setBackgroundColorRgb(0xa5ecd3)
       .build()
   }
 }


### PR DESCRIPTION
Fixes #370.

Now that we have non-test lesson data, we shouldn't be hardcoding test data anymore. This PR removes all such test data, even though it may break some tests.

Note that some test explorations are being retained, but they won't be displayed in the app.

Later on, we'll remove the temporary JSON files in favor of lessons pulled from Oppia's test server.