### PR TITLE
Fix #387: Concept card linking

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,8 +51,8 @@
     <activity
       android:name=".profile.PinPasswordActivity"
       android:screenOrientation="portrait"
-      android:theme="@style/OppiaThemeWithoutActionBar"
-      android:windowSoftInputMode="adjustResize" />
+      android:windowSoftInputMode="adjustResize"
+      android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".profile.ProfileActivity"
       android:theme="@style/OppiaThemeWithoutActionBar" />
@@ -116,8 +116,7 @@
       android:name=".topic.reviewcard.ReviewCardActivity"
       android:screenOrientation="portrait"
       android:theme="@style/OppiaThemeWithoutActionBar" />
-    <activity
-      android:name=".testing.ReviewCardFragmentTestActivity"
+    <activity android:name=".testing.ReviewCardFragmentTestActivity"
       android:screenOrientation="portrait"
       android:theme="@style/OppiaThemeWithoutActionBar" />
   </application>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -71,16 +71,7 @@
     <activity
       android:name=".splash.SplashActivity"
       android:screenOrientation="portrait"
-      android:theme="@style/SplashScreenTheme">
-      <intent-filter>
-        <action android:name="android.intent.action.MAIN" />
-        <category android:name="android.intent.category.LAUNCHER" />
-      </intent-filter>
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.DEFAULT" />
-      </intent-filter>
-    </activity>
+      android:theme="@style/SplashScreenTheme"/>
     <activity
       android:name=".story.StoryActivity"
       android:theme="@style/OppiaThemeWithoutActionBar" />
@@ -93,7 +84,16 @@
     <activity android:name=".testing.ContentCardTestActivity" />
     <activity android:name=".testing.ExplorationInjectionActivity" />
     <activity android:name=".testing.ExplorationTestActivity" />
-    <activity android:name=".testing.HtmlParserTestActivity" />
+    <activity android:name=".testing.HtmlParserTestActivity" >
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+    </activity>
     <activity android:name=".testing.InputInteractionViewTestActivity" />
     <activity android:name=".testing.RecentlyPlayedFragmentTestActivity" />
     <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,8 +51,8 @@
     <activity
       android:name=".profile.PinPasswordActivity"
       android:screenOrientation="portrait"
-      android:windowSoftInputMode="adjustResize"
-      android:theme="@style/OppiaThemeWithoutActionBar" />
+      android:theme="@style/OppiaThemeWithoutActionBar"
+      android:windowSoftInputMode="adjustResize" />
     <activity
       android:name=".profile.ProfileActivity"
       android:theme="@style/OppiaThemeWithoutActionBar" />
@@ -71,7 +71,16 @@
     <activity
       android:name=".splash.SplashActivity"
       android:screenOrientation="portrait"
-      android:theme="@style/SplashScreenTheme"/>
+      android:theme="@style/SplashScreenTheme">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+    </activity>
     <activity
       android:name=".story.StoryActivity"
       android:theme="@style/OppiaThemeWithoutActionBar" />
@@ -84,16 +93,7 @@
     <activity android:name=".testing.ContentCardTestActivity" />
     <activity android:name=".testing.ExplorationInjectionActivity" />
     <activity android:name=".testing.ExplorationTestActivity" />
-    <activity android:name=".testing.HtmlParserTestActivity" >
-      <intent-filter>
-        <action android:name="android.intent.action.MAIN" />
-        <category android:name="android.intent.category.LAUNCHER" />
-      </intent-filter>
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.DEFAULT" />
-      </intent-filter>
-    </activity>
+    <activity android:name=".testing.HtmlParserTestActivity" />
     <activity android:name=".testing.InputInteractionViewTestActivity" />
     <activity android:name=".testing.RecentlyPlayedFragmentTestActivity" />
     <activity
@@ -116,7 +116,8 @@
       android:name=".topic.reviewcard.ReviewCardActivity"
       android:screenOrientation="portrait"
       android:theme="@style/OppiaThemeWithoutActionBar" />
-    <activity android:name=".testing.ReviewCardFragmentTestActivity"
+    <activity
+      android:name=".testing.ReviewCardFragmentTestActivity"
       android:screenOrientation="portrait"
       android:theme="@style/OppiaThemeWithoutActionBar" />
   </application>

--- a/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivity.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivity.kt
@@ -18,7 +18,8 @@ const val EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY = "ExplorationActivity.topi
 private const val TAG_STOP_EXPLORATION_DIALOG = "STOP_EXPLORATION_DIALOG"
 
 /** The starting point for exploration. */
