### PR TITLE
Fix part of #885: Hifi for OngoingTopics and CompletedStories

### DIFF
--- a/app/src/main/res/drawable/grey_card_rounded_border.xml
+++ b/app/src/main/res/drawable/grey_card_rounded_border.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+  android:shape="rectangle">
+  <corners android:radius="4dp" />
+  <stroke
+    android:width="0.5dp"
+    android:color="@color/grey" />
+  <solid android:color="@color/white" />
+</shape>

--- a/app/src/main/res/drawable/primary_rounded_button.xml
+++ b/app/src/main/res/drawable/primary_rounded_button.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
-  android:shape="oval">
-  <solid android:color="@color/oppiaPrimaryText" />
+  android:shape="rectangle">
   <corners android:radius="4dp" />
+  <solid android:color="@color/colorPrimary" />
 </shape>

--- a/app/src/main/res/layout-land/completed_story_item.xml
+++ b/app/src/main/res/layout-land/completed_story_item.xml
@@ -13,17 +13,19 @@
 
   <com.google.android.material.card.MaterialCardView
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="28dp"
-    android:layout_marginTop="28dp"
-    android:layout_marginEnd="28dp"
+    android:layout_height="92dp"
+    android:layout_marginStart="96dp"
+    android:layout_marginTop="8dp"
+    android:layout_marginBottom="8dp"
+    android:layout_marginEnd="96dp"
     app:cardBackgroundColor="@color/white"
     app:cardCornerRadius="4dp"
     app:cardElevation="4dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content">
+      android:layout_height="match_parent"
+      android:background="@drawable/grey_card_rounded_border">
 
       <ImageView
         android:id="@+id/completed_story_lesson_thumbnail"
@@ -43,10 +45,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="12dp"
-        android:layout_marginTop="12dp"
         android:layout_marginEnd="12dp"
-        android:layout_marginBottom="12dp"
-        android:background="@color/white"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
@@ -60,6 +59,7 @@
           android:layout_marginBottom="4dp"
           android:ellipsize="end"
           android:fontFamily="sans-serif"
+          android:maxLines="2"
           android:text="@{viewModel.completedStory.storyName}"
           android:textColor="@color/oppiaPrimaryText"
           android:textSize="16sp" />
@@ -70,6 +70,7 @@
           android:layout_height="wrap_content"
           android:ellipsize="end"
           android:fontFamily="sans-serif-light"
+          android:maxLines="1"
           android:text="@{viewModel.completedStory.topicName}"
           android:textAllCaps="true"
           android:textColor="@color/oppiaPrimaryText"

--- a/app/src/main/res/layout-land/completed_story_list_fragment.xml
+++ b/app/src/main/res/layout-land/completed_story_list_fragment.xml
@@ -31,7 +31,7 @@
         android:fontFamily="sans-serif"
         android:minHeight="?attr/actionBarSize"
         android:textSize="20sp"
-        app:titleTextAppearance="@style/ToolbarTitle"
+        app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:navigationContentDescription="@string/go_to_previous_page"
         app:navigationIcon="?attr/homeAsUpIndicator"
         app:title="@string/stories_completed"

--- a/app/src/main/res/layout-land/completed_story_list_fragment.xml
+++ b/app/src/main/res/layout-land/completed_story_list_fragment.xml
@@ -31,6 +31,7 @@
         android:fontFamily="sans-serif"
         android:minHeight="?attr/actionBarSize"
         android:textSize="20sp"
+        app:titleTextAppearance="@style/ToolbarTitle"
         app:navigationContentDescription="@string/go_to_previous_page"
         app:navigationIcon="?attr/homeAsUpIndicator"
         app:title="@string/stories_completed"
@@ -51,7 +52,8 @@
         android:layout_height="match_parent"
         android:clipToPadding="false"
         android:overScrollMode="never"
-        android:paddingBottom="@dimen/bottom_white_space"
+        android:paddingTop="28dp"
+        android:paddingBottom="108dp"
         android:scrollbars="none"
         app:data="@{viewModel.completedStoryListLiveData}" />
 

