### PR TITLE
Fix #432: Radio button fixed

### DIFF
--- a/app/src/main/java/org/oppia/app/player/state/SelectionInteractionView.kt
+++ b/app/src/main/java/org/oppia/app/player/state/SelectionInteractionView.kt
@@ -39,22 +39,18 @@ class SelectionInteractionView @JvmOverloads constructor(
   lateinit var entityType: String
   private lateinit var explorationId: String
 
-  init {
-    adapter = createAdapter()
-  }
-
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
     FragmentManager.findFragment<InjectableFragment>(this).createViewComponent(this).inject(this)
   }
 
-  fun setItemInputType(selectionItemInputType: SelectionItemInputType) {
+  fun setAllOptionsItemInputType(selectionItemInputType: SelectionItemInputType) {
     // TODO(#299): Find a cleaner way to initialize the item input type. Using data-binding results in a race condition
     //  with setting the adapter data, so this needs to be done in an order-agnostic way. There should be a way to do
     //  this more efficiently and cleanly than always relying on notifying of potential changes in the adapter when the
     //  type is set (plus the type ought to be permanent).
     this.selectionItemInputType = selectionItemInputType
-    adapter!!.notifyDataSetChanged()
+    adapter = createAdapter()
   }
 
   // TODO(#264): Clean up HTML parser such that it can be handled completely through a binding adapter, allowing
@@ -106,10 +102,10 @@ class SelectionInteractionView @JvmOverloads constructor(
 }
 
 /** Sets the [SelectionItemInputType] for a specific [SelectionInteractionView] via data-binding. */
-@BindingAdapter("itemInputType")
-fun setItemInputType(
+@BindingAdapter("allOptionsItemInputType")
+fun setAllOptionsItemInputType(
   selectionInteractionView: SelectionInteractionView, selectionItemInputType: SelectionItemInputType
-) = selectionInteractionView.setItemInputType(selectionItemInputType)
+) = selectionInteractionView.setAllOptionsItemInputType(selectionItemInputType)
 
 /** Sets the exploration ID for a specific [SelectionInteractionView] via data-binding. */
 @BindingAdapter("explorationId")

--- a/app/src/main/res/layout/selection_interaction_item.xml
+++ b/app/src/main/res/layout/selection_interaction_item.xml
@@ -35,9 +35,9 @@
       android:layout_marginEnd="20dp"
       android:layout_marginBottom="@dimen/divider_margin_bottom"
       android:divider="@android:color/transparent"
+      app:allOptionsItemInputType="@{viewModel.getSelectionItemInputType()}"
       app:data="@{viewModel.choiceItems}"
       app:explorationId="@{viewModel.explorationId}"
-      app:itemInputType="@{viewModel.getSelectionItemInputType()}"
       app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
   </LinearLayout>
 </layout>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

This PR is actually a quite weird fix for radio buttons.

1. As soon as the `SelectionInteractionView` is used, the default  value for `selectionItemInputType` is `CheckBoxes`, which was getting updated later on in code but was not getting reflected in UI.
2. In `SelectionInteractionView`, even though the information that we have to show `RadioButton` is getting transferred correctly but `adapter!!.notifyDataSetChanged()` is not updating the UI.
3. In `selection_interaction_item.xml` changing the order of data binding and bringing `itemInputType` to top in `SelectionInteractionView` worked which made me wondering that do we need to follow order of xml attributes while writing them in `XML` file?
4. Because when we press `Option+cmd+L` which will reorganise the XML file in alphabetical order and again the same issue will arise, I changed the name of `itemInputType` to `allOptionstemInputType`, so that it remains on top even in case of reorganising.

![Screenshot_1574275914](https://user-images.githubusercontent.com/9396084/69268335-f1825e00-0bf4-11ea-9adb-62abf7743f53.png)

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
