### PR TITLE
Fix #683: Domain-App layer code for OngoingStoryList / Promoted Stories

### DIFF
--- a/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
@@ -24,6 +24,7 @@ import org.oppia.app.model.ProfileId
 import org.oppia.app.model.TopicList
 import org.oppia.app.model.TopicSummary
 import org.oppia.domain.profile.ProfileManagementController
+import org.oppia.domain.topic.StoryProgressTestHelper
 import org.oppia.domain.topic.TopicListController
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.logging.Logger
@@ -35,6 +36,7 @@ class HomeFragmentPresenter @Inject constructor(
   private val activity: AppCompatActivity,
   private val fragment: Fragment,
   private val profileManagementController: ProfileManagementController,
+  private val storyProgressTestHelper: StoryProgressTestHelper,
   private val topicListController: TopicListController,
   private val logger: Logger
 ) {
@@ -65,6 +67,9 @@ class HomeFragmentPresenter @Inject constructor(
     itemList.add(promotedStoryListViewModel)
     itemList.add(allTopicsViewModel)
     topicListAdapter = TopicListAdapter(activity, itemList, promotedStoryList)
+
+    storyProgressTestHelper.markRecentlyPlayedForFractionsExploration0(profileId)
+    storyProgressTestHelper.markRecentlyPlayedForRatiosExploration2(profileId)
 
     val homeLayoutManager = GridLayoutManager(activity.applicationContext, 2)
     homeLayoutManager.spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {

--- a/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
@@ -146,7 +146,7 @@ class HomeFragmentPresenter @Inject constructor(
   }
 
   private val ongoingStoryListSummaryResultLiveData: LiveData<AsyncResult<OngoingStoryList>> by lazy {
-    topicListController.getOngoingStoryList()
+    topicListController.getOngoingStoryList(profileId)
   }
 
   private fun subscribeToOngoingStoryList() {

--- a/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
@@ -29,6 +29,7 @@ import org.oppia.domain.topic.TopicListController
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.logging.Logger
 import javax.inject.Inject
+import kotlin.collections.ArrayList
 
 /** The presenter for [HomeFragment]. */
 @FragmentScope
@@ -60,6 +61,8 @@ class HomeFragmentPresenter @Inject constructor(
     internalProfileId = activity.intent.getIntExtra(KEY_NAVIGATION_PROFILE_ID, -1)
     profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
 
+    storyProgressTestHelper.markPartialStoryProgressForFractions(profileId, false)
+
     welcomeViewModel = WelcomeViewModel()
     promotedStoryListViewModel = PromotedStoryListViewModel(activity, internalProfileId)
     allTopicsViewModel = AllTopicsViewModel()
@@ -67,9 +70,6 @@ class HomeFragmentPresenter @Inject constructor(
     itemList.add(promotedStoryListViewModel)
     itemList.add(allTopicsViewModel)
     topicListAdapter = TopicListAdapter(activity, itemList, promotedStoryList)
-
-    storyProgressTestHelper.markRecentlyPlayedForFractionsExploration0(profileId)
-    storyProgressTestHelper.markRecentlyPlayedForRatiosExploration2(profileId)
 
     val homeLayoutManager = GridLayoutManager(activity.applicationContext, 2)
     homeLayoutManager.spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {

--- a/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
@@ -24,12 +24,10 @@ import org.oppia.app.model.ProfileId
 import org.oppia.app.model.TopicList
 import org.oppia.app.model.TopicSummary
 import org.oppia.domain.profile.ProfileManagementController
-import org.oppia.domain.topic.StoryProgressTestHelper
 import org.oppia.domain.topic.TopicListController
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.logging.Logger
 import javax.inject.Inject
-import kotlin.collections.ArrayList
 
 /** The presenter for [HomeFragment]. */
 @FragmentScope
@@ -37,7 +35,6 @@ class HomeFragmentPresenter @Inject constructor(
   private val activity: AppCompatActivity,
   private val fragment: Fragment,
   private val profileManagementController: ProfileManagementController,
-  private val storyProgressTestHelper: StoryProgressTestHelper,
   private val topicListController: TopicListController,
   private val logger: Logger
 ) {
@@ -60,8 +57,6 @@ class HomeFragmentPresenter @Inject constructor(
 
     internalProfileId = activity.intent.getIntExtra(KEY_NAVIGATION_PROFILE_ID, -1)
     profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
-
-    storyProgressTestHelper.markPartialStoryProgressForFractions(profileId, false)
 
     welcomeViewModel = WelcomeViewModel()
     promotedStoryListViewModel = PromotedStoryListViewModel(activity, internalProfileId)

--- a/app/src/main/java/org/oppia/app/home/recentlyplayed/RecentlyPlayedFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/recentlyplayed/RecentlyPlayedFragmentPresenter.kt
@@ -41,6 +41,8 @@ class RecentlyPlayedFragmentPresenter @Inject constructor(
 
     this.internalProfileId = internalProfileId
 
+    viewModel.setProfileId(internalProfileId)
+
     binding.ongoingStoryRecyclerView.apply {
       adapter = createRecyclerViewAdapter()
     }

--- a/app/src/main/java/org/oppia/app/home/recentlyplayed/RecentlyPlayedViewModel.kt
+++ b/app/src/main/java/org/oppia/app/home/recentlyplayed/RecentlyPlayedViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import org.oppia.app.R
 import org.oppia.app.model.OngoingStoryList
+import org.oppia.app.model.ProfileId
 import org.oppia.domain.topic.TopicListController
 import org.oppia.util.data.AsyncResult
 import javax.inject.Inject
@@ -20,8 +21,14 @@ class RecentlyPlayedViewModel @Inject constructor(
 
   private val itemList: MutableList<RecentlyPlayedItemViewModel> = ArrayList()
 
+  private lateinit var profileId: ProfileId
+
+  fun setProfileId(internalProfileId: Int) {
+    profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
+  }
+
   private val ongoingStoryListSummaryResultLiveData: LiveData<AsyncResult<OngoingStoryList>> by lazy {
-    topicListController.getOngoingStoryList()
+    topicListController.getOngoingStoryList(profileId)
   }
 
   val ongoingStoryLiveData: LiveData<List<RecentlyPlayedItemViewModel>>by lazy {

--- a/app/src/main/java/org/oppia/app/profileprogress/ProfileProgressViewModel.kt
+++ b/app/src/main/java/org/oppia/app/profileprogress/ProfileProgressViewModel.kt
@@ -68,7 +68,7 @@ class ProfileProgressViewModel @Inject constructor(
   }
 
   private val ongoingStoryListResultLiveData: LiveData<AsyncResult<OngoingStoryList>> by lazy {
-    topicListController.getOngoingStoryList()
+    topicListController.getOngoingStoryList(profileId)
   }
 
   private val ongoingStoryListLiveData: LiveData<OngoingStoryList> by lazy {

--- a/app/src/sharedTest/java/org/oppia/app/completedstorylist/CompletedStoryListActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/completedstorylist/CompletedStoryListActivityTest.kt
@@ -53,8 +53,8 @@ class CompletedStoryListActivityTest {
     setUpTestApplicationComponent()
 
     val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
-    storyProfileTestHelper.markFullStoryProgressForFractions(profileId)
-    storyProfileTestHelper.markFullStoryPartialTopicProgressForRatios(profileId)
+    storyProfileTestHelper.markFullStoryProgressForFractions(profileId, timestampOlderThanAWeek = false)
+    storyProfileTestHelper.markFullStoryPartialTopicProgressForRatios(profileId, timestampOlderThanAWeek = false)
   }
 
   @After

--- a/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
@@ -26,8 +26,10 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.espresso.util.HumanReadables
@@ -52,6 +54,7 @@ import org.junit.runner.RunWith
 import org.oppia.app.R
 import org.oppia.app.home.recentlyplayed.RecentlyPlayedActivity
 import org.oppia.app.profile.ProfileActivity
+import org.oppia.app.profileprogress.ProfileProgressActivity
 import org.oppia.app.recyclerview.RecyclerViewMatcher.Companion.atPosition
 import org.oppia.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
 import org.oppia.app.topic.TopicActivity
@@ -102,6 +105,18 @@ class HomeActivityTest {
       .setApplication(ApplicationProvider.getApplicationContext())
       .build()
       .inject(this)
+  }
+
+  @Test
+  fun testNavigationDrawerTestActivity_clickNavigationDrawerHamburger_clickOnHeader_opensProfileProgressActivity() {
+    launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      onView(withContentDescription(R.string.drawer_open_content_description)).check(
+        matches(isCompletelyDisplayed())
+      ).perform(click())
+      onView(withId(R.id.nav_header_profile_name)).perform(click())
+      intended(hasComponent(ProfileProgressActivity::class.java.name))
+      intended(hasExtra(ProfileProgressActivity.PROFILE_PROGRESS_ACTIVITY_PROFILE_ID_KEY, internalProfileId))
+    }
   }
 
   @Test

--- a/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
@@ -108,7 +108,7 @@ class HomeActivityTest {
   }
 
   @Test
-  fun testNavigationDrawerTestActivity_clickNavigationDrawerHamburger_clickOnHeader_opensProfileProgressActivity() {
+  fun testHomeActivity_clickNavigationDrawerHamburger_clickOnHeader_opensProfileProgressActivity() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
       onView(withContentDescription(R.string.drawer_open_content_description)).check(
         matches(isCompletelyDisplayed())

--- a/app/src/sharedTest/java/org/oppia/app/ongoingtopiclist/OngoingTopicListActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/ongoingtopiclist/OngoingTopicListActivityTest.kt
@@ -52,8 +52,8 @@ class OngoingTopicListActivityTest {
     setUpTestApplicationComponent()
 
     val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
-    storyProfileTestHelper.markFullStoryPartialTopicProgressForRatios(profileId)
-    storyProfileTestHelper.markPartialTopicProgressForFractions(profileId)
+    storyProfileTestHelper.markFullStoryPartialTopicProgressForRatios(profileId, timestampOlderThanAWeek = false)
+    storyProfileTestHelper.markPartialTopicProgressForFractions(profileId, timestampOlderThanAWeek = false)
   }
 
   @After

--- a/app/src/sharedTest/java/org/oppia/app/profileprogress/ProfileProgressFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profileprogress/ProfileProgressFragmentTest.kt
@@ -124,8 +124,8 @@ class ProfileProgressFragmentTest {
 
   @Test
   fun testProfileProgressFragmentWithProgress_recyclerViewItem0_checkOngoingTopicsCount_countIsTwo() {
-    storyProgressTestHelper.markPartialTopicProgressForFractions(profileId)
-    storyProgressTestHelper.markTwoPartialStoryProgressForRatios(profileId)
+    storyProgressTestHelper.markPartialTopicProgressForFractions(profileId, timestampOlderThanAWeek = false)
+    storyProgressTestHelper.markTwoPartialStoryProgressForRatios(profileId, timestampOlderThanAWeek = false)
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(0)).use {
       onView(
         atPositionOnView(
@@ -152,8 +152,8 @@ class ProfileProgressFragmentTest {
 
   @Test
   fun testProfileProgressFragmentWithProgress_recyclerViewItem0_checkOngoingTopicsString_descriptionIsCorrect() {
-    storyProgressTestHelper.markPartialTopicProgressForFractions(profileId)
-    storyProgressTestHelper.markTwoPartialStoryProgressForRatios(profileId)
+    storyProgressTestHelper.markPartialTopicProgressForFractions(profileId, timestampOlderThanAWeek = false)
+    storyProgressTestHelper.markTwoPartialStoryProgressForRatios(profileId, timestampOlderThanAWeek = false)
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(0)).use {
       onView(
         atPositionOnView(
@@ -180,8 +180,8 @@ class ProfileProgressFragmentTest {
 
   @Test
   fun testProfileProgressFragmentWithProgress_recyclerViewItem0_checkCompletedStoriesCount_countIsTwo() {
-    storyProgressTestHelper.markFullStoryPartialTopicProgressForRatios(profileId)
-    storyProgressTestHelper.markFullStoryProgressForFractions(profileId)
+    storyProgressTestHelper.markFullStoryPartialTopicProgressForRatios(profileId, timestampOlderThanAWeek = false)
+    storyProgressTestHelper.markFullStoryProgressForFractions(profileId, timestampOlderThanAWeek = false)
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(0)).use {
       onView(
         atPositionOnView(
@@ -208,8 +208,8 @@ class ProfileProgressFragmentTest {
 
   @Test
   fun testProfileProgressFragmentWithProgress_recyclerViewItem0_checkCompletedStoriesString_descriptionIsCorrect() {
-    storyProgressTestHelper.markFullStoryPartialTopicProgressForRatios(profileId)
-    storyProgressTestHelper.markFullStoryProgressForFractions(profileId)
+    storyProgressTestHelper.markFullStoryPartialTopicProgressForRatios(profileId, timestampOlderThanAWeek = false)
+    storyProgressTestHelper.markFullStoryProgressForFractions(profileId, timestampOlderThanAWeek = false)
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(0)).use {
       onView(
         atPositionOnView(
@@ -300,8 +300,8 @@ class ProfileProgressFragmentTest {
 
   @Test
   fun testProfileProgressActivityWithProgress_recyclerViewIndex0_clickTopicCount_opensOngoingTopicListActivity() {
-    storyProgressTestHelper.markPartialTopicProgressForFractions(profileId)
-    storyProgressTestHelper.markTwoPartialStoryProgressForRatios(profileId)
+    storyProgressTestHelper.markPartialTopicProgressForFractions(profileId, timestampOlderThanAWeek = false)
+    storyProgressTestHelper.markTwoPartialStoryProgressForRatios(profileId, timestampOlderThanAWeek = false)
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(0)).use {
       onView(atPositionOnView(R.id.profile_progress_list, 0, R.id.ongoing_topics_container)).perform(click())
       intended(hasComponent(OngoingTopicListActivity::class.java.name))
@@ -311,8 +311,8 @@ class ProfileProgressFragmentTest {
 
   @Test
   fun testProfileProgressActivityWithProgress_recyclerViewIndex0_clickStoryCount_opensCompletedStoryListActivity() {
-    storyProgressTestHelper.markFullStoryPartialTopicProgressForRatios(profileId)
-    storyProgressTestHelper.markFullStoryProgressForFractions(profileId)
+    storyProgressTestHelper.markFullStoryPartialTopicProgressForRatios(profileId, timestampOlderThanAWeek = false)
+    storyProgressTestHelper.markFullStoryProgressForFractions(profileId, timestampOlderThanAWeek = false)
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(0)).use {
       onView(atPositionOnView(R.id.profile_progress_list, 0, R.id.completed_stories_container)).perform(click())
       intended(hasComponent(CompletedStoryListActivity::class.java.name))

--- a/app/src/sharedTest/java/org/oppia/app/testing/NavigationDrawerTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/testing/NavigationDrawerTestActivityTest.kt
@@ -116,18 +116,6 @@ class NavigationDrawerTestActivityTest {
   }
 
   @Test
-  fun testNavigationDrawerTestActivity_clickNavigationDrawerHamburger_clickOnHeader_opensProfileProgressActivity() {
-    launch<NavigationDrawerTestActivity>(createNavigationDrawerActivityIntent(internalProfileId)).use {
-      onView(withContentDescription(R.string.drawer_open_content_description)).check(
-        matches(isCompletelyDisplayed())
-      ).perform(click())
-      onView(withId(R.id.header_linear_layout)).perform(click())
-      intended(hasComponent(ProfileProgressActivity::class.java.name))
-      intended(hasExtra(ProfileProgressActivity.PROFILE_PROGRESS_ACTIVITY_PROFILE_ID_KEY, internalProfileId))
-    }
-  }
-
-  @Test
   fun testNavigationDrawerTestActivity_clickNavigationDrawerHamburger_checkProfileProgress_displayProfileProgressSuccessfully() {
     launch<NavigationDrawerTestActivity>(createNavigationDrawerActivityIntent(internalProfileId)).use {
       onView(withContentDescription(R.string.drawer_open_content_description)).check(

--- a/app/src/sharedTest/java/org/oppia/app/testing/NavigationDrawerTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/testing/NavigationDrawerTestActivityTest.kt
@@ -80,7 +80,8 @@ class NavigationDrawerTestActivityTest {
     storyProfileTestHelper.markFullStoryPartialTopicProgressForRatios(
       ProfileId.newBuilder().setInternalId(
         internalProfileId
-      ).build()
+      ).build(),
+      timestampOlderThanAWeek = false
     )
   }
 

--- a/app/src/sharedTest/java/org/oppia/app/testing/NavigationDrawerTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/testing/NavigationDrawerTestActivityTest.kt
@@ -45,7 +45,6 @@ import org.oppia.app.administratorcontrols.AdministratorControlsActivity
 import org.oppia.app.model.ProfileId
 import org.oppia.app.mydownloads.MyDownloadsActivity
 import org.oppia.app.profile.ProfileActivity
-import org.oppia.app.profileprogress.ProfileProgressActivity
 import org.oppia.app.recyclerview.RecyclerViewMatcher
 import org.oppia.app.utility.OrientationChangeAction.Companion.orientationLandscape
 import org.oppia.domain.profile.ProfileTestHelper

--- a/domain/src/main/java/org/oppia/domain/topic/StoryProgressController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/StoryProgressController.kt
@@ -153,7 +153,6 @@ class StoryProgressController @Inject constructor(
         } else {
           chapterProgressBuilder.lastPlayedTimestamp = lastPlayedTimestamp
         }
-
         val storyProgressBuilder = StoryProgress.newBuilder().setStoryId(storyId)
         if (topicProgressDatabase.topicProgressMap[topicId]?.storyProgressMap?.get(storyId) != null) {
           storyProgressBuilder.putAllChapterProgress(topicProgressDatabase.topicProgressMap[topicId]!!.storyProgressMap[storyId]!!.chapterProgressMap)

--- a/domain/src/main/java/org/oppia/domain/topic/StoryProgressController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/StoryProgressController.kt
@@ -1,20 +1,19 @@
 package org.oppia.domain.topic
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.Deferred
-import org.json.JSONArray
 import org.oppia.app.model.ChapterPlayState
+import org.oppia.app.model.ChapterProgress
 import org.oppia.app.model.ProfileId
 import org.oppia.app.model.StoryProgress
 import org.oppia.app.model.TopicProgress
 import org.oppia.app.model.TopicProgressDatabase
 import org.oppia.data.persistence.PersistentCacheStore
-import org.oppia.domain.util.JsonAssetRetriever
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProvider
 import org.oppia.util.data.DataProviders
 import org.oppia.util.logging.Logger
+import java.util.*
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -42,13 +41,13 @@ private const val TRANSFORMED_GET_STORY_PROGRESS_LIST_PROVIDER_ID = "transformed
 private const val TRANSFORMED_GET_TOPIC_PROGRESS_PROVIDER_ID = "transformed_get_topic_progress_provider_id"
 private const val TRANSFORMED_GET_STORY_PROGRESS_PROVIDER_ID = "transformed_get_story_progress_provider_id"
 private const val ADD_STORY_PROGRESS_TRANSFORMED_PROVIDER_ID = "add_story_progress_transformed_id"
+private const val RECENTLY_PLAYED_CHAPTER_TRANSFORMED_PROVIDER_ID = "recently_played_chapter_transformed_id"
 
 /** Controller that records and provides completion statuses of chapters within the context of a story. */
 @Singleton
 class StoryProgressController @Inject constructor(
   private val cacheStoreFactory: PersistentCacheStore.Factory,
   private val dataProviders: DataProviders,
-  private val jsonAssetRetriever: JsonAssetRetriever,
   private val logger: Logger
 ) {
   // TODO(#21): Determine whether chapters can have missing prerequisites in the initial prototype, or if that just
@@ -59,13 +58,7 @@ class StoryProgressController @Inject constructor(
     SUCCESS
   }
 
-  private val trackedStoriesProgress: Map<String, TrackedStoryProgress> by lazy { createInitialStoryProgressState() }
-
   private val cacheStoreMap = mutableMapOf<ProfileId, PersistentCacheStore<TopicProgressDatabase>>()
-
-  fun retrieveStoryProgress(storyId: String): StoryProgress {
-    return createStoryProgressSnapshot(storyId)
-  }
 
   /**
    * Records the specified chapter completed within the context of the specified exploration, story, topic. Returns a [LiveData] that
@@ -86,13 +79,16 @@ class StoryProgressController @Inject constructor(
   ): LiveData<AsyncResult<Any?>> {
     val deferred =
       retrieveCacheStore(profileId).storeDataWithCustomChannelAsync(updateInMemoryCache = true) { topicProgressDatabase ->
-        val chapterPlayState = ChapterPlayState.COMPLETED
+        val chapterProgress = ChapterProgress.newBuilder()
+          .setChapterPlayState(ChapterPlayState.COMPLETED)
+          .setLastPlayedTimestamp(Date().time)
+          .build()
 
         val storyProgressBuilder = StoryProgress.newBuilder().setStoryId(storyId)
         if (topicProgressDatabase.topicProgressMap[topicId]?.storyProgressMap?.get(storyId) != null) {
           storyProgressBuilder.putAllChapterProgress(topicProgressDatabase.topicProgressMap[topicId]!!.storyProgressMap[storyId]!!.chapterProgressMap)
         }
-        storyProgressBuilder.putChapterProgress(explorationId, chapterPlayState)
+        storyProgressBuilder.putChapterProgress(explorationId, chapterProgress)
         val storyProgress = storyProgressBuilder.build()
 
         val topicProgressBuilder = TopicProgress.newBuilder().setTopicId(topicId)
@@ -109,7 +105,69 @@ class StoryProgressController @Inject constructor(
 
     return dataProviders.convertToLiveData(
       dataProviders.createInMemoryDataProviderAsync(ADD_STORY_PROGRESS_TRANSFORMED_PROVIDER_ID) {
-        return@createInMemoryDataProviderAsync getDeferredResult(profileId, deferred)
+        return@createInMemoryDataProviderAsync getDeferredResult(deferred)
+      })
+  }
+
+  /**
+   * Records the recently played chapter for a specified exploration, story, topic. Returns a [LiveData] that
+   * provides exactly one [AsyncResult] to indicate whether this operation has succeeded. This method will never return
+   * a pending result.
+   *
+   * @param profileId the ID corresponding to the profile for which progress needs to be stored.
+   * @param topicId the ID corresponding to the topic for which progress needs to be stored.
+   * @param storyId the ID corresponding to the story for which progress needs to be stored.
+   * @param explorationId the chapter id which will marked as [ChapterPlayState.NOT_STARTED] if it has not been [ChapterPlayState.COMPLETED] already.
+   * @return a [LiveData] that indicates the success/failure of this record progress operation.
+   */
+  fun recordRecentlyPlayedChapter(
+    profileId: ProfileId,
+    topicId: String,
+    storyId: String,
+    explorationId: String
+  ): LiveData<AsyncResult<Any?>> {
+    val deferred =
+      retrieveCacheStore(profileId).storeDataWithCustomChannelAsync(updateInMemoryCache = true) { topicProgressDatabase ->
+        val previousChapterProgress =
+          topicProgressDatabase
+            .topicProgressMap[topicId]?.storyProgressMap?.get(storyId)?.chapterProgressMap?.get(explorationId)
+        val chapterProgressBuilder = ChapterProgress.newBuilder()
+        val currentTimestamp = Date().time
+        if (previousChapterProgress != null) {
+          chapterProgressBuilder.chapterPlayState = previousChapterProgress.chapterPlayState
+          chapterProgressBuilder.lastPlayedTimestamp =
+            if (previousChapterProgress.lastPlayedTimestamp < currentTimestamp && previousChapterProgress.chapterPlayState != ChapterPlayState.COMPLETED) {
+              currentTimestamp
+            } else {
+              previousChapterProgress.lastPlayedTimestamp
+            }
+        } else {
+          chapterProgressBuilder.chapterPlayState = ChapterPlayState.STARTED_NOT_COMPLETED
+          chapterProgressBuilder.lastPlayedTimestamp = currentTimestamp
+        }
+
+        val storyProgressBuilder = StoryProgress.newBuilder().setStoryId(storyId)
+        if (topicProgressDatabase.topicProgressMap[topicId]?.storyProgressMap?.get(storyId) != null) {
+          storyProgressBuilder.putAllChapterProgress(topicProgressDatabase.topicProgressMap[topicId]!!.storyProgressMap[storyId]!!.chapterProgressMap)
+        }
+        storyProgressBuilder.putChapterProgress(explorationId, chapterProgressBuilder.build())
+        val storyProgress = storyProgressBuilder.build()
+
+        val topicProgressBuilder = TopicProgress.newBuilder().setTopicId(topicId)
+        if (topicProgressDatabase.topicProgressMap[topicId] != null) {
+          topicProgressBuilder
+            .putAllStoryProgress(topicProgressDatabase.topicProgressMap[topicId]!!.storyProgressMap)
+        }
+        topicProgressBuilder.putStoryProgress(storyId, storyProgress)
+        val topicProgress = topicProgressBuilder.build()
+
+        val topicDatabaseBuilder = topicProgressDatabase.toBuilder().putTopicProgress(topicId, topicProgress)
+        Pair(topicDatabaseBuilder.build(), StoryProgressActionStatus.SUCCESS)
+      }
+
+    return dataProviders.convertToLiveData(
+      dataProviders.createInMemoryDataProviderAsync(RECENTLY_PLAYED_CHAPTER_TRANSFORMED_PROVIDER_ID) {
+        return@createInMemoryDataProviderAsync getDeferredResult(deferred)
       })
   }
 
@@ -149,86 +207,10 @@ class StoryProgressController @Inject constructor(
     }
   }
 
-  private suspend fun getDeferredResult(
-    profileId: ProfileId?,
-    deferred: Deferred<StoryProgressActionStatus>
-  ): AsyncResult<Any?> {
+  private suspend fun getDeferredResult(deferred: Deferred<StoryProgressActionStatus>): AsyncResult<Any?> {
     return when (deferred.await()) {
       StoryProgressActionStatus.SUCCESS -> AsyncResult.success(null)
     }
-  }
-
-  // TODO(#21): Implement notifying story progress changes when a chapter is recorded as complete, and add tests for
-  //  this case.
-
-  /**
-   * Returns a [LiveData] corresponding to the story progress of the specified story, or a failure if no such story can
-   * be identified. This [LiveData] will update as the story's progress changes.
-   */
-  fun getStoryProgress(storyId: String): LiveData<AsyncResult<StoryProgress>> {
-    return try {
-      MutableLiveData(AsyncResult.success(createStoryProgressSnapshot(storyId)))
-    } catch (e: Exception) {
-      MutableLiveData(AsyncResult.failed(e))
-    }
-  }
-
-  private fun createStoryProgressSnapshot(storyId: String): StoryProgress {
-    check(storyId in trackedStoriesProgress) { "No story found with ID: $storyId" }
-    return trackedStoriesProgress.getValue(storyId).toStoryProgress()
-  }
-
-  private fun createInitialStoryProgressState(): Map<String, TrackedStoryProgress> {
-    return mapOf(
-      TEST_STORY_ID_0 to createStoryProgress0(),
-      TEST_STORY_ID_1 to createStoryProgress1(),
-      TEST_STORY_ID_2 to createStoryProgress2(),
-      FRACTIONS_STORY_ID_0 to createStoryProgressForJsonStory("fractions_stories.json", /* index= */ 0),
-      RATIOS_STORY_ID_0 to createStoryProgressForJsonStory("ratios_stories.json", /* index= */ 0),
-      RATIOS_STORY_ID_1 to createStoryProgressForJsonStory("ratios_stories.json", /* index= */ 1)
-    )
-  }
-
-  private fun createStoryProgressForJsonStory(fileName: String, index: Int): TrackedStoryProgress {
-    val storyData = jsonAssetRetriever.loadJsonFromAsset(fileName)?.getJSONArray("story_list")!!
-    val explorationIdList = getExplorationIdsFromStory(
-      storyData.getJSONObject(index).getJSONObject("story")
-        .getJSONObject("story_contents").getJSONArray("nodes")
-    )
-    return TrackedStoryProgress(
-      chapterList = explorationIdList,
-      completedChapters = setOf()
-    )
-  }
-
-  private fun getExplorationIdsFromStory(chapterData: JSONArray): List<String> {
-    val explorationIdList = mutableListOf<String>()
-    for (i in 0 until chapterData.length()) {
-      val chapter = chapterData.getJSONObject(i)
-      explorationIdList.add(chapter.getString("exploration_id"))
-    }
-    return explorationIdList
-  }
-
-  private fun createStoryProgress0(): TrackedStoryProgress {
-    return TrackedStoryProgress(
-      chapterList = listOf(TEST_EXPLORATION_ID_0),
-      completedChapters = setOf()
-    )
-  }
-
-  private fun createStoryProgress1(): TrackedStoryProgress {
-    return TrackedStoryProgress(
-      chapterList = listOf(TEST_EXPLORATION_ID_1, TEST_EXPLORATION_ID_2, TEST_EXPLORATION_ID_3),
-      completedChapters = setOf()
-    )
-  }
-
-  private fun createStoryProgress2(): TrackedStoryProgress {
-    return TrackedStoryProgress(
-      chapterList = listOf(TEST_EXPLORATION_ID_4),
-      completedChapters = setOf()
-    )
   }
 
   private fun retrieveCacheStore(profileId: ProfileId): PersistentCacheStore<TopicProgressDatabase> {
@@ -252,71 +234,5 @@ class StoryProgressController @Inject constructor(
     }
 
     return cacheStore
-  }
-
-  /**
-   * Mutable container for [StoryProgress] that provides support for determining whether a specific chapter can be
-   * played in the context of this story, marking a chapter as played, and converting to a [StoryProgress] object for
-   * reporting to the UI.
-   */
-  private class TrackedStoryProgress(private val chapterList: List<String>, completedChapters: Set<String>) {
-    private val trackedCompletedChapters: MutableSet<String> = completedChapters.toMutableSet()
-
-    // TODO(#21): Implement tests for the following invariant checking logic, if possible.
-    init {
-      // Verify that the progress object is well-defined by ensuring that the invariant where lessons must be played in
-      // order holds.
-      var expectedCompleted: Boolean? = null
-      chapterList.reversed().forEach { explorationId ->
-        val completedChapter = explorationId in trackedCompletedChapters
-        val expectedCompletedSnapshot = expectedCompleted
-        if (expectedCompletedSnapshot == null) {
-          // This should always be initialized for the last lesson. If  it's completed, all previous lessons must be
-          // completed. If it's not, then previous lessons may be completed or incomplete.
-          expectedCompleted = completedChapter
-        } else if (completedChapter != expectedCompletedSnapshot) {
-          // There's exactly one case where the expectation can change: if the next lesson is not completed. This means
-          // the current lesson is the most recent one completed in the list, and all previous lessons must also be
-          // completed.
-          check(!expectedCompletedSnapshot) {
-            "Expected lessons to be completed in order with no holes between them, and starting from the beginning " +
-                "of the story. Encountered uncompleted chapter right before a completed chapter: $explorationId"
-          }
-          // This is the first lesson that was completed after encountering one or more lessons that are not completed.
-          // All previous lessons in the list (the lessons next to be iterated) must be completed in order for the
-          // in-order invariant to hold.
-          expectedCompleted = true
-        }
-        // Otherwise, the invariant holds. Continue on to the previous lesson.
-      }
-    }
-
-    /**
-     * Returns whether the specified exploration ID can be played, or if it's missing prerequisites. Fails if the
-     * specified exploration ID is not contained in this story.
-     */
-    fun canPlayChapter(explorationId: String): Boolean {
-      // The chapter can be played only if it's the first one, or the chapter before it has been completed.
-      check(explorationId in chapterList) { "Chapter not found in story: $explorationId" }
-      val chapterIndex = chapterList.indexOf(explorationId)
-      return if (chapterIndex == 0) true else chapterList[chapterIndex - 1] in trackedCompletedChapters
-    }
-
-    /** Returns an immutable [StoryProgress] representation of this progress object. */
-    fun toStoryProgress(): StoryProgress {
-      val storyProgressBuilder = StoryProgress.newBuilder()
-      for (explorationId in chapterList) {
-        storyProgressBuilder.putChapterProgress(explorationId, buildChapterProgress(explorationId))
-      }
-      return storyProgressBuilder.build()
-    }
-
-    private fun buildChapterProgress(explorationId: String): ChapterPlayState {
-      return when {
-        explorationId in trackedCompletedChapters -> ChapterPlayState.COMPLETED
-        canPlayChapter(explorationId) -> ChapterPlayState.NOT_STARTED
-        else -> ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES /* Assume only reason is missing prerequisites. */
-      }
-    }
   }
 }

--- a/domain/src/main/java/org/oppia/domain/topic/StoryProgressController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/StoryProgressController.kt
@@ -81,6 +81,7 @@ class StoryProgressController @Inject constructor(
     val deferred =
       retrieveCacheStore(profileId).storeDataWithCustomChannelAsync(updateInMemoryCache = true) { topicProgressDatabase ->
         val chapterProgress = ChapterProgress.newBuilder()
+          .setExplorationId(explorationId)
           .setChapterPlayState(ChapterPlayState.COMPLETED)
           .setLastPlayedTimestamp(completionTimestamp)
           .build()

--- a/domain/src/main/java/org/oppia/domain/topic/StoryProgressTestHelper.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/StoryProgressTestHelper.kt
@@ -1,156 +1,244 @@
 package org.oppia.domain.topic
 
 import org.oppia.app.model.ProfileId
+import java.util.*
 import javax.inject.Inject
+
+private const val EIGHT_DAYS_IN_MS = 8 * 24 * 60 * 60 * 1000
 
 /** This helper allows tests to easily create dummy progress per profile-basis. */
 class StoryProgressTestHelper @Inject constructor(private val storyProgressController: StoryProgressController) {
 
+  private fun getCurrentTimestamp(): Long {
+    return Date().time
+  }
+
+  // Returns a timestamp which is atleast a week old than current.
+  private fun getOldTimestamp(): Long {
+    return Date().time - EIGHT_DAYS_IN_MS
+  }
+
   /** Creates a partial story progress for a particular profile. */
-  fun markPartialStoryProgressForFractions(profileId: ProfileId) {
+  fun markPartialStoryProgressForFractions(profileId: ProfileId, timestampOlderThanAWeek: Boolean) {
+    val timestamp = if (!timestampOlderThanAWeek) {
+      getCurrentTimestamp()
+    } else {
+      getOldTimestamp()
+    }
     storyProgressController.recordCompletedChapter(
       profileId,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0,
-      FRACTIONS_EXPLORATION_ID_0
+      FRACTIONS_EXPLORATION_ID_0,
+      timestamp
     )
   }
 
   /** Creates a partial topic progress for a particular profile. */
-  fun markPartialTopicProgressForFractions(profileId: ProfileId) {
+  fun markPartialTopicProgressForFractions(profileId: ProfileId, timestampOlderThanAWeek: Boolean) {
+    val timestamp = if (!timestampOlderThanAWeek) {
+      getCurrentTimestamp()
+    } else {
+      getOldTimestamp()
+    }
     storyProgressController.recordCompletedChapter(
       profileId,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0,
-      FRACTIONS_EXPLORATION_ID_0
+      FRACTIONS_EXPLORATION_ID_0,
+      timestamp
     )
   }
 
   /** Marks full story progress for a particular profile. */
-  fun markFullStoryProgressForFractions(profileId: ProfileId) {
+  fun markFullStoryProgressForFractions(profileId: ProfileId, timestampOlderThanAWeek: Boolean) {
+    val timestamp = if (!timestampOlderThanAWeek) {
+      getCurrentTimestamp()
+    } else {
+      getOldTimestamp()
+    }
     storyProgressController.recordCompletedChapter(
       profileId,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0,
-      FRACTIONS_EXPLORATION_ID_0
+      FRACTIONS_EXPLORATION_ID_0,
+      timestamp
     )
 
     storyProgressController.recordCompletedChapter(
       profileId,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0,
-      FRACTIONS_EXPLORATION_ID_1
+      FRACTIONS_EXPLORATION_ID_1,
+      timestamp
     )
   }
 
   /** Marks full topic progress for a particular profile. */
-  fun markFullTopicProgressForFractions(profileId: ProfileId) {
+  fun markFullTopicProgressForFractions(profileId: ProfileId, timestampOlderThanAWeek: Boolean) {
+    val timestamp = if (!timestampOlderThanAWeek) {
+      getCurrentTimestamp()
+    } else {
+      getOldTimestamp()
+    }
     storyProgressController.recordCompletedChapter(
       profileId,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0,
-      FRACTIONS_EXPLORATION_ID_0
+      FRACTIONS_EXPLORATION_ID_0,
+      timestamp
     )
 
     storyProgressController.recordCompletedChapter(
       profileId,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0,
-      FRACTIONS_EXPLORATION_ID_1
+      FRACTIONS_EXPLORATION_ID_1,
+      timestamp
     )
   }
 
   /** Marks one story progress full in ratios exploration for a particular profile. */
-  fun markFullStoryPartialTopicProgressForRatios(profileId: ProfileId) {
+  fun markFullStoryPartialTopicProgressForRatios(profileId: ProfileId, timestampOlderThanAWeek: Boolean) {
+    val timestamp = if (!timestampOlderThanAWeek) {
+      getCurrentTimestamp()
+    } else {
+      getOldTimestamp()
+    }
     storyProgressController.recordCompletedChapter(
       profileId,
       RATIOS_TOPIC_ID,
       RATIOS_STORY_ID_0,
-      RATIOS_EXPLORATION_ID_0
+      RATIOS_EXPLORATION_ID_0,
+      timestamp
     )
 
     storyProgressController.recordCompletedChapter(
       profileId,
       RATIOS_TOPIC_ID,
       RATIOS_STORY_ID_0,
-      RATIOS_EXPLORATION_ID_1
+      RATIOS_EXPLORATION_ID_1,
+      timestamp
     )
   }
 
   /** Marks two partial story progress in ratios exploration for a particular profile. */
-  fun markTwoPartialStoryProgressForRatios(profileId: ProfileId) {
+  fun markTwoPartialStoryProgressForRatios(profileId: ProfileId, timestampOlderThanAWeek: Boolean) {
+    val timestamp = if (!timestampOlderThanAWeek) {
+      getCurrentTimestamp()
+    } else {
+      getOldTimestamp()
+    }
     storyProgressController.recordCompletedChapter(
       profileId,
       RATIOS_TOPIC_ID,
       RATIOS_STORY_ID_0,
-      RATIOS_EXPLORATION_ID_0
+      RATIOS_EXPLORATION_ID_0,
+      timestamp
     )
 
     storyProgressController.recordCompletedChapter(
       profileId,
       RATIOS_TOPIC_ID,
       RATIOS_STORY_ID_1,
-      RATIOS_EXPLORATION_ID_2
+      RATIOS_EXPLORATION_ID_2,
+      timestamp
     )
   }
 
-  /** Marks exploration [FRACTIONS_EXPLORATION_ID_0] as recently played for a particular profile */
-  fun markRecentlyPlayedForFractionsExploration0(profileId: ProfileId) {
-    storyProgressController.recordCompletedChapter(
+  /** Marks exploration [FRACTIONS_EXPLORATION_ID_0] as recently played for a particular profile. */
+  fun markRecentlyPlayedForFractionsStory0Exploration0(profileId: ProfileId, timestampOlderThanAWeek: Boolean) {
+    val timestamp = if (!timestampOlderThanAWeek) {
+      getCurrentTimestamp()
+    } else {
+      getOldTimestamp()
+    }
+    storyProgressController.recordRecentlyPlayedChapter(
       profileId,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0,
-      FRACTIONS_EXPLORATION_ID_0
+      FRACTIONS_EXPLORATION_ID_0,
+      timestamp
     )
   }
 
-  /** Marks exploration [FRACTIONS_EXPLORATION_ID_1] as recently played for a particular profile */
-  fun markRecentlyPlayedForFractionsExploration1(profileId: ProfileId) {
-    storyProgressController.recordCompletedChapter(
+  /** Marks exploration [RATIOS_EXPLORATION_ID_0] as recently played for a particular profile. */
+  fun markRecentlyPlayedForRatiosStory0Exploration0(profileId: ProfileId, timestampOlderThanAWeek: Boolean) {
+    val timestamp = if (!timestampOlderThanAWeek) {
+      getCurrentTimestamp()
+    } else {
+      getOldTimestamp()
+    }
+    storyProgressController.recordRecentlyPlayedChapter(
+      profileId,
+      RATIOS_TOPIC_ID,
+      RATIOS_STORY_ID_0,
+      RATIOS_EXPLORATION_ID_0,
+      timestamp
+    )
+  }
+
+  /** Marks first exploration in both stories of Ratios as recently played for a particular profile. */
+  fun markRecentlyPlayedForRatiosStory0Exploration0AndStory1Exploration2(
+    profileId: ProfileId,
+    timestampOlderThanAWeek: Boolean
+  ) {
+    val timestamp = if (!timestampOlderThanAWeek) {
+      getCurrentTimestamp()
+    } else {
+      getOldTimestamp()
+    }
+
+    storyProgressController.recordRecentlyPlayedChapter(
+      profileId,
+      RATIOS_TOPIC_ID,
+      RATIOS_STORY_ID_0,
+      RATIOS_EXPLORATION_ID_0,
+      timestamp
+    )
+
+    storyProgressController.recordRecentlyPlayedChapter(
+      profileId,
+      RATIOS_TOPIC_ID,
+      RATIOS_STORY_ID_1,
+      RATIOS_EXPLORATION_ID_2,
+      timestamp
+    )
+  }
+
+  /** Marks first exploration in all stories of Ratios & Fractions as recently played for a particular profile. */
+  fun markRecentlyPlayedForFirstExplorationInAllStoriesInFractionsAndRatios(
+    profileId: ProfileId,
+    timestampOlderThanAWeek: Boolean
+  ) {
+    val timestamp = if (!timestampOlderThanAWeek) {
+      getCurrentTimestamp()
+    } else {
+      getOldTimestamp()
+    }
+
+    storyProgressController.recordRecentlyPlayedChapter(
       profileId,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0,
-      FRACTIONS_EXPLORATION_ID_1
+      FRACTIONS_EXPLORATION_ID_0,
+      timestamp
     )
-  }
 
-  /** Marks exploration [RATIOS_EXPLORATION_ID_0] as recently played for a particular profile */
-  fun markRecentlyPlayedForRatiosExploration0(profileId: ProfileId) {
-    storyProgressController.recordCompletedChapter(
+    storyProgressController.recordRecentlyPlayedChapter(
       profileId,
       RATIOS_TOPIC_ID,
       RATIOS_STORY_ID_0,
-      RATIOS_EXPLORATION_ID_0
+      RATIOS_EXPLORATION_ID_0,
+      timestamp
     )
-  }
 
-  /** Marks exploration [RATIOS_EXPLORATION_ID_1] as recently played for a particular profile */
-  fun markRecentlyPlayedForRatiosExploration1(profileId: ProfileId) {
-    storyProgressController.recordCompletedChapter(
+    storyProgressController.recordRecentlyPlayedChapter(
       profileId,
       RATIOS_TOPIC_ID,
-      RATIOS_STORY_ID_0,
-      RATIOS_EXPLORATION_ID_1
-    )
-  }
-
-  /** Marks exploration [RATIOS_EXPLORATION_ID_2] as recently played for a particular profile */
-  fun markRecentlyPlayedForRatiosExploration2(profileId: ProfileId) {
-    storyProgressController.recordCompletedChapter(
-      profileId,
-      RATIOS_TOPIC_ID,
-      RATIOS_STORY_ID_0,
-      RATIOS_EXPLORATION_ID_2
-    )
-  }
-
-  /** Marks exploration [RATIOS_EXPLORATION_ID_3] as recently played for a particular profile */
-  fun markRecentlyPlayedForRatiosExploration3(profileId: ProfileId) {
-    storyProgressController.recordCompletedChapter(
-      profileId,
-      RATIOS_TOPIC_ID,
-      RATIOS_STORY_ID_0,
-      RATIOS_EXPLORATION_ID_3
+      RATIOS_STORY_ID_1,
+      RATIOS_EXPLORATION_ID_2,
+      timestamp
     )
   }
 }

--- a/domain/src/main/java/org/oppia/domain/topic/StoryProgressTestHelper.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/StoryProgressTestHelper.kt
@@ -93,4 +93,64 @@ class StoryProgressTestHelper @Inject constructor(private val storyProgressContr
       RATIOS_EXPLORATION_ID_2
     )
   }
+
+  /** Marks exploration [FRACTIONS_EXPLORATION_ID_0] as recently played for a particular profile */
+  fun markRecentlyPlayedForFractionsExploration0(profileId: ProfileId) {
+    storyProgressController.recordCompletedChapter(
+      profileId,
+      FRACTIONS_TOPIC_ID,
+      FRACTIONS_STORY_ID_0,
+      FRACTIONS_EXPLORATION_ID_0
+    )
+  }
+
+  /** Marks exploration [FRACTIONS_EXPLORATION_ID_1] as recently played for a particular profile */
+  fun markRecentlyPlayedForFractionsExploration1(profileId: ProfileId) {
+    storyProgressController.recordCompletedChapter(
+      profileId,
+      FRACTIONS_TOPIC_ID,
+      FRACTIONS_STORY_ID_0,
+      FRACTIONS_EXPLORATION_ID_1
+    )
+  }
+
+  /** Marks exploration [RATIOS_EXPLORATION_ID_0] as recently played for a particular profile */
+  fun markRecentlyPlayedForRatiosExploration0(profileId: ProfileId) {
+    storyProgressController.recordCompletedChapter(
+      profileId,
+      RATIOS_TOPIC_ID,
+      RATIOS_STORY_ID_0,
+      RATIOS_EXPLORATION_ID_0
+    )
+  }
+
+  /** Marks exploration [RATIOS_EXPLORATION_ID_1] as recently played for a particular profile */
+  fun markRecentlyPlayedForRatiosExploration1(profileId: ProfileId) {
+    storyProgressController.recordCompletedChapter(
+      profileId,
+      RATIOS_TOPIC_ID,
+      RATIOS_STORY_ID_0,
+      RATIOS_EXPLORATION_ID_1
+    )
+  }
+
+  /** Marks exploration [RATIOS_EXPLORATION_ID_2] as recently played for a particular profile */
+  fun markRecentlyPlayedForRatiosExploration2(profileId: ProfileId) {
+    storyProgressController.recordCompletedChapter(
+      profileId,
+      RATIOS_TOPIC_ID,
+      RATIOS_STORY_ID_0,
+      RATIOS_EXPLORATION_ID_2
+    )
+  }
+
+  /** Marks exploration [RATIOS_EXPLORATION_ID_3] as recently played for a particular profile */
+  fun markRecentlyPlayedForRatiosExploration3(profileId: ProfileId) {
+    storyProgressController.recordCompletedChapter(
+      profileId,
+      RATIOS_TOPIC_ID,
+      RATIOS_STORY_ID_0,
+      RATIOS_EXPLORATION_ID_3
+    )
+  }
 }

--- a/domain/src/main/java/org/oppia/domain/topic/StoryProgressTestHelper.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/StoryProgressTestHelper.kt
@@ -1,7 +1,7 @@
 package org.oppia.domain.topic
 
 import org.oppia.app.model.ProfileId
-import java.util.*
+import java.util.Date
 import javax.inject.Inject
 
 private const val EIGHT_DAYS_IN_MS = 8 * 24 * 60 * 60 * 1000

--- a/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import org.json.JSONArray
 import org.json.JSONObject
 import org.oppia.app.model.ChapterPlayState
+import org.oppia.app.model.ChapterProgress
 import org.oppia.app.model.ChapterSummary
 import org.oppia.app.model.CompletedStory
 import org.oppia.app.model.CompletedStoryList
@@ -288,24 +289,39 @@ class TopicController @Inject constructor(
     topicProgressList.forEach { topicProgress ->
       val topic = retrieveTopic(topicProgress.topicId)
       if (topicProgress.storyProgressCount != 0) {
-        if (topic.storyCount != topicProgress.storyProgressCount) {
+        if (checkIfTopicIsOngoing(topic, topicProgress)) {
           ongoingTopicListBuilder.addTopic(topic)
-        } else {
-          if (!checkIfTopicIsFullyCompleted(topic, topicProgress)) {
-            ongoingTopicListBuilder.addTopic(topic)
-          }
         }
       }
     }
     return ongoingTopicListBuilder.build()
   }
 
-  private fun checkIfTopicIsFullyCompleted(topic: Topic, topicProgress: TopicProgress): Boolean {
+  private fun checkIfTopicIsOngoing(topic: Topic, topicProgress: TopicProgress): Boolean {
+    val completedChapterProgressList = ArrayList<ChapterProgress>()
+    val startedChapterProgressList = ArrayList<ChapterProgress>()
+    topicProgress.storyProgressMap.values.toList().forEach { storyProgress ->
+      completedChapterProgressList.addAll(storyProgress.chapterProgressMap.values.filter { chapterProgress -> chapterProgress.chapterPlayState == ChapterPlayState.COMPLETED })
+      startedChapterProgressList.addAll(storyProgress.chapterProgressMap.values.filter { chapterProgress -> chapterProgress.chapterPlayState == ChapterPlayState.STARTED_NOT_COMPLETED })
+    }
+
+    // If there is no completed chapter, it cannot be an ongoing-topic.
+    if (completedChapterProgressList.isEmpty()) {
+      return false
+    }
+
+    // If there is atleast 1 completed chapter and 1 not-completed chapter, it is definitely an ongoing-topic.
+    if (startedChapterProgressList.isNotEmpty()) {
+      return true
+    }
+
     topic.storyList.forEach { storySummary ->
       if (topicProgress.storyProgressMap.containsKey(storySummary.storyId)) {
         val storyProgress = topicProgress.storyProgressMap[storySummary.storyId]
         val lastChapterSummary = storySummary.chapterList.last()
         if (!storyProgress!!.chapterProgressMap.containsKey(lastChapterSummary.explorationId)) {
+          return false
+        } else if (storyProgress.chapterProgressMap[lastChapterSummary.explorationId]!!.chapterPlayState == ChapterPlayState.COMPLETED) {
           return false
         }
       }
@@ -322,7 +338,7 @@ class TopicController @Inject constructor(
       val storySummary = retrieveStory(storyProgress.storyId)
       val lastChapterSummary = storySummary.chapterList.last()
       if (storyProgress.chapterProgressMap.containsKey(lastChapterSummary.explorationId)
-        && storyProgress.chapterProgressMap[lastChapterSummary.explorationId] == ChapterPlayState.COMPLETED
+        && storyProgress.chapterProgressMap[lastChapterSummary.explorationId]!!.chapterPlayState == ChapterPlayState.COMPLETED
       ) {
         val completedStoryBuilder = CompletedStory.newBuilder()
           .setStoryId(storySummary.storyId)
@@ -401,7 +417,7 @@ class TopicController @Inject constructor(
     }
   }
 
-  private fun retrieveStory(storyId: String): StorySummary {
+  internal fun retrieveStory(storyId: String): StorySummary {
     return when (storyId) {
       TEST_STORY_ID_0 -> createTestTopic0Story0()
       TEST_STORY_ID_1 -> createTestTopic0Story1()
@@ -743,29 +759,21 @@ class TopicController @Inject constructor(
       .setStoryId(storyId)
       .setStoryName(storyData.getString("title"))
       .setStoryThumbnail(STORY_THUMBNAILS.getValue(storyId))
-      .addAllChapter(
-        createChaptersFromJson(
-          storyId, storyData.getJSONObject("story_contents").getJSONArray("nodes")
-        )
-      )
+      .addAllChapter(createChaptersFromJson(storyData.getJSONObject("story_contents").getJSONArray("nodes")))
       .build()
   }
 
-  private fun createChaptersFromJson(storyId: String, chapterData: JSONArray): List<ChapterSummary> {
+  private fun createChaptersFromJson(chapterData: JSONArray): List<ChapterSummary> {
     val chapterList = mutableListOf<ChapterSummary>()
-    val storyProgress = storyProgressController.retrieveStoryProgress(storyId)
 
-    val chapterProgressMap = storyProgress.chapterProgressMap
     for (i in 0 until chapterData.length()) {
       val chapter = chapterData.getJSONObject(i)
       val explorationId = chapter.getString("exploration_id")
-      val chapterPlayState = chapterProgressMap[explorationId] ?: ChapterPlayState.COMPLETION_STATUS_UNSPECIFIED
-
       chapterList.add(
         ChapterSummary.newBuilder()
           .setExplorationId(explorationId)
           .setName(chapter.getString("title"))
-          .setChapterPlayState(chapterPlayState)
+          .setChapterPlayState(ChapterPlayState.COMPLETION_STATUS_UNSPECIFIED)
           .setChapterThumbnail(EXPLORATION_THUMBNAILS.getValue(explorationId))
           .build()
       )

--- a/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
@@ -263,26 +263,25 @@ class TopicListController @Inject constructor(
           storyProgress.chapterProgressMap.values.filter { chapterProgress -> chapterProgress.chapterPlayState == ChapterPlayState.STARTED_NOT_COMPLETED }
             .sortedByDescending { chapterProgress -> chapterProgress.lastPlayedTimestamp }
 
-        if (startedChapterProgressList.isNotEmpty()) {
-          startedChapterProgressList.forEach { chapterProgress ->
-            val recentlyPlayerChapterSummary: ChapterSummary? = story.chapterList.find { chapterSummary ->
-              chapterProgress.explorationId == chapterSummary.explorationId
-            }
-            if (recentlyPlayerChapterSummary != null) {
-              val numberOfDaysPassed = (Date().time - chapterProgress.lastPlayedTimestamp) / ONE_DAY_IN_MS
-              val promotedStory = createPromotedStory(
-                storyId,
-                topic,
-                completedChapterProgressList.size,
-                story.chapterCount,
-                recentlyPlayerChapterSummary.name,
-                recentlyPlayerChapterSummary.explorationId
-              )
-              if (numberOfDaysPassed < ONE_WEEK_IN_DAYS) {
-                ongoingStoryListBuilder.addRecentStory(promotedStory)
-              } else {
-                ongoingStoryListBuilder.addOlderStory(promotedStory)
-              }
+        val recentlyPlayerChapterProgress: ChapterProgress? = startedChapterProgressList.firstOrNull()
+        if (recentlyPlayerChapterProgress != null) {
+          val recentlyPlayerChapterSummary: ChapterSummary? = story.chapterList.find { chapterSummary ->
+            recentlyPlayerChapterProgress.explorationId == chapterSummary.explorationId
+          }
+          if (recentlyPlayerChapterSummary != null) {
+            val numberOfDaysPassed = (Date().time - recentlyPlayerChapterProgress.lastPlayedTimestamp) / ONE_DAY_IN_MS
+            val promotedStory = createPromotedStory(
+              storyId,
+              topic,
+              completedChapterProgressList.size,
+              story.chapterCount,
+              recentlyPlayerChapterSummary.name,
+              recentlyPlayerChapterSummary.explorationId
+            )
+            if (numberOfDaysPassed < ONE_WEEK_IN_DAYS) {
+              ongoingStoryListBuilder.addRecentStory(promotedStory)
+            } else {
+              ongoingStoryListBuilder.addOlderStory(promotedStory)
             }
           }
         } else if (lastCompletedChapterProgress != null && lastCompletedChapterProgress.explorationId != story.chapterList.last().explorationId) {

--- a/domain/src/test/java/org/oppia/domain/topic/StoryProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/StoryProgressControllerTest.kt
@@ -42,7 +42,7 @@ import org.oppia.util.logging.LogLevel
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import org.robolectric.annotation.Config
-import java.util.*
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Singleton

--- a/domain/src/test/java/org/oppia/domain/topic/StoryProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/StoryProgressControllerTest.kt
@@ -61,19 +61,14 @@ class StoryProgressControllerTest {
   @field:TestDispatcher
   lateinit var testDispatcher: CoroutineDispatcher
 
-  @Inject
-  lateinit var context: Context
+  @Inject lateinit var context: Context
 
-  @Inject
-  lateinit var storyProgressController: StoryProgressController
+  @Inject lateinit var storyProgressController: StoryProgressController
 
-  @Inject
-  lateinit var profileTestHelper: ProfileTestHelper
+  @Inject lateinit var profileTestHelper: ProfileTestHelper
 
-  @Mock
-  lateinit var mockRecordProgressObserver: Observer<AsyncResult<Any?>>
-  @Captor
-  lateinit var recordProgressResultCaptor: ArgumentCaptor<AsyncResult<Any?>>
+  @Mock lateinit var mockRecordProgressObserver: Observer<AsyncResult<Any?>>
+  @Captor lateinit var recordProgressResultCaptor: ArgumentCaptor<AsyncResult<Any?>>
 
   private lateinit var profileId: ProfileId
 
@@ -148,8 +143,7 @@ class StoryProgressControllerTest {
     assertThat(recordProgressResultCaptor.value.isSuccess()).isTrue()
   }
 
-  @Qualifier
-  annotation class TestDispatcher
+  @Qualifier annotation class TestDispatcher
 
   // TODO(#89): Move this to a common test application component.
   @Module

--- a/domain/src/test/java/org/oppia/domain/topic/StoryProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/StoryProgressControllerTest.kt
@@ -2,6 +2,7 @@ package org.oppia.domain.topic
 
 import android.app.Application
 import android.content.Context
+import androidx.lifecycle.Observer
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
@@ -10,17 +11,30 @@ import dagger.Component
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.Mockito.atLeastOnce
+import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoRule
-import org.oppia.app.model.ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES
-import org.oppia.app.model.ChapterPlayState.NOT_STARTED
+import org.oppia.app.model.ProfileId
 import org.oppia.domain.profile.ProfileTestHelper
+import org.oppia.util.caching.CacheAssetsLocally
+import org.oppia.util.data.AsyncResult
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -28,9 +42,11 @@ import org.oppia.util.logging.LogLevel
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import org.robolectric.annotation.Config
+import java.util.*
 import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Singleton
+import kotlin.coroutines.EmptyCoroutineContext
 
 /** Tests for [StoryProgressController]. */
 @RunWith(AndroidJUnit4::class)
@@ -45,101 +61,47 @@ class StoryProgressControllerTest {
   @field:TestDispatcher
   lateinit var testDispatcher: CoroutineDispatcher
 
-  @Inject lateinit var context: Context
+  @Inject
+  lateinit var context: Context
 
-  @Inject lateinit var storyProgressController: StoryProgressController
+  @Inject
+  lateinit var storyProgressController: StoryProgressController
 
-  @Inject lateinit var profileTestHelper: ProfileTestHelper
+  @Inject
+  lateinit var profileTestHelper: ProfileTestHelper
+
+  @Mock
+  lateinit var mockRecordProgressObserver: Observer<AsyncResult<Any?>>
+  @Captor
+  lateinit var recordProgressResultCaptor: ArgumentCaptor<AsyncResult<Any?>>
+
+  private lateinit var profileId: ProfileId
+
+  private val timestamp = Date().time
+
+  private val coroutineContext by lazy {
+    EmptyCoroutineContext + testDispatcher
+  }
+
+  // https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/
+  @ObsoleteCoroutinesApi
+  private val testThread = newSingleThreadContext("TestMain")
 
   @Before
+  @ExperimentalCoroutinesApi
+  @ObsoleteCoroutinesApi
   fun setUp() {
+    profileId = ProfileId.newBuilder().setInternalId(0).build()
+    Dispatchers.setMain(testThread)
     setUpTestApplicationComponent()
   }
 
-  @Test
-  fun testGetStoryProgress_validStory_isSuccessful() {
-    val storyProgressLiveData = storyProgressController.getStoryProgress(TEST_STORY_ID_0)
-
-    val storyProgressResult = storyProgressLiveData.value
-    assertThat(storyProgressResult).isNotNull()
-    assertThat(storyProgressResult!!.isSuccess()).isTrue()
-  }
-
-  @Test
-  fun testGetStoryProgress_validStory_providesCorrectChapterProgress() {
-    val storyProgressLiveData = storyProgressController.getStoryProgress(TEST_STORY_ID_0)
-
-    val storyProgress = storyProgressLiveData.value!!.getOrThrow()
-    assertThat(storyProgress.chapterProgressCount).isEqualTo(1)
-    assertThat(storyProgress.chapterProgressMap[TEST_EXPLORATION_ID_0]).isEqualTo(NOT_STARTED)
-  }
-
-  @Test
-  fun testGetStoryProgress_validSecondStory_providesCorrectChapterProgress() {
-    val storyProgressLiveData = storyProgressController.getStoryProgress(TEST_STORY_ID_1)
-
-    // The third chapter should be missing prerequisites since chapter prior to it has yet to be completed.
-    val storyProgress = storyProgressLiveData.value!!.getOrThrow()
-    assertThat(storyProgress.chapterProgressCount).isEqualTo(3)
-    assertThat(storyProgress.chapterProgressMap[TEST_EXPLORATION_ID_1]).isEqualTo(NOT_STARTED)
-    assertThat(storyProgress.chapterProgressMap[TEST_EXPLORATION_ID_2]).isEqualTo(NOT_PLAYABLE_MISSING_PREREQUISITES)
-    assertThat(storyProgress.chapterProgressMap[TEST_EXPLORATION_ID_3]).isEqualTo(NOT_PLAYABLE_MISSING_PREREQUISITES)
-  }
-
-  @Test
-  fun testGetStoryProgress_validFractionsStory_providesCorrectChapterProgress() {
-    val storyProgressLiveData = storyProgressController.getStoryProgress(FRACTIONS_STORY_ID_0)
-
-    // The third chapter should be missing prerequisites since chapter prior to it has yet to be completed.
-    val storyProgress = storyProgressLiveData.value!!.getOrThrow()
-    assertThat(storyProgress.chapterProgressCount).isEqualTo(2)
-    assertThat(storyProgress.chapterProgressMap[FRACTIONS_EXPLORATION_ID_0]).isEqualTo(NOT_STARTED)
-    assertThat(storyProgress.chapterProgressMap[FRACTIONS_EXPLORATION_ID_1]).isEqualTo(
-      NOT_PLAYABLE_MISSING_PREREQUISITES
-    )
-  }
-
-  @Test
-  fun testGetStoryProgress_validFirstRatiosStory_providesCorrectChapterProgress() {
-    val storyProgressLiveData = storyProgressController.getStoryProgress(RATIOS_STORY_ID_0)
-
-    // The third chapter should be missing prerequisites since chapter prior to it has yet to be completed.
-    val storyProgress = storyProgressLiveData.value!!.getOrThrow()
-    assertThat(storyProgress.chapterProgressCount).isEqualTo(2)
-    assertThat(storyProgress.chapterProgressMap[RATIOS_EXPLORATION_ID_0]).isEqualTo(NOT_STARTED)
-    assertThat(storyProgress.chapterProgressMap[RATIOS_EXPLORATION_ID_1]).isEqualTo(NOT_PLAYABLE_MISSING_PREREQUISITES)
-  }
-
-  @Test
-  fun testGetStoryProgress_validSecondRatiosStory_providesCorrectChapterProgress() {
-    val storyProgressLiveData = storyProgressController.getStoryProgress(RATIOS_STORY_ID_1)
-
-    // The third chapter should be missing prerequisites since chapter prior to it has yet to be completed.
-    val storyProgress = storyProgressLiveData.value!!.getOrThrow()
-    assertThat(storyProgress.chapterProgressCount).isEqualTo(2)
-    assertThat(storyProgress.chapterProgressMap[RATIOS_EXPLORATION_ID_2]).isEqualTo(NOT_STARTED)
-    assertThat(storyProgress.chapterProgressMap[RATIOS_EXPLORATION_ID_3]).isEqualTo(NOT_PLAYABLE_MISSING_PREREQUISITES)
-  }
-
-  @Test
-  fun testGetStoryProgress_validThirdStory_providesCorrectChapterProgress() {
-    val storyProgressLiveData = storyProgressController.getStoryProgress(TEST_STORY_ID_2)
-
-    val storyProgress = storyProgressLiveData.value!!.getOrThrow()
-    assertThat(storyProgress.chapterProgressCount).isEqualTo(1)
-    assertThat(storyProgress.chapterProgressMap[TEST_EXPLORATION_ID_4]).isEqualTo(NOT_STARTED)
-  }
-
-  @Test
-  fun testGetStoryProgress_invalidStory_providesError() {
-    val storyProgressLiveData = storyProgressController.getStoryProgress("invalid_story_id")
-
-    val storyProgressResult = storyProgressLiveData.value
-    assertThat(storyProgressResult).isNotNull()
-    assertThat(storyProgressResult!!.isFailure()).isTrue()
-    assertThat(storyProgressResult.getErrorOrNull())
-      .hasMessageThat()
-      .contains("No story found with ID: invalid_story_id")
+  @After
+  @ExperimentalCoroutinesApi
+  @ObsoleteCoroutinesApi
+  fun tearDown() {
+    Dispatchers.resetMain()
+    testThread.close()
   }
 
   private fun setUpTestApplicationComponent() {
@@ -149,7 +111,45 @@ class StoryProgressControllerTest {
       .inject(this)
   }
 
-  @Qualifier annotation class TestDispatcher
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testStoryProgressController_recordCompletedChapter_isSuccessful() =
+    runBlockingTest(coroutineContext) {
+      storyProgressController.recordCompletedChapter(
+        profileId,
+        FRACTIONS_TOPIC_ID,
+        FRACTIONS_STORY_ID_0,
+        FRACTIONS_EXPLORATION_ID_0,
+        timestamp
+      ).observeForever(mockRecordProgressObserver)
+      advanceUntilIdle()
+
+      verifyRecordProgressSucceeded()
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testStoryProgressController_recordRecentlyPlayedChapter_isSuccessful() =
+    runBlockingTest(coroutineContext) {
+      storyProgressController.recordRecentlyPlayedChapter(
+        profileId,
+        FRACTIONS_TOPIC_ID,
+        FRACTIONS_STORY_ID_0,
+        FRACTIONS_EXPLORATION_ID_0,
+        timestamp
+      ).observeForever(mockRecordProgressObserver)
+      advanceUntilIdle()
+
+      verifyRecordProgressSucceeded()
+    }
+
+  private fun verifyRecordProgressSucceeded() {
+    verify(mockRecordProgressObserver, atLeastOnce()).onChanged(recordProgressResultCaptor.capture())
+    assertThat(recordProgressResultCaptor.value.isSuccess()).isTrue()
+  }
+
+  @Qualifier
+  annotation class TestDispatcher
 
   // TODO(#89): Move this to a common test application component.
   @Module
@@ -182,6 +182,8 @@ class StoryProgressControllerTest {
       return testDispatcher
     }
 
+    // TODO(#59): Either isolate these to their own shared test module, or use the real logging
+    //  module in tests to avoid needing to specify these settings for tests.
     @EnableConsoleLog
     @Provides
     fun provideEnableConsoleLog(): Boolean = true
@@ -193,6 +195,10 @@ class StoryProgressControllerTest {
     @GlobalLogLevel
     @Provides
     fun provideGlobalLogLevel(): LogLevel = LogLevel.VERBOSE
+
+    @CacheAssetsLocally
+    @Provides
+    fun provideCacheAssetsLocally(): Boolean = false
   }
 
   // TODO(#89): Move this to a common test application component.

--- a/domain/src/test/java/org/oppia/domain/topic/StoryProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/StoryProgressControllerTest.kt
@@ -79,8 +79,7 @@ class StoryProgressControllerTest {
   }
 
   // https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/
-  @ObsoleteCoroutinesApi
-  private val testThread = newSingleThreadContext("TestMain")
+  @ObsoleteCoroutinesApi private val testThread = newSingleThreadContext("TestMain")
 
   @Before
   @ExperimentalCoroutinesApi

--- a/domain/src/test/java/org/oppia/domain/topic/StoryProgressTestHelperTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/StoryProgressTestHelperTest.kt
@@ -63,42 +63,28 @@ class StoryProgressTestHelperTest {
   @JvmField
   val mockitoRule: MockitoRule = MockitoJUnit.rule()
 
-  @Inject
-  lateinit var context: Context
+  @Inject lateinit var context: Context
 
-  @Inject
-  lateinit var storyProgressTestHelper: StoryProgressTestHelper
+  @Inject lateinit var storyProgressTestHelper: StoryProgressTestHelper
 
-  @Inject
-  lateinit var topicController: TopicController
+  @Inject lateinit var topicController: TopicController
 
-  @Inject
-  lateinit var topicListController: TopicListController
+  @Inject lateinit var topicListController: TopicListController
 
-  @Mock
-  lateinit var mockCompletedStoryListObserver: Observer<AsyncResult<CompletedStoryList>>
-  @Captor
-  lateinit var completedStoryListResultCaptor: ArgumentCaptor<AsyncResult<CompletedStoryList>>
+  @Mock lateinit var mockCompletedStoryListObserver: Observer<AsyncResult<CompletedStoryList>>
+  @Captor lateinit var completedStoryListResultCaptor: ArgumentCaptor<AsyncResult<CompletedStoryList>>
 
-  @Mock
-  lateinit var mockOngoingStoryListObserver: Observer<AsyncResult<OngoingStoryList>>
-  @Captor
-  lateinit var ongoingStoryListResultCaptor: ArgumentCaptor<AsyncResult<OngoingStoryList>>
+  @Mock lateinit var mockOngoingStoryListObserver: Observer<AsyncResult<OngoingStoryList>>
+  @Captor lateinit var ongoingStoryListResultCaptor: ArgumentCaptor<AsyncResult<OngoingStoryList>>
 
-  @Mock
-  lateinit var mockOngoingTopicListObserver: Observer<AsyncResult<OngoingTopicList>>
-  @Captor
-  lateinit var ongoingTopicListResultCaptor: ArgumentCaptor<AsyncResult<OngoingTopicList>>
+  @Mock lateinit var mockOngoingTopicListObserver: Observer<AsyncResult<OngoingTopicList>>
+  @Captor lateinit var ongoingTopicListResultCaptor: ArgumentCaptor<AsyncResult<OngoingTopicList>>
 
-  @Mock
-  lateinit var mockStorySummaryObserver: Observer<AsyncResult<StorySummary>>
-  @Captor
-  lateinit var storySummaryResultCaptor: ArgumentCaptor<AsyncResult<StorySummary>>
+  @Mock lateinit var mockStorySummaryObserver: Observer<AsyncResult<StorySummary>>
+  @Captor lateinit var storySummaryResultCaptor: ArgumentCaptor<AsyncResult<StorySummary>>
 
-  @Mock
-  lateinit var mockTopicObserver: Observer<AsyncResult<Topic>>
-  @Captor
-  lateinit var topicResultCaptor: ArgumentCaptor<AsyncResult<Topic>>
+  @Mock lateinit var mockTopicObserver: Observer<AsyncResult<Topic>>
+  @Captor lateinit var topicResultCaptor: ArgumentCaptor<AsyncResult<Topic>>
 
   @Inject
   @field:TestDispatcher
@@ -723,8 +709,7 @@ class StoryProgressTestHelperTest {
     assertThat(ongoingStoryListResultCaptor.value.isSuccess()).isTrue()
   }
 
-  @Qualifier
-  annotation class TestDispatcher
+  @Qualifier annotation class TestDispatcher
 
   // TODO(#89): Move this to a common test application component.
   @Module

--- a/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
@@ -67,10 +67,9 @@ private const val INVALID_TOPIC_ID_1 = "INVALID_TOPIC_ID_1"
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 class TopicControllerTest {
-  @Inject
-  lateinit var storyProgressController: StoryProgressController
-  @Inject
-  lateinit var topicController: TopicController
+
+  @Inject lateinit var storyProgressController: StoryProgressController
+  @Inject lateinit var topicController: TopicController
 
   @Rule
   @JvmField
@@ -80,42 +79,28 @@ class TopicControllerTest {
   @JvmField
   val executorRule = InstantTaskExecutorRule()
 
-  @Mock
-  lateinit var mockCompletedStoryListObserver: Observer<AsyncResult<CompletedStoryList>>
-  @Captor
-  lateinit var completedStoryListResultCaptor: ArgumentCaptor<AsyncResult<CompletedStoryList>>
+  @Mock lateinit var mockCompletedStoryListObserver: Observer<AsyncResult<CompletedStoryList>>
+  @Captor lateinit var completedStoryListResultCaptor: ArgumentCaptor<AsyncResult<CompletedStoryList>>
 
-  @Mock
-  lateinit var mockOngoingTopicListObserver: Observer<AsyncResult<OngoingTopicList>>
-  @Captor
-  lateinit var ongoingTopicListResultCaptor: ArgumentCaptor<AsyncResult<OngoingTopicList>>
+  @Mock lateinit var mockOngoingTopicListObserver: Observer<AsyncResult<OngoingTopicList>>
+  @Captor lateinit var ongoingTopicListResultCaptor: ArgumentCaptor<AsyncResult<OngoingTopicList>>
 
-  @Mock
-  lateinit var mockQuestionListObserver: Observer<AsyncResult<List<Question>>>
-  @Captor
-  lateinit var questionListResultCaptor: ArgumentCaptor<AsyncResult<List<Question>>>
+  @Mock lateinit var mockQuestionListObserver: Observer<AsyncResult<List<Question>>>
+  @Captor lateinit var questionListResultCaptor: ArgumentCaptor<AsyncResult<List<Question>>>
 
-  @Mock
-  lateinit var mockRecordProgressObserver: Observer<AsyncResult<Any?>>
-  @Captor
-  lateinit var recordProgressResultCaptor: ArgumentCaptor<AsyncResult<Any?>>
+  @Mock lateinit var mockRecordProgressObserver: Observer<AsyncResult<Any?>>
+  @Captor lateinit var recordProgressResultCaptor: ArgumentCaptor<AsyncResult<Any?>>
 
-  @Mock
-  lateinit var mockStorySummaryObserver: Observer<AsyncResult<StorySummary>>
-  @Captor
-  lateinit var storySummaryResultCaptor: ArgumentCaptor<AsyncResult<StorySummary>>
+  @Mock lateinit var mockStorySummaryObserver: Observer<AsyncResult<StorySummary>>
+  @Captor lateinit var storySummaryResultCaptor: ArgumentCaptor<AsyncResult<StorySummary>>
 
-  @Mock
-  lateinit var mockTopicObserver: Observer<AsyncResult<Topic>>
-  @Captor
-  lateinit var topicResultCaptor: ArgumentCaptor<AsyncResult<Topic>>
+  @Mock lateinit var mockTopicObserver: Observer<AsyncResult<Topic>>
+  @Captor lateinit var topicResultCaptor: ArgumentCaptor<AsyncResult<Topic>>
+
+  @Inject lateinit var dataProviders: DataProviders
 
   @Inject
-  lateinit var dataProviders: DataProviders
-
-  @Inject
-  @field:TestDispatcher
-  lateinit var testDispatcher: CoroutineDispatcher
+  @field:TestDispatcher lateinit var testDispatcher: CoroutineDispatcher
 
   private lateinit var profileId1: ProfileId
   private lateinit var profileId2: ProfileId
@@ -1187,8 +1172,7 @@ class TopicControllerTest {
     return story.chapterList.map(ChapterSummary::getExplorationId)
   }
 
-  @Qualifier
-  annotation class TestDispatcher
+  @Qualifier annotation class TestDispatcher
 
   // TODO(#89): Move this to a common test application component.
   @Module

--- a/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
@@ -54,7 +54,7 @@ import org.oppia.util.logging.LogLevel
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import org.robolectric.annotation.Config
-import java.util.*
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Singleton

--- a/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
@@ -54,6 +54,7 @@ import org.oppia.util.logging.LogLevel
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import org.robolectric.annotation.Config
+import java.util.*
 import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -66,8 +67,10 @@ private const val INVALID_TOPIC_ID_1 = "INVALID_TOPIC_ID_1"
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 class TopicControllerTest {
-  @Inject lateinit var storyProgressController: StoryProgressController
-  @Inject lateinit var topicController: TopicController
+  @Inject
+  lateinit var storyProgressController: StoryProgressController
+  @Inject
+  lateinit var topicController: TopicController
 
   @Rule
   @JvmField
@@ -77,25 +80,38 @@ class TopicControllerTest {
   @JvmField
   val executorRule = InstantTaskExecutorRule()
 
-  @Mock lateinit var mockCompletedStoryListObserver: Observer<AsyncResult<CompletedStoryList>>
-  @Captor lateinit var completedStoryListResultCaptor: ArgumentCaptor<AsyncResult<CompletedStoryList>>
+  @Mock
+  lateinit var mockCompletedStoryListObserver: Observer<AsyncResult<CompletedStoryList>>
+  @Captor
+  lateinit var completedStoryListResultCaptor: ArgumentCaptor<AsyncResult<CompletedStoryList>>
 
-  @Mock lateinit var mockOngoingTopicListObserver: Observer<AsyncResult<OngoingTopicList>>
-  @Captor lateinit var ongoingTopicListResultCaptor: ArgumentCaptor<AsyncResult<OngoingTopicList>>
+  @Mock
+  lateinit var mockOngoingTopicListObserver: Observer<AsyncResult<OngoingTopicList>>
+  @Captor
+  lateinit var ongoingTopicListResultCaptor: ArgumentCaptor<AsyncResult<OngoingTopicList>>
 
-  @Mock lateinit var mockQuestionListObserver: Observer<AsyncResult<List<Question>>>
-  @Captor lateinit var questionListResultCaptor: ArgumentCaptor<AsyncResult<List<Question>>>
+  @Mock
+  lateinit var mockQuestionListObserver: Observer<AsyncResult<List<Question>>>
+  @Captor
+  lateinit var questionListResultCaptor: ArgumentCaptor<AsyncResult<List<Question>>>
 
-  @Mock lateinit var mockRecordProgressObserver: Observer<AsyncResult<Any?>>
-  @Captor lateinit var recordProgressResultCaptor: ArgumentCaptor<AsyncResult<Any?>>
+  @Mock
+  lateinit var mockRecordProgressObserver: Observer<AsyncResult<Any?>>
+  @Captor
+  lateinit var recordProgressResultCaptor: ArgumentCaptor<AsyncResult<Any?>>
 
-  @Mock lateinit var mockStorySummaryObserver: Observer<AsyncResult<StorySummary>>
-  @Captor lateinit var storySummaryResultCaptor: ArgumentCaptor<AsyncResult<StorySummary>>
+  @Mock
+  lateinit var mockStorySummaryObserver: Observer<AsyncResult<StorySummary>>
+  @Captor
+  lateinit var storySummaryResultCaptor: ArgumentCaptor<AsyncResult<StorySummary>>
 
-  @Mock lateinit var mockTopicObserver: Observer<AsyncResult<Topic>>
-  @Captor lateinit var topicResultCaptor: ArgumentCaptor<AsyncResult<Topic>>
+  @Mock
+  lateinit var mockTopicObserver: Observer<AsyncResult<Topic>>
+  @Captor
+  lateinit var topicResultCaptor: ArgumentCaptor<AsyncResult<Topic>>
 
-  @Inject lateinit var dataProviders: DataProviders
+  @Inject
+  lateinit var dataProviders: DataProviders
 
   @Inject
   @field:TestDispatcher
@@ -103,6 +119,8 @@ class TopicControllerTest {
 
   private lateinit var profileId1: ProfileId
   private lateinit var profileId2: ProfileId
+
+  private val currentTimestamp = Date().time
 
   private val coroutineContext by lazy {
     EmptyCoroutineContext + testDispatcher
@@ -1087,7 +1105,8 @@ class TopicControllerTest {
       profileId1,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0,
-      FRACTIONS_EXPLORATION_ID_0
+      FRACTIONS_EXPLORATION_ID_0,
+      currentTimestamp
     ).observeForever(mockRecordProgressObserver)
   }
 
@@ -1096,7 +1115,8 @@ class TopicControllerTest {
       profileId1,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0,
-      FRACTIONS_EXPLORATION_ID_1
+      FRACTIONS_EXPLORATION_ID_1,
+      currentTimestamp
     ).observeForever(mockRecordProgressObserver)
   }
 
@@ -1105,7 +1125,8 @@ class TopicControllerTest {
       profileId1,
       RATIOS_TOPIC_ID,
       RATIOS_STORY_ID_0,
-      RATIOS_EXPLORATION_ID_0
+      RATIOS_EXPLORATION_ID_0,
+      currentTimestamp
     ).observeForever(mockRecordProgressObserver)
   }
 
@@ -1114,7 +1135,8 @@ class TopicControllerTest {
       profileId1,
       RATIOS_TOPIC_ID,
       RATIOS_STORY_ID_0,
-      RATIOS_EXPLORATION_ID_1
+      RATIOS_EXPLORATION_ID_1,
+      currentTimestamp
     ).observeForever(mockRecordProgressObserver)
   }
 
@@ -1165,7 +1187,8 @@ class TopicControllerTest {
     return story.chapterList.map(ChapterSummary::getExplorationId)
   }
 
-  @Qualifier annotation class TestDispatcher
+  @Qualifier
+  annotation class TestDispatcher
 
   // TODO(#89): Move this to a common test application component.
   @Module

--- a/domain/src/test/java/org/oppia/domain/topic/TopicListControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicListControllerTest.kt
@@ -2,6 +2,7 @@ package org.oppia.domain.topic
 
 import android.app.Application
 import android.content.Context
+import androidx.lifecycle.Observer
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
@@ -10,13 +11,32 @@ import dagger.Component
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.Mockito.atLeastOnce
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnit
+import org.mockito.junit.MockitoRule
+import org.oppia.app.model.ChapterPlayState
 import org.oppia.app.model.LessonThumbnailGraphic
+import org.oppia.app.model.OngoingStoryList
+import org.oppia.app.model.ProfileId
 import org.oppia.util.caching.CacheAssetsLocally
+import org.oppia.util.data.AsyncResult
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -30,16 +50,67 @@ import org.robolectric.annotation.Config
 import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Singleton
+import kotlin.coroutines.EmptyCoroutineContext
 
 /** Tests for [TopicListController]. */
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 class TopicListControllerTest {
-  @Inject lateinit var topicListController: TopicListController
+
+  @Rule
+  @JvmField
+  val mockitoRule: MockitoRule = MockitoJUnit.rule()
+
+  @Inject
+  lateinit var context: Context
+
+  @Inject
+  lateinit var topicListController: TopicListController
+
+  @Inject
+  lateinit var storyProgressController: StoryProgressController
+
+  @Mock
+  lateinit var mockOngoingStoryListObserver: Observer<AsyncResult<OngoingStoryList>>
+  @Captor
+  lateinit var ongoingStoryListResultCaptor: ArgumentCaptor<AsyncResult<OngoingStoryList>>
+
+  @Inject
+  @field:TestDispatcher
+  lateinit var testDispatcher: CoroutineDispatcher
+
+  private val coroutineContext by lazy {
+    EmptyCoroutineContext + testDispatcher
+  }
+
+  // https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/
+  @ObsoleteCoroutinesApi
+  private val testThread = newSingleThreadContext("TestMain")
+
+  private lateinit var profileId0: ProfileId
 
   @Before
+  @ExperimentalCoroutinesApi
+  @ObsoleteCoroutinesApi
   fun setUp() {
+    profileId0 = ProfileId.newBuilder().setInternalId(0).build()
+    Dispatchers.setMain(testThread)
     setUpTestApplicationComponent()
+  }
+
+  @After
+  @ExperimentalCoroutinesApi
+  @ObsoleteCoroutinesApi
+  fun tearDown() {
+    Dispatchers.resetMain()
+    testThread.close()
+  }
+
+  private fun setUpTestApplicationComponent() {
+    DaggerTopicListControllerTest_TestApplicationComponent.builder()
+      .setApplication(ApplicationProvider.getApplicationContext())
+      .build()
+      .inject(this)
   }
 
   // TODO(#15): Add tests for recommended lessons rather than promoted, and tests for the 'continue playing' LiveData
@@ -178,104 +249,55 @@ class TopicListControllerTest {
   }
 
   @Test
-  fun testRetrieveTopicList_promotedLesson_hasCorrectLessonInfo() {
-    val topicListLiveData = topicListController.getTopicList()
+  @ExperimentalCoroutinesApi
+  fun testRetrieveOngoingStoryList_defaultLesson_hasCorrectInfo() =
+    runBlockingTest(coroutineContext) {
+      topicListController.getOngoingStoryList(profileId0).observeForever(mockOngoingStoryListObserver)
+      advanceUntilIdle()
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
-    val promotedStory = topicList.promotedStory
-    assertThat(promotedStory.storyId).isEqualTo(FRACTIONS_STORY_ID_0)
-    assertThat(promotedStory.storyName).isEqualTo("Matthew Goes to the Bakery")
+      verifyGetOngoingStoryListSucceeded()
+      verifyDefaultOngoingStoryListSucceeded()
+    }
+
+  // Fractions - Exp1 - seen
+  // Fractions - Exp1 -finished
+  // Fractions - Exp1 -finished and Exp2 Seen
+  // Fractions - Exp1 -finished and Exp2 finished
+
+  // Ratios - Exp0 -Seen and Exp2 -Seen
+  // Ratios - Exp0 -Finished and Exp2 -Seen
+
+  // Ratios - Exp0 -Finished and Exp2 -Finished and Fractions Exp0 Finished - Recent
+
+  // Ratios - Exp0 -Finished and Exp2 -Finished and Fractions Exp0 Finished - Old
+
+  // Ratios - Exp0 -Finished and Exp2 -Finished and Fractions Exp0 Finished - Recent/old
+
+  private fun verifyGetOngoingStoryListSucceeded() {
+    verify(mockOngoingStoryListObserver, atLeastOnce()).onChanged(ongoingStoryListResultCaptor.capture())
+    assertThat(ongoingStoryListResultCaptor.value.isSuccess()).isTrue()
   }
 
-  @Test
-  fun testRetrieveTopicList_promotedLesson_hasCorrectTopicInfo() {
-    val topicListLiveData = topicListController.getTopicList()
+  private fun verifyDefaultOngoingStoryListSucceeded() {
+    val ongoingTopicList = ongoingStoryListResultCaptor.value.getOrThrow()
+    assertThat(ongoingTopicList.recentStoryList.size).isEqualTo(2)
+    assertThat(ongoingTopicList.recentStoryList[0].explorationId).isEqualTo(FRACTIONS_EXPLORATION_ID_0)
+    assertThat(ongoingTopicList.recentStoryList[0].storyId).isEqualTo(FRACTIONS_STORY_ID_0)
+    assertThat(ongoingTopicList.recentStoryList[0].topicId).isEqualTo(FRACTIONS_TOPIC_ID)
+    assertThat(ongoingTopicList.recentStoryList[0].topicName).isEqualTo("Fractions")
+    assertThat(ongoingTopicList.recentStoryList[0].nextChapterName).isEqualTo("What is a Fraction?")
+    assertThat(ongoingTopicList.recentStoryList[0].lessonThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.DUCK_AND_CHICKEN)
+    assertThat(ongoingTopicList.recentStoryList[0].completedChapterCount).isEqualTo(0)
+    assertThat(ongoingTopicList.recentStoryList[0].totalChapterCount).isEqualTo(2)
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
-    val promotedStory = topicList.promotedStory
-    assertThat(promotedStory.topicId).isEqualTo(FRACTIONS_TOPIC_ID)
-    assertThat(promotedStory.topicName).isEqualTo("Fractions")
-  }
-
-  @Test
-  fun testRetrieveTopicList_promotedLesson_hasCorrectCompletionStats() {
-    val topicListLiveData = topicListController.getTopicList()
-
-    val topicList = topicListLiveData.value!!.getOrThrow()
-    val promotedStory = topicList.promotedStory
-    assertThat(promotedStory.completedChapterCount).isEqualTo(0)
-    assertThat(promotedStory.totalChapterCount).isEqualTo(2)
-  }
-
-  @Test
-  fun testRetrieveOngoingStoryList_isSuccessful() {
-    val ongoingStoryListLiveData = topicListController.getOngoingStoryList()
-
-    val ongoingStoryListResult = ongoingStoryListLiveData.value
-    assertThat(ongoingStoryListResult).isNotNull()
-    assertThat(ongoingStoryListResult!!.isSuccess()).isTrue()
-  }
-
-  @Test
-  fun testRetrieveOngoingStoryList_withinSevenDays_hasOngoingLesson() {
-    val ongoingStoryListLiveData = topicListController.getOngoingStoryList()
-
-    val ongoingStoryList = ongoingStoryListLiveData.value!!.getOrThrow()
-    assertThat(ongoingStoryList.recentStoryCount).isEqualTo(2)
-  }
-
-  @Test
-  fun testRetrieveOngoingStoryList_recentLesson_hasCorrectStoryInfo() {
-    val ongoingStoryListLiveData = topicListController.getOngoingStoryList()
-
-    val ongoingStoryList = ongoingStoryListLiveData.value!!.getOrThrow()
-    val recentLesson = ongoingStoryList.getRecentStory(0)
-    assertThat(recentLesson.storyId).isEqualTo(FRACTIONS_STORY_ID_0)
-    assertThat(recentLesson.storyName).isEqualTo("Matthew Goes to the Bakery")
-  }
-
-  @Test
-  fun testRetrieveOngoingStoryList_recentLesson_hasCorrectTopicInfo() {
-    val ongoingStoryListLiveData = topicListController.getOngoingStoryList()
-
-    val ongoingStoryList = ongoingStoryListLiveData.value!!.getOrThrow()
-    val recentLesson = ongoingStoryList.getRecentStory(0)
-    assertThat(recentLesson.topicId).isEqualTo(FRACTIONS_TOPIC_ID)
-    assertThat(recentLesson.topicName).isEqualTo("Fractions")
-  }
-
-  @Test
-  fun testRetrieveOngoingStoryList_recentLesson_hasCorrectCompletionStats() {
-    val ongoingStoryListLiveData = topicListController.getOngoingStoryList()
-
-    val ongoingStoryList = ongoingStoryListLiveData.value!!.getOrThrow()
-    val recentLesson = ongoingStoryList.getRecentStory(0)
-    assertThat(recentLesson.completedChapterCount).isEqualTo(0)
-    assertThat(recentLesson.totalChapterCount).isEqualTo(2)
-  }
-
-  @Test
-  fun testRetrieveOngoingStoryList_recentLesson_hasCorrectThumbnail() {
-    val ongoingStoryListLiveData = topicListController.getOngoingStoryList()
-
-    val ongoingStoryList = ongoingStoryListLiveData.value!!.getOrThrow()
-    val recentLesson = ongoingStoryList.getRecentStory(0)
-    assertThat(recentLesson.lessonThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.DUCK_AND_CHICKEN)
-  }
-
-  @Test
-  fun testRetrieveOngoingStoryList_earlierThanSevenDays_doesNotHaveOngoingLesson() {
-    val ongoingStoryListLiveData = topicListController.getOngoingStoryList()
-
-    val ongoingStoryList = ongoingStoryListLiveData.value!!.getOrThrow()
-    assertThat(ongoingStoryList.olderStoryCount).isEqualTo(0)
-  }
-
-  private fun setUpTestApplicationComponent() {
-    DaggerTopicListControllerTest_TestApplicationComponent.builder()
-      .setApplication(ApplicationProvider.getApplicationContext())
-      .build()
-      .inject(this)
+    assertThat(ongoingTopicList.recentStoryList[1].explorationId).isEqualTo(RATIOS_EXPLORATION_ID_0)
+    assertThat(ongoingTopicList.recentStoryList[1].storyId).isEqualTo(RATIOS_STORY_ID_0)
+    assertThat(ongoingTopicList.recentStoryList[1].topicId).isEqualTo(RATIOS_TOPIC_ID)
+    assertThat(ongoingTopicList.recentStoryList[1].nextChapterName).isEqualTo("What is a Ratio?")
+    assertThat(ongoingTopicList.recentStoryList[1].topicName).isEqualTo("Ratios and Proportional Reasoning")
+    assertThat(ongoingTopicList.recentStoryList[1].lessonThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.CHILD_WITH_FRACTIONS_HOMEWORK)
+    assertThat(ongoingTopicList.recentStoryList[1].completedChapterCount).isEqualTo(0)
+    assertThat(ongoingTopicList.recentStoryList[1].totalChapterCount).isEqualTo(2)
   }
 
   @Qualifier

--- a/domain/src/test/java/org/oppia/domain/topic/TopicListControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicListControllerTest.kt
@@ -64,19 +64,14 @@ class TopicListControllerTest {
   @JvmField
   val mockitoRule: MockitoRule = MockitoJUnit.rule()
 
-  @Inject
-  lateinit var context: Context
+  @Inject lateinit var context: Context
 
-  @Inject
-  lateinit var topicListController: TopicListController
+  @Inject lateinit var topicListController: TopicListController
 
-  @Inject
-  lateinit var storyProgressController: StoryProgressController
+  @Inject lateinit var storyProgressController: StoryProgressController
 
-  @Mock
-  lateinit var mockOngoingStoryListObserver: Observer<AsyncResult<OngoingStoryList>>
-  @Captor
-  lateinit var ongoingStoryListResultCaptor: ArgumentCaptor<AsyncResult<OngoingStoryList>>
+  @Mock lateinit var mockOngoingStoryListObserver: Observer<AsyncResult<OngoingStoryList>>
+  @Captor lateinit var ongoingStoryListResultCaptor: ArgumentCaptor<AsyncResult<OngoingStoryList>>
 
   @Inject
   @field:TestDispatcher
@@ -612,8 +607,7 @@ class TopicListControllerTest {
     return Date().time - NINE_DAYS_IN_MS
   }
 
-  @Qualifier
-  annotation class TestDispatcher
+  @Qualifier annotation class TestDispatcher
 
   // TODO(#89): Move this to a common test application component.
   @Module

--- a/domain/src/test/java/org/oppia/domain/topic/TopicListControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicListControllerTest.kt
@@ -47,7 +47,7 @@ import org.oppia.util.parser.ImageDownloadUrlTemplate
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import org.robolectric.annotation.Config
-import java.util.*
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Singleton

--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -86,20 +86,6 @@ message ChapterSummary {
   // Summary of this chapter.
   string summary = 3;
 
-  enum Playability {
-    // The completion status is unknown.
-    COMPLETION_STATUS_UNSPECIFIED = 0;
-
-    // The chapter has not yet been started, but can be started by the player.
-    NOT_STARTED = 1;
-
-    // The chapter has not yet been started, and can't since the player is missing prerequisites.
-    MISSING_PREREQUISITES = 2;
-
-    // The chapter has been completed by the player.
-    COMPLETED = 3;
-  }
-
   // Indicates the playable state of the current chapter, including whether it's already been completed.
   ChapterPlayState chapter_play_state = 4;
 

--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -254,8 +254,11 @@ enum ChapterPlayState {
   // The chapter has not yet been started, and cannot be started since the player is missing prerequisites.
   NOT_PLAYABLE_MISSING_PREREQUISITES = 2;
 
+  // The chapter has been started but not completed by the player.
+  STARTED_NOT_COMPLETED = 3;
+
   // The chapter has been completed by the player.
-  COMPLETED = 3;
+  COMPLETED = 4;
 }
 
 // Top level proto used to store topic progress per-profile.
@@ -279,7 +282,19 @@ message StoryProgress {
   string story_id = 1;
 
   // Map from exploration ID to ChapterPlayState.
-  map<string, ChapterPlayState> chapter_progress = 2;
+  map<string, ChapterProgress> chapter_progress = 2;
+}
+
+// Represents the chapter progress.
+message ChapterProgress {
+  // The ID corresponding to the chapter.
+  string chapter_id = 1;
+
+  // The playability state of chapter.
+  ChapterPlayState chapter_play_state = 2;
+
+  // Timestamp to record last time the exploration was played in ms.
+  int64 last_played_timestamp = 3;
 }
 
 // Represents user's preference for using cellular data

--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -140,9 +140,6 @@ message OngoingTopicList {
 
 // Corresponds to the list of topics that can be shown on the homescreen.
 message TopicList {
-  // Corresponds to the story promoted at the top of the homescreen. Either the story is in-progress, or it's a
-  // recommended story if no other stories are in progress.
-  PromotedStory promoted_story = 1;
 
   // All topics that are available to the player.
   repeated TopicSummary topic_summary = 2;
@@ -287,8 +284,8 @@ message StoryProgress {
 
 // Represents the chapter progress.
 message ChapterProgress {
-  // The ID corresponding to the chapter.
-  string chapter_id = 1;
+  // The ID corresponding to the exploration.
+  string exploration_id = 1;
 
   // The playability state of chapter.
   ChapterPlayState chapter_play_state = 2;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

This PR makes `OngoingStoryList` dynamic which is visible in HomeFragment-Carousel and `ContinuePlayingActiivty`.

This PR also changes some code of `app` module otherwise the application would crash while running this PR.

## Concepts reviewer should know before checking this PR.
1. Earlier TopicList (list of topics shown on home screen) was containing `PromotedStory` because earlier in `HomeScreen` there was only one `PromotedStory` at a time and not more than that. But now as the implementation has changed such that there can be multiple `PromotedStory`s on home screen, therefore `PromotedStory` has been removed from `TopicList` in proto file as well as code and test cases.
2. List of `PromotedStory` is combined to form `OngoingStoryList` which is then used in `app` module.
3. Definition of `PromotedStory`: **(a.)** If learner has opened the exploration but has never finished it, that means learner has shown interest in that story and therefore it is considered a `PromotedStory`. **(b.)** If a learner has finished one exploration in any story, then the next available exploration which has not yet started is considered as `PromotedStory`. If the application has just started and there is progress history for user then in that case we are showing first exploration of `Fractions` and `Ratios` as default promoted story for now.
4. `ChapterPlayState`: This defines the playability of any exploration. Earlier it use to have 4 values: **(a.)** `COMPLETION_STATUS_UNSPECIFIED`- completion status is unknown, **(b.)** `NOT_STARTED` - the exploration has not yet been started, but can be started by the player, **(c.)** `NOT_PLAYABLE_MISSING_PREREQUISITES` - the exploration is not playable as earlier exploration has not finished, **(d.)** `COMPLETED` - the exploration has been completed. Now I have added one more play state to differentiate correctly that the learner has started playing the exploration but has not yet finished the exploration - `STARTED_NOT_COMPLETED`.
5. There were two `ChapterPlayState` enums in `topic.proto`, removed one of them to make code more clear.

## Algorithm for creating a `OngoingStoryList`: 
- Only one exploration should be promoted from one story at a time.
- Lets take a case where we have one topic named `TOPIC_1`, one story named `STORY_1` and three exploration inside it, i.e. `EXP_1`, `EXP_2`.
- **Case 1**: No exploration has been opened and no exploration has been finished. In this case we will not promoted any exploration from this topic as learner has never shown any interest in this topic.
- **Case 2**: Learner has opened `EXP_1` but has not finished it yet. In this case we will promote `EXP_1`.
- **Case 3**: Learner has finished `EXP_1` but has not opened `EXP_2`. In this case we will promote `EXP_2` anyway as learner has shown interest and has finished `EXP_1`.
- **Case 4**: Learner has finished `EXP_1` but has opened `EXP_2`. In this case we will promote `EXP_2` has learner has directly shown interest in `EXP_2`.
- **Case 5**: Learner has finished all three exploration. In this case we will not promote anything from this topic as everything has already finished.

## Recent vs. Old Promoted Stories:
Promoted Story can be of two types recent and old. Recent means the last interest was show in this story was within 7 days. Old means that the interest was shown in the story before 1 week.

We will update the timestamp for `last_played_timestamp` in `ChapterProgress` every-time an exploration has been visited keeping in mind that it has not been finished already. If the exploration has been finished already we will not update its `last_played_timestamp` anymore.

## Testing this PR
Inject `StoryProgressTestHelper` in `HomeFragmentPresenter` and use any function of this class in `handleOnCreate` function. [Sample Gist](https://gist.github.com/rt4914/5258375c8d2cca81b6a5b62ccab8e143)

Also for test cases if they fail, bring your app in foreground and run that specific test case again.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
