### PR TITLE
Audio Bug Fix - Remove elevation

### DIFF
--- a/app/src/main/res/layout/state_fragment.xml
+++ b/app/src/main/res/layout/state_fragment.xml
@@ -23,7 +23,6 @@
       android:layout_height="match_parent"
       android:clipToPadding="false"
       android:divider="@android:color/transparent"
-      android:elevation="4dp"
       android:overScrollMode="never"
       android:paddingTop="@{viewModel.isAudioBarVisible().get()? @dimen/padding_72dp : @dimen/padding_24dp}"
       android:scrollbars="none"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

In StateFragment, audio was not playable because the entire recyclerview was coming on top of audio player. To fix that I have removed the elevation given to Recyclerview.


Also, if you approve this, directly merge this so that others won't face this issue.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
