### PR TITLE
Fix #676: Full implementation of was_profile_ever_added flag

### DIFF
--- a/domain/src/main/java/org/oppia/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/domain/profile/ProfileManagementController.kt
@@ -42,7 +42,6 @@ private const val SET_PROFILE_TRANSFORMED_PROVIDER_ID = "set_profile_transformed
 private const val UPDATE_STORY_TEXT_SIZE_TRANSFORMED_ID = "update_story_text_size_transformed_id"
 private const val UPDATE_APP_LANGUAGE_TRANSFORMED_PROVIDER_ID = "update_app_language_transformed_id"
 private const val UPDATE_AUDIO_LANGUAGE_TRANSFORMED_PROVIDER_ID = "update_audio_language_transformed_id"
-private const val MARK_PROFILE_EVER_ADDED_TRANSFORMED_PROVIDER_ID = "mark_profile_ever_added_transformed_id"
 
 const val PROFILE_AVATAR_FILE_NAME = "profile_avatar.png"
 

--- a/domain/src/main/java/org/oppia/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/domain/profile/ProfileManagementController.kt
@@ -31,6 +31,7 @@ import javax.inject.Singleton
 
 private const val TRANSFORMED_GET_PROFILES_PROVIDER_ID = "transformed_get_profiles_provider_id"
 private const val TRANSFORMED_GET_PROFILE_PROVIDER_ID = "transformed_get_profile_provider_id"
+private const val TRANSFORMED_GET_WAS_PROFILE_EVER_ADDED_PROVIDER_ID = "transformed_was_profile_ever_added_provider_id"
 private const val ADD_PROFILE_TRANSFORMED_PROVIDER_ID = "add_profile_transformed_id"
 private const val UPDATE_NAME_TRANSFORMED_PROVIDER_ID = "update_name_transformed_id"
 private const val UPDATE_PIN_TRANSFORMED_PROVIDER_ID = "update_pin_transformed_id"
@@ -41,6 +42,7 @@ private const val SET_PROFILE_TRANSFORMED_PROVIDER_ID = "set_profile_transformed
 private const val UPDATE_STORY_TEXT_SIZE_TRANSFORMED_ID = "update_story_text_size_transformed_id"
 private const val UPDATE_APP_LANGUAGE_TRANSFORMED_PROVIDER_ID = "update_app_language_transformed_id"
 private const val UPDATE_AUDIO_LANGUAGE_TRANSFORMED_PROVIDER_ID = "update_audio_language_transformed_id"
+private const val MARK_PROFILE_EVER_ADDED_TRANSFORMED_PROVIDER_ID = "mark_profile_ever_added_transformed_id"
 
 const val PROFILE_AVATAR_FILE_NAME = "profile_avatar.png"
 
@@ -120,6 +122,19 @@ class ProfileManagementController @Inject constructor(
     return dataProviders.convertToLiveData(transformedDataProvider)
   }
 
