### PR TITLE
Fix #909: Highfi StoryTextSizeActivity

### DIFF
--- a/app/src/main/res/drawable/story_text_size_seekbar_thumb.xml
+++ b/app/src/main/res/drawable/story_text_size_seekbar_thumb.xml
@@ -1,0 +1,10 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+  <item>
+    <shape android:shape="oval">
+      <size
+        android:width="12dp"
+        android:height="12dp" />
+      <solid android:color="@color/oppiaPrimaryLight"/>
+    </shape>
+  </item>
+</layer-list>

--- a/app/src/main/res/layout-land/story_text_size_activity.xml
+++ b/app/src/main/res/layout-land/story_text_size_activity.xml
@@ -104,6 +104,11 @@
                 android:paddingStart="8dp"
                 android:paddingEnd="8dp">
 
+                <View
+                  android:layout_width="1dp"
+                  android:layout_height="match_parent"
+                  android:background="@color/seekbarDivider" />
+
                 <Space
                   android:layout_width="0dp"
                   android:layout_height="match_parent"

--- a/app/src/main/res/layout-land/story_text_size_activity.xml
+++ b/app/src/main/res/layout-land/story_text_size_activity.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools">
+  xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
@@ -27,94 +26,145 @@
         app:navigationContentDescription="@string/go_to_previous_page"
         app:navigationIcon="?attr/homeAsUpIndicator"
         app:title="@string/title_story_text_size"
+        app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
       android:layout_width="0dp"
       android:layout_height="0dp"
-      android:background="@color/profileEditBackground"
+      android:background="@color/generalNavigationBackground"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintHorizontal_bias="0.0"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/story_list_app_bar_layout"
-      app:layout_constraintVertical_bias="1.0">
+      app:layout_constraintTop_toBottomOf="@id/story_list_app_bar_layout">
 
-      <LinearLayout
+      <ScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/white"
-        android:orientation="vertical">
+        android:overScrollMode="never"
+        android:scrollbars="none">
 
-        <TextView
-          android:id="@+id/preview_textview"
-          android:layout_width="match_parent"
-          android:layout_height="116dp"
-          android:fontFamily="sans-serif"
-          android:gravity="center"
-          android:text="@string/story_text_will_look_like_this" />
-
-        <View
-          android:layout_width="match_parent"
-          android:layout_height="1dp"
-          android:background="@drawable/toolbar_drop_shadow" />
-
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
+          android:layout_marginTop="12dp"
           android:background="@color/white"
-          android:orientation="horizontal">
+          android:orientation="vertical">
 
           <TextView
-            android:id="@+id/story_text_size_small_textview"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="168dp"
-            android:layout_marginTop="32dp"
-            android:layout_marginBottom="32dp"
-            android:gravity="center"
-            android:text="@string/constant_string_for_text_size"
-            android:textSize="16sp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-          <SeekBar
-            android:id="@+id/story_text_size_seekBar"
+            android:id="@+id/preview_textview"
             android:layout_width="match_parent"
-            android:layout_height="12dp"
-            android:layout_marginStart="192dp"
-            android:layout_marginTop="36dp"
-            android:layout_marginEnd="204dp"
-            android:layout_marginBottom="36dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/story_text_size_big_textview"
-            app:layout_constraintStart_toEndOf="@+id/story_text_size_small_textview"
-            app:layout_constraintTop_toTopOf="parent" />
-
-          <TextView
-            android:id="@+id/story_text_size_big_textview"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="32dp"
-            android:layout_marginEnd="168dp"
-            android:layout_marginBottom="32dp"
+            android:layout_height="116dp"
             android:fontFamily="sans-serif"
             android:gravity="center"
