### PR TITLE
Fix #662: Introduced download permissions for admin settings in domain layer.

### DIFF
--- a/domain/src/main/java/org/oppia/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/domain/profile/ProfileManagementController.kt
@@ -10,6 +10,7 @@ import androidx.exifinterface.media.ExifInterface
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.Deferred
+import org.oppia.app.model.AdminSettings
 import org.oppia.app.model.AppLanguage
 import org.oppia.app.model.AudioLanguage
 import org.oppia.app.model.Profile
@@ -36,6 +37,8 @@ private const val ADD_PROFILE_TRANSFORMED_PROVIDER_ID = "add_profile_transformed
 private const val UPDATE_NAME_TRANSFORMED_PROVIDER_ID = "update_name_transformed_id"
 private const val UPDATE_PIN_TRANSFORMED_PROVIDER_ID = "update_pin_transformed_id"
 private const val UPDATE_DOWNLOAD_ACCESS_TRANSFORMED_PROVIDER_ID = "update_download_access_transformed_id"
+private const val UPDATE_DOWNLOAD_AND__UPDATE_ONLY_ON_WIFI_TRANSFORMED_PROVIDER_ID = "update_download_and_update_only_on_wifi_transformed_id"
+private const val UPDATE_AUTOMATICALLY_UPDATE_TOPICS_TRANSFORMED_PROVIDER_ID = "update_automatically_update_topics_transformed_id"
 private const val LOGIN_PROFILE_TRANSFORMED_PROVIDER_ID = "login_profile_transformed_id"
 private const val DELETE_PROFILE_TRANSFORMED_PROVIDER_ID = "delete_profile_transformed_id"
 private const val SET_PROFILE_TRANSFORMED_PROVIDER_ID = "set_profile_transformed_id"
@@ -276,6 +279,56 @@ class ProfileManagementController @Inject constructor(
     }
     return dataProviders.convertToLiveData(
       dataProviders.createInMemoryDataProviderAsync(UPDATE_DOWNLOAD_ACCESS_TRANSFORMED_PROVIDER_ID) {
+        return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
+      })
+  }
+
+  /**
+   * Updates the download and updates access of an admin profile only on wifi.
+   *
+   * @param profileId the ID corresponding to the profile being updated.
+   * @param allowDownloadAndUpdateOnlyOnWifi New download access status for the profile being updated only on wifi.
+   * @return a [LiveData] that indicates the success/failure of this update operation.
+   */
+  fun updateAllowDownloadAndUpdateOnlyOnWifi(
+    profileId: ProfileId, adminSettings: AdminSettings.Builder
+  ): LiveData<AsyncResult<Any?>> {
+    val deferred = profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
+      val profile = it.profilesMap[profileId.internalId] ?: return@storeDataWithCustomChannelAsync Pair(
+        it,
+        ProfileActionStatus.PROFILE_NOT_FOUND
+      )
+      val updatedProfile = profile.toBuilder().setAdminSettings(adminSettings).build()
+      val profileDatabaseBuilder = it.toBuilder().putProfiles(profileId.internalId, updatedProfile)
+      Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
+    }
+    return dataProviders.convertToLiveData(
+      dataProviders.createInMemoryDataProviderAsync(UPDATE_DOWNLOAD_AND__UPDATE_ONLY_ON_WIFI_TRANSFORMED_PROVIDER_ID) {
+        return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
+      })
+  }
+
+  /**
+   * Updates the automatic update settings of topics of an admin profile.
+   *
+   * @param profileId the ID corresponding to the profile being updated.
+   * @param allowAutomaticallyUpdateOfTopics automatically update new contents of topics.
+   * @return a [LiveData] that indicates the success/failure of this update operation.
+   */
+  fun updateAllowAutomaticallyUpdateTopics(
+    profileId: ProfileId, adminSettings: AdminSettings.Builder
+  ): LiveData<AsyncResult<Any?>> {
+    val deferred = profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
+      val profile = it.profilesMap[profileId.internalId] ?: return@storeDataWithCustomChannelAsync Pair(
+        it,
+        ProfileActionStatus.PROFILE_NOT_FOUND
+      )
+      val updatedProfile = profile.toBuilder().setAdminSettings(adminSettings).build()
+      val profileDatabaseBuilder = it.toBuilder().putProfiles(profileId.internalId, updatedProfile)
+      Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
+    }
+    return dataProviders.convertToLiveData(
+      dataProviders.createInMemoryDataProviderAsync(UPDATE_DOWNLOAD_AND__UPDATE_ONLY_ON_WIFI_TRANSFORMED_PROVIDER_ID) {
         return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
       })
   }

