### PR TITLE
Fix #425: Update HasNumeratorEqualTo classifier to match the parsing logic

### DIFF
--- a/domain/src/main/java/org/oppia/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProvider.kt
+++ b/domain/src/main/java/org/oppia/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProvider.kt
@@ -19,7 +19,7 @@ internal class FractionInputHasNumeratorEqualToRuleClassifierProvider @Inject co
 
   override fun createRuleClassifier(): RuleClassifier {
     return classifierFactory.createMultiTypeSingleInputClassifier(
-      InteractionObject.ObjectTypeCase.FRACTION, InteractionObject.ObjectTypeCase.NON_NEGATIVE_INT, "x", this)
+      InteractionObject.ObjectTypeCase.FRACTION, InteractionObject.ObjectTypeCase.SIGNED_INT, "x", this)
   }
 
   // TODO(#210): Add tests for this classifier.


### PR DESCRIPTION
Fix #425.

This was missed as part of #450: we updated the type being parsed but not the corresponding classifier. HasDenominatorEqualTo does not have the same since it's already using the correct type.