### PR TITLE
Fix #366: Disable landscape support for now.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.app">
 
+  <!-- TODO(#56): Reenable landscape support. -->
+
   <uses-permission android:name="android.permission.INTERNET" />
   <application
     android:name=".application.OppiaApplication"
@@ -13,19 +15,30 @@
     android:theme="@style/OppiaTheme">
     <activity
       android:name=".home.continueplaying.ContinuePlayingActivity"
-      android:theme="@style/OppiaThemeWithoutActionBar" />
-    <activity android:name=".home.HomeActivity" />
+      android:theme="@style/OppiaThemeWithoutActionBar"
+      android:screenOrientation="portrait" />
+    <activity
+      android:name=".home.HomeActivity"
+      android:screenOrientation="portrait" />
     <activity android:name=".player.audio.testing.AudioFragmentTestActivity" />
     <activity
       android:name=".player.exploration.ExplorationActivity"
-      android:theme="@style/OppiaThemeWithoutActionBar" />
+      android:theme="@style/OppiaThemeWithoutActionBar"
+      android:screenOrientation="portrait" />
     <activity android:name=".player.state.testing.StateFragmentTestActivity" />
-    <activity android:name=".profile.ProfileActivity" />
-    <activity android:name=".settings.profile.ProfileRenameActivity" />
-    <activity android:name=".settings.profile.ProfileResetPinActivity" />
+    <activity
+      android:name=".profile.ProfileActivity"
+      android:screenOrientation="portrait" />
+    <activity
+      android:name=".settings.profile.ProfileRenameActivity"
+      android:screenOrientation="portrait" />
+    <activity
+      android:name=".settings.profile.ProfileResetPinActivity"
+      android:screenOrientation="portrait" />
     <activity
       android:name=".splash.SplashActivity"
-      android:theme="@style/SplashScreenTheme">
+      android:theme="@style/SplashScreenTheme"
+      android:screenOrientation="portrait">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
@@ -37,7 +50,8 @@
     </activity>
     <activity
       android:name=".story.StoryActivity"
-      android:theme="@style/OppiaThemeWithoutActionBar" />
+      android:theme="@style/OppiaThemeWithoutActionBar"
+      android:screenOrientation="portrait" />
     <activity android:name=".story.testing.StoryFragmentTestActivity" />
     <activity android:name=".testing.BindableAdapterTestActivity" />
     <activity android:name=".testing.ContentCardTestActivity" />
@@ -51,9 +65,12 @@
       android:name=".testing.TopicTestActivityForStory"
       android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity android:name=".topic.conceptcard.testing.ConceptCardFragmentTestActivity" />
-    <activity android:name=".topic.questionplayer.QuestionPlayerActivity" />
+    <activity
+      android:name=".topic.questionplayer.QuestionPlayerActivity"
+      android:screenOrientation="portrait" />
     <activity
       android:name=".topic.TopicActivity"
-      android:theme="@style/OppiaThemeWithoutActionBar" />
+      android:theme="@style/OppiaThemeWithoutActionBar"
+      android:screenOrientation="portrait" />
   </application>
 </manifest>

--- a/app/src/sharedTest/java/org/oppia/app/home/ContinuePlayingFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/home/ContinuePlayingFragmentTest.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.not
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.app.R
@@ -191,6 +192,7 @@ class ContinuePlayingFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testContinuePlayingTestActivity_changeConfiguration_recyclerViewItem0_showsLastWeekSectionTitle() {
     ActivityScenario.launch(ContinuePlayingFragmentTestActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
@@ -209,6 +211,7 @@ class ContinuePlayingFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testContinuePlayingTestActivity_changeConfiguration_recyclerViewItem3_showsLastMonthSectionTitle() {
     ActivityScenario.launch(ContinuePlayingFragmentTestActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
@@ -224,6 +227,7 @@ class ContinuePlayingFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testContinuePlayingTestActivity_changeConfiguration_recyclerViewItem4_chapterNameIsCorrect() {
     ActivityScenario.launch(ContinuePlayingFragmentTestActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())

--- a/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
@@ -39,6 +39,7 @@ import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.Matcher
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.app.R
@@ -108,6 +109,7 @@ class HomeActivityTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testHomeActivity_recyclerViewIndex0_configurationChange_displaysWelcomeMessageCorrectly() {
     launch(HomeActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
@@ -178,6 +180,7 @@ class HomeActivityTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testHomeActivity_recyclerViewIndex1_configurationChange_promotedCard_storyNameIsCorrect() {
     launch(HomeActivity::class.java).use {
       onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(1))
@@ -262,6 +265,7 @@ class HomeActivityTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testHomeActivity_recyclerViewIndex4_topicSummary_configurationChange_lessonCountIsCorrect() {
     launch(HomeActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())

--- a/app/src/sharedTest/java/org/oppia/app/player/audio/AudioFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/audio/AudioFragmentTest.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.hamcrest.Description
 import org.hamcrest.TypeSafeMatcher
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.app.R
@@ -113,6 +114,7 @@ class AudioFragmentTest {
 
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testAudioFragment_invokePrepared_playAudio_configurationChange_checkStillPlaying() {
     invokePreparedListener(shadowMediaPlayer)
     onView(withId(R.id.ivPlayPauseAudio)).perform(click())

--- a/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import org.hamcrest.CoreMatchers.not
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -302,6 +303,7 @@ class StateFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testStateFragment_loadExplorationTest5_submitAnswer_clickContinueButton_configurationChange_previousAndInteractionButtonIsDisplayed() {
     ActivityScenario.launch(HomeActivity::class.java).use {
       onView(withId(R.id.play_exploration_button)).perform(click())
@@ -405,6 +407,7 @@ class StateFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testItemSelectionInput_showsCheckBox_withMaxSelectionAllowed_userSelectsDesiredOptions_correctError() {
     launch(ContentCardTestActivity::class.java).use {
       onView(withId(R.id.play_exploration_button_2)).perform(click())

--- a/app/src/sharedTest/java/org/oppia/app/testing/InputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/testing/InputInteractionViewTestActivityTest.kt
@@ -10,6 +10,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.app.R
@@ -53,6 +54,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testNumberInputInteractionView_withInputtedText_onConfigurationChange_hasCorrectPendingAnswer() {
     val activityScenario = ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view)).perform(typeText("9"))
@@ -62,6 +64,7 @@ class InputInteractionViewTestActivityTest {
     onView(withId(R.id.test_number_input_interaction_view)).check(matches(isDisplayed())).check(matches(withText("9")))
   }
 
+  @Test
   fun testTextInputInteractionView_withNoInputText_hasCorrectPendingAnswerType() {
     val activityScenario = ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     activityScenario.onActivity { activity ->
@@ -84,6 +87,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testTextInputInteractionView_withInputtedText_onConfigurationChange_hasCorrectPendingAnswer() {
     val activityScenario = ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_text_input_interaction_view)).perform(typeText("abc"))
@@ -190,6 +194,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testFractionInputInteractionView_withInputtedText_onConfigurationChange_hasCorrectPendingAnswer() {
     val activityScenario = ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view)).perform(typeText("9/5"))

--- a/app/src/sharedTest/java/org/oppia/app/topic/TopicFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/TopicFragmentTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.Matchers
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.app.R
@@ -233,6 +234,7 @@ class TopicFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testTopicFragment_clickOnPlayTab_configurationChange_showsSameTabAndItsContent() {
     launch(TopicTestActivity::class.java).use {
       onView(
@@ -264,6 +266,7 @@ class TopicFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testTopicFragment_clickOnTrainTab_configurationChange_showsSameTabAndItsContent() {
     launch(TopicTestActivity::class.java).use {
       onView(
@@ -286,6 +289,7 @@ class TopicFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testTopicFragment_clickOnReviewTab_configurationChange_showsSameTabAndItsContent() {
     launch(TopicTestActivity::class.java).use {
       onView(
@@ -309,6 +313,7 @@ class TopicFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testTopicFragment_configurationChange_showsDefaultTabAndItsContent() {
     launch(TopicTestActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())

--- a/app/src/sharedTest/java/org/oppia/app/topic/conceptcard/ConceptCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/conceptcard/ConceptCardFragmentTest.kt
@@ -17,6 +17,7 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineDispatcher
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.app.R
@@ -62,6 +63,7 @@ class ConceptCardFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testConceptCardFragment_openDialogFragmentWithSkill2_afterConfigurationChange_workedExamplesAreDisplayed() {
     onView(withId(R.id.open_dialog_2)).perform(click())
     activityScenario.onActivity { activity ->

--- a/app/src/sharedTest/java/org/oppia/app/topic/overview/TopicOverviewFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/overview/TopicOverviewFragmentTest.kt
@@ -17,6 +17,7 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineDispatcher
 import org.hamcrest.Matchers.containsString
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -76,6 +77,7 @@ class TopicOverviewFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testTopicOverviewFragment_loadFragment_configurationChange_checkTopicName_isCorrect() {
     activityTestRule.launchActivity(null)
     activityTestRule.activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE

--- a/app/src/sharedTest/java/org/oppia/app/topic/play/TopicPlayFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/play/TopicPlayFragmentTest.kt
@@ -28,6 +28,7 @@ import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -121,6 +122,7 @@ class TopicPlayFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testTopicPlayFragment_loadFragmentWithTopicTestId0_configurationChange_storyName_isCorrect() {
     activityTestRule.launchActivity(null)
     activityTestRule.activity.requestedOrientation = Configuration.ORIENTATION_LANDSCAPE
@@ -230,6 +232,7 @@ class TopicPlayFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testTopicPlayFragment_loadFragmentWithTopicTestId0_clickExpandListIconIndex0_configurationChange_chapterListIsVisible() {
     ActivityScenario.launch(TopicActivity::class.java).use {
       onView(atPositionOnView(R.id.story_summary_recycler_view, 0, R.id.expand_list_icon)).perform(click())

--- a/app/src/sharedTest/java/org/oppia/app/topic/review/TopicReviewFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/review/TopicReviewFragmentTest.kt
@@ -18,6 +18,7 @@ import dagger.Component
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineDispatcher
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -77,6 +78,7 @@ class TopicReviewFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testTopicTrainFragment_loadFragment_configurationChange_skillsAreDisplayed() {
     ActivityScenario.launch(TopicActivity::class.java).use {
       it.onActivity { activity ->

--- a/app/src/sharedTest/java/org/oppia/app/topic/train/TopicTrainFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/train/TopicTrainFragmentTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -111,6 +112,7 @@ class TopicTrainFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testTopicTrainFragment_loadFragment_selectSkills_configurationChange_skillsAreSelected() {
     onView(atPosition(R.id.skill_recycler_view, 0)).perform(click())
     activityScenario.onActivity { activity ->
@@ -121,6 +123,7 @@ class TopicTrainFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testTopicTrainFragment_loadFragment_configurationChange_startButtonRemainsInactive() {
     onView(withId(R.id.topic_train_start_button)).check(matches(not(isClickable())))
     activityScenario.onActivity { activity ->
@@ -131,6 +134,7 @@ class TopicTrainFragmentTest {
   }
 
   @Test
+  @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
   fun testTopicTrainFragment_loadFragment_selectSkills_configurationChange_startButtonRemainsActive() {
     onView(atPosition(R.id.skill_recycler_view, 0)).perform(click())
     activityScenario.onActivity { activity ->


### PR DESCRIPTION
Fix #366.

This PR locks Oppia to portrait mode, and disables landscape in all non-test activities. It also disables all configuration change tests.

We should aim to reenable landscape support later in December so that we can work on #56. This is a temporary measure until we have landscape layouts in place.