### PR TITLE
Rich text image centre fix

### DIFF
--- a/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
@@ -7,6 +7,8 @@ import android.graphics.Rect
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.text.Html
+import android.view.View
+import android.view.ViewTreeObserver
 import android.widget.TextView
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
@@ -51,19 +53,21 @@ class UrlImageParser private constructor(
     override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
       val drawable = BitmapDrawable(context.resources, resource)
       htmlContentTextView.post {
-        val drawableHeight = drawable.intrinsicHeight
-        val drawableWidth = drawable.intrinsicWidth
-        val initialDrawableMargin = if (imageCenterAlign) {
-          calculateInitialMargin(drawableWidth)
-        } else {
-          0
+        htmlContentTextView.width {
+          val drawableHeight = drawable.intrinsicHeight
+          val drawableWidth = drawable.intrinsicWidth
+          val initialDrawableMargin = if (imageCenterAlign) {
+            calculateInitialMargin(it, drawableWidth)
+          } else {
+            0
+          }
+          val rect = Rect(initialDrawableMargin, 0, drawableWidth + initialDrawableMargin, drawableHeight)
+          drawable.bounds = rect
+          urlDrawable.bounds = rect
+          urlDrawable.drawable = drawable
+          htmlContentTextView.text = htmlContentTextView.text
+          htmlContentTextView.invalidate()
         }
-        val rect = Rect(initialDrawableMargin, 0, drawableWidth + initialDrawableMargin, drawableHeight)
-        drawable.bounds = rect
-        urlDrawable.bounds = rect
-        urlDrawable.drawable = drawable
-        htmlContentTextView.text = htmlContentTextView.text
-        htmlContentTextView.invalidate()
       }
     }
   }
@@ -78,9 +82,25 @@ class UrlImageParser private constructor(
     }
   }
 
-  private fun calculateInitialMargin(drawableWidth: Int): Int {
-    val availableAreaWidth = htmlContentTextView.width
-    return (availableAreaWidth - drawableWidth) / 2
+  private fun calculateInitialMargin(availableAreaWidth: Int, drawableWidth: Int): Int {
+    val margin = (availableAreaWidth - drawableWidth) / 2
+    return if (margin > 0) {
+      margin
+    } else {
+      0
+    }
+  }
+
+  // Reference: https://stackoverflow.com/a/51865494
+  fun <T : View> T.width(function: (Int) -> Unit) {
+    if (width == 0)
+      viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
+        override fun onGlobalLayout() {
+          viewTreeObserver.removeOnGlobalLayoutListener(this)
+          function(width)
+        }
+      })
+    else function(width)
   }
 
   class Factory @Inject constructor(

--- a/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
@@ -7,7 +7,6 @@ import android.graphics.Rect
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.text.Html
-import android.view.View
 import android.view.ViewTreeObserver
 import android.widget.TextView
 import com.bumptech.glide.request.target.CustomTarget
@@ -92,15 +91,17 @@ class UrlImageParser private constructor(
   }
 
   // Reference: https://stackoverflow.com/a/51865494
-  fun <T : View> T.width(calculateWidth: (Int) -> Unit) {
-    if (width == 0)
+  private fun TextView.width(computeWidthOnGlobalLayout: (Int) -> Unit) {
+    if (width == 0) {
       viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
         override fun onGlobalLayout() {
           viewTreeObserver.removeOnGlobalLayoutListener(this)
-          calculateWidth(width)
+          computeWidthOnGlobalLayout(width)
         }
       })
-    else calculateWidth(width)
+    } else {
+      computeWidthOnGlobalLayout(width)
+    }
   }
 
   class Factory @Inject constructor(

--- a/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
@@ -92,15 +92,15 @@ class UrlImageParser private constructor(
   }
 
   // Reference: https://stackoverflow.com/a/51865494
-  fun <T : View> T.width(function: (Int) -> Unit) {
+  fun <T : View> T.width(calculateWidth: (Int) -> Unit) {
     if (width == 0)
       viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
         override fun onGlobalLayout() {
           viewTreeObserver.removeOnGlobalLayoutListener(this)
-          function(width)
+          calculateWidth(width)
         }
       })
-    else function(width)
+    else calculateWidth(width)
   }
 
   class Factory @Inject constructor(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

@BenHenning had observed one issue in which if we open exploration, again and again quickly, then in some cases (approximately 10-20% times) the image in content card would cut from the very start. Check below image:
![Screenshot_1575389556](https://user-images.githubusercontent.com/9396084/70075284-7a03f400-1622-11ea-94a2-87ee7a5319b8.png)

This has been fixed to keep image always in centre.

Also, to test this, you will need to open exploration again and again quickly as shown in gif. Make sure you test this atleast 10 times quickly.

![image-issue-2](https://user-images.githubusercontent.com/9396084/70075510-f8609600-1622-11ea-8d20-836bfc30e19d.gif)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
