### PR TITLE
Fix #899: Navigation Drawer Highfi

### DIFF
--- a/app/src/main/res/drawable/side_nav_bar.xml
+++ b/app/src/main/res/drawable/side_nav_bar.xml
@@ -1,9 +1,0 @@
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-  android:shape="rectangle">
-  <gradient
-    android:angle="135"
-    android:centerColor="@color/navBarHeaderBackground"
-    android:endColor="@color/navBarHeaderBackground"
-    android:startColor="@color/navBarHeaderBackground"
-    android:type="linear" />
-</shape>

--- a/app/src/main/res/layout/drawer_fragment.xml
+++ b/app/src/main/res/layout/drawer_fragment.xml
@@ -52,23 +52,26 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_gravity="bottom"
+          android:layout_marginTop="16dp"
+          android:layout_marginStart="24dp"
+          android:layout_marginEnd="24dp"
+          android:layout_marginBottom="36dp"
           android:orientation="horizontal"
-          android:padding="16dp"
+          android:paddingTop="16dp"
+          android:paddingBottom="16dp"
           android:visibility="@{footerViewModel.isAdmin ? View.VISIBLE : View.GONE}">
 
           <ImageView
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_gravity="center_vertical"
-            android:layout_margin="4dp"
             android:src="@drawable/ic_admin_settings_icon_brown_24dp" />
 
           <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
-            android:layout_marginStart="32dp"
-            android:layout_marginEnd="32dp"
+            android:layout_marginStart="12dp"
             android:fontFamily="sans-serif-medium"
             android:text="@string/administrator_controls"
             android:textColor="@color/highlightedNavMenuItem"

--- a/app/src/main/res/layout/nav_header_navigation_drawer.xml
+++ b/app/src/main/res/layout/nav_header_navigation_drawer.xml
@@ -13,8 +13,8 @@
   <LinearLayout
     android:id="@+id/header_linear_layout"
     android:layout_width="match_parent"
-    android:layout_height="176dp"
-    android:background="@drawable/side_nav_bar"
+    android:layout_height="wrap_content"
+    android:background="@color/navBarHeaderBackground"
     android:gravity="bottom"
     android:onClick="@{(v) -> viewModel.onHeaderClicked()}"
     android:orientation="vertical"
@@ -25,9 +25,8 @@
     android:theme="@style/ThemeOverlay.AppCompat.Dark">
 
     <de.hdodenhof.circleimageview.CircleImageView
-      android:layout_width="72dp"
-      android:layout_height="72dp"
-      android:paddingTop="8dp"
+      android:layout_width="64dp"
+      android:layout_height="64dp"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
@@ -37,10 +36,9 @@
       android:id="@+id/nav_header_profile_name"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:layout_marginTop="8dp"
       android:fontFamily="sans-serif-medium"
-      android:paddingTop="8dp"
       android:text="@{viewModel.profile.name}"
-      android:textAppearance="@style/TextAppearance.AppCompat.Body1"
       android:textColor="@color/white"
       android:textSize="14sp" />
 
@@ -48,6 +46,8 @@
       android:id="@+id/profile_progress_text_view"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:layout_marginTop="4dp"
+      android:layout_marginBottom="8dp"
       android:fontFamily="sans-serif"
       android:text="@{@plurals/completed_story_count(viewModel.completedStoryCount, viewModel.completedStoryCount).concat(@string/bar_separator).concat(@plurals/ongoing_topic_count(viewModel.ongoingTopicCount, viewModel.ongoingTopicCount))}"
       android:textColor="@color/white"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Mock: https://xd.adobe.com/view/0687f00c-695b-437a-79a6-688e7f4f7552-70b6/screen/79c56b13-218b-48fc-a403-b085d46953f3/Settings-Side-Menu-1

This PR does not follow the exact measurements mentioned in the mocks because those measurement were not aligning with the android navigation drawer design standards. Therefore for the footer of the drawer I had to make sure that I follow android standards rather than mock. As a result the app looks correct on HDPI as well as XHDPI devices.

## Screenshots (Firs 3 - HDPI last XHDPI)
![Screenshot_1585510963](https://user-images.githubusercontent.com/9396084/77858967-4cbc0100-7224-11ea-9a31-f9138b1f1dff.png)
![Screenshot_1585510973](https://user-images.githubusercontent.com/9396084/77858970-4f1e5b00-7224-11ea-92a3-2a3c2bfecec6.png)
![Screenshot_1585510977](https://user-images.githubusercontent.com/9396084/77858971-4fb6f180-7224-11ea-88f4-b1daa65d38b6.png)
![Screenshot_1585511068](https://user-images.githubusercontent.com/9396084/77858972-504f8800-7224-11ea-836d-956965316def.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
