### PR TITLE
Fix #535,Fix part of #530: Material card-view issue fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,7 @@ dependencies {
       'androidx.multidex:multidex:2.0.1',
       'androidx.recyclerview:recyclerview:1.0.0',
       'com.github.bumptech.glide:glide:4.9.0',
-      'com.google.android.material:material:1.0.0-alpha1',
+      'com.google.android.material:material:1.2.0-alpha02',
       'com.google.android.material:material:1.0.0',
       'com.google.dagger:dagger:2.24',
       'com.google.guava:guava:28.1-android',

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,7 +68,6 @@ dependencies {
       'androidx.recyclerview:recyclerview:1.0.0',
       'com.github.bumptech.glide:glide:4.9.0',
       'com.google.android.material:material:1.2.0-alpha02',
-      'com.google.android.material:material:1.0.0',
       'com.google.dagger:dagger:2.24',
       'com.google.guava:guava:28.1-android',
       'de.hdodenhof:circleimageview:3.0.1',

--- a/app/src/main/res/layout/story_chapter_view.xml
+++ b/app/src/main/res/layout/story_chapter_view.xml
@@ -27,6 +27,7 @@
       android:clickable="@{viewModel.chapterSummary.chapterPlayState != ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES}"
       android:onClick="@{viewModel.onExplorationClicked}"
       app:cardCornerRadius="4dp"
+      app:cardBackgroundColor="@color/white"
       app:cardElevation="@{viewModel.chapterSummary.chapterPlayState != ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES ? @dimen/elevation_4dp : @dimen/elevation_0dp}"
       app:strokeColor="@{viewModel.chapterSummary.chapterPlayState != ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES ? @color/colorPrimary : @color/chapterCardGreyBorder}"
       app:strokeWidth="2dp">

--- a/app/src/main/res/layout/topic_review_summary_view.xml
+++ b/app/src/main/res/layout/topic_review_summary_view.xml
@@ -14,8 +14,9 @@
     android:layout_height="wrap_content"
     android:layout_margin="12dp"
     android:clipToPadding="true"
+    app:cardBackgroundColor="@color/white"
     app:cardCornerRadius="8dp"
-    app:cardElevation="0dp"
+    app:cardElevation="4dp"
     app:cardMaxElevation="4dp"
     app:strokeColor="@color/oppiaBrown"
     app:strokeWidth="2dp">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,7 +6,7 @@
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorPrimary</item>
   </style>
-  name="Theme.MyApp" parent="Theme.MaterialComponents.DayNight"
+
   <style name="OppiaThemeWithoutActionBar" parent="Theme.MaterialComponents.NoActionBar">
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
@@ -97,7 +97,6 @@
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorPrimary</item>
   </style>
-  
   <!-- TOPIC TABLAYOUT STYLE -->
   <style name="AppTabLayout" parent="Widget.Design.TabLayout">
     <item name="tabIndicatorColor">@color/white</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-  <style name="OppiaTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+  <style name="OppiaTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorPrimary</item>
   </style>
-
-  <style name="OppiaThemeWithoutActionBar" parent="Theme.AppCompat.Light.NoActionBar">
+  name="Theme.MyApp" parent="Theme.MaterialComponents.DayNight"
+  <style name="OppiaThemeWithoutActionBar" parent="Theme.MaterialComponents.NoActionBar">
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccent</item>
@@ -39,7 +39,7 @@
     <item name="android:activityOpenExitAnimation">@anim/fade_out</item>
   </style>
 
-  <style name="FullScreenDialogStyle" parent="Theme.AppCompat.Dialog">
+  <style name="FullScreenDialogStyle" parent="Theme.MaterialComponents.Dialog">
     <item name="android:windowNoTitle">true</item>
     <item name="colorPrimaryDark">@color/colorConceptToolbarHeading</item>
     <!-- Set this to true if you want Full Screen without status bar -->
@@ -52,7 +52,7 @@
     <item name="android:windowExitAnimation">@anim/slide_down</item>
   </style>
   <!-- STATE BUTTON ACTIVE STYLE -->
-  <style name="StateButtonActive" parent="TextAppearance.AppCompat.Widget.Button">
+  <style name="StateButtonActive" parent="TextAppearance.MaterialComponents.Button">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:background">@drawable/state_button_primary_background</item>
@@ -81,7 +81,7 @@
     <item name="tabTextColor">@android:color/white</item>
   </style>
   <!-- STATE BUTTON INACTIVE STYLE -->
-  <style name="StateButtonInactive" parent="TextAppearance.AppCompat.Widget.Button">
+  <style name="StateButtonInactive" parent="TextAppearance.MaterialComponents.Button">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:padding">8dp</item>
@@ -92,7 +92,7 @@
     <item name="android:clickable">false</item>
   </style>
 
-  <style name="AlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
+  <style name="AlertDialogTheme" parent="Theme.MaterialComponents.Light.Dialog.Alert">
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorPrimary</item>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
To use Material Components, we need to either use a Theme.MaterialComponents.* theme or a Theme.MaterialComponents.*.Bridge theme.

See here for more info on migrating to a MaterialComponents theme (recommended) - https://github.com/material-components/material-components-android/blob/master/docs/getting-started.md#4-change-your-app-theme-to-inherit-from-a-material-components-theme

Additionally, we don't need to add two dependencies for Material in your :app module's build.gradle file. Below are the latest stable, beta and alpha versions of the library. Should use a single version, depending on the features vs. stability our app needs.
So i removed com.google.android.material:material:1.0.0 and used alpha.

stable: com.google.android.material:material:1.0.0
beta: com.google.android.material:material:1.1.0-beta02
alpha: com.google.android.material:material:1.2.0-alpha02
Card corner white spacing fixed for all API

### **Oppia Android API 19 4.4.2 (Kitkat) UI issues.**

**Chapter List (Mathew goes..)**

<img width="342" alt="Untitled" src="https://user-images.githubusercontent.com/54615666/70408180-33245d00-1a6d-11ea-8431-fd1de4033c5e.png">

- [x] Material Cards UI issues 

- [x] Drop shadow

- [x] Card borders

**Review** 

<img width="172" alt="Untitled" src="https://user-images.githubusercontent.com/54615666/70408227-5e0eb100-1a6d-11ea-833d-b6a61cb38c56.png">

- [x] Material Cards UI issues 

- [x] Drop shadow

- [x] Card borders

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
