### PR TITLE
Fix #895: Admin Auth high fi

### DIFF
--- a/app/src/main/res/drawable/edit_text_red_border.xml
+++ b/app/src/main/res/drawable/edit_text_red_border.xml
@@ -2,8 +2,8 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
   <stroke
     android:width="1dp"
-    android:color="@color/red" />
-  <corners android:radius="6dp" />
+    android:color="@color/editTextError" />
+  <corners android:radius="4dp" />
   <solid android:color="@color/white" />
   <padding
     android:left="10dp"

--- a/app/src/main/res/layout-land/admin_auth_activity.xml
+++ b/app/src/main/res/layout-land/admin_auth_activity.xml
@@ -113,6 +113,7 @@
             android:layout_marginTop="44dp"
             android:layout_marginEnd="28dp"
             android:background="@{viewModel.isSubmitButtonActive ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
+            android:clickable="@{viewModel.isSubmitButtonActive}"
             android:minHeight="48dp"
             android:text="@string/admin_auth_submit"
             android:textColor="@{viewModel.isSubmitButtonActive ? @color/white : @color/submitButtonInactiveText }"

--- a/app/src/main/res/layout-land/admin_auth_activity.xml
+++ b/app/src/main/res/layout-land/admin_auth_activity.xml
@@ -35,6 +35,7 @@
         app:navigationContentDescription="@string/admin_auth_close"
         app:navigationIcon="@drawable/ic_close_white_24dp"
         app:title="@string/admin_auth_toolbar"
+        app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>
 
@@ -50,40 +51,13 @@
         android:id="@+id/admin_auth_landscape_scrollView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:overScrollMode="never"
         android:scrollbars="none">
 
         <androidx.constraintlayout.widget.ConstraintLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:paddingBottom="92dp">
-
-          <Button
-            android:id="@+id/admin_auth_submit_button"
-            style="@style/StateButtonActive"
-            android:layout_marginEnd="28dp"
-            android:layout_marginTop="24dp"
-            android:background="@{viewModel.isSubmitButtonActive ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
-            android:minHeight="48dp"
-            android:text="@string/admin_auth_submit"
-            android:textColor="@{viewModel.isSubmitButtonActive ? @color/white : @color/submitButtonInactiveText }"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="@id/admin_auth_input_pin"
-            app:layout_constraintHorizontal_bias="1.0"
-            app:layout_constraintStart_toStartOf="@id/admin_auth_input_pin"
-            app:layout_constraintTop_toBottomOf="@id/admin_auth_input_pin" />
-
-          <TextView
-            android:id="@+id/admin_auth_sub_text"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:fontFamily="sans-serif"
-            android:text="@string/admin_auth_sub"
-            android:textColor="@color/oppiaPrimaryText"
-            android:textSize="16sp"
-            app:layout_constraintEnd_toEndOf="@+id/admin_auth_heading_textview"
-            app:layout_constraintStart_toStartOf="@+id/admin_auth_heading_textview"
-            app:layout_constraintTop_toBottomOf="@id/admin_auth_heading_textview" />
 
           <TextView
             android:id="@+id/admin_auth_heading_textview"
@@ -102,12 +76,25 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-            <org.oppia.app.profile.ProfileInputView
+          <TextView
+            android:id="@+id/admin_auth_sub_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:fontFamily="sans-serif"
+            android:text="@string/admin_auth_sub"
+            android:textColor="@color/black_54"
+            android:textSize="16sp"
+            app:layout_constraintEnd_toEndOf="@+id/admin_auth_heading_textview"
+            app:layout_constraintStart_toStartOf="@+id/admin_auth_heading_textview"
+            app:layout_constraintTop_toBottomOf="@id/admin_auth_heading_textview" />
+
+          <org.oppia.app.profile.ProfileInputView
             android:id="@+id/admin_auth_input_pin"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
             android:layout_marginStart="140dp"
+            android:layout_marginTop="16dp"
             android:layout_marginEnd="140dp"
             android:addTextChangedListener="@{viewModel.inputPinTextWatcher}"
             android:imeOptions="actionDone"
@@ -119,6 +106,21 @@
             app:layout_constraintTop_toBottomOf="@id/admin_auth_sub_text"
             profile:error="@{viewModel.errorMessage}"
             profile:labelMargin="@{@dimen/margin_8}" />
