### PR TITLE
Fix #721: Missing test cases for AddProfileActivity

### DIFF
--- a/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
@@ -1,7 +1,14 @@
 package org.oppia.app.profile
 
+import android.app.Activity.RESULT_OK
 import android.app.Application
+import android.app.Instrumentation.ActivityResult
+import android.content.ContentResolver
 import android.content.Context
+import android.content.Intent
+import android.content.res.Resources
+import android.net.Uri
+import android.provider.MediaStore
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
@@ -12,7 +19,10 @@ import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
 import androidx.test.espresso.matcher.ViewMatchers.isClickable
 import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -26,6 +36,7 @@ import dagger.Provides
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
+import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
 import org.junit.After
@@ -283,6 +294,47 @@ class AddProfileActivityTest {
         .perform(typeText("123"), closeSoftKeyboard())
       onView(withId(R.id.allow_download_switch)).check(matches(isClickable()))
     }
+  }
+
+  @Test
+  fun testAddProfileActivity_imageSelectAvatar_checkGalleryIntent() {
+    val expectedIntent: Matcher<Intent> = allOf(
+      hasAction(Intent.ACTION_PICK),
+      hasData(MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+    )
+    val activityResult = createGalleryPickActivityResultStub()
+    intending(expectedIntent).respondWith(activityResult)
+    ActivityScenario.launch(AddProfileActivity::class.java).use {
+      onView(withId(R.id.upload_image_button)).perform(click())
+      intended(expectedIntent)
+    }
+  }
+
+  @Test
+  fun testAddProfileActivity_imageSelectEdit_checkGalleryIntent() {
+    val expectedIntent: Matcher<Intent> = allOf(
+      hasAction(Intent.ACTION_PICK),
+      hasData(MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+    )
+    val activityResult = createGalleryPickActivityResultStub()
+    intending(expectedIntent).respondWith(activityResult)
+    ActivityScenario.launch(AddProfileActivity::class.java).use {
+      onView(withId(R.id.edit_image_fab)).perform(click())
+      intended(expectedIntent)
+    }
+  }
+
+  private fun createGalleryPickActivityResultStub(): ActivityResult {
+    val resources: Resources = context.resources
+    val imageUri = Uri.parse(
+      ContentResolver.SCHEME_ANDROID_RESOURCE + "://" +
+          resources.getResourcePackageName(R.mipmap.ic_launcher) + '/' +
+          resources.getResourceTypeName(R.mipmap.ic_launcher) + '/' +
+          resources.getResourceEntryName(R.mipmap.ic_launcher)
+    )
+    val resultIntent = Intent()
+    resultIntent.setData(imageUri)
+    return ActivityResult(RESULT_OK, resultIntent)
   }
 
   @Qualifier


### PR DESCRIPTION
## Explanation
Fixes #721 

Added test case for image selection gallery intent for AddProfileActivity

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
