### PR TITLE
Fix #387: Add support for showing concept cards in explorations [BLOCKED ON MISSING TESTS]

### DIFF
--- a/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivity.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivity.kt
@@ -9,13 +9,14 @@ import org.oppia.app.R
 import org.oppia.app.activity.InjectableAppCompatActivity
 import org.oppia.app.player.stopexploration.StopExplorationDialogFragment
 import org.oppia.app.player.stopexploration.StopExplorationInterface
+import org.oppia.app.topic.conceptcard.ConceptCardListener
 import javax.inject.Inject
 
 const val EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY = "ExplorationActivity.exploration_id"
 private const val TAG_STOP_EXPLORATION_DIALOG = "STOP_EXPLORATION_DIALOG"
 
 /** The starting point for exploration. */
-class ExplorationActivity : InjectableAppCompatActivity(), StopExplorationInterface {
+class ExplorationActivity : InjectableAppCompatActivity(), StopExplorationInterface, ConceptCardListener {
   @Inject
   lateinit var explorationActivityPresenter: ExplorationActivityPresenter
   private lateinit var explorationId: String
@@ -64,4 +65,6 @@ class ExplorationActivity : InjectableAppCompatActivity(), StopExplorationInterf
     }
     return super.onOptionsItemSelected(item)
   }
+
+  override fun dismissConceptCard() = explorationActivityPresenter.dismissConceptCard()
 }

--- a/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivityPresenter.kt
@@ -67,6 +67,10 @@ class ExplorationActivityPresenter @Inject constructor(
     getExplorationFragment()?.handlePlayAudio()
   }
 
+  fun dismissConceptCard() {
+    getExplorationFragment()?.dismissConceptCard()
+  }
+
   private fun updateToolbarTitle(explorationId: String) {
     subscribeToExploration(explorationDataController.getExplorationById(explorationId))
   }

--- a/app/src/main/java/org/oppia/app/player/exploration/ExplorationFragment.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/ExplorationFragment.kt
@@ -22,4 +22,6 @@ class ExplorationFragment : InjectableFragment() {
   }
 
   fun handlePlayAudio() = explorationFragmentPresenter.handlePlayAudio()
+
+  fun dismissConceptCard() = explorationFragmentPresenter.dismissConceptCard()
 }

--- a/app/src/main/java/org/oppia/app/player/exploration/ExplorationFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/ExplorationFragmentPresenter.kt
@@ -34,6 +34,8 @@ class ExplorationFragmentPresenter @Inject constructor(
     getStateFragment()?.handlePlayAudio()
   }
 
+  fun dismissConceptCard() = getStateFragment()?.dismissConceptCard()
+
   private fun getStateFragment(): StateFragment? {
     return fragment.childFragmentManager.findFragmentById(R.id.state_fragment_placeholder) as StateFragment?
   }

--- a/app/src/main/java/org/oppia/app/player/state/StateFragment.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateFragment.kt
@@ -53,4 +53,6 @@ class StateFragment : InjectableFragment(), CellularDataInterface, InteractionAn
   }
 
   fun handlePlayAudio() = stateFragmentPresenter.handleAudioClick()
+
+  fun dismissConceptCard() = stateFragmentPresenter.dismissConceptCard()
 }

--- a/app/src/main/java/org/oppia/app/testing/ConceptCardFragmentTestActivity.kt
+++ b/app/src/main/java/org/oppia/app/testing/ConceptCardFragmentTestActivity.kt
@@ -17,7 +17,7 @@ class ConceptCardFragmentTestActivity : InjectableAppCompatActivity(), ConceptCa
     conceptCardFragmentTestActivityController.handleOnCreate()
   }
 
-  override fun dismiss() {
+  override fun dismissConceptCard() {
     getConceptCardFragment()?.dismiss()
   }
 

--- a/app/src/main/java/org/oppia/app/testing/TopicTestActivity.kt
+++ b/app/src/main/java/org/oppia/app/testing/TopicTestActivity.kt
@@ -51,7 +51,7 @@ class TopicTestActivity : InjectableAppCompatActivity(), RouteToQuestionPlayerLi
     }
   }
 
