### PR TITLE
Route to exploration in promoted story list (Continue Playing)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,17 @@
       android:theme="@style/OppiaThemeWithoutActionBar"
       android:screenOrientation="portrait"
       android:windowSoftInputMode="adjustResize"/>
+    <activity
+      android:name=".testing.ExplorationTestActivity" >
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+    </activity>
     <activity android:name=".player.state.testing.StateFragmentTestActivity" />
     <activity
       android:name=".profile.AddProfileActivity"
@@ -47,14 +58,6 @@
       android:name=".splash.SplashActivity"
       android:theme="@style/SplashScreenTheme"
       android:screenOrientation="portrait">
-      <intent-filter>
-        <action android:name="android.intent.action.MAIN" />
-        <category android:name="android.intent.category.LAUNCHER" />
-      </intent-filter>
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.DEFAULT" />
-      </intent-filter>
     </activity>
     <activity
       android:name=".story.StoryActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,16 +27,7 @@
       android:screenOrientation="portrait"
       android:windowSoftInputMode="adjustResize"/>
     <activity
-      android:name=".testing.ExplorationTestActivity" >
-      <intent-filter>
-        <action android:name="android.intent.action.MAIN" />
-        <category android:name="android.intent.category.LAUNCHER" />
-      </intent-filter>
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.DEFAULT" />
-      </intent-filter>
-    </activity>
+      android:name=".testing.ExplorationTestActivity" />
     <activity android:name=".player.state.testing.StateFragmentTestActivity" />
     <activity
       android:name=".profile.AddProfileActivity"
@@ -58,6 +49,14 @@
       android:name=".splash.SplashActivity"
       android:theme="@style/SplashScreenTheme"
       android:screenOrientation="portrait">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
     </activity>
     <activity
       android:name=".story.StoryActivity"

--- a/app/src/main/java/org/oppia/app/activity/ActivityComponent.kt
+++ b/app/src/main/java/org/oppia/app/activity/ActivityComponent.kt
@@ -24,6 +24,7 @@ import org.oppia.app.testing.TopicTestActivity
 import org.oppia.app.testing.TopicTestActivityForStory
 import org.oppia.app.topic.TopicActivity
 import org.oppia.app.testing.ConceptCardFragmentTestActivity
+import org.oppia.app.testing.ExplorationTestActivity
 import org.oppia.app.topic.questionplayer.QuestionPlayerActivity
 import javax.inject.Provider
 
