### PR TITLE
Update question player dummy text to be 'coming soon'

### DIFF
--- a/app/src/main/res/layout/question_player_fragment.xml
+++ b/app/src/main/res/layout/question_player_fragment.xml
@@ -10,7 +10,7 @@
       android:id="@+id/dummy_text_view"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:text="This is dummy TextView for testing"
+      android:text="Questions functionality is coming soon"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/sharedTest/java/org/oppia/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -27,7 +27,7 @@ class QuestionPlayerActivityTest {
   @Test
   fun testQuestionPlayerActivity_loadQuestionPlayerFragment_hasDummyString() {
     ActivityScenario.launch(QuestionPlayerActivity::class.java).use {
-      onView(withId(R.id.dummy_text_view)).check(matches(withText("This is dummy TextView for testing")))
+      onView(withId(R.id.dummy_text_view)).check(matches(withText("Questions functionality is coming soon")))
     }
   }
 


### PR DESCRIPTION
Update question player dummy text to be 'coming soon' instead of a dummy string to better indicate that the fragment is known as incomplete.