### PR TITLE
Fix #885: Highfi Recently Played Activity

### DIFF
--- a/app/src/main/res/layout-land/ongoing_story_card.xml
+++ b/app/src/main/res/layout-land/ongoing_story_card.xml
@@ -14,9 +14,9 @@
   <com.google.android.material.card.MaterialCardView
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginStart="28dp"
+    android:layout_marginStart="96dp"
     android:layout_marginTop="28dp"
-    android:layout_marginEnd="28dp"
+    android:layout_marginEnd="96dp"
     app:cardBackgroundColor="@color/white"
     app:cardCornerRadius="4dp"
     app:cardElevation="4dp">

--- a/app/src/main/res/layout-land/recently_played_fragment.xml
+++ b/app/src/main/res/layout-land/recently_played_fragment.xml
@@ -34,6 +34,7 @@
         app:navigationContentDescription="@string/go_to_previous_page"
         app:navigationIcon="?attr/homeAsUpIndicator"
         app:title="@string/recently_played_activity"
+        app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>
 
@@ -51,8 +52,8 @@
         android:layout_height="match_parent"
         android:clipToPadding="false"
         android:overScrollMode="never"
-        android:paddingTop="8dp"
-        android:paddingBottom="172dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="108dp"
         android:scrollbars="none"
         app:data="@{viewModel.ongoingStoryLiveData}"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />

--- a/app/src/main/res/layout-land/section_title.xml
+++ b/app/src/main/res/layout-land/section_title.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <data>
+
+    <import type="android.view.View" />
+
+    <variable
+      name="viewModel"
+      type="org.oppia.app.home.recentlyplayed.SectionTitleViewModel" />
+  </data>
+
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <View
+      android:id="@+id/divider_view"
+      android:layout_width="match_parent"
+      android:layout_height="1dp"
+      android:layout_marginTop="28dp"
+      android:background="@color/divider"
+      android:visibility="@{viewModel.isDividerVisible? View.VISIBLE : View.GONE}" />
+
+    <TextView
+      android:id="@+id/section_title_text_view"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="96dp"
+      android:layout_marginTop="28dp"
+      android:layout_marginEnd="96dp"
+      android:fontFamily="sans-serif-medium"
+      android:text="@{viewModel.sectionTitleText}"
+      android:textColor="@color/oppiaPrimaryText"
+      android:textSize="18sp" />
+  </LinearLayout>
+</layout>

--- a/app/src/main/res/layout/recently_played_fragment.xml
+++ b/app/src/main/res/layout/recently_played_fragment.xml
@@ -34,6 +34,7 @@
         app:navigationContentDescription="@string/go_to_previous_page"
         app:navigationIcon="?attr/homeAsUpIndicator"
         app:title="@string/recently_played_activity"
+        app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #885 

To test this PR in `HomeFragmentPresenter` inject `StoryProgressTestHelper` and mark dummy progress:
```
storyProgressTestHelper.markRecentlyPlayedForRatiosStory0Exploration0AndStory1Exploration2(profileId, false)
storyProgressTestHelper.markRecentlyPlayedForFractionsStory0Exploration0(profileId, true)
```

## Mocks
https://xd.adobe.com/view/0687f00c-695b-437a-79a6-688e7f4f7552-70b6/screen/2b6c8e95-5ac7-4472-bc2b-1c318a3f7e5c/HP-Continue-Playing-/
https://xd.adobe.com/view/ee9e607b-dbd6-4372-48dc-b687d32af3da-98af/screen/0e6ba726-1930-4f39-9c73-51df10a1c766/HP-Continue-Playing-/

## Screenshot
![Screenshot_1585300223](https://user-images.githubusercontent.com/9396084/77740693-b0cea180-7039-11ea-967a-a3ed22fa0dff.png)
![Screenshot_1585300300](https://user-images.githubusercontent.com/9396084/77740696-b4622880-7039-11ea-9719-cd1e6a5beaa1.png)
![Screenshot_1585300310](https://user-images.githubusercontent.com/9396084/77740698-b4fabf00-7039-11ea-9db4-d4af9aed26d6.png)

## Intentional Design Change
In cards of these stories, the mock contains a consistent shadow on all sides but in android whenever we use elevation shadow appears on three side and not at the top. Now this was communicated with Chantel last year and she said its fine if we follow android thing in this. But if we see the v7 mocks for `OngoingTopicList` and `CompletedStoryList` cards in this contains a very light border. This looks nice and good and therefore I am using that same border in this PR also, to make such cards look consistent.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