+
+          <Button
+            android:id="@+id/admin_auth_submit_button"
+            style="@style/StateButtonActive"
+            android:layout_marginTop="44dp"
+            android:layout_marginEnd="28dp"
+            android:background="@{viewModel.isSubmitButtonActive ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
+            android:minHeight="48dp"
+            android:text="@string/admin_auth_submit"
+            android:textColor="@{viewModel.isSubmitButtonActive ? @color/white : @color/submitButtonInactiveText }"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/admin_auth_input_pin"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="@id/admin_auth_input_pin"
+            app:layout_constraintTop_toBottomOf="@id/admin_auth_input_pin" />
         </androidx.constraintlayout.widget.ConstraintLayout>
       </ScrollView>
 

--- a/app/src/main/res/layout-land/profile_input_view.xml
+++ b/app/src/main/res/layout-land/profile_input_view.xml
@@ -28,19 +28,20 @@
       android:layout_marginTop="4dp"
       android:background="@drawable/add_profile_edit_text_background"
       android:fontFamily="sans-serif"
-      android:padding="8dp"
       android:minHeight="48dp"
+      android:padding="8dp"
+      android:saveEnabled="false"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="14sp"
-      android:textStyle="italic"
-      android:saveEnabled="false"/>
+      android:textStyle="italic" />
 
     <TextView
       android:id="@+id/error_text"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:fontFamily="sans-serif"
-      android:textSize="12sp"
-      android:textColor="@color/editTextError" />
+      android:gravity="top"
+      android:textColor="@color/editTextError"
+      android:textSize="12sp" />
   </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/admin_auth_activity.xml
+++ b/app/src/main/res/layout/admin_auth_activity.xml
@@ -106,6 +106,7 @@
           android:layout_marginEnd="28dp"
           android:layout_marginBottom="44dp"
           android:background="@{viewModel.isSubmitButtonActive ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
+          android:clickable="@{viewModel.isSubmitButtonActive}"
           android:minHeight="48dp"
           android:text="@string/admin_auth_submit"
           android:textColor="@{viewModel.isSubmitButtonActive ? @color/white : @color/submitButtonInactiveText }"

--- a/app/src/main/res/layout/admin_auth_activity.xml
+++ b/app/src/main/res/layout/admin_auth_activity.xml
@@ -36,6 +36,7 @@
         app:navigationContentDescription="@string/admin_auth_close"
         app:navigationIcon="@drawable/ic_close_white_24dp"
         app:title="@string/admin_auth_toolbar"
+        app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>
 
@@ -50,38 +51,6 @@
       <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-
-        <Button
-          android:id="@+id/admin_auth_submit_button"
-          style="@style/StateButtonActive"
-          android:layout_marginTop="44dp"
-          android:layout_marginEnd="28dp"
-          android:layout_marginBottom="44dp"
-          android:background="@{viewModel.isSubmitButtonActive ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
-          android:minHeight="48dp"
-          android:text="@string/admin_auth_submit"
-          android:textColor="@{viewModel.isSubmitButtonActive ? @color/white : @color/submitButtonInactiveText }"
-          app:layout_constraintBottom_toBottomOf="parent"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintHorizontal_bias="1.0"
-          app:layout_constraintStart_toStartOf="@+id/admin_auth_sub_text"
-          app:layout_constraintTop_toBottomOf="@id/admin_auth_input_pin"
-          app:layout_constraintVertical_bias="0.0" />
-
-        <TextView
-          android:id="@+id/admin_auth_sub_text"
-          android:layout_width="0dp"
-          android:layout_height="wrap_content"
-          android:layout_marginStart="28dp"
-          android:layout_marginTop="12dp"
-          android:layout_marginEnd="28dp"
-          android:fontFamily="sans-serif"
-          android:text="@string/admin_auth_sub"
-          android:textColor="@color/oppiaPrimaryText"
-          android:textSize="16sp"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@id/admin_auth_heading_textview" />
 
         <TextView
           android:id="@+id/admin_auth_heading_textview"
@@ -99,6 +68,21 @@
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toTopOf="parent" />
 
