### PR TITLE
Fix #468: Low fi topic train with support for API below 21

### DIFF
--- a/app/src/main/java/org/oppia/app/application/OppiaApplication.kt
+++ b/app/src/main/java/org/oppia/app/application/OppiaApplication.kt
@@ -2,10 +2,11 @@ package org.oppia.app.application
 
 import android.app.Application
 import androidx.appcompat.app.AppCompatActivity
+import androidx.multidex.MultiDexApplication
 import org.oppia.app.activity.ActivityComponent
 
 /** The root [Application] of the Oppia app. */
-class OppiaApplication: Application() {
+class OppiaApplication: MultiDexApplication() {
   /** The root [ApplicationComponent]. */
   private val component: ApplicationComponent by lazy {
     DaggerApplicationComponent.builder()

--- a/app/src/main/java/org/oppia/app/topic/train/TopicTrainFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/topic/train/TopicTrainFragmentPresenter.kt
@@ -41,6 +41,7 @@ class TopicTrainFragmentPresenter @Inject constructor(
     val binding = TopicTrainFragmentBinding.inflate(inflater, container, /* attachToRoot= */ false)
 
     skillSelectionAdapter = SkillSelectionAdapter(this)
+    binding.skillRecyclerView.isNestedScrollingEnabled = false
     binding.skillRecyclerView.apply {
       adapter = skillSelectionAdapter
     }

--- a/app/src/main/res/layout/topic_train_fragment.xml
+++ b/app/src/main/res/layout/topic_train_fragment.xml
@@ -15,7 +15,7 @@
       type="org.oppia.app.topic.train.TopicTrainFragmentPresenter" />
   </data>
 
-  <ScrollView
+  <androidx.core.widget.NestedScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/oppiaBackground"
@@ -79,5 +79,5 @@
         android:text="@string/topic_train_start"
         android:textColor="@{viewModel.isSubmitButtonActive()? @color/white : @color/submitButtonInactive}" />
     </LinearLayout>
-  </ScrollView>
+  </androidx.core.widget.NestedScrollView>
 </layout>

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -13,6 +13,7 @@ android {
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    multiDexEnabled true
   }
 
   compileOptions {
@@ -42,6 +43,7 @@ dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
   implementation(
       'androidx.appcompat:appcompat:1.0.2',
+      'com.android.support:multidex:1.0.3',
       'com.google.dagger:dagger:2.24',
       'com.google.protobuf:protobuf-lite:3.0.0',
       'com.squareup.moshi:moshi-kotlin:1.8.0',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Issue
Reference: https://github.com/oppia/oppia-android/pull/466#discussion_r349034147
In current implementation of TopicTrainTab, the structure is like this:
 1. Two TextViews at top.
 2. Recyclerview for skills
 3. `Start` button at the end.

Now, in this case, if the the skills list is big then the scrolling will be nested scrolling, which you can check in above link.

## Obvious solution
One obvious solution was to make recyclerview handle multiple-view-types similar to `StateFragment` and `HomeFragment` which will make even the two textviews and `Start` button an item of recyclerview.
For now, I have not done this, considering the the other solution seems much more easier to me.

## New solution
Use `NestedScrollView` and make `Recyclerview` `nestedScrolling = false`, this solves the issue and in the end only `NestedScrollView` is scrollable. But when we run this app on API below 21 this crashed with following error:
<img width="1481" alt="Screenshot 2019-11-25 at 12 31 27 PM" src="https://user-images.githubusercontent.com/9396084/69519233-854e8400-0f7f-11ea-9eeb-f8d36dcac6cd.png">

To solve this I followed the steps mentioned on https://stackoverflow.com/a/55177763

If this solution gets approved, then I believe that creating carousel in HomeFragment will become much more easier.


## Testing Approach:
1. Add dummy skills in `fractions_skills.json` file in domain layer so that Topic Train Tab is scrollable enough. Make sure that IDs are different in each skill.
2. Test in Device with API >=21 and API< 21.
## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