--- a/app/src/main/res/layout-land/ongoing_topic_item.xml
+++ b/app/src/main/res/layout-land/ongoing_topic_item.xml
@@ -15,9 +15,10 @@
 
   <com.google.android.material.card.MaterialCardView
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="92dp"
     android:layout_marginStart="96dp"
-    android:layout_marginTop="16dp"
+    android:layout_marginTop="8dp"
+    android:layout_marginBottom="8dp"
     android:layout_marginEnd="96dp"
     app:cardBackgroundColor="@color/white"
     app:cardCornerRadius="4dp"
@@ -25,15 +26,14 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content">
+      android:layout_height="match_parent"
+      android:background="@drawable/grey_card_rounded_border">
 
       <ImageView
         android:id="@+id/topic_thumbnail"
         android:layout_width="80dp"
         android:layout_height="0dp"
         android:layout_marginStart="8dp"
-        android:layout_marginTop="20dp"
-        android:layout_marginBottom="24dp"
         android:scaleType="centerInside"
         android:src="@{viewModel.topic.topicThumbnail.thumbnailGraphic}"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -46,9 +46,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="12dp"
-        android:layout_marginTop="24dp"
-        android:layout_marginEnd="44dp"
-        android:layout_marginBottom="24dp"
+        android:layout_marginEnd="8dp"
         android:background="@color/white"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -71,8 +69,6 @@
           android:id="@+id/story_count_text_view"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="4dp"
           android:ellipsize="end"
           android:fontFamily="sans-serif"
           android:maxLines="1"

--- a/app/src/main/res/layout-land/ongoing_topic_list_fragment.xml
+++ b/app/src/main/res/layout-land/ongoing_topic_list_fragment.xml
@@ -34,6 +34,7 @@
         app:navigationContentDescription="@string/go_to_previous_page"
         app:navigationIcon="?attr/homeAsUpIndicator"
         app:title="@string/topics_in_progress"
+        app:titleTextAppearance="@style/ToolbarTitle"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>
 
@@ -51,8 +52,8 @@
         android:layout_height="match_parent"
         android:clipToPadding="false"
         android:overScrollMode="never"
-        android:paddingBottom="@dimen/bottom_white_space"
-        android:layout_marginTop="20dp"
+        android:paddingTop="28dp"
+        android:paddingBottom="108dp"
         android:scrollbars="none"
         app:data="@{viewModel.ongoingTopicListViewModelLiveData}" />
 

--- a/app/src/main/res/layout-land/ongoing_topic_list_fragment.xml
+++ b/app/src/main/res/layout-land/ongoing_topic_list_fragment.xml
@@ -34,7 +34,7 @@
         app:navigationContentDescription="@string/go_to_previous_page"
         app:navigationIcon="?attr/homeAsUpIndicator"
         app:title="@string/topics_in_progress"
-        app:titleTextAppearance="@style/ToolbarTitle"
+        app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/layout/completed_story_item.xml
+++ b/app/src/main/res/layout/completed_story_item.xml
@@ -13,17 +13,19 @@
 
   <com.google.android.material.card.MaterialCardView
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="92dp"
     android:layout_marginStart="28dp"
-    android:layout_marginTop="28dp"
+    android:layout_marginTop="8dp"
     android:layout_marginEnd="28dp"
+    android:layout_marginBottom="8dp"
     app:cardBackgroundColor="@color/white"
     app:cardCornerRadius="4dp"
     app:cardElevation="4dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content">
+      android:layout_height="match_parent"
+      android:background="@drawable/grey_card_rounded_border">
 
       <ImageView
         android:id="@+id/completed_story_lesson_thumbnail"
@@ -43,10 +45,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="12dp"
-        android:layout_marginTop="12dp"
         android:layout_marginEnd="12dp"
-        android:layout_marginBottom="12dp"
-        android:background="@color/white"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
@@ -60,6 +59,7 @@
           android:layout_marginBottom="4dp"
           android:ellipsize="end"
           android:fontFamily="sans-serif"
+          android:maxLines="2"
           android:text="@{viewModel.completedStory.storyName}"
           android:textColor="@color/oppiaPrimaryText"
           android:textSize="16sp" />