-            android:text="@string/constant_string_for_text_size"
-            android:textSize="28sp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.0" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-      </LinearLayout>
+            android:text="@string/story_text_will_look_like_this"
+            android:textColor="@color/oppiaPrimaryText"
+            android:textSize="16sp" />
+
+          <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/black_12" />
+
+          <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="84dp"
+            android:background="@color/white"
+            android:orientation="horizontal">
+
+            <TextView
+              android:id="@+id/story_text_size_small_textview"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_marginStart="168dp"
+              android:fontFamily="sans-serif"
+              android:gravity="center"
+              android:text="@string/constant_string_for_text_size"
+              android:textColor="@color/oppiaPrimaryText"
+              android:textSize="16sp"
+              app:layout_constraintBottom_toBottomOf="parent"
+              app:layout_constraintStart_toStartOf="parent"
+              app:layout_constraintTop_toTopOf="parent" />
+
+            <FrameLayout
+              android:layout_width="0dp"
+              android:layout_height="12dp"
+              android:layout_marginStart="4dp"
+              android:layout_marginEnd="4dp"
+              app:layout_constraintBottom_toBottomOf="parent"
+              app:layout_constraintEnd_toStartOf="@+id/story_text_size_big_textview"
+              app:layout_constraintStart_toEndOf="@+id/story_text_size_small_textview"
+              app:layout_constraintTop_toTopOf="parent">
+
+              <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="horizontal"
+                android:paddingStart="8dp"
+                android:paddingEnd="8dp">
+
+                <Space
+                  android:layout_width="0dp"
+                  android:layout_height="match_parent"
+                  android:layout_weight="1" />
+
+                <View
+                  android:layout_width="1dp"
+                  android:layout_height="match_parent"
+                  android:background="@color/seekbarDivider" />
+
+                <Space
+                  android:layout_width="0dp"
+                  android:layout_height="match_parent"
+                  android:layout_weight="1" />
+
+                <View
+                  android:layout_width="1dp"
+                  android:layout_height="match_parent"
+                  android:background="@color/seekbarDivider" />
+
+                <Space
+                  android:layout_width="0dp"
+                  android:layout_height="match_parent"
+                  android:layout_weight="1" />
+
+                <View
+                  android:layout_width="1dp"
+                  android:layout_height="match_parent"
+                  android:background="@color/seekbarDivider" />
+              </LinearLayout>
+
+              <SeekBar
+                android:id="@+id/story_text_size_seekBar"
+                style="@style/StoryTextSizeSeekBar"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:paddingStart="8dp"
+                android:paddingEnd="8dp"
+                android:thumb="@drawable/story_text_size_seekbar_thumb" />
+            </FrameLayout>
+
+            <TextView
+              android:id="@+id/story_text_size_big_textview"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_marginEnd="168dp"
+              android:fontFamily="sans-serif"
+              android:gravity="center"
+              android:text="@string/constant_string_for_text_size"
+              android:textColor="@color/oppiaPrimaryText"
+              android:textSize="28sp"
+              app:layout_constraintBottom_toBottomOf="parent"
+              app:layout_constraintEnd_toEndOf="parent"
+              app:layout_constraintTop_toTopOf="parent" />
+          </androidx.constraintlayout.widget.ConstraintLayout>
+        </LinearLayout>
+      </ScrollView>
 
       <View
-        android:id="@+id/story_text_size_toolbar_shadow_view"
         android:layout_width="match_parent"
-        android:layout_height="12dp"
+        android:layout_height="8dp"
         android:background="@drawable/toolbar_drop_shadow" />
     </FrameLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/story_text_size_activity.xml
+++ b/app/src/main/res/layout/story_text_size_activity.xml
@@ -97,6 +97,11 @@
               android:paddingStart="8dp"
               android:paddingEnd="8dp">
 
+              <View
+                android:layout_width="1dp"
+                android:layout_height="match_parent"
+                android:background="@color/seekbarDivider" />
+
               <Space
                 android:layout_width="0dp"
                 android:layout_height="match_parent"

--- a/app/src/main/res/layout/story_text_size_activity.xml
+++ b/app/src/main/res/layout/story_text_size_activity.xml
@@ -32,7 +32,7 @@
     <FrameLayout
       android:layout_width="0dp"
       android:layout_height="0dp"
-      android:background="@color/profileEditBackground"
+      android:background="@color/generalNavigationBackground"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
@@ -41,25 +41,28 @@
       <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="28dp"
         android:background="@color/white"
         android:orientation="vertical">
 
         <TextView
           android:id="@+id/preview_textview"
           android:layout_width="match_parent"
-          android:layout_height="200dp"
+          android:layout_height="196dp"
           android:fontFamily="sans-serif"
           android:gravity="center"
-          android:text="@string/story_text_will_look_like_this" />
+          android:text="@string/story_text_will_look_like_this"
+          android:textColor="@color/oppiaPrimaryText"
+          android:textSize="16sp" />
 
         <View
           android:layout_width="match_parent"
           android:layout_height="1dp"
-          android:background="@drawable/toolbar_drop_shadow" />
+          android:background="@color/black_12" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
           android:layout_width="match_parent"
-          android:layout_height="wrap_content"
+          android:layout_height="132dp"
           android:background="@color/white"
           android:orientation="horizontal">
 
@@ -68,48 +71,90 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="32dp"
-            android:layout_marginTop="60dp"
-            android:layout_marginBottom="60dp"
+            android:fontFamily="sans-serif"
             android:gravity="center"
             android:text="@string/constant_string_for_text_size"
+            android:textColor="@color/oppiaPrimaryText"
             android:textSize="16sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-          <SeekBar
-            android:id="@+id/story_text_size_seekBar"
-            android:layout_width="match_parent"
-            android:layout_height="27dp"
-            android:layout_marginStart="44dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="44dp"
-            android:layout_marginBottom="8dp"
+          <FrameLayout
+            android:layout_width="0dp"
+            android:layout_height="12dp"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/story_text_size_big_textview"
             app:layout_constraintStart_toEndOf="@+id/story_text_size_small_textview"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent">
