### PR TITLE
Fix #688: Update extra spacing in topic_lessons_story_summary

### DIFF
--- a/app/src/main/res/layout/topic_lessons_story_summary.xml
+++ b/app/src/main/res/layout/topic_lessons_story_summary.xml
@@ -156,7 +156,6 @@
           android:id="@+id/chapter_recycler_view"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginStart="56dp"
           android:layout_marginTop="8dp"
           android:layout_marginBottom="8dp"
           app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Removed MarginStart Attribute, which removed the extra space at the left of topic lessons

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
