### PR TITLE
Fix #837 : Highfi: DefaultAudioLanguage

### DIFF
--- a/app/src/main/res/layout-land/language_items.xml
+++ b/app/src/main/res/layout-land/language_items.xml
@@ -8,35 +8,52 @@
       type="CharSequence" />
   </data>
 
-  <RelativeLayout
-    android:id="@+id/radio_container"
+  <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="4dp"
-    android:gravity="center_vertical"
-    android:minHeight="48dp">
+    android:orientation="vertical">
 
-    <androidx.appcompat.widget.AppCompatRadioButton
-      android:id="@+id/language_radio_button"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="20dp"
-      android:clickable="false"
-      android:gravity="center_vertical"
-      android:padding="4dp"
-      app:buttonTint="@color/defaultAudioActivityRadioButton" />
-
-    <TextView
-      android:id="@+id/language_text_view"
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/radio_container"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginStart="28dp"
-      android:layout_toEndOf="@+id/language_radio_button"
-      android:fontFamily="sans-serif"
-      android:gravity="center_vertical"
-      android:paddingTop="4dp"
-      android:text="@{languageString}"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="16sp" />
-  </RelativeLayout>
+      android:minHeight="48dp">
+
+      <TextView
+        android:id="@+id/language_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="4dp"
+        android:layout_toEndOf="@+id/language_radio_button"
+        android:fontFamily="sans-serif"
+        android:text="@{languageString}"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/language_radio_button"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.45" />
+
+      <androidx.appcompat.widget.AppCompatRadioButton
+        android:id="@+id/language_radio_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:clickable="false"
+        app:buttonTint="@color/defaultAudioActivityRadioButton"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/language_text_view"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.5" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <View
+      android:layout_width="match_parent"
+      android:layout_height="1dp"
+      android:background="@color/grey"/>
+  </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/language_items.xml
+++ b/app/src/main/res/layout/language_items.xml
@@ -8,32 +8,52 @@
       type="CharSequence" />
   </data>
 
-  <RelativeLayout
-    android:id="@+id/radio_container"
+  <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="4dp"
-    android:gravity="center_vertical"
-    android:minHeight="48dp">
+    android:orientation="vertical">
 
-    <androidx.appcompat.widget.AppCompatRadioButton
-      android:id="@+id/language_radio_button"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:clickable="false"
-      android:padding="4dp"
-      app:buttonTint="@color/defaultAudioActivityRadioButton" />
-
-    <TextView
-      android:id="@+id/language_text_view"
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/radio_container"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginStart="4dp"
-      android:layout_toEndOf="@+id/language_radio_button"
-      android:fontFamily="sans-serif"
-      android:paddingTop="4dp"
-      android:text="@{languageString}"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="16sp" />
-  </RelativeLayout>
+      android:minHeight="48dp">
+
+      <TextView
+        android:id="@+id/language_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="4dp"
+        android:layout_toEndOf="@+id/language_radio_button"
+        android:fontFamily="sans-serif"
+        android:text="@{languageString}"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/language_radio_button"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.45" />
+
+      <androidx.appcompat.widget.AppCompatRadioButton
+        android:id="@+id/language_radio_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:clickable="false"
+        app:buttonTint="@color/defaultAudioActivityRadioButton"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/language_text_view"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.5" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <View
+      android:layout_width="match_parent"
+      android:layout_height="1dp"
+      android:background="@color/grey"/>
+  </LinearLayout>
 </layout>


### PR DESCRIPTION
## Explanation

    Fixes #837 

## Mocks
Portrait Mock: https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/f8cf647c-85ea-4900-b98a-9449dd3a82a6/OP-Default-Audio-Language-
Landscape Mock: https://xd.adobe.com/view/ee9e607b-dbd6-4372-48dc-b687d32af3da-98af/screen/85cbe1f0-8405-472b-abb0-fc83a0680aca/OP-Default-Audio-Language-
   
## Screenshots

 
![Screenshot_2020-03-20-18-56-24-497_org oppia app](https://user-images.githubusercontent.com/59963912/77167815-bc234980-6adc-11ea-9505-8f8c8d0204a9.jpg)
![Screenshot_2020-03-20-18-56-28-664_org oppia app](https://user-images.githubusercontent.com/59963912/77167819-bd547680-6adc-11ea-9d04-a4fca275e8d2.jpg)
![Screenshot_2020-03-20-18-56-31-172_org oppia app](https://user-images.githubusercontent.com/59963912/77167822-bded0d00-6adc-11ea-8eb3-4b2737e86cf8.jpg)




## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