@@ -70,6 +70,7 @@
           android:layout_height="wrap_content"
           android:ellipsize="end"
           android:fontFamily="sans-serif-light"
+          android:maxLines="1"
           android:text="@{viewModel.completedStory.topicName}"
           android:textAllCaps="true"
           android:textColor="@color/oppiaPrimaryText"

--- a/app/src/main/res/layout/completed_story_list_fragment.xml
+++ b/app/src/main/res/layout/completed_story_list_fragment.xml
@@ -51,7 +51,8 @@
         android:layout_height="match_parent"
         android:clipToPadding="false"
         android:overScrollMode="never"
-        android:paddingBottom="@dimen/bottom_white_space"
+        android:paddingTop="24dp"
+        android:paddingBottom="108dp"
         android:scrollbars="none"
         app:data="@{viewModel.completedStoryListLiveData}" />
 

--- a/app/src/main/res/layout/onboarding_fragment.xml
+++ b/app/src/main/res/layout/onboarding_fragment.xml
@@ -24,81 +24,83 @@
       android:id="@+id/onboarding_slide_view_pager"
       android:layout_width="match_parent"
       android:layout_height="0dp"
-      android:layout_marginBottom="0dp"
       android:overScrollMode="never"
       android:scrollbars="none"
-      app:layout_constraintBottom_toTopOf="@id/bottom_container"
+      app:layout_constraintBottom_toTopOf="@id/bottom_frame_layout"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent" />
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:id="@+id/get_started_container"
+    <FrameLayout
+      android:id="@+id/bottom_frame_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:paddingStart="56dp"
-      android:paddingEnd="56dp"
-      android:paddingBottom="36dp"
-      android:visibility="@{viewModel.slideNumber == (viewModel.totalNumberOfSlides - 1) ? View.VISIBLE: View.GONE, default=gone}"
+      android:layout_marginTop="16dp"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent">
 
-      <Button
-        android:id="@+id/get_started_button"
+      <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/get_started_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/colorPrimary"
-        android:fontFamily="sans-serif-medium"
-        android:minHeight="48dp"
-        android:onClick="@{(v) -> presenter.clickOnGetStarted()}"
-        android:text="@string/get_started"
-        android:textColor="@color/white"
-        android:textSize="14sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        android:paddingStart="56dp"
+        android:paddingEnd="56dp"
+        android:paddingBottom="24dp"
+        android:visibility="@{viewModel.slideNumber == (viewModel.totalNumberOfSlides - 1) ? View.VISIBLE: View.GONE, default=gone}">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:id="@+id/bottom_container"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:paddingStart="8dp"
-      android:paddingEnd="8dp"
-      android:visibility="@{viewModel.slideNumber != (viewModel.totalNumberOfSlides - 1) ? View.VISIBLE: View.GONE, default=visible}"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent">
+        <Button
+          android:id="@+id/get_started_button"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:background="@drawable/primary_rounded_button"
+          android:fontFamily="sans-serif-medium"
+          android:minHeight="48dp"
+          android:onClick="@{(v) -> presenter.clickOnGetStarted()}"
+          android:text="@string/get_started"
+          android:textColor="@color/white"
+          android:textSize="14sp"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="parent" />
+      </androidx.constraintlayout.widget.ConstraintLayout>
 
-      <LinearLayout
-        android:id="@+id/slide_dots_container"
-        android:layout_width="wrap_content"
+      <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/bottom_container"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:paddingStart="28dp"
+        android:paddingEnd="28dp"
+        android:paddingBottom="16dp"
+        android:visibility="@{viewModel.slideNumber != (viewModel.totalNumberOfSlides - 1) ? View.VISIBLE: View.GONE, default=visible}">
 