--- a/domain/src/main/java/org/oppia/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/domain/profile/ProfileManagementController.kt
@@ -138,6 +138,34 @@ class ProfileManagementController @Inject constructor(
   }
 
   /**
+   * Updates whether to allow download and update only on wifi or not for admin settings.
+   *
+   * @param profileId the ID corresponding to the profile being updated.
+   * @param allowDownloadAndUpdateOnlyOnWifi New download access status for the profile being updated only on wifi.
+   * @return a [LiveData] that indicates the success/failure of this update operation.
+   */
+  fun updateAllowDownloadAndUpdateOnlyOnWifi(
+    profileId: ProfileId, adminSettings: AdminSettings.Builder
+  ): LiveData<AsyncResult<Any?>> {
+    val deferred = profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
+      val profile = it.profilesMap[profileId.internalId] ?: return@storeDataWithCustomChannelAsync Pair(
+        it,
+        ProfileActionStatus.PROFILE_NOT_FOUND
+      )
+      val profileDatabaseBuilder =
+        it.toBuilder()
+          .putProfiles(profileId.internalId, profile.toBuilder().setAdminSettings(adminSettings).build())
+      Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
+
+    }
+    return dataProviders.convertToLiveData(
+      dataProviders.createInMemoryDataProviderAsync(UPDATE_DOWNLOAD_AND_UPDATE_ONLY_ON_WIFI_TRANSFORMED_PROVIDER_ID) {
+        return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
+      })
+  }
+
+
+  /**
    * Adds a new profile with the specified parameters.
    *
    * @param name Name of the new profile.
@@ -283,55 +311,55 @@ class ProfileManagementController @Inject constructor(
       })
   }
 
-  /**
-   * Updates whether to allow download and update only on wifi or not for admin settings.
-   *
-   * @param profileId the ID corresponding to the profile being updated.
-   * @param allowDownloadAndUpdateOnlyOnWifi New download access status for the profile being updated only on wifi.
-   * @return a [LiveData] that indicates the success/failure of this update operation.
-   */
-  fun updateAllowDownloadAndUpdateOnlyOnWifi(
-    profileId: ProfileId, adminSettings: AdminSettings.Builder
-  ): LiveData<AsyncResult<Any?>> {
-    val deferred = profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
-      val profile = it.profilesMap[profileId.internalId] ?: return@storeDataWithCustomChannelAsync Pair(
-        it,
-        ProfileActionStatus.PROFILE_NOT_FOUND
-      )
-      val updatedProfile = profile.toBuilder().setAdminSettings(adminSettings).build()
-      val profileDatabaseBuilder = it.toBuilder().putProfiles(profileId.internalId, updatedProfile)
-      Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
-    }
-    return dataProviders.convertToLiveData(
-      dataProviders.createInMemoryDataProviderAsync(UPDATE_DOWNLOAD_AND_UPDATE_ONLY_ON_WIFI_TRANSFORMED_PROVIDER_ID) {
-        return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
-      })
-  }
-
-  /**
-   * Updates whether to allow automatic update of topics for admin settings.
-   *
-   * @param profileId the ID corresponding to the profile being updated.
-   * @param allowAutomaticallyUpdateOfTopics automatically update new contents of topics.
-   * @return a [LiveData] that indicates the success/failure of this update operation.
-   */
-  fun updateAllowAutomaticallyUpdateTopics(
-    profileId: ProfileId, adminSettings: AdminSettings.Builder
-  ): LiveData<AsyncResult<Any?>> {
-    val deferred = profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
-      val profile = it.profilesMap[profileId.internalId] ?: return@storeDataWithCustomChannelAsync Pair(
-        it,
-        ProfileActionStatus.PROFILE_NOT_FOUND
-      )
-      val updatedProfile = profile.toBuilder().setAdminSettings(adminSettings).build()
-      val profileDatabaseBuilder = it.toBuilder().putProfiles(profileId.internalId, updatedProfile)
-      Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
-    }
-    return dataProviders.convertToLiveData(
-      dataProviders.createInMemoryDataProviderAsync(UPDATE_AUTOMATICALLY_UPDATE_TOPICS_TRANSFORMED_PROVIDER_ID) {
-        return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
-      })
-  }
+//  /**
+//   * Updates whether to allow download and update only on wifi or not for admin settings.
+//   *
+//   * @param profileId the ID corresponding to the profile being updated.
+//   * @param allowDownloadAndUpdateOnlyOnWifi New download access status for the profile being updated only on wifi.
+//   * @return a [LiveData] that indicates the success/failure of this update operation.
+//   */
+//  fun updateAllowDownloadAndUpdateOnlyOnWifi(
+//    profileId: ProfileId, adminSettings: AdminSettings.Builder
+//  ): LiveData<AsyncResult<Any?>> {
+//    val deferred = profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
+//      val profile = it.profilesMap[profileId.internalId] ?: return@storeDataWithCustomChannelAsync Pair(
+//        it,
+//        ProfileActionStatus.PROFILE_NOT_FOUND
+//      )
+//      val updatedProfile = profile.toBuilder().setAdminSettings(adminSettings).build()
+//      val profileDatabaseBuilder = it.toBuilder().putProfiles(profileId.internalId, updatedProfile)
+//      Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
+//    }
+//    return dataProviders.convertToLiveData(
+//      dataProviders.createInMemoryDataProviderAsync(UPDATE_DOWNLOAD_AND_UPDATE_ONLY_ON_WIFI_TRANSFORMED_PROVIDER_ID) {
+//        return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
+//      })
+//  }
+//
+//  /**
+//   * Updates whether to allow automatic update of topics for admin settings.
+//   *
+//   * @param profileId the ID corresponding to the profile being updated.
+//   * @param allowAutomaticallyUpdateOfTopics automatically update new contents of topics.
+//   * @return a [LiveData] that indicates the success/failure of this update operation.
+//   */
+//  fun updateAllowAutomaticallyUpdateTopics(
+//    profileId: ProfileId, adminSettings: AdminSettings.Builder
+//  ): LiveData<AsyncResult<Any?>> {
+//    val deferred = profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
+//      val profile = it.profilesMap[profileId.internalId] ?: return@storeDataWithCustomChannelAsync Pair(
+//        it,
+//        ProfileActionStatus.PROFILE_NOT_FOUND
+//      )
+//      val updatedProfile = profile.toBuilder().setAdminSettings(adminSettings).build()
+//      val profileDatabaseBuilder = it.toBuilder().putProfiles(profileId.internalId, updatedProfile)
+//      Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
+//    }
+//    return dataProviders.convertToLiveData(
+//      dataProviders.createInMemoryDataProviderAsync(UPDATE_AUTOMATICALLY_UPDATE_TOPICS_TRANSFORMED_PROVIDER_ID) {
+//        return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
+//      })
+//  }
 
   /**
    * Updates the story text size of the profile.

--- a/domain/src/main/java/org/oppia/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/domain/profile/ProfileManagementController.kt
@@ -37,7 +37,7 @@ private const val ADD_PROFILE_TRANSFORMED_PROVIDER_ID = "add_profile_transformed
 private const val UPDATE_NAME_TRANSFORMED_PROVIDER_ID = "update_name_transformed_id"
 private const val UPDATE_PIN_TRANSFORMED_PROVIDER_ID = "update_pin_transformed_id"
 private const val UPDATE_DOWNLOAD_ACCESS_TRANSFORMED_PROVIDER_ID = "update_download_access_transformed_id"
-private const val UPDATE_DOWNLOAD_AND__UPDATE_ONLY_ON_WIFI_TRANSFORMED_PROVIDER_ID = "update_download_and_update_only_on_wifi_transformed_id"
+private const val UPDATE_DOWNLOAD_AND_UPDATE_ONLY_ON_WIFI_TRANSFORMED_PROVIDER_ID = "update_download_and_update_only_on_wifi_transformed_id"
 private const val UPDATE_AUTOMATICALLY_UPDATE_TOPICS_TRANSFORMED_PROVIDER_ID = "update_automatically_update_topics_transformed_id"
 private const val LOGIN_PROFILE_TRANSFORMED_PROVIDER_ID = "login_profile_transformed_id"
 private const val DELETE_PROFILE_TRANSFORMED_PROVIDER_ID = "delete_profile_transformed_id"
@@ -284,7 +284,7 @@ class ProfileManagementController @Inject constructor(
   }
 
   /**
-   * Updates the download and updates access of an admin profile only on wifi.
+   * Updates whether to allow download and update only on wifi or not for admin settings.
    *
    * @param profileId the ID corresponding to the profile being updated.
    * @param allowDownloadAndUpdateOnlyOnWifi New download access status for the profile being updated only on wifi.
@@ -303,13 +303,13 @@ class ProfileManagementController @Inject constructor(
       Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
     }
     return dataProviders.convertToLiveData(
-      dataProviders.createInMemoryDataProviderAsync(UPDATE_DOWNLOAD_AND__UPDATE_ONLY_ON_WIFI_TRANSFORMED_PROVIDER_ID) {
+      dataProviders.createInMemoryDataProviderAsync(UPDATE_DOWNLOAD_AND_UPDATE_ONLY_ON_WIFI_TRANSFORMED_PROVIDER_ID) {
         return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
       })
   }
 
   /**
-   * Updates the automatic update settings of topics of an admin profile.
+   * Updates whether to allow automatic update of topics for admin settings.
    *
    * @param profileId the ID corresponding to the profile being updated.
    * @param allowAutomaticallyUpdateOfTopics automatically update new contents of topics.
@@ -328,7 +328,7 @@ class ProfileManagementController @Inject constructor(
       Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
     }
     return dataProviders.convertToLiveData(
-      dataProviders.createInMemoryDataProviderAsync(UPDATE_DOWNLOAD_AND__UPDATE_ONLY_ON_WIFI_TRANSFORMED_PROVIDER_ID) {
+      dataProviders.createInMemoryDataProviderAsync(UPDATE_AUTOMATICALLY_UPDATE_TOPICS_TRANSFORMED_PROVIDER_ID) {
         return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
       })
   }

--- a/domain/src/test/java/org/oppia/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/profile/ProfileManagementControllerTest.kt
@@ -31,6 +31,7 @@ import org.mockito.Mockito.atLeastOnce
 import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoRule
+import org.oppia.app.model.AdminSettings
 import org.oppia.app.model.AppLanguage
 import org.oppia.app.model.AudioLanguage
 import org.oppia.app.model.Profile
@@ -392,6 +393,46 @@ class ProfileManagementControllerTest {
       assertThat(updateResultCaptor.value.isFailure()).isTrue()
       assertThat(updateResultCaptor.value.getErrorOrNull()).hasMessageThat()
         .contains("ProfileId 6 does not match an existing Profile")
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testUpdateAllowDownloadAndUpdateOnlyOnWifi_addProfiles_updateDownloadAndUpdateOnlyOnWifi_checkUpdateIsSuccessful() =
+    runBlockingTest(coroutineContext) {
+      addTestProfiles()
+      advanceUntilIdle()
+
+      val profileId = ProfileId.newBuilder().setInternalId(0).build()
+      profileManagementController.updateAllowDownloadAndUpdateOnlyOnWifi(profileId, AdminSettings.newBuilder().setAllowDownloadAndUpdateOnlyOnWifi(true))
+        .observeForever(mockUpdateResultObserver)
+      advanceUntilIdle()
+      profileManagementController.getProfile(profileId).observeForever(mockProfileObserver)
+
+      verify(mockUpdateResultObserver, atLeastOnce()).onChanged(updateResultCaptor.capture())
+      verify(mockProfileObserver, atLeastOnce()).onChanged(profileResultCaptor.capture())
+      assertThat(updateResultCaptor.value.isSuccess()).isTrue()
+      assertThat(profileResultCaptor.value.isSuccess()).isTrue()
+      assertThat(profileResultCaptor.value.getOrThrow().allowDownloadAndUpdateOnlyOnWifi).isEqualTo(false)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testUpdateAllowAutomaticallyUpdateTopics_addProfiles_automaticallyUpdateTopics_checkUpdateIsSuccessful() =
+    runBlockingTest(coroutineContext) {
+      addTestProfiles()
+      advanceUntilIdle()
+
+      val profileId = ProfileId.newBuilder().setInternalId(0).build()
+      profileManagementController.updateAllowAutomaticallyUpdateTopics(profileId, AdminSettings.newBuilder().setAutomaticallyUpdateTopics(true))
+        .observeForever(mockUpdateResultObserver)
+      advanceUntilIdle()
+      profileManagementController.getProfile(profileId).observeForever(mockProfileObserver)
+
+      verify(mockUpdateResultObserver, atLeastOnce()).onChanged(updateResultCaptor.capture())
+      verify(mockProfileObserver, atLeastOnce()).onChanged(profileResultCaptor.capture())
+      assertThat(updateResultCaptor.value.isSuccess()).isTrue()
+      assertThat(profileResultCaptor.value.isSuccess()).isTrue()
+      assertThat(profileResultCaptor.value.getOrThrow().automaticallyUpdateTopics).isEqualTo(false)
     }
 
   @Test

--- a/domain/src/test/java/org/oppia/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/profile/ProfileManagementControllerTest.kt
@@ -78,6 +78,9 @@ class ProfileManagementControllerTest {
   @Mock lateinit var mockWasProfileAddedResultObserver: Observer<AsyncResult<Boolean>>
   @Captor lateinit var wasProfileAddedResultCaptor: ArgumentCaptor<AsyncResult<Boolean>>
 
+  @Mock lateinit var mockAdminSettingsResultObserver: Observer<AsyncResult<Any?>>
+  @Captor lateinit var adminsSettingsResultCaptor: ArgumentCaptor<AsyncResult<Boolean>>
+
   private val PROFILES_LIST = listOf<Profile>(
     Profile.newBuilder().setName("James").setPin("123").setAllowDownloadAccess(true).build(),
     Profile.newBuilder().setName("Sean").setPin("234").setAllowDownloadAccess(false).build(),
@@ -404,36 +407,37 @@ class ProfileManagementControllerTest {
 
       val profileId = ProfileId.newBuilder().setInternalId(0).build()
       profileManagementController.updateAllowDownloadAndUpdateOnlyOnWifi(profileId, AdminSettings.newBuilder().setAllowDownloadAndUpdateOnlyOnWifi(true))
-        .observeForever(mockUpdateResultObserver)
+        .observeForever(mockAdminSettingsResultObserver)
       advanceUntilIdle()
       profileManagementController.getProfile(profileId).observeForever(mockProfileObserver)
 
-      verify(mockUpdateResultObserver, atLeastOnce()).onChanged(updateResultCaptor.capture())
+      verify(mockAdminSettingsResultObserver, atLeastOnce()).onChanged(adminsSettingsResultCaptor.capture())
       verify(mockProfileObserver, atLeastOnce()).onChanged(profileResultCaptor.capture())
       assertThat(updateResultCaptor.value.isSuccess()).isTrue()
-      assertThat(profileResultCaptor.value.isSuccess()).isTrue()
-      assertThat(profileResultCaptor.value.getOrThrow().allowDownloadAndUpdateOnlyOnWifi).isEqualTo(false)
+      assertThat(adminsSettingsResultCaptor.value.isSuccess()).isTrue()
+      val downloadAndUpdateOnlyOnWifi = adminsSettingsResultCaptor.value.getOrThrow()
+      assertThat(downloadAndUpdateOnlyOnWifi).isFalse()
     }
 
-  @Test
-  @ExperimentalCoroutinesApi
-  fun testUpdateAllowAutomaticallyUpdateTopics_addProfiles_automaticallyUpdateTopics_checkUpdateIsSuccessful() =
-    runBlockingTest(coroutineContext) {
-      addTestProfiles()
-      advanceUntilIdle()
-
-      val profileId = ProfileId.newBuilder().setInternalId(0).build()
-      profileManagementController.updateAllowAutomaticallyUpdateTopics(profileId, AdminSettings.newBuilder().setAutomaticallyUpdateTopics(true))
-        .observeForever(mockUpdateResultObserver)
-      advanceUntilIdle()
-      profileManagementController.getProfile(profileId).observeForever(mockProfileObserver)
-
-      verify(mockUpdateResultObserver, atLeastOnce()).onChanged(updateResultCaptor.capture())
-      verify(mockProfileObserver, atLeastOnce()).onChanged(profileResultCaptor.capture())
-      assertThat(updateResultCaptor.value.isSuccess()).isTrue()
-      assertThat(profileResultCaptor.value.isSuccess()).isTrue()
-      assertThat(profileResultCaptor.value.getOrThrow().automaticallyUpdateTopics).isEqualTo(false)
-    }
+//  @Test
+//  @ExperimentalCoroutinesApi
+//  fun testUpdateAllowAutomaticallyUpdateTopics_addProfiles_automaticallyUpdateTopics_checkUpdateIsSuccessful() =
+//    runBlockingTest(coroutineContext) {
+//      addTestProfiles()
+//      advanceUntilIdle()
+//
+//      val profileId = ProfileId.newBuilder().setInternalId(0).build()
+//      profileManagementController.updateAllowAutomaticallyUpdateTopics(profileId, AdminSettings.newBuilder().setAutomaticallyUpdateTopics(true))
+//        .observeForever(mockUpdateResultObserver)
+//      advanceUntilIdle()
+//      profileManagementController.getProfile(profileId).observeForever(mockProfileObserver)
+//
+//      verify(mockUpdateResultObserver, atLeastOnce()).onChanged(updateResultCaptor.capture())
+//      verify(mockProfileObserver, atLeastOnce()).onChanged(profileResultCaptor.capture())
+//      assertThat(updateResultCaptor.value.isSuccess()).isTrue()
+//      assertThat(profileResultCaptor.value.isSuccess()).isTrue()
+//      assertThat(profileResultCaptor.value.getOrThrow().automaticallyUpdateTopics).isEqualTo(false)
+//    }
 
   @Test
   @ExperimentalCoroutinesApi

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -14,7 +14,7 @@ message ProfileDatabase {
   bool was_profile_ever_added = 2;
 
   // Mapping from unique ID to profile.
-  map<int32, Profile> profiles = 4;
+  map<int32, Profile> profiles = 3;
 }
 
 // Structure for a admin.

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -17,12 +17,12 @@ message ProfileDatabase {
   map<int32, Profile> profiles = 3;
 }
 
-// Structure for a admin.
+// Structure for admin settings.
 message AdminSettings{
-  // Determines whether profile can download and update content only on wifi.
+  // Determines whether to download and update content only on wifi.
   bool allow_download_and_update_only_on_wifi = 1;
 
-  // Determines whether profile can automatically update new contents of topics.
+  // Determines whether app can automatically update topics.
   bool automatically_update_topics = 2;
 }
 

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -14,7 +14,16 @@ message ProfileDatabase {
   bool was_profile_ever_added = 2;
 
   // Mapping from unique ID to profile.
-  map<int32, Profile> profiles = 3;
+  map<int32, Profile> profiles = 4;
+}
+
+// Structure for a admin.
+message AdminSettings{
+  // Determines whether profile can download and update content only on wifi.
+  bool allow_download_and_update_only_on_wifi = 1;
+
+  // Determines whether profile can automatically update new contents of topics.
+  bool automatically_update_topics = 2;
 }
 
 // Structure for a single profile.
@@ -53,6 +62,9 @@ message Profile {
 
   // Represents user selected app-language.
   AppLanguage app_language = 12;
+
+  // Determine admins settings.
+  AdminSettings adminSettings = 13;
 }
 
 // Represents a profile avatar image.

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -15,6 +15,9 @@ message ProfileDatabase {
 
   // Mapping from unique ID to profile.
   map<int32, Profile> profiles = 3;
+
+  // Mapping from unique ID to profile.
+  AdminSettings adminSettings = 4;
 }
 
 // Structure for admin settings.


### PR DESCRIPTION

## Explanation
This PR saves download permission settings in domain layer.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