-  override fun dismiss() {
+  override fun dismissConceptCard() {
     getConceptCardFragment()?.dismiss()
   }
 

--- a/app/src/main/java/org/oppia/app/testing/TopicTestActivityForStory.kt
+++ b/app/src/main/java/org/oppia/app/testing/TopicTestActivityForStory.kt
@@ -53,7 +53,7 @@ class TopicTestActivityForStory : InjectableAppCompatActivity(), RouteToQuestion
     }
   }
 
-  override fun dismiss() {
+  override fun dismissConceptCard() {
     getConceptCardFragment()?.dismiss()
   }
 

--- a/app/src/main/java/org/oppia/app/topic/TopicActivity.kt
+++ b/app/src/main/java/org/oppia/app/topic/TopicActivity.kt
@@ -53,7 +53,7 @@ class TopicActivity : InjectableAppCompatActivity(), RouteToQuestionPlayerListen
     }
   }
 
-  override fun dismiss() {
+  override fun dismissConceptCard() {
     getConceptCardFragment()?.dismiss()
   }
 

--- a/app/src/main/java/org/oppia/app/topic/conceptcard/ConceptCardFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/topic/conceptcard/ConceptCardFragmentPresenter.kt
@@ -31,7 +31,7 @@ class ConceptCardFragmentPresenter @Inject constructor(
 
     binding.conceptCardToolbar.setNavigationIcon(R.drawable.ic_close_white_24dp)
     binding.conceptCardToolbar.setNavigationOnClickListener {
-      (fragment.requireActivity() as? ConceptCardListener)?.dismiss()
+      (fragment.requireActivity() as? ConceptCardListener)?.dismissConceptCard()
     }
 
     binding.let {

--- a/app/src/main/java/org/oppia/app/topic/conceptcard/ConceptCardListener.kt
+++ b/app/src/main/java/org/oppia/app/topic/conceptcard/ConceptCardListener.kt
@@ -3,5 +3,5 @@ package org.oppia.app.topic.conceptcard
 /** Allows parent activity to dismiss the [ConceptCardFragment] */
 interface ConceptCardListener {
   /** Called when the concept card dialog should be dismissed. */
-  fun dismiss()
+  fun dismissConceptCard()
 }

--- a/domain/src/main/assets/fractions_exploration1.json
+++ b/domain/src/main/assets/fractions_exploration1.json
@@ -1928,7 +1928,7 @@
               "param_changes": [],
               "feedback": {
                 "content_id": "feedback_3",
-                "html": "<p>That's not correct -- it looks like you've forgotten what the numerator and denominator represent. Take a look at the short <oppia-noninteractive-link text-with-value=\"&amp;quot;refresher lesson&amp;quot;\" url-with-value=\"&amp;quot;https://www.oppia.org/explore/xHwiGtvK2N4L?parent=MjZzEVOG47_1&amp;quot;\"></oppia-noninteractive-link> to refresh your memory if you need to.</p>"
+                "html": "<p>That's not correct -- it looks like you've forgotten what the numerator and denominator represent. Take a look at the short <oppia-concept-card-link skill-id=\"UxTGIJqaHMLa\">refresher lesson</oppia-concept-card-link> to refresh your memory if you need to.</p>"
               },
               "dest": "Matthew gets conned",
               "refresher_exploration_id": null,

--- a/utility/src/main/java/org/oppia/util/parser/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/util/parser/CustomHtmlContentHandler.kt
@@ -1,0 +1,141 @@
+package org.oppia.util.parser
+
+import android.text.Editable
+import android.text.Html
+import android.text.Spannable
+import org.xml.sax.Attributes
+import org.xml.sax.ContentHandler
+import org.xml.sax.Locator
+import org.xml.sax.XMLReader
+
+/**
+ * A custom [ContentHandler] and [Html.TagHandler] for processing custom HTML tags. This class must be used if a custom
+ * tag attribute must be parsed.
+ *
+ * This is based on the implementation provided in https://stackoverflow.com/a/36528149.
+ */
+class CustomHtmlContentHandler private constructor(
+  private val customTagHandlers: Map<String, CustomTagHandler>
+): ContentHandler, Html.TagHandler {
+  private var originalContentHandler: ContentHandler? = null
+  private var currentTrackedTag: TrackedTag? = null
+  private var currentTrackedCustomTag: TrackedCustomTag? = null
+
+  override fun endElement(uri: String?, localName: String?, qName: String?) {
+    originalContentHandler?.endElement(uri, localName, qName)
+    currentTrackedTag = null
+  }
+
+  override fun processingInstruction(target: String?, data: String?) {
+    originalContentHandler?.processingInstruction(target, data)
+  }
+
+  override fun startPrefixMapping(prefix: String?, uri: String?) {
+    originalContentHandler?.startPrefixMapping(prefix, uri)
+  }
+
+  override fun ignorableWhitespace(ch: CharArray?, start: Int, length: Int) {
+    originalContentHandler?.ignorableWhitespace(ch, start, length)
+  }
+
+  override fun characters(ch: CharArray?, start: Int, length: Int) {
+    originalContentHandler?.characters(ch, start, length)
+  }
+
+  override fun endDocument() {
+    originalContentHandler?.endDocument()
+  }
+
+  override fun startElement(uri: String?, localName: String?, qName: String?, atts: Attributes?) {
+    // Defer custom tag management to the tag handler so that Android's element parsing takes precedence.
+    currentTrackedTag = TrackedTag(checkNotNull(localName), checkNotNull(atts))
+    originalContentHandler?.startElement(uri, localName, qName, atts)
+  }
+
+  override fun skippedEntity(name: String?) {
+    originalContentHandler?.skippedEntity(name)
+  }
+
+  override fun setDocumentLocator(locator: Locator?) {
+    originalContentHandler?.setDocumentLocator(locator)
+  }
+
+  override fun endPrefixMapping(prefix: String?) {
+    originalContentHandler?.endPrefixMapping(prefix)
+  }
+
+  override fun startDocument() {
+    originalContentHandler?.startDocument()
+  }
+
+  override fun handleTag(opening: Boolean, tag: String?, output: Editable?, xmlReader: XMLReader?) {
+    check(output != null) { "Expected non-null editable." }
+    when {
+      originalContentHandler == null -> {
+        check(tag == "init-custom-handler") { "Expected first custom tag to be initializing the custom handler." }
+        checkNotNull(xmlReader) { "Expected reader to not be null" }
+        originalContentHandler = xmlReader.contentHandler
+        xmlReader.contentHandler = this
+      }
+      opening -> {
+        if (tag in customTagHandlers) {
+          val localCurrentTrackedTag = currentTrackedTag
+          check(localCurrentTrackedTag != null) { "Expected tag details to be to be cached for current tag." }
+          check(localCurrentTrackedTag.tag == tag) {
+            "Expected tracked tag $currentTrackedTag to match custom tag: $tag"
+          }
+          check(currentTrackedCustomTag == null) { "Custom content handler does not support nested custom tags." }
+          currentTrackedCustomTag = TrackedCustomTag(
+            localCurrentTrackedTag.tag, localCurrentTrackedTag.attributes, output.length
+          )
+        }
+      }
+      tag in customTagHandlers -> {
+        val localCurrentTrackedCustomTag = currentTrackedCustomTag
+        check(localCurrentTrackedCustomTag != null) { "Expected custom tag to be initialized tracked." }
+        check(localCurrentTrackedCustomTag.tag == tag) {
+          "Expected tracked tag $currentTrackedTag to match custom tag: $tag"
+        }
+        val (_, attributes, openTagIndex) = localCurrentTrackedCustomTag
+        customTagHandlers.getValue(tag).handleTag(attributes, openTagIndex, output.length, output)
+      }
+    }
+  }
+
+  private data class TrackedTag(val tag: String, val attributes: Attributes)
+  private data class TrackedCustomTag(val tag: String, val attributes: Attributes, val openTagIndex: Int)
+
+  /** Handler interface for a custom tag and its attributes. */
+  interface CustomTagHandler {
+    /**
+     * Called when a custom tag is encountered. This is always called after the closing tag.
+     *
+     * @param attributes The tag's attributes
+     * @param openIndex The index in the output [Editable] at which this tag begins
+     * @param closeIndex The index in the output [Editable] at which this tag ends
+     * @param output The destination [Editable] to which spans can be added
+     */
+    fun handleTag(attributes: Attributes, openIndex: Int, closeIndex: Int, output: Editable)
+  }
+
+  companion object {
+    /**
+     * Returns a new [Spannable] with HTML parsed from [html] using the specified [imageGetter] for handling image
+     * retrieval, and map of tags to [CustomTagHandler]s for handling custom tags. All possible custom tags must be
+     * registered in the [customTagHandlers] map.
+     */
+    fun fromHtml(
+      html: String, imageGetter: Html.ImageGetter, customTagHandlers: Map<String, CustomTagHandler>
+    ): Spannable {
+      // Adjust the HTML to allow the custom content handler to properly initialize custom tag tracking.
+      val adjustedHtml = "<init-custom-handler/>$html"
+      return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+        Html.fromHtml(
+          adjustedHtml, Html.FROM_HTML_MODE_LEGACY, imageGetter, CustomHtmlContentHandler(customTagHandlers)
+        ) as Spannable
+      } else {
+        Html.fromHtml(adjustedHtml, imageGetter, CustomHtmlContentHandler(customTagHandlers)) as Spannable
+      }
+    }
+  }
+}

--- a/utility/src/main/java/org/oppia/util/parser/HtmlParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/HtmlParser.kt
@@ -1,8 +1,12 @@
 package org.oppia.util.parser
 
-import android.text.Html
+import android.text.Editable
 import android.text.Spannable
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
+import android.view.View
 import android.widget.TextView
+import org.xml.sax.Attributes
 import javax.inject.Inject
 
 private const val CUSTOM_IMG_TAG = "oppia-noninteractive-image"
@@ -10,41 +14,78 @@ private const val REPLACE_IMG_TAG = "img"
 private const val CUSTOM_IMG_FILE_PATH_ATTRIBUTE = "filepath-with-value"
 private const val REPLACE_IMG_FILE_PATH_ATTRIBUTE = "src"
 
+private const val CUSTOM_CONCEPT_CARD_TAG = "oppia-concept-card-link"
+
 /** Html Parser to parse custom Oppia tags with Android-compatible versions. */
 class HtmlParser private constructor(
   private val urlImageParserFactory : UrlImageParser.Factory,
   private val entityType: String,
-  private val entityId: String
+  private val entityId: String,
+  customOppiaTagActionListener: CustomOppiaTagActionListener?
 ) {
+  private val conceptCardTagHandler = ConceptCardTagHandler(customOppiaTagActionListener)
 
   /**
-   * This method replaces custom Oppia tags with Android-compatible versions for a given raw HTML string, and returns the HTML [Spannable].
-   * @param rawString rawString argument is the string from the string-content
-   * @param htmlContentTextView htmlContentTextView argument is the TextView, that need to be passed as argument to ImageGetter class for image parsing
-   * @return Spannable Spannable represents the styled text.
+   * Parses a raw HTML string with support for custom Oppia tags.
+   *
+   * @param rawString raw HTML to parse
+   * @param htmlContentTextView the [TextView] that will contain the returned [Spannable]
+   * @param supportsLinks whether the provided [TextView] should support link forwarding (it's recommended not to use
+   *     this for [TextView]s that are within other layouts that need to support clicking (default false)
+   * @return a [Spannable] representing the styled text.
    */
-  fun parseOppiaHtml(rawString: String, htmlContentTextView: TextView): Spannable {
+  fun parseOppiaHtml(rawString: String, htmlContentTextView: TextView, supportsLinks: Boolean = false): Spannable {
     var htmlContent = rawString
     if (htmlContent.contains(CUSTOM_IMG_TAG)) {
-      htmlContent = htmlContent.replace(CUSTOM_IMG_TAG, REPLACE_IMG_TAG, /* ignoreCase= */false)
-      htmlContent = htmlContent.replace(
-        CUSTOM_IMG_FILE_PATH_ATTRIBUTE,
-        REPLACE_IMG_FILE_PATH_ATTRIBUTE, /* ignoreCase= */false
-      )
+      htmlContent = htmlContent.replace(CUSTOM_IMG_TAG, REPLACE_IMG_TAG)
+      htmlContent = htmlContent.replace( CUSTOM_IMG_FILE_PATH_ATTRIBUTE, REPLACE_IMG_FILE_PATH_ATTRIBUTE)
       htmlContent = htmlContent.replace("&amp;quot;", "")
     }
 
+    // https://stackoverflow.com/a/8662457
+    if (supportsLinks) {
+      htmlContentTextView.movementMethod = LinkMovementMethod.getInstance()
+    }
+
     val imageGetter =  urlImageParserFactory.create(htmlContentTextView, entityType, entityId)
-    return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-      Html.fromHtml(htmlContent, Html.FROM_HTML_MODE_LEGACY, imageGetter, /* tagHandler= */ null) as Spannable
-    } else {
-      Html.fromHtml(htmlContent, imageGetter, /* tagHandler= */ null) as Spannable
+    return CustomHtmlContentHandler.fromHtml(
+      htmlContent, imageGetter, mapOf(CUSTOM_CONCEPT_CARD_TAG to conceptCardTagHandler)
+    )
+  }
+
+  // https://mohammedlakkadshaw.com/blog/handling-custom-tags-in-android-using-html-taghandler.html/
+  private class ConceptCardTagHandler(
+    private val customOppiaTagActionListener: CustomOppiaTagActionListener?
+  ): CustomHtmlContentHandler.CustomTagHandler {
+    override fun handleTag(attributes: Attributes, openIndex: Int, closeIndex: Int, output: Editable) {
+      val skillId = attributes.getValue("skill-id")
+      output.setSpan(object : ClickableSpan() {
+        override fun onClick(view: View) {
+          customOppiaTagActionListener?.onConceptCardLinkClicked(view, skillId)
+        }
+      }, openIndex, closeIndex, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
     }
   }
 
+  /** Listener that's called when a custom tag triggers an event. */
+  interface CustomOppiaTagActionListener {
+    /**
+     * Called when an embedded concept card link is clicked in the specified view with the skillId corresponding to the
+     * card that should be shown.
+     */
+    fun onConceptCardLinkClicked(view: View, skillId: String)
+  }
+
+  /** Factory for creating new [HtmlParser]s. */
   class Factory @Inject constructor(private val urlImageParserFactory: UrlImageParser.Factory) {
-    fun create(entityType: String, entityId: String): HtmlParser {
-      return HtmlParser(urlImageParserFactory, entityType, entityId)
+    /**
+     * Returns a new [HtmlParser] with the specified entity type and ID for loading images, and an optionally specified
+     * [CustomOppiaTagActionListener] for handling custom Oppia tag events.
+     */
+    fun create(
+      entityType: String, entityId: String, customOppiaTagActionListener: CustomOppiaTagActionListener? = null
+    ): HtmlParser {
+      return HtmlParser(urlImageParserFactory, entityType, entityId, customOppiaTagActionListener)
     }
   }
 }


### PR DESCRIPTION
Fix #387.

This introduces support for showing custom Oppia concept card links in feedback and content HTML. This requires a custom content handler with some hacky tag injection, but this seems like the best we can do (see https://stackoverflow.com/a/36528149 for context).

This updates the 'meaning of equal parts' exploration to include this new tag. This isn't yet finished on Oppia backend (FYI @aks681), so what we're working with in the meantime is a tag of the sort: <oppia-concept-card-link skill-id="UxTGIJqaHMLa">refresher lesson</oppia-concept-card-link>.

This PR is ready for review, but not submission yet since tests need to be written.