+
+            <LinearLayout
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="horizontal"
+              android:paddingStart="8dp"
+              android:paddingEnd="8dp">
+
+              <Space
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1" />
+
+              <View
+                android:layout_width="1dp"
+                android:layout_height="match_parent"
+                android:background="@color/seekbarDivider" />
+
+              <Space
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1" />
+
+              <View
+                android:layout_width="1dp"
+                android:layout_height="match_parent"
+                android:background="@color/seekbarDivider" />
+
+              <Space
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1" />
+
+              <View
+                android:layout_width="1dp"
+                android:layout_height="match_parent"
+                android:background="@color/seekbarDivider" />
+            </LinearLayout>
+
+            <SeekBar
+              android:id="@+id/story_text_size_seekBar"
+              style="@style/StoryTextSizeSeekBar"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:paddingStart="8dp"
+              android:paddingEnd="8dp"
+              android:thumb="@drawable/story_text_size_seekbar_thumb" />
+          </FrameLayout>
 
           <TextView
             android:id="@+id/story_text_size_big_textview"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="60dp"
             android:layout_marginEnd="32dp"
-            android:layout_marginBottom="60dp"
             android:fontFamily="sans-serif"
             android:gravity="center"
             android:text="@string/constant_string_for_text_size"
+            android:textColor="@color/oppiaPrimaryText"
             android:textSize="28sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.0" />
+            app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
       </LinearLayout>
 
       <View
-        android:id="@+id/story_text_size_toolbar_shadow_view"
         android:layout_width="match_parent"
         android:layout_height="8dp"
         android:background="@drawable/toolbar_drop_shadow" />

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -34,4 +34,10 @@
     <item name="android:buttonBarNegativeButtonStyle">@style/textAllCaps</item>
     <item name="android:buttonBarPositiveButtonStyle">@style/textAllCaps</item>
   </style>
+
+  <style name="StoryTextSizeSeekBar" parent="Widget.AppCompat.SeekBar">
+    <item name="android:progressBackgroundTint">@color/black_26</item>
+    <item name="android:progressTint">@color/oppiaPrimaryLight</item>
+    <item name="android:colorControlActivated">@color/oppiaPrimaryLight</item>
+  </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,6 +11,7 @@
   <!-- OPPIA COLORS -->
   <color name="oppiaDarkBlue">#2D4A9D</color>
   <color name="oppiaPrimaryText">#333333</color>
+  <color name="oppiaPrimaryLight">#009688</color>
   <color name="oppiaPrimaryText30">#4D333333</color>
   <color name="oppiaPrimaryTextDark">#DE000000</color>
   <color name="oppiaPrimaryDark">#00645C</color>
@@ -41,6 +42,7 @@
   <color name="transparent">#00000000</color>
   <color name="black_12">#1F000000</color>
   <color name="black_20">#33000000</color>
+  <color name="black_26">#42000000</color>
   <color name="black_54">#8A000000</color>
   <color name="whiteLight">#F9F9F9</color>
   <color name="red">#FF0000</color>
@@ -121,4 +123,6 @@
   <color name="avatar_background_22">#AB29CC</color>
   <color name="avatar_background_23">#CC29B1</color>
   <color name="avatar_background_24">#CC2970</color>
+  <!-- StoryTextSizeActivity -->
+  <color name="seekbarDivider">#707070</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -279,7 +279,7 @@
   <string name="title_story_text_size">Story Text Size</string>
   <string name="title_app_language">App Language</string>
   <string name="title_default_audio">Default Audio Language</string>
-  <string name="story_text_will_look_like_this">Story text will look like this</string>
+  <string name="story_text_will_look_like_this">Story text will look like this.</string>
   <string name="constant_string_for_text_size">A</string>
   <string name="audio_language">Default Audio</string>
   <string name="app_language">App Language</string>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #909

Mock: https://xd.adobe.com/view/0687f00c-695b-437a-79a6-688e7f4f7552-70b6/screen/2eaf085a-c2a7-4b1d-b515-5b32f8642669/OP-Story-Text-Size-

https://xd.adobe.com/view/ee9e607b-dbd6-4372-48dc-b687d32af3da-98af/screen/2eaf085a-c2a7-4b1d-b515-5b32f8642669/OP-Story-Text-Size-

## Screenshot
![Screenshot_1585555780](https://user-images.githubusercontent.com/9396084/77889957-51b49b00-728c-11ea-97f7-1516a0a410da.png)
![Screenshot_1585555782](https://user-images.githubusercontent.com/9396084/77889965-5416f500-728c-11ea-8b5c-f001e1679545.png)

## Accessibility Test:
The accessibility test fails because `A` is appearing twice in this screen. This failure is acceptable as the UX is correct for this case.
![as_9](https://user-images.githubusercontent.com/9396084/77935280-dcb68500-72ce-11ea-93aa-b115b9efcdb2.png)

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