@@ -50,6 +51,7 @@ interface ActivityComponent {
   fun inject(continuePlayingActivity: ContinuePlayingActivity)
   fun inject(continuePlayingFragmentTestActivity: ContinuePlayingFragmentTestActivity)
   fun inject(explorationActivity: ExplorationActivity)
+  fun inject(explorationTestActivity: ExplorationTestActivity)
   fun inject(homeActivity: HomeActivity)
   fun inject(htmlParserTestActivity: HtmlParserTestActivity)
   fun inject(profileActivity: ProfileActivity)

--- a/app/src/main/java/org/oppia/app/home/HomeActivity.kt
+++ b/app/src/main/java/org/oppia/app/home/HomeActivity.kt
@@ -7,7 +7,7 @@ import org.oppia.app.topic.TopicActivity
 import javax.inject.Inject
 
 /** The central activity for all users entering the app. */
-class HomeActivity : InjectableAppCompatActivity(), RouteToExplorationListener, RouteToTopicListener {
+class HomeActivity : InjectableAppCompatActivity(), RouteToTopicListener {
   @Inject
   lateinit var homeActivityPresenter: HomeActivityPresenter
 
@@ -15,10 +15,6 @@ class HomeActivity : InjectableAppCompatActivity(), RouteToExplorationListener, 
     super.onCreate(savedInstanceState)
     activityComponent.inject(this)
     homeActivityPresenter.handleOnCreate()
-  }
-
-  override fun routeToExploration(explorationId: String) {
-    startActivity(ExplorationActivity.createExplorationActivityIntent(this, explorationId))
   }
 
   override fun routeToTopic(topicId: String) {

--- a/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
@@ -20,15 +20,10 @@ import org.oppia.app.model.TopicList
 import org.oppia.app.model.TopicSummary
 import org.oppia.app.model.UserAppHistory
 import org.oppia.domain.UserAppHistoryController
-import org.oppia.domain.exploration.ExplorationDataController
-import org.oppia.domain.exploration.TEST_EXPLORATION_ID_30
 import org.oppia.domain.topic.TopicListController
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.logging.Logger
 import javax.inject.Inject
-
-private const val EXPLORATION_ID = TEST_EXPLORATION_ID_30
-private const val TAG_HOME_FRAGMENT = "HomeFragment"
 
 /** The presenter for [HomeFragment]. */
 @FragmentScope
@@ -37,10 +32,8 @@ class HomeFragmentPresenter @Inject constructor(
   private val fragment: Fragment,
   private val userAppHistoryController: UserAppHistoryController,
   private val topicListController: TopicListController,
-  private val explorationDataController: ExplorationDataController,
   private val logger: Logger
 ) {
-  private val routeToExplorationListener = activity as RouteToExplorationListener
   private val routeToTopicListener = activity as RouteToTopicListener
   private val itemList: MutableList<HomeItemViewModel> = ArrayList()
   private lateinit var topicListAdapter: TopicListAdapter
@@ -77,22 +70,6 @@ class HomeFragmentPresenter @Inject constructor(
     subscribeToUserAppHistory()
     subscribeToTopicList()
     return binding.root
-  }
-
-  fun playExplorationButton(v: View) {
-    explorationDataController.stopPlayingExploration()
-    explorationDataController.startPlayingExploration(
-      EXPLORATION_ID
-    ).observe(fragment, Observer<AsyncResult<Any?>> { result ->
-      when {
-        result.isPending() -> logger.d(TAG_HOME_FRAGMENT, "Loading exploration")
-        result.isFailure() -> logger.e(TAG_HOME_FRAGMENT, "Failed to load exploration", result.getErrorOrNull()!!)
-        else -> {
-          logger.d(TAG_HOME_FRAGMENT, "Successfully loaded exploration")
-          routeToExplorationListener.routeToExploration(EXPLORATION_ID)
-        }
-      }
-    })
   }
 
   private val topicListSummaryResultLiveData: LiveData<AsyncResult<TopicList>> by lazy {

--- a/app/src/main/java/org/oppia/app/home/RouteToExplorationListener.kt
+++ b/app/src/main/java/org/oppia/app/home/RouteToExplorationListener.kt
@@ -2,5 +2,5 @@ package org.oppia.app.home
 
 /** Listener for when an activity should route to a exploration. */
 interface RouteToExplorationListener {
-  fun routeToExploration(explorationId: String)
+  fun routeToExploration(explorationId: String, topicId: String?)
 }

--- a/app/src/main/java/org/oppia/app/home/continueplaying/ContinuePlayingActivity.kt
+++ b/app/src/main/java/org/oppia/app/home/continueplaying/ContinuePlayingActivity.kt
@@ -4,13 +4,15 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import org.oppia.app.activity.InjectableAppCompatActivity
-import org.oppia.app.story.StoryActivity
-import org.oppia.app.topic.RouteToStoryListener
+import org.oppia.app.home.RouteToExplorationListener
+import org.oppia.app.player.exploration.ExplorationActivity
 import javax.inject.Inject
 
 /** Activity for recent stories. */
-class ContinuePlayingActivity : InjectableAppCompatActivity(), RouteToStoryListener {
-  @Inject lateinit var continuePlayingActivityPresenter: ContinuePlayingActivityPresenter
+class ContinuePlayingActivity : InjectableAppCompatActivity(), RouteToExplorationListener {
+
+  @Inject
+  lateinit var continuePlayingActivityPresenter: ContinuePlayingActivityPresenter
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -25,7 +27,7 @@ class ContinuePlayingActivity : InjectableAppCompatActivity(), RouteToStoryListe
     }
   }
 
-  override fun routeToStory(storyId: String) {
-    startActivity(StoryActivity.createStoryActivityIntent(this, storyId))
+  override fun routeToExploration(explorationId: String) {
+    startActivity(ExplorationActivity.createExplorationActivityIntent(this, explorationId))
   }
 }

--- a/app/src/main/java/org/oppia/app/home/continueplaying/ContinuePlayingActivity.kt
+++ b/app/src/main/java/org/oppia/app/home/continueplaying/ContinuePlayingActivity.kt
@@ -11,8 +11,7 @@ import javax.inject.Inject
 /** Activity for recent stories. */
 class ContinuePlayingActivity : InjectableAppCompatActivity(), RouteToExplorationListener {
 
-  @Inject
-  lateinit var continuePlayingActivityPresenter: ContinuePlayingActivityPresenter
+  @Inject lateinit var continuePlayingActivityPresenter: ContinuePlayingActivityPresenter
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/java/org/oppia/app/home/continueplaying/ContinuePlayingActivity.kt
+++ b/app/src/main/java/org/oppia/app/home/continueplaying/ContinuePlayingActivity.kt
@@ -27,7 +27,7 @@ class ContinuePlayingActivity : InjectableAppCompatActivity(), RouteToExploratio
     }
   }
 
-  override fun routeToExploration(explorationId: String) {
-    startActivity(ExplorationActivity.createExplorationActivityIntent(this, explorationId))
+  override fun routeToExploration(explorationId: String, topicId: String?) {
+    startActivity(ExplorationActivity.createExplorationActivityIntent(this, explorationId, topicId))
   }
 }

--- a/app/src/main/java/org/oppia/app/home/continueplaying/ContinuePlayingFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/continueplaying/ContinuePlayingFragmentPresenter.kt
@@ -95,10 +95,10 @@ class ContinuePlayingFragmentPresenter @Inject constructor(
   }
 
   fun onOngoingStoryClicked(promotedStory: PromotedStory) {
-    playExploration(promotedStory.explorationId)
+    playExploration(promotedStory.explorationId, promotedStory.topicId)
   }
 
-  private fun playExploration(explorationId: String) {
+  private fun playExploration(explorationId: String, topicId: String) {
     explorationDataController.startPlayingExploration(
       explorationId
     ).observe(fragment, Observer<AsyncResult<Any?>> { result ->
@@ -111,7 +111,8 @@ class ContinuePlayingFragmentPresenter @Inject constructor(
         )
         else -> {
           logger.d("ContinuePlayingFragment", "Successfully loaded exploration")
-          routeToExplorationListener.routeToExploration(explorationId)
+          routeToExplorationListener.routeToExploration(explorationId, topicId)
+          (activity as ContinuePlayingActivity).finish()
         }
       }
     })

--- a/app/src/main/java/org/oppia/app/home/continueplaying/ContinuePlayingFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/continueplaying/ContinuePlayingFragmentPresenter.kt
@@ -112,7 +112,7 @@ class ContinuePlayingFragmentPresenter @Inject constructor(
         else -> {
           logger.d("ContinuePlayingFragment", "Successfully loaded exploration")
           routeToExplorationListener.routeToExploration(explorationId, topicId)
-          (activity as ContinuePlayingActivity).finish()
+          activity.finish()
         }
       }
     })

--- a/app/src/main/java/org/oppia/app/home/continueplaying/ContinuePlayingFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/continueplaying/ContinuePlayingFragmentPresenter.kt
@@ -11,11 +11,13 @@ import androidx.lifecycle.Transformations
 import org.oppia.app.R
 import org.oppia.app.databinding.ContinuePlayingFragmentBinding
 import org.oppia.app.fragment.FragmentScope
+import org.oppia.app.home.RouteToExplorationListener
 import org.oppia.app.model.OngoingStoryList
 import org.oppia.app.model.PromotedStory
-import org.oppia.app.topic.RouteToStoryListener
+import org.oppia.domain.exploration.ExplorationDataController
 import org.oppia.domain.topic.TopicListController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.logging.Logger
 import javax.inject.Inject
 
 /** The presenter for [ContinuePlayingFragment]. */
@@ -23,10 +25,12 @@ import javax.inject.Inject
 class ContinuePlayingFragmentPresenter @Inject constructor(
   private val activity: AppCompatActivity,
   private val fragment: Fragment,
+  private val logger: Logger,
+  private val explorationDataController: ExplorationDataController,
   private val topicListController: TopicListController
 ) {
 
-  private val routeToStoryListener = activity as RouteToStoryListener
+  private val routeToExplorationListener = activity as RouteToExplorationListener
 
   private lateinit var binding: ContinuePlayingFragmentBinding
 
@@ -91,6 +95,25 @@ class ContinuePlayingFragmentPresenter @Inject constructor(
   }
 
   fun onOngoingStoryClicked(promotedStory: PromotedStory) {
-    routeToStoryListener.routeToStory(promotedStory.storyId)
+    playExploration(promotedStory.explorationId)
+  }
+
+  private fun playExploration(explorationId: String) {
+    explorationDataController.startPlayingExploration(
+      explorationId
+    ).observe(fragment, Observer<AsyncResult<Any?>> { result ->
+      when {
+        result.isPending() -> logger.d("ContinuePlayingFragment", "Loading exploration")
+        result.isFailure() -> logger.e(
+          "ContinuePlayingFragment",
+          "Failed to load exploration",
+          result.getErrorOrNull()!!
+        )
+        else -> {
+          logger.d("ContinuePlayingFragment", "Successfully loaded exploration")
+          routeToExplorationListener.routeToExploration(explorationId)
+        }
+      }
+    })
   }
 }

--- a/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivity.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivity.kt
@@ -12,7 +12,8 @@ import org.oppia.app.player.stopexploration.StopExplorationDialogFragment
 import org.oppia.app.player.stopexploration.StopExplorationInterface
 import javax.inject.Inject
 
-const val EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY = "ExplorationActivity.exploration_id"
+const val EXPLORATION_ACTIVITY_EXPLORATION_ID_ARGUMENT_KEY = "ExplorationActivity.exploration_id"
+const val EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY = "ExplorationActivity.topic_id"
 private const val TAG_STOP_EXPLORATION_DIALOG = "STOP_EXPLORATION_DIALOG"
 
 /** The starting point for exploration. */
@@ -20,19 +21,24 @@ class ExplorationActivity : InjectableAppCompatActivity(), StopExplorationInterf
   @Inject
   lateinit var explorationActivityPresenter: ExplorationActivityPresenter
   private lateinit var explorationId: String
+  private var topicId: String? = null
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     activityComponent.inject(this)
-    explorationId = intent.getStringExtra(EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY)
-    explorationActivityPresenter.handleOnCreate(explorationId)
+    explorationId = intent.getStringExtra(EXPLORATION_ACTIVITY_EXPLORATION_ID_ARGUMENT_KEY)
+    topicId = intent.getStringExtra(EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY)
+    explorationActivityPresenter.handleOnCreate(explorationId, topicId)
   }
 
   companion object {
     /** Returns a new [Intent] to route to [ExplorationActivity] for a specified topic ID. */
-    fun createExplorationActivityIntent(context: Context, explorationId: String): Intent {
+    fun createExplorationActivityIntent(context: Context, explorationId: String, topicId: String?): Intent {
       val intent = Intent(context, ExplorationActivity::class.java)
-      intent.putExtra(EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY, explorationId)
+      intent.putExtra(EXPLORATION_ACTIVITY_EXPLORATION_ID_ARGUMENT_KEY, explorationId)
+      if(topicId!=null) {
+        intent.putExtra(EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY, topicId)
+      }
       return intent
     }
   }

--- a/app/src/main/java/org/oppia/app/player/exploration/ExplorationFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/ExplorationFragmentPresenter.kt
@@ -19,7 +19,7 @@ class ExplorationFragmentPresenter @Inject constructor(
     val binding = ExplorationFragmentBinding.inflate(inflater, container, /* attachToRoot= */ false).root
 
     if (getStateFragment() == null) {
-      val explorationId = fragment.arguments!!.getString(EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY)
+      val explorationId = fragment.arguments!!.getString(EXPLORATION_ACTIVITY_EXPLORATION_ID_ARGUMENT_KEY)
       checkNotNull(explorationId) { "StateFragment must be created with an exploration ID" }
       val stateFragment = StateFragment.newInstance(explorationId)
       fragment.childFragmentManager.beginTransaction().add(

--- a/app/src/main/java/org/oppia/app/story/StoryActivity.kt
+++ b/app/src/main/java/org/oppia/app/story/StoryActivity.kt
@@ -10,7 +10,8 @@ import javax.inject.Inject
 
 /** Activity for stories. */
 class StoryActivity : InjectableAppCompatActivity(), RouteToExplorationListener {
-  @Inject lateinit var storyActivityPresenter: StoryActivityPresenter
+  @Inject
+  lateinit var storyActivityPresenter: StoryActivityPresenter
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -21,8 +22,8 @@ class StoryActivity : InjectableAppCompatActivity(), RouteToExplorationListener 
     storyActivityPresenter.handleOnCreate(storyId)
   }
 
-  override fun routeToExploration(explorationId: String) {
-    startActivity(ExplorationActivity.createExplorationActivityIntent(this, explorationId))
+  override fun routeToExploration(explorationId: String, topicId: String?) {
+    startActivity(ExplorationActivity.createExplorationActivityIntent(this, explorationId, topicId))
   }
 
   companion object {

--- a/app/src/main/java/org/oppia/app/story/StoryFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/story/StoryFragmentPresenter.kt
@@ -2,11 +2,15 @@ package org.oppia.app.story
 
 import android.content.res.Resources
 import android.util.DisplayMetrics
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.LinearSmoothScroller
+import androidx.recyclerview.widget.RecyclerView
 import org.oppia.app.databinding.StoryChapterViewBinding
 import org.oppia.app.databinding.StoryFragmentBinding
 import org.oppia.app.databinding.StoryHeaderViewBinding
@@ -17,10 +21,6 @@ import org.oppia.app.story.storyitemviewmodel.StoryHeaderViewModel
 import org.oppia.app.story.storyitemviewmodel.StoryItemViewModel
 import org.oppia.app.viewmodel.ViewModelProvider
 import javax.inject.Inject
-import android.util.TypedValue
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.LinearSmoothScroller
-import androidx.recyclerview.widget.RecyclerView
 
 /** The presenter for [StoryFragment]. */
 class StoryFragmentPresenter @Inject constructor(
@@ -61,7 +61,7 @@ class StoryFragmentPresenter @Inject constructor(
   }
 
   fun handleSelectExploration(explorationId: String) {
-    routeToExplorationListener.routeToExploration(explorationId)
+    routeToExplorationListener.routeToExploration(explorationId, /* topicId= */ null)
   }
 
   private fun createRecyclerViewAdapter(): BindableAdapter<StoryItemViewModel> {

--- a/app/src/main/java/org/oppia/app/story/testing/StoryFragmentTestActivity.kt
+++ b/app/src/main/java/org/oppia/app/story/testing/StoryFragmentTestActivity.kt
@@ -19,7 +19,7 @@ class StoryFragmentTestActivity : InjectableAppCompatActivity(), RouteToExplorat
     storyFragmentTestActivityPresenter.handleOnCreate()
   }
 
-  override fun routeToExploration(explorationId: String) {
+  override fun routeToExploration(explorationId: String, topicId: String?) {
     // Do nothing since routing should be tested at the StoryActivity level.
   }
 

--- a/app/src/main/java/org/oppia/app/testing/ContinuePlayingFragmentTestActivity.kt
+++ b/app/src/main/java/org/oppia/app/testing/ContinuePlayingFragmentTestActivity.kt
@@ -1,15 +1,14 @@
 package org.oppia.app.testing
 
-import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import org.oppia.app.activity.InjectableAppCompatActivity
-import org.oppia.app.story.StoryActivity
-import org.oppia.app.topic.RouteToStoryListener
+import org.oppia.app.home.RouteToExplorationListener
+import org.oppia.app.player.exploration.ExplorationActivity
 import javax.inject.Inject
 
 /** Test activity for recent stories. */
-class ContinuePlayingFragmentTestActivity : InjectableAppCompatActivity(), RouteToStoryListener {
+class ContinuePlayingFragmentTestActivity : InjectableAppCompatActivity(),
+  RouteToExplorationListener {
   @Inject lateinit var continuePlayingFragmentTestActivityPresenter: ContinuePlayingFragmentTestActivityPresenter
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -18,14 +17,7 @@ class ContinuePlayingFragmentTestActivity : InjectableAppCompatActivity(), Route
     continuePlayingFragmentTestActivityPresenter.handleOnCreate()
   }
 
-  companion object {
-    /** Returns a new [Intent] to route to [ContinuePlayingFragmentTestActivity]. */
-    fun createContinuePlayingActivityIntent(context: Context): Intent {
-      return Intent(context, ContinuePlayingFragmentTestActivity::class.java)
-    }
-  }
-
-  override fun routeToStory(storyId: String) {
-    startActivity(StoryActivity.createStoryActivityIntent(this, storyId))
+  override fun routeToExploration(explorationId: String, topicId: String?) {
+    startActivity(ExplorationActivity.createExplorationActivityIntent(this, explorationId, topicId))
   }
 }

--- a/app/src/main/java/org/oppia/app/testing/ExplorationTestActivity.kt
+++ b/app/src/main/java/org/oppia/app/testing/ExplorationTestActivity.kt
@@ -1,0 +1,24 @@
+package org.oppia.app.testing
+
+import android.os.Bundle
+import org.oppia.app.activity.InjectableAppCompatActivity
+import org.oppia.app.home.RouteToExplorationListener
+import org.oppia.app.player.exploration.ExplorationActivity
+import org.oppia.app.topic.TopicFragment
+import javax.inject.Inject
+
+/** The activity for testing [TopicFragment]. */
+class ExplorationTestActivity : InjectableAppCompatActivity(), RouteToExplorationListener {
+  @Inject
+  lateinit var explorationTestActivityPresenter: ExplorationTestActivityPresenter
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    activityComponent.inject(this)
+    explorationTestActivityPresenter.handleOnCreate()
+  }
+
+  override fun routeToExploration(explorationId: String, topicId: String?) {
+    startActivity(ExplorationActivity.createExplorationActivityIntent(this, explorationId, topicId))
+  }
+}

--- a/app/src/main/java/org/oppia/app/testing/ExplorationTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/testing/ExplorationTestActivityPresenter.kt
@@ -1,0 +1,51 @@
+package org.oppia.app.testing
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
+import kotlinx.android.synthetic.main.exploration_test_activity.*
+import org.oppia.app.R
+import org.oppia.app.activity.ActivityScope
+import org.oppia.app.home.RouteToExplorationListener
+import org.oppia.domain.exploration.ExplorationDataController
+import org.oppia.domain.exploration.TEST_EXPLORATION_ID_5
+import org.oppia.util.data.AsyncResult
+import org.oppia.util.logging.Logger
+import javax.inject.Inject
+
+private const val EXPLORATION_ID = TEST_EXPLORATION_ID_5
+private const val TAG_EXPLORATION_TEST_ACTIVITY = "ExplorationTestActivity"
+
+/** The presenter for [ExplorationTestActivityPresenter]. */
+@ActivityScope
+class ExplorationTestActivityPresenter @Inject constructor(
+  private val activity: AppCompatActivity,
+  private val explorationDataController: ExplorationDataController,
+  private val logger: Logger
+) {
+
+  private val routeToExplorationListener = activity as RouteToExplorationListener
+
+  fun handleOnCreate() {
+    activity.setContentView(R.layout.exploration_test_activity)
+
+    activity.play_exploration_button.setOnClickListener {
+      playExplorationButton()
+    }
+  }
+
+  private fun playExplorationButton() {
+    explorationDataController.stopPlayingExploration()
+    explorationDataController.startPlayingExploration(
+      EXPLORATION_ID
+    ).observe(activity, Observer<AsyncResult<Any?>> { result ->
+      when {
+        result.isPending() -> logger.d(TAG_EXPLORATION_TEST_ACTIVITY, "Loading exploration")
+        result.isFailure() -> logger.e(TAG_EXPLORATION_TEST_ACTIVITY, "Failed to load exploration", result.getErrorOrNull()!!)
+        else -> {
+          logger.d(TAG_EXPLORATION_TEST_ACTIVITY, "Successfully loaded exploration")
+          routeToExplorationListener.routeToExploration(EXPLORATION_ID, null)
+        }
+      }
+    })
+  }
+}

--- a/app/src/main/java/org/oppia/app/testing/TopicTestActivity.kt
+++ b/app/src/main/java/org/oppia/app/testing/TopicTestActivity.kt
@@ -47,8 +47,8 @@ class TopicTestActivity : InjectableAppCompatActivity(), RouteToQuestionPlayerLi
     getConceptCardFragment()?.dismiss()
   }
 
-  override fun routeToExploration(explorationId: String) {
-    startActivity(ExplorationActivity.createExplorationActivityIntent(this, explorationId))
+  override fun routeToExploration(explorationId: String, topicId: String?) {
+    startActivity(ExplorationActivity.createExplorationActivityIntent(this, explorationId, topicId))
   }
 
   private fun getConceptCardFragment(): ConceptCardFragment? {

--- a/app/src/main/java/org/oppia/app/testing/TopicTestActivityForStory.kt
+++ b/app/src/main/java/org/oppia/app/testing/TopicTestActivityForStory.kt
@@ -49,8 +49,8 @@ class TopicTestActivityForStory : InjectableAppCompatActivity(), RouteToQuestion
     getConceptCardFragment()?.dismiss()
   }
 
-  override fun routeToExploration(explorationId: String) {
-    startActivity(ExplorationActivity.createExplorationActivityIntent(this, explorationId))
+  override fun routeToExploration(explorationId: String, topicId: String?) {
+    startActivity(ExplorationActivity.createExplorationActivityIntent(this, explorationId, topicId))
   }
 
   private fun getConceptCardFragment(): ConceptCardFragment? {

--- a/app/src/main/java/org/oppia/app/topic/TopicActivity.kt
+++ b/app/src/main/java/org/oppia/app/topic/TopicActivity.kt
@@ -51,8 +51,8 @@ class TopicActivity : InjectableAppCompatActivity(), RouteToQuestionPlayerListen
     getConceptCardFragment()?.dismiss()
   }
 
-  override fun routeToExploration(explorationId: String) {
-    startActivity(ExplorationActivity.createExplorationActivityIntent(this, explorationId))
+  override fun routeToExploration(explorationId: String, topicId: String?) {
+    startActivity(ExplorationActivity.createExplorationActivityIntent(this, explorationId, topicId))
   }
 
   private fun getConceptCardFragment(): ConceptCardFragment? {

--- a/app/src/main/java/org/oppia/app/topic/play/TopicPlayFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/topic/play/TopicPlayFragmentPresenter.kt
@@ -116,10 +116,10 @@ class TopicPlayFragmentPresenter @Inject constructor(
   }
 
   override fun selectChapterSummary(chapterSummary: ChapterSummary) {
-    playExploration(chapterSummary.explorationId)
+    playExploration(chapterSummary.explorationId, topicId)
   }
 
-  private fun playExploration(explorationId: String) {
+  private fun playExploration(explorationId: String, topicId: String) {
     explorationDataController.startPlayingExploration(
       explorationId
     ).observe(fragment, Observer<AsyncResult<Any?>> { result ->
@@ -128,7 +128,7 @@ class TopicPlayFragmentPresenter @Inject constructor(
         result.isFailure() -> logger.e("TopicPlayFragment", "Failed to load exploration", result.getErrorOrNull()!!)
         else -> {
           logger.d("TopicPlayFragment", "Successfully loaded exploration")
-          routeToExplorationListener.routeToExploration(explorationId)
+          routeToExplorationListener.routeToExploration(explorationId, topicId)
         }
       }
     })

--- a/app/src/main/res/layout/exploration_test_activity.xml
+++ b/app/src/main/res/layout/exploration_test_activity.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:background="@color/white"
+  android:gravity="center"
+  android:orientation="vertical">
+
+  <Button
+    android:id="@+id/play_exploration_button"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="Play exploration" />
+</LinearLayout>

--- a/app/src/main/res/layout/home_fragment.xml
+++ b/app/src/main/res/layout/home_fragment.xml
@@ -17,15 +17,6 @@
     android:gravity="center"
     android:orientation="vertical">
 
-    <Button
-      android:id="@+id/play_exploration_button"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="16dp"
-      android:onClick="@{presenter::playExplorationButton}"
-      android:text="Play exploration"
-      android:visibility="gone" />
-
     <androidx.recyclerview.widget.RecyclerView
       android:id="@+id/home_recycler_view"
       android:layout_width="match_parent"

--- a/app/src/sharedTest/java/org/oppia/app/home/ContinuePlayingFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/home/ContinuePlayingFragmentTest.kt
@@ -3,27 +3,45 @@ package org.oppia.app.home
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.not
+import org.junit.After
+import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.app.R
+import org.oppia.app.player.exploration.EXPLORATION_ACTIVITY_EXPLORATION_ID_ARGUMENT_KEY
+import org.oppia.app.player.exploration.EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY
+import org.oppia.app.player.exploration.ExplorationActivity
 import org.oppia.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
 import org.oppia.app.testing.ContinuePlayingFragmentTestActivity
 import org.oppia.app.utility.EspressoTestsMatchers.withDrawable
 import org.oppia.app.utility.OrientationChangeAction.Companion.orientationLandscape
+import org.oppia.domain.topic.FRACTIONS_EXPLORATION_ID_1
+import org.oppia.domain.topic.FRACTIONS_TOPIC_ID
 
 /** Tests for [ContinuePlayingFragmentTestActivity]. */
 @RunWith(AndroidJUnit4::class)
 class ContinuePlayingFragmentTest {
+
+  @Before
+  fun setUp() {
+    Intents.init()
+  }
 
   @Test
   fun testContinuePlayingTestActivity_recyclerViewItem0_doesNotShowSectionDivider() {
@@ -97,7 +115,7 @@ class ContinuePlayingFragmentTest {
         )
       ).check(
         matches(
-          withText(containsString("Second Story"))
+          withText(containsString("Matthew Goes to the Bakery"))
         )
       )
     }
@@ -119,7 +137,7 @@ class ContinuePlayingFragmentTest {
         )
       ).check(
         matches(
-          withText(containsString("First Topic"))
+          withText(containsString("FRACTIONS"))
         )
       )
     }
@@ -148,6 +166,33 @@ class ContinuePlayingFragmentTest {
   }
 
   @Test
+  fun testContinuePlayingTestActivity_recyclerViewItem1_clickStory_intentsToExplorationActivity() {
+    ActivityScenario.launch(ContinuePlayingFragmentTestActivity::class.java).use {
+      onView(withId(R.id.ongoing_story_recycler_view)).perform(
+        scrollToPosition<RecyclerView.ViewHolder>(
+          1
+        )
+      )
+      onView(
+        atPositionOnView(
+          R.id.ongoing_story_recycler_view,
+          1,
+          R.id.lesson_thumbnail
+        )
+      ).perform(click())
+
+      intended(
+        allOf(
+          hasExtra(EXPLORATION_ACTIVITY_EXPLORATION_ID_ARGUMENT_KEY, FRACTIONS_EXPLORATION_ID_1),
+          hasExtra(EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY, FRACTIONS_TOPIC_ID),
+          hasComponent(ExplorationActivity::class.java.name)
+        )
+      )
+    }
+  }
+
+  @Test
+  @Ignore("Only one item available from domain layer") // TODO(#77): Reenable this test
   fun testContinuePlayingTestActivity_recyclerViewItem3_showsLastMonthSectionTitle() {
     ActivityScenario.launch(ContinuePlayingFragmentTestActivity::class.java).use {
       onView(withId(R.id.ongoing_story_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(3))
@@ -162,6 +207,7 @@ class ContinuePlayingFragmentTest {
   }
 
   @Test
+  @Ignore("Only one item available from domain layer") // TODO(#77): Reenable this test
   fun testContinuePlayingTestActivity_recyclerViewItem3_showsSectionDivider() {
     ActivityScenario.launch(ContinuePlayingFragmentTestActivity::class.java).use {
       onView(withId(R.id.ongoing_story_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(3))
@@ -170,6 +216,7 @@ class ContinuePlayingFragmentTest {
   }
 
   @Test
+  @Ignore("Only one item available from domain layer") // TODO(#77): Reenable this test
   fun testContinuePlayingTestActivity_recyclerViewItem4_chapterNameIsCorrect() {
     ActivityScenario.launch(ContinuePlayingFragmentTestActivity::class.java).use {
       onView(withId(R.id.ongoing_story_recycler_view)).perform(
@@ -248,5 +295,10 @@ class ContinuePlayingFragmentTest {
         )
       )
     }
+  }
+
+  @After
+  fun tearDown() {
+    Intents.release()
   }
 }

--- a/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
@@ -49,6 +49,8 @@ import org.oppia.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
 import org.oppia.app.topic.TopicActivity
 import org.oppia.app.utility.OrientationChangeAction.Companion.orientationLandscape
 import org.oppia.domain.UserAppHistoryController
+import org.oppia.domain.topic.FRACTIONS_STORY_ID_0
+import org.oppia.domain.topic.FRACTIONS_TOPIC_ID
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -173,7 +175,7 @@ class HomeActivityTest {
       onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(1))
       onView(atPositionOnView(R.id.home_recycler_view, 1, R.id.story_name_text_view)).check(
         matches(
-          withText(containsString("Second Story"))
+          withText(containsString("Matthew Goes to the Bakery"))
         )
       )
     }
@@ -187,7 +189,7 @@ class HomeActivityTest {
       onView(isRoot()).perform(orientationLandscape())
       onView(atPositionOnView(R.id.home_recycler_view, 1, R.id.story_name_text_view)).check(
         matches(
-          withText(containsString("Second Story"))
+          withText(containsString("Matthew Goes to the Bakery"))
         )
       )
     }
@@ -199,8 +201,8 @@ class HomeActivityTest {
       onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(1))
       onView(atPosition(R.id.home_recycler_view, 1)).perform(click())
       intended(hasComponent(TopicActivity::class.java.name))
-      intended(hasExtra(TopicActivity.TOPIC_ACTIVITY_TOPIC_ID_ARGUMENT_KEY, "test_topic_id_0"))
-      intended(hasExtra(TopicActivity.TOPIC_ACTIVITY_STORY_ID_ARGUMENT_KEY, "test_story_id_1"))
+      intended(hasExtra(TopicActivity.TOPIC_ACTIVITY_TOPIC_ID_ARGUMENT_KEY, FRACTIONS_TOPIC_ID))
+      intended(hasExtra(TopicActivity.TOPIC_ACTIVITY_STORY_ID_ARGUMENT_KEY, FRACTIONS_STORY_ID_0))
     }
   }
 
@@ -210,7 +212,7 @@ class HomeActivityTest {
       onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(1))
       onView(atPositionOnView(R.id.home_recycler_view, 1, R.id.topic_name_text_view)).check(
         matches(
-          withText(containsString("FIRST TOPIC"))
+          withText(containsString("FRACTIONS"))
         )
       )
     }
@@ -234,7 +236,7 @@ class HomeActivityTest {
       onView(withId(R.id.home_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(3))
       onView(atPositionOnView(R.id.home_recycler_view, 3, R.id.lesson_count_text_view)).check(
         matches(
-          withText(containsString("2 Lessons"))
+          withText(containsString("4 Lessons"))
         )
       )
     }

--- a/app/src/sharedTest/java/org/oppia/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/exploration/ExplorationActivityTest.kt
@@ -77,7 +77,7 @@ class ExplorationActivityTest {
 
   private fun createExplorationActivityIntent(explorationId: String): Intent {
     return ExplorationActivity.createExplorationActivityIntent(
-      ApplicationProvider.getApplicationContext(), explorationId
+      ApplicationProvider.getApplicationContext(), explorationId, null
     )
   }
 

--- a/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import org.json.JSONObject
@@ -32,8 +31,8 @@ import org.oppia.app.model.TopicSummary
 import org.oppia.app.model.Voiceover
 import org.oppia.app.model.VoiceoverMapping
 import org.oppia.domain.exploration.ExplorationRetriever
-import org.oppia.util.caching.AssetRepository
 import org.oppia.domain.util.JsonAssetRetriever
+import org.oppia.util.caching.AssetRepository
 import org.oppia.util.caching.CacheAssetsLocally
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.logging.Logger
@@ -245,7 +244,12 @@ class TopicListController @Inject constructor(
             storySummary.chapterList.find { chapterSummary -> chapterSummary.explorationId == nextChapterId }
           ongoingStoryListBuilder.addRecentStory(
             createPromotedStory(
-              storyId, topic, completedChapterCount, storyProgress.chapterProgressCount, nextChapterSummary?.name
+              storyId,
+              topic,
+              completedChapterCount,
+              storyProgress.chapterProgressCount,
+              nextChapterSummary?.name,
+              nextChapterSummary?.explorationId
             )
           )
         }
@@ -255,7 +259,12 @@ class TopicListController @Inject constructor(
   }
 
   private fun createPromotedStory(
-    storyId: String, topic: Topic, completedChapterCount: Int, totalChapterCount: Int, nextChapterName: String?
+    storyId: String,
+    topic: Topic,
+    completedChapterCount: Int,
+    totalChapterCount: Int,
+    nextChapterName: String?,
+    explorationId: String?
   ): PromotedStory {
     val storySummary = topic.storyList.find { summary -> summary.storyId == storyId }!!
     val promotedStoryBuilder = PromotedStory.newBuilder()
@@ -266,8 +275,9 @@ class TopicListController @Inject constructor(
       .setCompletedChapterCount(completedChapterCount)
       .setTotalChapterCount(totalChapterCount)
       .setLessonThumbnail(STORY_THUMBNAILS.getValue(storyId))
-    if (nextChapterName != null) {
+    if (nextChapterName != null && explorationId != null) {
       promotedStoryBuilder.nextChapterName = nextChapterName
+      promotedStoryBuilder.explorationId = explorationId
     }
     return promotedStoryBuilder.build()
   }

--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -163,15 +163,18 @@ message PromotedStory {
   // The name of the next chapter (exploration title) to complete.
   string next_chapter_name = 5;
 
+  // The id of the next chapter (exploration title) to complete.
+  string exploration_id = 6;
+
   // The number of lessons the player has completed in this story. This may be 0 if the promoted story is promoted for
   // reasons other than to complete it (e.g. it's recommended).
-  int32 completed_chapter_count = 6;
+  int32 completed_chapter_count = 7;
 
   // The total number of lessons this story contains.
-  int32 total_chapter_count = 7;
+  int32 total_chapter_count = 8;
 
   // The thumbnail that should be displayed for this promoted story.
-  LessonThumbnail lesson_thumbnail = 8;
+  LessonThumbnail lesson_thumbnail = 9;
 }
 
 // A homescreen summary of a topic.

--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -163,7 +163,7 @@ message PromotedStory {
   // The name of the next chapter (exploration title) to complete.
   string next_chapter_name = 5;
 
-  // The id of the next chapter (exploration title) to complete.
+  // The exploration id next chapter to complete.
   string exploration_id = 6;
 
   // The number of lessons the player has completed in this story. This may be 0 if the promoted story is promoted for


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

This PR mainly changes the item click route in ContinuePlaying Screen.
Earlier it was redirecting to `ChapterList` screen but now it will directly start the exploration and when we leave this screen it should intent to `TopicActivity` and not `ContinuePlayingActivity` again.

![continue_playing_routing](https://user-images.githubusercontent.com/9396084/70356210-e3da0300-1899-11ea-9304-91744afd139a.gif)

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
