### PR TITLE
Fix patterns for fractions and whitespace normalization

### DIFF
--- a/app/src/main/java/org/oppia/app/parser/StringToFractionParser.kt
+++ b/app/src/main/java/org/oppia/app/parser/StringToFractionParser.kt
@@ -6,8 +6,8 @@ import org.oppia.domain.util.normalizeWhitespace
 /** This class contains method that helps to parse string to fraction. */
 class StringToFractionParser {
   private val wholeNumberOnlyRegex = """^-? ?(\d+)$""".toRegex()
-  private val fractionOnlyRegex = """^-? ?(\d+) ?/ ?(\d)+$""".toRegex()
-  private val mixedNumberRegex = """^-? ?(\d)+ ?(\d+) ?/ ?(\d)+$""".toRegex()
+  private val fractionOnlyRegex = """^-? ?(\d+) ?/ ?(\d+)$""".toRegex()
+  private val mixedNumberRegex = """^-? ?(\d+) ?(\d+) ?/ ?(\d+)$""".toRegex()
 
   fun getFractionFromString(text: String): Fraction {
     // Normalize whitespace to ensure that answer follows a simpler subset of possible patterns.

--- a/app/src/main/java/org/oppia/app/parser/StringToFractionParser.kt
+++ b/app/src/main/java/org/oppia/app/parser/StringToFractionParser.kt
@@ -7,7 +7,7 @@ import org.oppia.domain.util.normalizeWhitespace
 class StringToFractionParser {
   private val wholeNumberOnlyRegex = """^-? ?(\d+)$""".toRegex()
   private val fractionOnlyRegex = """^-? ?(\d+) ?/ ?(\d+)$""".toRegex()
-  private val mixedNumberRegex = """^-? ?(\d+) ?(\d+) ?/ ?(\d+)$""".toRegex()
+  private val mixedNumberRegex = """^-? ?(\d+) (\d+) ?/ ?(\d+)$""".toRegex()
 
   fun getFractionFromString(text: String): Fraction {
     // Normalize whitespace to ensure that answer follows a simpler subset of possible patterns.

--- a/domain/src/main/java/org/oppia/domain/util/StringExtensions.kt
+++ b/domain/src/main/java/org/oppia/domain/util/StringExtensions.kt
@@ -5,5 +5,5 @@ package org.oppia.domain.util
  * https://github.com/oppia/oppia/blob/392323/core/templates/dev/head/filters/string-utility-filters/normalize-whitespace.filter.ts.
  */
 fun String.normalizeWhitespace(): String {
-  return trim().replace(Regex.fromLiteral("\\s{2,}"), " ")
+  return trim().replace("\\s{2,}".toRegex(), " ")
 }


### PR DESCRIPTION
@nikitamarysolomanpvt pointed out a few bugs with both fractions and whitespace normalization as part of #376.

See #376 for details around what bugs exist for the fractions patterns & why.

The normalization pattern was a mistake on my part: Regex.fromLiteral() doesn't do what I think it does. Using String's toRegex() is the correct way to do things.

We really should add tests for these. Filed #414 to track this.