+        <TextView
+          android:id="@+id/admin_auth_sub_text"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_marginStart="28dp"
+          android:layout_marginTop="12dp"
+          android:layout_marginEnd="28dp"
+          android:fontFamily="sans-serif"
+          android:text="@string/admin_auth_sub"
+          android:textColor="@color/black_54"
+          android:textSize="16sp"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/admin_auth_heading_textview" />
+
         <org.oppia.app.profile.ProfileInputView
           android:id="@+id/admin_auth_input_pin"
           android:layout_width="match_parent"
@@ -114,6 +98,23 @@
           app:layout_constraintTop_toBottomOf="@id/admin_auth_sub_text"
           profile:error="@{viewModel.errorMessage}"
           profile:labelMargin="@{@dimen/margin_8}" />
+
+        <Button
+          android:id="@+id/admin_auth_submit_button"
+          style="@style/StateButtonActive"
+          android:layout_marginTop="44dp"
+          android:layout_marginEnd="28dp"
+          android:layout_marginBottom="44dp"
+          android:background="@{viewModel.isSubmitButtonActive ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
+          android:minHeight="48dp"
+          android:text="@string/admin_auth_submit"
+          android:textColor="@{viewModel.isSubmitButtonActive ? @color/white : @color/submitButtonInactiveText }"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintHorizontal_bias="1.0"
+          app:layout_constraintStart_toStartOf="@+id/admin_auth_sub_text"
+          app:layout_constraintTop_toBottomOf="@id/admin_auth_input_pin"
+          app:layout_constraintVertical_bias="0.0" />
       </androidx.constraintlayout.widget.ConstraintLayout>
 
       <View

--- a/app/src/sharedTest/java/org/oppia/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profile/AdminAuthActivityTest.kt
@@ -121,7 +121,7 @@ class AdminAuthActivityTest {
       )
     ).use {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.admin_auth_input_pin)))).perform(
-        typeText("123"),
+        typeText("12354"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_auth_submit_button)).perform(click())
@@ -131,12 +131,6 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).check(matches(withText(context.resources.getString(R.string.admin_auth_incorrect))))
-
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.admin_auth_input_pin)))).perform(
-        typeText("4"),
-        closeSoftKeyboard()
-      )
-      onView(allOf(withId(R.id.error_text), isDescendantOfA(withId(R.id.admin_auth_input_pin)))).check(matches(withText("")))
     }
   }
 
@@ -258,7 +252,7 @@ class AdminAuthActivityTest {
       )
     ).use {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.admin_auth_input_pin)))).perform(
-        typeText("123"),
+        typeText("12354"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_auth_submit_button)).perform(click())


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #895 

Mocks:  https://xd.adobe.com/view/0687f00c-695b-437a-79a6-688e7f4f7552-70b6/screen/785546bd-b160-4d9b-b5d6-53ddc1b4a80a/PC-MP-Admin-Authorization-Add-Profile-Empty-1
https://xd.adobe.com/view/ee9e607b-dbd6-4372-48dc-b687d32af3da-98af/screen/a0c84710-3970-4488-beea-6fe6abbdb38a/PC-MP-Admin-Authorization-Admin-Controls-Empty-

This PR changes some lowfi as well as finishes highfi.

## Screenshots:
![Screenshot_1585503745](https://user-images.githubusercontent.com/9396084/77856146-d1058880-7212-11ea-8231-dbfe94f7cce6.png)

![Screenshot_1585503750](https://user-images.githubusercontent.com/9396084/77856147-d4007900-7212-11ea-9b5f-e858cdd5768f.png)
![Screenshot_1585503758](https://user-images.githubusercontent.com/9396084/77856149-d4990f80-7212-11ea-918e-f33df7254048.png)
![Screenshot_1585503759](https://user-images.githubusercontent.com/9396084/77856150-d531a600-7212-11ea-9c76-6f25ddab505e.png)

When there is no text Accessibility Scanner fails which is expected result and when the pin has been entered Accessibility Scanner pass which is correct.

## Known Issues
1. The color of error was no where to be found and therefore the correct color was taken from https://xd.adobe.com/view/0687f00c-695b-437a-79a6-688e7f4f7552-70b6/screen/216ef636-187a-4c7a-b420-1aa48e95586d/PM-Q1-Fraction-Input-Incorrect-Input-2-
2. The subtext in landscape and portrait has different color codes and the correct one is that of portrait mode and therefore it was used in both.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