+  /** Returns a boolean determining whether the profile was ever added or not. */
+  fun getWasProfileEverAdded(): LiveData<AsyncResult<Boolean>> {
+    val transformedDataProvider =
+      dataProviders.transformAsync<ProfileDatabase, Boolean>(
+        TRANSFORMED_GET_WAS_PROFILE_EVER_ADDED_PROVIDER_ID,
+        profileDataStore
+      ) {
+        val wasProfileEverAdded = it.wasProfileEverAdded
+        AsyncResult.success(wasProfileEverAdded)
+      }
+    return dataProviders.convertToLiveData(transformedDataProvider)
+  }
+
   /**
    * Adds a new profile with the specified parameters.
    *
@@ -174,8 +189,13 @@ class ProfileManagementController @Inject constructor(
         newProfileBuilder.avatar = ProfileAvatar.newBuilder().setAvatarColorRgb(colorRgb).build()
       }
 
+      val wasProfileEverAdded = !it.wasProfileEverAdded && !isAdmin
+
       val profileDatabaseBuilder =
-        it.toBuilder().putProfiles(nextProfileId, newProfileBuilder.build()).setNextProfileId(nextProfileId + 1)
+        it.toBuilder()
+          .putProfiles(nextProfileId, newProfileBuilder.build())
+          .setWasProfileEverAdded(wasProfileEverAdded)
+          .setNextProfileId(nextProfileId + 1)
       Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
     }
     return dataProviders.convertToLiveData(

--- a/domain/src/test/java/org/oppia/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/profile/ProfileManagementControllerTest.kt
@@ -65,20 +65,14 @@ class ProfileManagementControllerTest {
   @Inject lateinit var profileTestHelper: ProfileTestHelper
   @Inject lateinit var profileManagementController: ProfileManagementController
 
-  @Mock
-  lateinit var mockProfilesObserver: Observer<AsyncResult<List<Profile>>>
-  @Captor
-  lateinit var profilesResultCaptor: ArgumentCaptor<AsyncResult<List<Profile>>>
+  @Mock lateinit var mockProfilesObserver: Observer<AsyncResult<List<Profile>>>
+  @Captor lateinit var profilesResultCaptor: ArgumentCaptor<AsyncResult<List<Profile>>>
 
-  @Mock
-  lateinit var mockProfileObserver: Observer<AsyncResult<Profile>>
-  @Captor
-  lateinit var profileResultCaptor: ArgumentCaptor<AsyncResult<Profile>>
+  @Mock lateinit var mockProfileObserver: Observer<AsyncResult<Profile>>
+  @Captor lateinit var profileResultCaptor: ArgumentCaptor<AsyncResult<Profile>>
 
-  @Mock
-  lateinit var mockUpdateResultObserver: Observer<AsyncResult<Any?>>
-  @Captor
-  lateinit var updateResultCaptor: ArgumentCaptor<AsyncResult<Any?>>
+  @Mock lateinit var mockUpdateResultObserver: Observer<AsyncResult<Any?>>
+  @Captor lateinit var updateResultCaptor: ArgumentCaptor<AsyncResult<Any?>>
 
   private val PROFILES_LIST = listOf<Profile>(
     Profile.newBuilder().setName("James").setPin("123").setAllowDownloadAccess(true).build(),
@@ -397,7 +391,6 @@ class ProfileManagementControllerTest {
         .contains("ProfileId 6 does not match an existing Profile")
     }
 
-
   @Test
   @ExperimentalCoroutinesApi
   fun testUpdateStoryTextSize_addProfiles_updateWithFontSize18_checkUpdateIsSuccessful() =
@@ -579,6 +572,108 @@ class ProfileManagementControllerTest {
           "org.oppia.domain.profile.ProfileManagementController\$ProfileNotFoundException: " +
               "ProfileId 6 is not associated with an existing profile"
         )
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testWasProfileEverAdded_addAdminProfile_checkIfProfileEverAdded() = runBlockingTest(coroutineContext) {
+    profileManagementController.addProfile(
+      name = "James",
+      pin = "123",
+      avatarImagePath = null,
+      allowDownloadAccess = true,
+      colorRgb = -10710042,
+      isAdmin = true,
+      storyTextSize = StoryTextSize.SMALL_TEXT_SIZE,
+      appLanguage = AppLanguage.ENGLISH_APP_LANGUAGE,
+      audioLanguage = AudioLanguage.ENGLISH_AUDIO_LANGUAGE
+    ).observeForever(mockUpdateResultObserver)
+    advanceUntilIdle()
+
+    val profileDatabase = readProfileDatabase()
+
+    verify(mockUpdateResultObserver, atLeastOnce()).onChanged(updateResultCaptor.capture())
+    assertThat(updateResultCaptor.value.isSuccess()).isTrue()
+    assertThat(profileDatabase.wasProfileEverAdded).isEqualTo(false)
+  }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testWasProfileEverAdded_addAdminProfile_addUserProfile_checkIfProfileEverAdded() =
+    runBlockingTest(coroutineContext) {
+      profileManagementController.addProfile(
+        name = "James",
+        pin = "12345",
+        avatarImagePath = null,
+        allowDownloadAccess = true,
+        colorRgb = -10710042,
+        isAdmin = true,
+        storyTextSize = StoryTextSize.SMALL_TEXT_SIZE,
+        appLanguage = AppLanguage.ENGLISH_APP_LANGUAGE,
+        audioLanguage = AudioLanguage.ENGLISH_AUDIO_LANGUAGE
+      ).observeForever(mockUpdateResultObserver)
+      advanceUntilIdle()
+
+      profileManagementController.addProfile(
+        name = "Rajat",
+        pin = "01234",
+        avatarImagePath = null,
+        allowDownloadAccess = true,
+        colorRgb = -10710042,
+        isAdmin = false,
+        storyTextSize = StoryTextSize.SMALL_TEXT_SIZE,
+        appLanguage = AppLanguage.ENGLISH_APP_LANGUAGE,
+        audioLanguage = AudioLanguage.ENGLISH_AUDIO_LANGUAGE
+      ).observeForever(mockUpdateResultObserver)
+      advanceUntilIdle()
+
+      val profileDatabase = readProfileDatabase()
+
+      verify(mockUpdateResultObserver, atLeastOnce()).onChanged(updateResultCaptor.capture())
+      assertThat(updateResultCaptor.value.isSuccess()).isTrue()
+      assertThat(profileDatabase.wasProfileEverAdded).isEqualTo(true)
+      assertThat(profileDatabase.profilesMap.size).isEqualTo(2)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testWasProfileEverAdded_addAdminProfile_addUserProfile_deleteUserProfile_checkIfProfileEverAdded() =
+    runBlockingTest(coroutineContext) {
+      profileManagementController.addProfile(
+        name = "James",
+        pin = "12345",
+        avatarImagePath = null,
+        allowDownloadAccess = true,
+        colorRgb = -10710042,
+        isAdmin = true,
+        storyTextSize = StoryTextSize.SMALL_TEXT_SIZE,
+        appLanguage = AppLanguage.ENGLISH_APP_LANGUAGE,
+        audioLanguage = AudioLanguage.ENGLISH_AUDIO_LANGUAGE
+      ).observeForever(mockUpdateResultObserver)
+      advanceUntilIdle()
+
+      profileManagementController.addProfile(
+        name = "Rajat",
+        pin = "01234",
+        avatarImagePath = null,
+        allowDownloadAccess = true,
+        colorRgb = -10710042,
+        isAdmin = false,
+        storyTextSize = StoryTextSize.SMALL_TEXT_SIZE,
+        appLanguage = AppLanguage.ENGLISH_APP_LANGUAGE,
+        audioLanguage = AudioLanguage.ENGLISH_AUDIO_LANGUAGE
+      ).observeForever(mockUpdateResultObserver)
+      advanceUntilIdle()
+
+      val profileId1 = ProfileId.newBuilder().setInternalId(1).build()
+      profileManagementController.deleteProfile(profileId1)
+      advanceUntilIdle()
+
+      val profileDatabase = readProfileDatabase()
+
+      verify(mockUpdateResultObserver, atLeastOnce()).onChanged(updateResultCaptor.capture())
+      assertThat(updateResultCaptor.value.isSuccess()).isTrue()
+      assertThat(profileDatabase.profilesMap.size).isEqualTo(1)
     }
 
   @ExperimentalCoroutinesApi

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -10,8 +10,11 @@ message ProfileDatabase {
   // Represents the next unique ID for adding a profile.
   int32 next_profile_id = 1;
 
+  // Determines whether profile was ever added or not.
+  bool was_profile_ever_added = 2;
+
   // Mapping from unique ID to profile.
-  map<int32, Profile> profiles = 2;
+  map<int32, Profile> profiles = 3;
 }
 
 // Structure for a single profile.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Domain layer code to have functionality where we can keep track whether atleast 1 child profile has been added or not. Even if that child profile is deleted later on, its fine. This functionality will be used in app module to control the UI in following ways:

[ProfileChooser - If no profile has been added yet](https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/8cdde1f8-daae-438c-8fdd-084e5d227080/PC-SP-Profile-Chooser-v2)
[ProfileChooser - General](https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/18e69208-8528-424a-a368-b2c5d530d235/PC-SP-Profile-Chooser-)


@veena14cs @nikitamarysolomanpvt me and @BenHenning had discussion about how to implement this and he mentioned that we should just introduce a boolean in `ProfileDatase` and control that. Now assuming that this implementation is fairly straight forward, I will probably won't pass this to @BenHenning so make sure that you review it thoroughly. Once this is done, I will actually need to create few tasks where this feature will be controlled in app module and that task will be assigned to new contributors.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