-      <TextView
-        android:id="@+id/skip_text_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:fontFamily="sans-serif-medium"
-        android:gravity="center"
-        android:minHeight="48dp"
-        android:onClick="@{(v) -> presenter.clickOnSkip()}"
-        android:paddingStart="8dp"
-        android:paddingEnd="8dp"
-        android:text="@string/skip"
-        android:textAllCaps="true"
-        android:textColor="@color/colorPrimary"
-        android:textSize="14sp"
-        app:layout_constraintBottom_toBottomOf="@+id/slide_dots_container"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/slide_dots_container" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        <LinearLayout
+          android:id="@+id/slide_dots_container"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:orientation="horizontal"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+          android:id="@+id/skip_text_view"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:fontFamily="sans-serif-medium"
+          android:gravity="center"
+          android:minHeight="48dp"
+          android:onClick="@{(v) -> presenter.clickOnSkip()}"
+          android:text="@string/skip"
+          android:textAllCaps="true"
+          android:textColor="@color/colorPrimary"
+          android:textSize="14sp"
+          app:layout_constraintBottom_toBottomOf="@+id/slide_dots_container"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toTopOf="@+id/slide_dots_container" />
+      </androidx.constraintlayout.widget.ConstraintLayout>
+    </FrameLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/onboarding_slide.xml
+++ b/app/src/main/res/layout/onboarding_slide.xml
@@ -11,15 +11,15 @@
 
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:orientation="vertical">
 
     <ImageView
       android:id="@+id/slide_image_view"
       android:layout_width="0dp"
       android:layout_height="0dp"
-      android:src="@{viewModel.slideImage}"
       android:contentDescription="@{viewModel.contentDescription}"
+      android:src="@{viewModel.slideImage}"
       app:layout_constraintDimensionRatio="V,4:4"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
@@ -29,32 +29,36 @@
       android:id="@+id/slide_title_text_view"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
-      android:fontFamily="sans-serif-medium"
-      android:layout_marginStart="28dp"
+      android:layout_marginStart="48dp"
       android:layout_marginTop="16dp"
-      android:layout_marginEnd="28dp"
+      android:layout_marginEnd="48dp"
+      android:layout_marginBottom="16dp"
+      android:fontFamily="sans-serif-medium"
       android:gravity="center_horizontal"
+      android:maxLines="1"
       android:text="@{viewModel.title}"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="24sp"
+      app:layout_constraintBottom_toTopOf="@id/slide_description_text_view"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/slide_image_view" />
+      app:layout_constraintStart_toStartOf="parent" />
 
     <TextView
       android:id="@+id/slide_description_text_view"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
-      android:fontFamily="sans-serif"
-      android:layout_marginTop="16dp"
       android:layout_marginStart="48dp"
       android:layout_marginEnd="48dp"
+      android:layout_marginBottom="32dp"
+      android:fontFamily="sans-serif"
       android:gravity="center_horizontal"
+      android:maxLines="2"
+      android:minLines="2"
       android:text="@{viewModel.description}"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="16sp"
+      app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/slide_title_text_view" />
+      app:layout_constraintStart_toStartOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/ongoing_topic_item.xml
+++ b/app/src/main/res/layout/ongoing_topic_item.xml
@@ -15,17 +15,19 @@
 
   <com.google.android.material.card.MaterialCardView
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="92dp"
     android:layout_marginStart="28dp"
-    android:layout_marginTop="28dp"
+    android:layout_marginTop="8dp"
     android:layout_marginEnd="28dp"
+    android:layout_marginBottom="8dp"
     app:cardBackgroundColor="@color/white"
     app:cardCornerRadius="4dp"
     app:cardElevation="4dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content">
+      android:layout_height="match_parent"
+      android:background="@drawable/grey_card_rounded_border">
 
       <ImageView
         android:id="@+id/topic_thumbnail"
@@ -44,9 +46,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="12dp"
-        android:layout_marginTop="12dp"
-        android:layout_marginEnd="12dp"
-        android:layout_marginBottom="12dp"
+        android:layout_marginEnd="8dp"
         android:background="@color/white"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -69,8 +69,6 @@
           android:id="@+id/story_count_text_view"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="4dp"
           android:ellipsize="end"
           android:fontFamily="sans-serif"
           android:maxLines="1"

--- a/app/src/main/res/layout/ongoing_topic_list_fragment.xml
+++ b/app/src/main/res/layout/ongoing_topic_list_fragment.xml
@@ -51,7 +51,8 @@
         android:layout_height="match_parent"
         android:clipToPadding="false"
         android:overScrollMode="never"