-class ExplorationActivity : InjectableAppCompatActivity(), StopExplorationInterface, StateKeyboardButtonListener, AudioButtonListener, ConceptCardListener {
+class ExplorationActivity : InjectableAppCompatActivity(), StopExplorationInterface, StateKeyboardButtonListener,
+  AudioButtonListener, ConceptCardListener {
 
   @Inject lateinit var explorationActivityPresenter: ExplorationActivityPresenter
   private lateinit var explorationId: String
@@ -37,7 +38,7 @@ class ExplorationActivity : InjectableAppCompatActivity(), StopExplorationInterf
     fun createExplorationActivityIntent(context: Context, explorationId: String, topicId: String?): Intent {
       val intent = Intent(context, ExplorationActivity::class.java)
       intent.putExtra(EXPLORATION_ACTIVITY_EXPLORATION_ID_ARGUMENT_KEY, explorationId)
-      if(topicId!=null) {
+      if (topicId != null) {
         intent.putExtra(EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY, topicId)
       }
       return intent

--- a/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivity.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivity.kt
@@ -10,6 +10,7 @@ import org.oppia.app.player.audio.AudioButtonListener
 import org.oppia.app.player.state.listener.StateKeyboardButtonListener
 import org.oppia.app.player.stopexploration.StopExplorationDialogFragment
 import org.oppia.app.player.stopexploration.StopExplorationInterface
+import org.oppia.app.topic.conceptcard.ConceptCardListener
 import javax.inject.Inject
 
 const val EXPLORATION_ACTIVITY_EXPLORATION_ID_ARGUMENT_KEY = "ExplorationActivity.exploration_id"
@@ -17,7 +18,8 @@ const val EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY = "ExplorationActivity.topi
 private const val TAG_STOP_EXPLORATION_DIALOG = "STOP_EXPLORATION_DIALOG"
 
 /** The starting point for exploration. */
-class ExplorationActivity : InjectableAppCompatActivity(), StopExplorationInterface, StateKeyboardButtonListener, AudioButtonListener {
+class ExplorationActivity : InjectableAppCompatActivity(), StopExplorationInterface, StateKeyboardButtonListener, AudioButtonListener, ConceptCardListener {
+
   @Inject lateinit var explorationActivityPresenter: ExplorationActivityPresenter
   private lateinit var explorationId: String
   private var topicId: String? = null
@@ -82,5 +84,9 @@ class ExplorationActivity : InjectableAppCompatActivity(), StopExplorationInterf
 
   override fun onEditorAction(actionCode: Int) {
     explorationActivityPresenter.onKeyboardAction(actionCode)
+  }
+
+  override fun dismissConceptCard() {
+    explorationActivityPresenter.dismissConceptCard()
   }
 }

--- a/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivityPresenter.kt
@@ -105,6 +105,10 @@ class ExplorationActivityPresenter @Inject constructor(
     })
   }
 
+  fun dismissConceptCard() {
+    getExplorationFragment()?.dismissConceptCard()
+  }
+
   private fun updateToolbarTitle(explorationId: String) {
     subscribeToExploration(explorationDataController.getExplorationById(explorationId))
   }

--- a/app/src/main/java/org/oppia/app/player/exploration/ExplorationFragment.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/ExplorationFragment.kt
@@ -28,4 +28,6 @@ class ExplorationFragment : InjectableFragment() {
   fun setAudioBarVisibility(isVisible: Boolean) = explorationFragmentPresenter.setAudioBarVisibility(isVisible)
 
   fun scrollToTop() = explorationFragmentPresenter.scrollToTop()
+
+  fun dismissConceptCard() = explorationFragmentPresenter.dismissConceptCard()
 }

--- a/app/src/main/java/org/oppia/app/player/exploration/ExplorationFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/ExplorationFragmentPresenter.kt
@@ -38,6 +38,8 @@ class ExplorationFragmentPresenter @Inject constructor(
 
   fun scrollToTop() = getStateFragment()?.scrollToTop()
 
+  fun dismissConceptCard() = getStateFragment()?.dismissConceptCard()
+
   private fun getStateFragment(): StateFragment? {
     return fragment.childFragmentManager.findFragmentById(R.id.state_fragment_placeholder) as StateFragment?
   }

--- a/app/src/main/java/org/oppia/app/player/state/StateFragment.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateFragment.kt
@@ -56,4 +56,6 @@ class StateFragment : InjectableFragment(), InteractionAnswerReceiver, Interacti
   fun setAudioBarVisibility(visibility: Boolean) = stateFragmentPresenter.setAudioBarVisibility(visibility)
 
   fun scrollToTop() = stateFragmentPresenter.scrollToTop()
+
+  fun dismissConceptCard() = stateFragmentPresenter.dismissConceptCard()
 }

--- a/app/src/main/java/org/oppia/app/testing/ConceptCardFragmentTestActivity.kt
+++ b/app/src/main/java/org/oppia/app/testing/ConceptCardFragmentTestActivity.kt
@@ -17,7 +17,7 @@ class ConceptCardFragmentTestActivity : InjectableAppCompatActivity(), ConceptCa
     conceptCardFragmentTestActivityController.handleOnCreate()
   }
 
-  override fun dismiss() {
+  override fun dismissConceptCard() {
     getConceptCardFragment()?.dismiss()
   }
 

--- a/app/src/main/java/org/oppia/app/testing/HtmlParserTestActivity.kt
+++ b/app/src/main/java/org/oppia/app/testing/HtmlParserTestActivity.kt
@@ -2,14 +2,18 @@ package org.oppia.app.testing
 
 import android.os.Bundle
 import android.text.Spannable
+import android.view.View
 import android.widget.TextView
 import org.oppia.app.R
 import org.oppia.app.activity.InjectableAppCompatActivity
+import org.oppia.app.topic.conceptcard.ConceptCardFragment
 import org.oppia.util.parser.HtmlParser
 import javax.inject.Inject
 
+private const val CONCEPT_CARD_DIALOG_FRAGMENT_TAG = "CONCEPT_CARD_FRAGMENT"
+
 /** This is a dummy activity to test Html parsing. */
-class HtmlParserTestActivity : InjectableAppCompatActivity() {
+class HtmlParserTestActivity : InjectableAppCompatActivity(), HtmlParser.CustomOppiaTagActionListener {
   @Inject lateinit var htmlParserFactory: HtmlParser.Factory
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,13 +23,24 @@ class HtmlParserTestActivity : InjectableAppCompatActivity() {
 
     val testHtmlContentTextView: TextView = findViewById(R.id.test_html_content_text_view)
     val rawDummyString =
-      "\u003cp\u003e\"Let's try one last question,\" said Mr. Baker. \"Here's a pineapple cake cut into pieces.\"\u003c/p\u003e\u003coppia-noninteractive-image alt-with-value=\"\u0026amp;quot;Pineapple cake with 7/9 having cherries.\u0026amp;quot;\" caption-with-value=\"\u0026amp;quot;\u0026amp;quot;\" filepath-with-value=\"\u0026amp;quot;pineapple_cake_height_479_width_480.png\u0026amp;quot;\"\u003e\u003c/oppia-noninteractive-image\u003e\u003cp\u003e\u00a0\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eQuestion 6\u003c/strong\u003e: What fraction of the cake has big red cherries in the pineapple slices?\u003c/p\u003e"
+      "\u003cp\u003e\"Let's try one last question,\" said Mr. Baker. \"Here's a pineapple cake cut into pieces.\"\u003c/p\u003e\u003coppia-noninteractive-image alt-with-value=\"\u0026amp;quot;Pineapple cake with 7/9 having cherries.\u0026amp;quot;\" caption-with-value=\"\u0026amp;quot;\u0026amp;quot;\" filepath-with-value=\"\u0026amp;quot;pineapple_cake_height_479_width_480.png\u0026amp;quot;\"\u003e\u003c/oppia-noninteractive-image\u003e\u003cp\u003e\u00a0\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eQuestion 6\u003c/strong\u003e: What fraction of the cake has big red cherries in the pineapple slices?\u003c/p\u003e<p>Take a look at the short <oppia-noninteractive-skillreview skill_id-with-value=\"UxTGIJqaHMLa\" text-with-value=\"refresher lesson\"></oppia-noninteractive-skillreview> to refresh your memory if you need to.</p>"
+
+    val htmlParser = htmlParserFactory.create(/* entityType= */ "exploration",
+      /* entityId= */"oppia",
+      /* imageCenterAlign= */
+      false,
+      customOppiaTagActionListener = this
+    )
     val htmlResult: Spannable =
-      htmlParserFactory.create( /* entityType= */ "exploration", /* entityId= */ "oppia", /* imageCenterAlign= */ false)
-        .parseOppiaHtml(
-          rawDummyString,
-          testHtmlContentTextView
-        )
+      htmlParser.parseOppiaHtml(
+        rawDummyString,
+        testHtmlContentTextView,
+        supportsLinks = true
+      )
     testHtmlContentTextView.text = htmlResult
+  }
+
+  override fun onConceptCardLinkClicked(view: View, skillId: String) {
+    ConceptCardFragment.newInstance(skillId).showNow(this.supportFragmentManager, CONCEPT_CARD_DIALOG_FRAGMENT_TAG)
   }
 }

--- a/app/src/main/java/org/oppia/app/topic/conceptcard/ConceptCardFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/topic/conceptcard/ConceptCardFragmentPresenter.kt
@@ -20,7 +20,7 @@ class ConceptCardFragmentPresenter @Inject constructor(
 
   /**
    * Sets up data binding and toolbar.
-   * Host activity must inherit ConceptCardListener to dismiss this fragment.
+   * Host activity must inherit ConceptCardListener to dismissConceptCard this fragment.
    */
   fun handleCreateView(inflater: LayoutInflater, container: ViewGroup?, id: String): View? {
     val binding = ConceptCardFragmentBinding.inflate(inflater, container, /* attachToRoot= */ false)
@@ -31,7 +31,7 @@ class ConceptCardFragmentPresenter @Inject constructor(
 
     binding.conceptCardToolbar.setNavigationIcon(R.drawable.ic_close_white_24dp)
     binding.conceptCardToolbar.setNavigationOnClickListener {
-      (fragment.requireActivity() as? ConceptCardListener)?.dismiss()
+      (fragment.requireActivity() as? ConceptCardListener)?.dismissConceptCard()
     }
 
     binding.let {

--- a/app/src/main/java/org/oppia/app/topic/conceptcard/ConceptCardFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/topic/conceptcard/ConceptCardFragmentPresenter.kt
@@ -20,7 +20,7 @@ class ConceptCardFragmentPresenter @Inject constructor(
 
   /**
    * Sets up data binding and toolbar.
-   * Host activity must inherit ConceptCardListener to dismissConceptCard this fragment.
+   * Host activity must inherit ConceptCardListener to dismiss this fragment.
    */
   fun handleCreateView(inflater: LayoutInflater, container: ViewGroup?, id: String): View? {
     val binding = ConceptCardFragmentBinding.inflate(inflater, container, /* attachToRoot= */ false)

--- a/app/src/main/java/org/oppia/app/topic/conceptcard/ConceptCardListener.kt
+++ b/app/src/main/java/org/oppia/app/topic/conceptcard/ConceptCardListener.kt
@@ -1,6 +1,6 @@
 package org.oppia.app.topic.conceptcard
 
-/** Allows parent activity to dismissConceptCard the [ConceptCardFragment] */
+/** Allows parent activity to dismiss the [ConceptCardFragment] */
 interface ConceptCardListener {
   /** Called when the concept card dialog should be dismissed. */
   fun dismissConceptCard()

--- a/app/src/main/java/org/oppia/app/topic/conceptcard/ConceptCardListener.kt
+++ b/app/src/main/java/org/oppia/app/topic/conceptcard/ConceptCardListener.kt
@@ -1,7 +1,7 @@
 package org.oppia.app.topic.conceptcard
 
-/** Allows parent activity to dismiss the [ConceptCardFragment] */
+/** Allows parent activity to dismissConceptCard the [ConceptCardFragment] */
 interface ConceptCardListener {
   /** Called when the concept card dialog should be dismissed. */
-  fun dismiss()
+  fun dismissConceptCard()
 }

--- a/domain/src/main/assets/fractions_exploration1.json
+++ b/domain/src/main/assets/fractions_exploration1.json
@@ -1928,7 +1928,7 @@
               "param_changes": [],
               "feedback": {
                 "content_id": "feedback_3",
-                "html": "<p>That's not correct -- it looks like you've forgotten what the numerator and denominator represent. Take a look at the short <oppia-concept-card-link skill-id=\"UxTGIJqaHMLa\">refresher lesson</oppia-concept-card-link> to refresh your memory if you need to.</p>"
+                "html": "<p>That's not correct -- it looks like you've forgotten what the numerator and denominator represent. Take a look at the short <oppia-noninteractive-skillreview skill_id-with-value=\"UxTGIJqaHMLa\" text-with-value=\"refresher lesson\"></oppia-noninteractive-skillreview> to refresh your memory if you need to.</p>"
               },
               "dest": "Matthew gets conned",
               "refresher_exploration_id": null,
@@ -1956,7 +1956,7 @@
               "param_changes": [],
               "feedback": {
                 "content_id": "feedback_10",
-                "html": "<p>That's not correct -- it looks like you've forgotten what the numerator and denominator represent. Take a look at the short <oppia-concept-card-link skill-id=\"UxTGIJqaHMLa\">refresher lesson</oppia-concept-card-link> to refresh your memory if you need to.</p>"
+                "html": "<p>That's not correct -- it looks like you've forgotten what the numerator and denominator represent. Take a look at the short <oppia-noninteractive-skillreview skill_id-with-value=\"UxTGIJqaHMLa\" text-with-value=\"refresher lesson\"></oppia-noninteractive-skillreview> to refresh your memory if you need to.</p>"
               },
               "dest": "Matthew gets conned",
               "refresher_exploration_id": null,

--- a/domain/src/main/assets/fractions_exploration1.json
+++ b/domain/src/main/assets/fractions_exploration1.json
@@ -1928,7 +1928,7 @@
               "param_changes": [],
               "feedback": {
                 "content_id": "feedback_3",
-                "html": "<p>That's not correct -- it looks like you've forgotten what the numerator and denominator represent. Take a look at the short <oppia-noninteractive-link text-with-value=\"&amp;quot;refresher lesson&amp;quot;\" url-with-value=\"&amp;quot;https://www.oppia.org/explore/xHwiGtvK2N4L?parent=MjZzEVOG47_1&amp;quot;\"></oppia-noninteractive-link> to refresh your memory if you need to.</p>"
+                "html": "<p>That's not correct -- it looks like you've forgotten what the numerator and denominator represent. Take a look at the short <oppia-concept-card-link skill-id=\"UxTGIJqaHMLa\">refresher lesson</oppia-concept-card-link> to refresh your memory if you need to.</p>"
               },
               "dest": "Matthew gets conned",
               "refresher_exploration_id": null,
@@ -1956,7 +1956,7 @@
               "param_changes": [],
               "feedback": {
                 "content_id": "feedback_10",
-                "html": "<p>That's not correct -- it looks like you've forgotten what the denominator represents. Take a look at the short <oppia-noninteractive-link text-with-value=\"&amp;quot;refresher lesson&amp;quot;\" url-with-value=\"&amp;quot;https://www.oppia.org/explore/xHwiGtvK2N4L?parent=MjZzEVOG47_1&amp;quot;\"></oppia-noninteractive-link> to refresh your memory if you need to.</p>"
+                "html": "<p>That's not correct -- it looks like you've forgotten what the numerator and denominator represent. Take a look at the short <oppia-concept-card-link skill-id=\"UxTGIJqaHMLa\">refresher lesson</oppia-concept-card-link> to refresh your memory if you need to.</p>"
               },
               "dest": "Matthew gets conned",
               "refresher_exploration_id": null,

--- a/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
@@ -536,7 +536,7 @@ class TopicController @Inject constructor(
         ChapterSummary.newBuilder()
           .setExplorationId(explorationId)
           .setName(chapter.getString("title"))
-          .setChapterPlayState(chapterPlayState)
+          .setChapterPlayState(ChapterPlayState.COMPLETED)
           .setChapterThumbnail(EXPLORATION_THUMBNAILS.getValue(explorationId))
           .build()
       )

--- a/utility/src/main/java/org/oppia/util/parser/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/util/parser/CustomHtmlContentHandler.kt
@@ -97,7 +97,7 @@ class CustomHtmlContentHandler private constructor(
           "Expected tracked tag $currentTrackedTag to match custom tag: $tag"
         }
         val (_, attributes, openTagIndex) = localCurrentTrackedCustomTag
-        customTagHandlers.getValue(tag).handleTag(attributes, openTagIndex, output.length, output)
+        customTagHandlers.getValue(tag).handleTag(attributes, openTagIndex, output)
       }
     }
   }
@@ -112,10 +112,9 @@ class CustomHtmlContentHandler private constructor(
      *
      * @param attributes The tag's attributes
      * @param openIndex The index in the output [Editable] at which this tag begins
-     * @param closeIndex The index in the output [Editable] at which this tag ends
      * @param output The destination [Editable] to which spans can be added
      */
-    fun handleTag(attributes: Attributes, openIndex: Int, closeIndex: Int, output: Editable)
+    fun handleTag(attributes: Attributes, openIndex: Int, output: Editable)
   }
 
   companion object {

--- a/utility/src/main/java/org/oppia/util/parser/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/util/parser/CustomHtmlContentHandler.kt
@@ -1,0 +1,141 @@
+package org.oppia.util.parser
+
+import android.text.Editable
+import android.text.Html
+import android.text.Spannable
+import org.xml.sax.Attributes
+import org.xml.sax.ContentHandler
+import org.xml.sax.Locator
+import org.xml.sax.XMLReader
+
+/**
+ * A custom [ContentHandler] and [Html.TagHandler] for processing custom HTML tags. This class must be used if a custom
+ * tag attribute must be parsed.
+ *
+ * This is based on the implementation provided in https://stackoverflow.com/a/36528149.
+ */
+class CustomHtmlContentHandler private constructor(
+  private val customTagHandlers: Map<String, CustomTagHandler>
+): ContentHandler, Html.TagHandler {
+  private var originalContentHandler: ContentHandler? = null
+  private var currentTrackedTag: TrackedTag? = null
+  private var currentTrackedCustomTag: TrackedCustomTag? = null
+
+  override fun endElement(uri: String?, localName: String?, qName: String?) {
+    originalContentHandler?.endElement(uri, localName, qName)
+    currentTrackedTag = null
+  }
+
+  override fun processingInstruction(target: String?, data: String?) {
+    originalContentHandler?.processingInstruction(target, data)
+  }
+
+  override fun startPrefixMapping(prefix: String?, uri: String?) {
+    originalContentHandler?.startPrefixMapping(prefix, uri)
+  }
+
+  override fun ignorableWhitespace(ch: CharArray?, start: Int, length: Int) {
+    originalContentHandler?.ignorableWhitespace(ch, start, length)
+  }
+
+  override fun characters(ch: CharArray?, start: Int, length: Int) {
+    originalContentHandler?.characters(ch, start, length)
+  }
+
+  override fun endDocument() {
+    originalContentHandler?.endDocument()
+  }
+
+  override fun startElement(uri: String?, localName: String?, qName: String?, atts: Attributes?) {
+    // Defer custom tag management to the tag handler so that Android's element parsing takes precedence.
+    currentTrackedTag = TrackedTag(checkNotNull(localName), checkNotNull(atts))
+    originalContentHandler?.startElement(uri, localName, qName, atts)
+  }
+
+  override fun skippedEntity(name: String?) {
+    originalContentHandler?.skippedEntity(name)
+  }
+
+  override fun setDocumentLocator(locator: Locator?) {
+    originalContentHandler?.setDocumentLocator(locator)
+  }
+
+  override fun endPrefixMapping(prefix: String?) {
+    originalContentHandler?.endPrefixMapping(prefix)
+  }
+
+  override fun startDocument() {
+    originalContentHandler?.startDocument()
+  }
+
+  override fun handleTag(opening: Boolean, tag: String?, output: Editable?, xmlReader: XMLReader?) {
+    check(output != null) { "Expected non-null editable." }
+    when {
+      originalContentHandler == null -> {
+        check(tag == "init-custom-handler") { "Expected first custom tag to be initializing the custom handler." }
+        checkNotNull(xmlReader) { "Expected reader to not be null" }
+        originalContentHandler = xmlReader.contentHandler
+        xmlReader.contentHandler = this
+      }
+      opening -> {
+        if (tag in customTagHandlers) {
+          val localCurrentTrackedTag = currentTrackedTag
+          check(localCurrentTrackedTag != null) { "Expected tag details to be to be cached for current tag." }
+          check(localCurrentTrackedTag.tag == tag) {
+            "Expected tracked tag $currentTrackedTag to match custom tag: $tag"
+          }
+          check(currentTrackedCustomTag == null) { "Custom content handler does not support nested custom tags." }
+          currentTrackedCustomTag = TrackedCustomTag(
+            localCurrentTrackedTag.tag, localCurrentTrackedTag.attributes, output.length
+          )
+        }
+      }
+      tag in customTagHandlers -> {
+        val localCurrentTrackedCustomTag = currentTrackedCustomTag
+        check(localCurrentTrackedCustomTag != null) { "Expected custom tag to be initialized tracked." }
+        check(localCurrentTrackedCustomTag.tag == tag) {
+          "Expected tracked tag $currentTrackedTag to match custom tag: $tag"
+        }
+        val (_, attributes, openTagIndex) = localCurrentTrackedCustomTag
+        customTagHandlers.getValue(tag).handleTag(attributes, openTagIndex, output.length, output)
+      }
+    }
+  }
+
+  private data class TrackedTag(val tag: String, val attributes: Attributes)
+  private data class TrackedCustomTag(val tag: String, val attributes: Attributes, val openTagIndex: Int)
+
+  /** Handler interface for a custom tag and its attributes. */
+  interface CustomTagHandler {
+    /**
+     * Called when a custom tag is encountered. This is always called after the closing tag.
+     *
+     * @param attributes The tag's attributes
+     * @param openIndex The index in the output [Editable] at which this tag begins
+     * @param closeIndex The index in the output [Editable] at which this tag ends
+     * @param output The destination [Editable] to which spans can be added
+     */
+    fun handleTag(attributes: Attributes, openIndex: Int, closeIndex: Int, output: Editable)
+  }
+
+  companion object {
+    /**
+     * Returns a new [Spannable] with HTML parsed from [html] using the specified [imageGetter] for handling image
+     * retrieval, and map of tags to [CustomTagHandler]s for handling custom tags. All possible custom tags must be
+     * registered in the [customTagHandlers] map.
+     */
+    fun fromHtml(
+      html: String, imageGetter: Html.ImageGetter, customTagHandlers: Map<String, CustomTagHandler>
+    ): Spannable {
+      // Adjust the HTML to allow the custom content handler to properly initialize custom tag tracking.
+      val adjustedHtml = "<init-custom-handler/>$html"
+      return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+        Html.fromHtml(
+          adjustedHtml, Html.FROM_HTML_MODE_LEGACY, imageGetter, CustomHtmlContentHandler(customTagHandlers)
+        ) as Spannable
+      } else {
+        Html.fromHtml(adjustedHtml, imageGetter, CustomHtmlContentHandler(customTagHandlers)) as Spannable
+      }
+    }
+  }
+}

--- a/utility/src/main/java/org/oppia/util/parser/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/util/parser/CustomHtmlContentHandler.kt
@@ -16,7 +16,7 @@ import org.xml.sax.XMLReader
  */
 class CustomHtmlContentHandler private constructor(
   private val customTagHandlers: Map<String, CustomTagHandler>
-): ContentHandler, Html.TagHandler {
+) : ContentHandler, Html.TagHandler {
   private var originalContentHandler: ContentHandler? = null
   private var currentTrackedTag: TrackedTag? = null
   private var currentTrackedCustomTag: TrackedCustomTag? = null
@@ -103,7 +103,7 @@ class CustomHtmlContentHandler private constructor(
   }
 
   private data class TrackedTag(val tag: String, val attributes: Attributes)
-  private data class TrackedCustomTag(val tag: String, val attributes: Attributes, val openTagIndex: Int)
+  data class TrackedCustomTag(val tag: String, val attributes: Attributes, val openTagIndex: Int)
 
   /** Handler interface for a custom tag and its attributes. */
   interface CustomTagHandler {

--- a/utility/src/main/java/org/oppia/util/parser/HtmlParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/HtmlParser.kt
@@ -1,11 +1,14 @@
 package org.oppia.util.parser
 
+import android.text.Editable
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.Spanned
+import android.text.method.LinkMovementMethod
 import android.text.style.BulletSpan
+import android.text.style.ClickableSpan
+import android.view.View
 import android.widget.TextView
-import androidx.core.text.HtmlCompat
 import javax.inject.Inject
 
 private const val CUSTOM_IMG_TAG = "oppia-noninteractive-image"
@@ -13,13 +16,18 @@ private const val REPLACE_IMG_TAG = "img"
 private const val CUSTOM_IMG_FILE_PATH_ATTRIBUTE = "filepath-with-value"
 private const val REPLACE_IMG_FILE_PATH_ATTRIBUTE = "src"
 
+private const val CUSTOM_CONCEPT_CARD_TAG = "oppia-concept-card-link"
+
 /** Html Parser to parse custom Oppia tags with Android-compatible versions. */
 class HtmlParser private constructor(
   private val urlImageParserFactory: UrlImageParser.Factory,
   private val entityType: String,
   private val entityId: String,
-  private val imageCenterAlign: Boolean
+  private val imageCenterAlign: Boolean,
+  customOppiaTagActionListener: CustomOppiaTagActionListener?
 ) {
+
+  private val conceptCardTagHandler = ConceptCardTagHandler(customOppiaTagActionListener)
 
   /**
    * This method replaces custom Oppia tags with Android-compatible versions for a given raw HTML string, and returns the HTML [Spannable].
@@ -27,7 +35,7 @@ class HtmlParser private constructor(
    * @param htmlContentTextView htmlContentTextView argument is the TextView, that need to be passed as argument to ImageGetter class for image parsing
    * @return Spannable Spannable represents the styled text.
    */
-  fun parseOppiaHtml(rawString: String, htmlContentTextView: TextView): Spannable {
+  fun parseOppiaHtml(rawString: String, htmlContentTextView: TextView, supportsLinks: Boolean = false): Spannable {
     var htmlContent = rawString
     if (htmlContent.contains("\n\t")) {
       htmlContent = htmlContent.replace("\n\t", "")
@@ -37,17 +45,19 @@ class HtmlParser private constructor(
     }
 
     if (htmlContent.contains(CUSTOM_IMG_TAG)) {
-      htmlContent = htmlContent.replace(CUSTOM_IMG_TAG, REPLACE_IMG_TAG, /* ignoreCase= */false)
-      htmlContent = htmlContent.replace(
-        CUSTOM_IMG_FILE_PATH_ATTRIBUTE,
-        REPLACE_IMG_FILE_PATH_ATTRIBUTE, /* ignoreCase= */false
-      )
+      htmlContent = htmlContent.replace(CUSTOM_IMG_TAG, REPLACE_IMG_TAG)
+      htmlContent = htmlContent.replace(CUSTOM_IMG_FILE_PATH_ATTRIBUTE, REPLACE_IMG_FILE_PATH_ATTRIBUTE)
       htmlContent = htmlContent.replace("&amp;quot;", "")
+    }
+
+    // https://stackoverflow.com/a/8662457
+    if (supportsLinks) {
+      htmlContentTextView.movementMethod = LinkMovementMethod.getInstance()
     }
 
     val imageGetter = urlImageParserFactory.create(htmlContentTextView, entityType, entityId, imageCenterAlign)
 
-    val htmlSpannable = HtmlCompat.fromHtml(htmlContent, HtmlCompat.FROM_HTML_MODE_LEGACY, imageGetter, LiTagHandler()) as Spannable
+    val htmlSpannable = CustomHtmlContentHandler.fromHtml(htmlContent,imageGetter, mapOf(CUSTOM_CONCEPT_CARD_TAG to conceptCardTagHandler)) as Spannable
 
     val spannableBuilder = SpannableStringBuilder(htmlSpannable)
     val bulletSpans = spannableBuilder.getSpans(0, spannableBuilder.length, BulletSpan::class.java)
@@ -84,9 +94,32 @@ class HtmlParser private constructor(
     return spannable.delete(0, trimStart).delete(spannable.length - trimEnd, spannable.length)
   }
 
+  // https://mohammedlakkadshaw.com/blog/handling-custom-tags-in-android-using-html-taghandler.html/
+  private class ConceptCardTagHandler(
+    private val customOppiaTagActionListener: CustomOppiaTagActionListener?
+  ): CustomHtmlContentHandler.CustomTagHandler {
+    override fun handleTag(attributes: org.xml.sax.Attributes, openIndex: Int, closeIndex: Int, output: Editable) {
+      val skillId = attributes.getValue("skill-id")
+      output.setSpan(object : ClickableSpan() {
+        override fun onClick(view: View) {
+          customOppiaTagActionListener?.onConceptCardLinkClicked(view, skillId)
+        }
+      }, openIndex, closeIndex, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+    }
+  }
+
+  /** Listener that's called when a custom tag triggers an event. */
+  interface CustomOppiaTagActionListener {
+    /**
+     * Called when an embedded concept card link is clicked in the specified view with the skillId corresponding to the
+     * card that should be shown.
+     */
+    fun onConceptCardLinkClicked(view: View, skillId: String)
+  }
+
   class Factory @Inject constructor(private val urlImageParserFactory: UrlImageParser.Factory) {
-    fun create(entityType: String, entityId: String, imageCenterAlign: Boolean): HtmlParser {
-      return HtmlParser(urlImageParserFactory, entityType, entityId, imageCenterAlign)
+    fun create(entityType: String, entityId: String, imageCenterAlign: Boolean, customOppiaTagActionListener: CustomOppiaTagActionListener? = null): HtmlParser {
+      return HtmlParser(urlImageParserFactory, entityType, entityId, imageCenterAlign, customOppiaTagActionListener)
     }
   }
 }

--- a/utility/src/main/java/org/oppia/util/parser/HtmlParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/HtmlParser.kt
@@ -99,7 +99,7 @@ class HtmlParser private constructor(
   }
 
   // https://mohammedlakkadshaw.com/blog/handling-custom-tags-in-android-using-html-taghandler.html/
-  private class ConceptCardTagHandler(
+  class ConceptCardTagHandler(
     private val customOppiaTagActionListener: CustomOppiaTagActionListener?
   ) : CustomHtmlContentHandler.CustomTagHandler {
     override fun handleTag(attributes: org.xml.sax.Attributes, openIndex: Int, output: Editable) {

--- a/utility/src/main/java/org/oppia/util/parser/HtmlParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/HtmlParser.kt
@@ -57,7 +57,11 @@ class HtmlParser private constructor(
 
     val imageGetter = urlImageParserFactory.create(htmlContentTextView, entityType, entityId, imageCenterAlign)
 
-    val htmlSpannable = CustomHtmlContentHandler.fromHtml(htmlContent,imageGetter, mapOf(CUSTOM_CONCEPT_CARD_TAG to conceptCardTagHandler)) as Spannable
+    val htmlSpannable = CustomHtmlContentHandler.fromHtml(
+      htmlContent,
+      imageGetter,
+      mapOf(CUSTOM_CONCEPT_CARD_TAG to conceptCardTagHandler)
+    ) as Spannable
 
     val spannableBuilder = SpannableStringBuilder(htmlSpannable)
     val bulletSpans = spannableBuilder.getSpans(0, spannableBuilder.length, BulletSpan::class.java)
@@ -97,7 +101,7 @@ class HtmlParser private constructor(
   // https://mohammedlakkadshaw.com/blog/handling-custom-tags-in-android-using-html-taghandler.html/
   private class ConceptCardTagHandler(
     private val customOppiaTagActionListener: CustomOppiaTagActionListener?
-  ): CustomHtmlContentHandler.CustomTagHandler {
+  ) : CustomHtmlContentHandler.CustomTagHandler {
     override fun handleTag(attributes: org.xml.sax.Attributes, openIndex: Int, closeIndex: Int, output: Editable) {
       val skillId = attributes.getValue("skill-id")
       output.setSpan(object : ClickableSpan() {
@@ -118,7 +122,12 @@ class HtmlParser private constructor(
   }
 
   class Factory @Inject constructor(private val urlImageParserFactory: UrlImageParser.Factory) {
-    fun create(entityType: String, entityId: String, imageCenterAlign: Boolean, customOppiaTagActionListener: CustomOppiaTagActionListener? = null): HtmlParser {
+    fun create(
+      entityType: String,
+      entityId: String,
+      imageCenterAlign: Boolean,
+      customOppiaTagActionListener: CustomOppiaTagActionListener? = null
+    ): HtmlParser {
       return HtmlParser(urlImageParserFactory, entityType, entityId, imageCenterAlign, customOppiaTagActionListener)
     }
   }

--- a/utility/src/main/java/org/oppia/util/parser/HtmlParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/HtmlParser.kt
@@ -16,7 +16,7 @@ private const val REPLACE_IMG_TAG = "img"
 private const val CUSTOM_IMG_FILE_PATH_ATTRIBUTE = "filepath-with-value"
 private const val REPLACE_IMG_FILE_PATH_ATTRIBUTE = "src"
 
-private const val CUSTOM_CONCEPT_CARD_TAG = "oppia-concept-card-link"
+private const val CUSTOM_CONCEPT_CARD_TAG = "oppia-noninteractive-skillreview"
 
 /** Html Parser to parse custom Oppia tags with Android-compatible versions. */
 class HtmlParser private constructor(
@@ -102,13 +102,17 @@ class HtmlParser private constructor(
   private class ConceptCardTagHandler(
     private val customOppiaTagActionListener: CustomOppiaTagActionListener?
   ) : CustomHtmlContentHandler.CustomTagHandler {
-    override fun handleTag(attributes: org.xml.sax.Attributes, openIndex: Int, closeIndex: Int, output: Editable) {
-      val skillId = attributes.getValue("skill-id")
+    override fun handleTag(attributes: org.xml.sax.Attributes, openIndex: Int, output: Editable) {
+      val skillId = attributes.getValue("skill_id-with-value")
+      val linkText = attributes.getValue("text-with-value")
+
+      output.insert(openIndex, linkText)
+
       output.setSpan(object : ClickableSpan() {
         override fun onClick(view: View) {
           customOppiaTagActionListener?.onConceptCardLinkClicked(view, skillId)
         }
-      }, openIndex, closeIndex, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+      }, openIndex, output.length, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #387 
This PR adds the concept card linking inside exploration player. This has been done by using #422 
Thanks to @BenHenning for #422 

TAG information (as confirmed with @seanlip ):

`<oppia-noninteractive-skillreview skill_id-with-value="<[skillId]>" text-with-value="<[linkText]>"></oppia-noninteractive-skillreview>`

## How to test this:
Approach 1. Make `HtmlParserTestActivity` as your launcher activity.
Approach 2. Start `Meaning of Equal Parts` exploration. First answer is `D. last option`. In second state, answer 3/2 and you should see a `refresher lesson` text.

## Pending Issues:
- [ ] LiTagHandler is not getting used.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
