### PR TITLE
Fix #425: Update fraction rule parsing to use non-negative int instead of double

### DIFF
--- a/domain/src/main/java/org/oppia/domain/util/StateRetriever.kt
+++ b/domain/src/main/java/org/oppia/domain/util/StateRetriever.kt
@@ -184,7 +184,7 @@ class StateRetriever @Inject constructor(
           "HasDenominatorEqualTo", "HasNumeratorEqualTo" -> ruleSpecBuilder.putInput(
             inputName,
             InteractionObject.newBuilder()
-              .setReal(inputsJson.getDouble(inputName))
+              .setNonNegativeInt(inputsJson.getInt(inputName))
               .build()
           )
           else -> ruleSpecBuilder.putInput(inputName, createExactInputFromJson(inputsJson, inputName, interactionId))

--- a/domain/src/main/java/org/oppia/domain/util/StateRetriever.kt
+++ b/domain/src/main/java/org/oppia/domain/util/StateRetriever.kt
@@ -181,7 +181,13 @@ class StateRetriever @Inject constructor(
       while (inputKeysIterator.hasNext()) {
         val inputName = inputKeysIterator.next()
         when (ruleSpecBuilder.ruleType) {
-          "HasDenominatorEqualTo", "HasNumeratorEqualTo" -> ruleSpecBuilder.putInput(
+          "HasNumeratorEqualTo" -> ruleSpecBuilder.putInput(
+            inputName,
+            InteractionObject.newBuilder()
+              .setSignedInt(inputsJson.getInt(inputName))
+              .build()
+          )
+          "HasDenominatorEqualTo" -> ruleSpecBuilder.putInput(
             inputName,
             InteractionObject.newBuilder()
               .setNonNegativeInt(inputsJson.getInt(inputName))


### PR DESCRIPTION
Fix #425.

It seems that we were incorrectly setting 'double' instead of 'nonNegativeInt' for some fractions rules, causing the rules to fail classification during answer submission and more or less break the experience.

This fixes that, but doesn't audit or fix other cases. There are no tests crossing these pipelines yet, and #449 tracks creating these tests.

It may be worth considering always falling back to default when the classification fails, or find another robust way to handle it rather than do nothing.