-        android:paddingBottom="@dimen/bottom_white_space"
+        android:paddingTop="28dp"
+        android:paddingBottom="108dp"
         android:scrollbars="none"
         app:data="@{viewModel.ongoingTopicListViewModelLiveData}" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -90,9 +90,6 @@
   <color name="green_shade_40">#6644A85A</color>
   <color name="green_shade_10">#1A44A85A</color>
   <color name="light_green">#D9F3E7</color>
-  <!-- ONBOARDING FLOW -->
-  <color name="onboardingDotActive">#333333</color>
-  <color name="onboardingDotInactive">#4D333333</color>
   <!-- AVATAR BACKGROUND COLORS -->
   <color name="avatar_background_1">#E65C5C</color>
   <color name="avatar_background_2">#E6935C</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -89,7 +89,7 @@
   </style>
 
   <style name="ToolbarTextAppearance" parent="TextAppearance.Widget.AppCompat.Toolbar.Title">
-    <item name="android:textSize">24sp</item>
+    <item name="android:textSize">20sp</item>
     <item name="android:textColor">@color/white</item>
   </style>
 
@@ -140,9 +140,5 @@
     <item name="android:textColor">@color/tab_icon_color_selector</item>
     <item name="android:fontFamily">sans-serif-medium</item>
     <item name="textAllCaps">true</item>
-  </style>
-
-  <style name="ToolbarTitle" parent="@style/TextAppearance.Widget.AppCompat.Toolbar.Title">
-    <item name="android:textSize">20sp</item>
   </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -141,4 +141,8 @@
     <item name="android:fontFamily">sans-serif-medium</item>
     <item name="textAllCaps">true</item>
   </style>
+
+  <style name="ToolbarTitle" parent="@style/TextAppearance.Widget.AppCompat.Toolbar.Title">
+    <item name="android:textSize">20sp</item>
+  </style>
 </resources>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes part of #885 

This PR finishes Highfi for OngoingTopicList and CompletedStoryList.

To test this PR inject `StoryProgressTestHelper` to mark dummy progress in HomeFragmentPresenter.

First use these functions for testing `OngoingTopicList`
`storyProgressTestHelper.markTwoPartialStoryProgressForRatios(profileId, false)`
`storyProgressTestHelper.markPartialStoryProgressForFractions(profileId, false)`
After this use these functions for testing `CompletedStoryList`
`storyProgressTestHelper.markFullTopicProgressForFractions(profileId, false)`
`storyProgressTestHelper.markFullStoryPartialTopicProgressForRatios(profileId, false)`

## Mock Links:
https://xd.adobe.com/view/ee9e607b-dbd6-4372-48dc-b687d32af3da-98af/screen/ce21cbf2-0439-47d7-bb37-005cfc6b9742/UP-Topics-in-Progress-
https://xd.adobe.com/view/ee9e607b-dbd6-4372-48dc-b687d32af3da-98af/screen/48c041b4-dad1-4972-8564-4783766e8af7/UP-Stories-Completed-
https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/a80d1be8-d4b4-4fee-a46d-296b5aa6a110/UP-Topics-in-Progress-
https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/f54ae7d1-9530-44d6-8783-21559b13635c/UP-Stories-Completed-

## Screenshots:
![Screenshot_1585266035](https://user-images.githubusercontent.com/9396084/77707142-45111800-6fea-11ea-9fbf-2aa0f2e83ea0.png)
![Screenshot_1585266038](https://user-images.githubusercontent.com/9396084/77707145-47737200-6fea-11ea-9d91-fc0a6e2cb4d7.png)
![Screenshot_1585266105](https://user-images.githubusercontent.com/9396084/77707149-4b06f900-6fea-11ea-8e8f-532118472fc1.png)
![Screenshot_1585266111](https://user-images.githubusercontent.com/9396084/77707150-4b06f900-6fea-11ea-9d6b-c22e663fc747.png)


## UI Notes:
The top/bottom margin for the image in these items was 22 and 25 now, I can shift it to 24 each side but to keep it simple I did not introduced it therefore the image is automatically in centre which would happened also in the case of `24dp` margin on top and bottom.



## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
