### PR TITLE
Remove padding for scroll view in concept card

### DIFF
--- a/app/src/main/res/layout/concept_card_fragment.xml
+++ b/app/src/main/res/layout/concept_card_fragment.xml
@@ -36,8 +36,7 @@
 
       <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingBottom="@dimen/bottom_white_space">
+        android:layout_height="match_parent">
 
         <LinearLayout
           android:layout_width="match_parent"


### PR DESCRIPTION
I'm not sure why there was padding at the bottom of the concept card, but it causes the text to look weird/get cut off on smaller screens or with text zoom:

![image](https://user-images.githubusercontent.com/12983742/70206189-87c98000-16db-11ea-89a7-f17b180f6652.png)
