### PR TITLE
Update leave topic dialog text

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
   <string name="cellular_data_alert_dialog_checkbox">Don\'t show this message again</string>
   <string name="concept_card_toolbar_title">Concept Card</string>
   <string name="stop_exploration_dialog_title">Leave to Topic Page?</string>
-  <string name="stop_exploration_dialog_description">Your progress will be saved.</string>
+  <string name="stop_exploration_dialog_description">Your progress will not be saved.</string>
   <string name="stop_exploration_dialog_cancel_button">Cancel</string>
   <string name="stop_exploration_dialog_leave_button">Leave</string>
   <string name="topic_train_master_these_skills">Master These Skills</string>


### PR DESCRIPTION
Update leave topic dialog text to indicate that progress is NOT saved. This matches the product design & mocks.

This doesn't correspond to any bugs, but it's probably worth including as part of #494. I noticed this in passing while working on questions.