### PR TITLE
Fix #41: Highfi StoryActivity Updated

### DIFF
--- a/app/src/main/java/org/oppia/app/databinding/DrawableBindingAdapters.kt
+++ b/app/src/main/java/org/oppia/app/databinding/DrawableBindingAdapters.kt
@@ -14,6 +14,13 @@ fun setBackgroundDrawable(view: View, @ColorInt colorRgb: Int) {
   (view.background as GradientDrawable).setColor((0xff000000 or colorRgb.toLong()).toInt())
 }
 
+@BindingAdapter("app:topRoundedRectDrawableWithColor")
+fun setTopBackgroundDrawable(view: View, @ColorInt colorRgb: Int) {
+  view.setBackgroundResource(R.drawable.top_rounded_rect_background)
+  // The input color needs to have alpha channel prepended to it.
+  (view.background as GradientDrawable).setColor((0xff000000 or colorRgb.toLong()).toInt())
+}
+
 @BindingAdapter("app:bottomRoundedRectDrawableWithColor")
 fun setBottomBackgroundDrawable(view: View, @ColorInt colorRgb: Int) {
   view.setBackgroundResource(R.drawable.bottom_rounded_rect_background)

--- a/app/src/main/res/drawable/top_rounded_rect_background.xml
+++ b/app/src/main/res/drawable/top_rounded_rect_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?><!-- https://stackoverflow.com/a/16161493/3689782 -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+  <corners
+    android:bottomLeftRadius="0dp"
+    android:bottomRightRadius="0dp"
+    android:topLeftRadius="4dp"
+    android:topRightRadius="4dp" />
+</shape>

--- a/app/src/main/res/layout-land/story_chapter_view.xml
+++ b/app/src/main/res/layout-land/story_chapter_view.xml
@@ -27,9 +27,7 @@
       android:clickable="@{viewModel.chapterSummary.chapterPlayState != ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES}"
       android:onClick="@{(v) -> viewModel.onExplorationClicked()}"
       app:cardCornerRadius="4dp"
-      app:cardElevation="@{viewModel.chapterSummary.chapterPlayState != ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES ? @dimen/elevation_4dp : @dimen/elevation_0dp}"
-      app:strokeColor="@{viewModel.chapterSummary.chapterPlayState != ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES ? @color/colorPrimary : @color/chapterCardGreyBorder}"
-      app:strokeWidth="2dp">
+      app:cardElevation="@{viewModel.chapterSummary.chapterPlayState != ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES ? @dimen/elevation_4dp : @dimen/elevation_0dp}">
 
       <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout-land/story_fragment.xml
+++ b/app/src/main/res/layout-land/story_fragment.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:tools="http://schemas.android.com/tools"
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools">
 
   <data>
+
     <variable
       name="viewModel"
       type="org.oppia.app.story.StoryViewModel" />
@@ -30,10 +31,10 @@
         android:background="?attr/colorPrimary"
         android:fontFamily="sans-serif"
         android:minHeight="?attr/actionBarSize"
-        android:textSize="20sp"
         app:navigationContentDescription="@string/go_to_previous_page"
         app:navigationIcon="?attr/homeAsUpIndicator"
         app:title="@{viewModel.storyNameLiveData}"
+        app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>
 
@@ -49,6 +50,7 @@
         android:id="@+id/story_chapter_list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/white"
         android:clipToPadding="false"
         android:overScrollMode="never"
         android:paddingBottom="60dp"
@@ -61,9 +63,6 @@
         android:layout_width="match_parent"
         android:layout_height="6dp"
         android:background="@drawable/toolbar_drop_shadow" />
-
     </FrameLayout>
-
   </androidx.constraintlayout.widget.ConstraintLayout>
-
 </layout>

--- a/app/src/main/res/layout/story_chapter_view.xml
+++ b/app/src/main/res/layout/story_chapter_view.xml
@@ -27,9 +27,7 @@
       android:clickable="@{viewModel.chapterSummary.chapterPlayState != ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES}"
       android:onClick="@{(v) -> viewModel.onExplorationClicked()}"
       app:cardCornerRadius="4dp"
-      app:cardElevation="@{viewModel.chapterSummary.chapterPlayState != ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES ? @dimen/elevation_4dp : @dimen/elevation_0dp}"
-      app:strokeColor="@{viewModel.chapterSummary.chapterPlayState != ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES ? @color/colorPrimary : @color/chapterCardGreyBorder}"
-      app:strokeWidth="2dp">
+      app:cardElevation="@{viewModel.chapterSummary.chapterPlayState != ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES ? @dimen/elevation_4dp : @dimen/elevation_0dp}">
 
       <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -47,15 +45,7 @@
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toTopOf="parent"
-          app:roundedRectDrawableWithColor="@{viewModel.chapterThumbnail.backgroundColorRgb}" />
-
-        <View
-          android:layout_width="match_parent"
-          android:layout_height="2dp"
-          android:background="@{viewModel.chapterSummary.chapterPlayState !=ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES ? @color/colorPrimary : @color/chapterCardGreyBorder}"
-          app:layout_constraintBottom_toBottomOf="@id/chapter_thumbnail"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toStartOf="parent" />
+          app:topRoundedRectDrawableWithColor="@{viewModel.chapterThumbnail.backgroundColorRgb}" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
           android:layout_width="match_parent"
@@ -125,9 +115,11 @@
     <FrameLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:layout_margin="16dp"
+      android:layout_marginStart="28dp"
+      android:layout_marginTop="16dp"
+      android:layout_marginEnd="28dp"
+      android:layout_marginBottom="16dp"
       android:background="@color/chapterCardShadow"
-      android:padding="8dp"
       android:visibility="@{viewModel.chapterSummary.chapterPlayState == ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES ? View.VISIBLE : View.INVISIBLE}" />
   </FrameLayout>
 </layout>

--- a/app/src/main/res/layout/story_fragment.xml
+++ b/app/src/main/res/layout/story_fragment.xml
@@ -30,10 +30,10 @@
         android:background="?attr/colorPrimary"
         android:fontFamily="sans-serif"
         android:minHeight="?attr/actionBarSize"
-        android:textSize="20sp"
         app:navigationContentDescription="@string/go_to_previous_page"
         app:navigationIcon="?attr/homeAsUpIndicator"
         app:title="@{viewModel.storyNameLiveData}"
+        app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>
 
@@ -49,6 +49,7 @@
         android:id="@+id/story_chapter_list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/white"
         android:clipToPadding="false"
         android:overScrollMode="never"
         android:paddingBottom="@dimen/bottom_white_space"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

This issue was already fixed but now the mocks have updated. This PR deals with the highfi  work.

Mock Link: https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/5abb0ace-19ee-48b8-8154-919154f924d2/TP-CL-Chapter-List-/

Change mentioned by @mschanteltc :
- Border is removed from all sides.

## Screenshot:
![Screenshot_1585718800](https://user-images.githubusercontent.com/9396084/78102557-3b334e80-7408-11ea-9e02-9ac063283e4e.png)
![Screenshot_1585718805](https://user-images.githubusercontent.com/9396084/78102562-3ec6d580-7408-11ea-815f-0deb24062905.png)
![Screenshot_1585718884](https://user-images.githubusercontent.com/9396084/78102565-3f5f6c00-7408-11ea-953d-337bc7f67109.png)
![Screenshot_1585718888](https://user-images.githubusercontent.com/9396084/78102569-3ff80280-7408-11ea-80d2-fe6cfa8fbd68.png)

## Accessibility Tests:
The tests fail for the card which is not clickable and therefore it is fine.
![as_15](https://user-images.githubusercontent.com/9396084/78102766-bd237780-7408-11ea-8bbf-60ff07619c1b.png)
![as_16](https://user-images.githubusercontent.com/9396084/78102770-bdbc0e00-7408-11ea-888f-f40e35553636.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
