### PR TITLE
Fix part of #931: Lowfi-add-profile-update

### DIFF
--- a/app/src/main/java/org/oppia/app/profile/AddProfileActivity.kt
+++ b/app/src/main/java/org/oppia/app/profile/AddProfileActivity.kt
@@ -40,4 +40,9 @@ class AddProfileActivity : InjectableAppCompatActivity() {
     super.onActivityResult(requestCode, resultCode, data)
     addProfileFragmentPresenter.handleOnActivityResult(requestCode, resultCode, data)
   }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    addProfileFragmentPresenter.dismissAlertDialog()
+  }
 }

--- a/app/src/main/java/org/oppia/app/profile/AddProfileActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/profile/AddProfileActivityPresenter.kt
@@ -48,6 +48,7 @@ class AddProfileActivityPresenter @Inject constructor(
   private var inputtedPin = false
   private var checkboxStateClicked = false
   private var inputtedConfirmPin = false
+  private lateinit var alertDialog: AlertDialog
 
   @ExperimentalCoroutinesApi
   fun handleOnCreate() {
@@ -114,6 +115,9 @@ class AddProfileActivityPresenter @Inject constructor(
     binding.inputName.setInput(profileViewModel.inputName.get().toString())
     binding.inputPin.setInput(profileViewModel.inputPin.get().toString())
     binding.inputConfirmPin.setInput(profileViewModel.inputConfirmPin.get().toString())
+    if (profileViewModel.showInfoAlertPopup.get()!!) {
+      showInfoDialog()
+    }
   }
 
   private fun setValidPin(binding: AddProfileActivityBinding) {
@@ -244,11 +248,22 @@ class AddProfileActivityPresenter @Inject constructor(
   }
 
   private fun showInfoDialog() {
-    AlertDialog.Builder(activity as Context, R.style.AlertDialogTheme)
+    profileViewModel.showInfoAlertPopup.set(true)
+    alertDialog = AlertDialog.Builder(activity as Context, R.style.AlertDialogTheme)
       .setMessage(R.string.add_profile_pin_info)
       .setPositiveButton(R.string.add_profile_close) { dialog, _ ->
+        profileViewModel.showInfoAlertPopup.set(false)
         dialog.dismiss()
-      }.create().show()
+      }
+      .setCancelable(false)
+      .create()
+    alertDialog.show()
+  }
+
+  fun dismissAlertDialog() {
+    if (::alertDialog.isInitialized && alertDialog.isShowing) {
+      alertDialog.dismiss()
+    }
   }
 
   private fun getAddProfileViewModel(): AddProfileViewModel {

--- a/app/src/main/java/org/oppia/app/profile/AddProfileActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/profile/AddProfileActivityPresenter.kt
@@ -84,6 +84,7 @@ class AddProfileActivityPresenter @Inject constructor(
     binding.inputName.post {
       addTextChangedListener(binding.inputName) { name ->
         name?.let {
+          profileViewModel.isButtonActive.set(it.isNotEmpty())
           profileViewModel.nameErrorMsg.set("")
           profileViewModel.inputName.set(it.toString())
         }

--- a/app/src/main/java/org/oppia/app/profile/AddProfileViewModel.kt
+++ b/app/src/main/java/org/oppia/app/profile/AddProfileViewModel.kt
@@ -16,6 +16,7 @@ class AddProfileViewModel @Inject constructor() : ObservableViewModel() {
   val inputPin = ObservableField("")
   val inputConfirmPin = ObservableField("")
   val createPin = ObservableField(false)
+  val isButtonActive = ObservableField(false)
 
   fun clearAllErrorMessages() {
     pinErrorMsg.set("")

--- a/app/src/main/java/org/oppia/app/profile/AddProfileViewModel.kt
+++ b/app/src/main/java/org/oppia/app/profile/AddProfileViewModel.kt
@@ -17,6 +17,7 @@ class AddProfileViewModel @Inject constructor() : ObservableViewModel() {
   val inputConfirmPin = ObservableField("")
   val createPin = ObservableField(false)
   val isButtonActive = ObservableField(false)
+  val showInfoAlertPopup = ObservableField<Boolean>(false)
 
   fun clearAllErrorMessages() {
     pinErrorMsg.set("")

--- a/app/src/main/res/layout-land/add_profile_activity.xml
+++ b/app/src/main/res/layout-land/add_profile_activity.xml
@@ -12,166 +12,179 @@
       type="org.oppia.app.profile.AddProfileViewModel" />
   </data>
 
-  <ScrollView
-    android:id="@+id/scroll"
+  <FrameLayout
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/addProfileBackground">
+    android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <ScrollView
+      android:id="@+id/scroll"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:paddingTop="40dp"
-      android:paddingBottom="40dp">
-
-      <Button
-        android:id="@+id/create_button"
-        style="@style/StateButtonActive"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="60dp"
-        android:layout_marginEnd="32dp"
-        android:text="@string/add_profile_create_btn"
-        android:textAllCaps="true"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/pin_container" />
-
-      <CheckBox
-        android:id="@+id/checkbox_pin"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="24dp"
-        android:text="@string/add_profile_create_a_3_digit_pin"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/input_name" />
-
-      <ImageView
-        android:id="@+id/info_icon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:layout_marginEnd="40dp"
-        android:src="@drawable/ic_info_icon"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/checkbox_pin" />
-
-      <TextView
-        android:id="@+id/required_heading"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
-        android:layout_marginEnd="32dp"
-        android:text="@string/add_profile_required"
-        android:textSize="12sp"
-        app:layout_constraintTop_toBottomOf="@+id/upload_image_button" />
+      android:layout_height="match_parent"
+      android:background="@color/addProfileBackground">
 
       <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/pin_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:visibility="@{viewModel.createPin ? View.VISIBLE : View.GONE}"
-        app:layout_constraintTop_toBottomOf="@+id/checkbox_pin">
+        android:paddingTop="40dp"
+        android:paddingBottom="40dp">
+
+        <de.hdodenhof.circleimageview.CircleImageView
+          android:id="@+id/upload_image_button"
+          android:layout_width="136dp"
+          android:layout_height="136dp"
+          android:paddingBottom="8dp"
+          android:src="@drawable/ic_default_avatar"
+          app:civ_circle_background_color="@color/grey"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+          android:id="@+id/edit_image_fab"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:src="@drawable/ic_edit"
+          app:backgroundTint="@color/white"
+          app:fabSize="mini"
+          app:layout_constraintBottom_toBottomOf="@+id/upload_image_button"
+          app:layout_constraintEnd_toEndOf="@+id/upload_image_button" />
+
+        <org.oppia.app.profile.ProfileInputView
+          android:id="@+id/input_name"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          app:label="@string/add_profile_input_name"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@+id/required_heading"
+          profile:error="@{viewModel.nameErrorMsg}" />
+
+        <CheckBox
+          android:id="@+id/checkbox_pin"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginStart="24dp"
+          android:text="@string/add_profile_create_a_3_digit_pin"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@+id/input_name" />
+
+        <ImageView
+          android:id="@+id/info_icon"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginEnd="40dp"
+          android:src="@drawable/ic_info_icon"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toTopOf="@+id/checkbox_pin" />
+
+        <TextView
+          android:id="@+id/required_heading"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginStart="32dp"
+          android:layout_marginEnd="32dp"
+          android:text="@string/add_profile_required"
+          android:textSize="12sp"
+          app:layout_constraintTop_toBottomOf="@+id/upload_image_button" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
-          android:id="@+id/allow_download_container"
+          android:id="@+id/pin_container"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginStart="64dp"
-          android:layout_marginTop="32dp"
-          android:layout_marginEnd="32dp"
-          app:layout_constraintTop_toBottomOf="@+id/input_confirm_pin">
+          android:visibility="@{viewModel.createPin ? View.VISIBLE : View.GONE}"
+          app:layout_constraintTop_toBottomOf="@+id/checkbox_pin">
 
-          <LinearLayout
-            android:layout_width="0dp"
+          <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/allow_download_container"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginStart="64dp"
+            android:layout_marginTop="32dp"
             android:layout_marginEnd="32dp"
-            android:orientation="vertical"
-            app:layout_constraintEnd_toStartOf="@+id/allow_download_switch"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toBottomOf="@+id/input_confirm_pin">
 
-            <TextView
-              android:id="@+id/allow_download_heading"
+            <LinearLayout
+              android:layout_width="0dp"
+              android:layout_height="wrap_content"
+              android:layout_marginEnd="32dp"
+              android:orientation="vertical"
+              app:layout_constraintEnd_toStartOf="@+id/allow_download_switch"
+              app:layout_constraintStart_toStartOf="parent"
+              app:layout_constraintTop_toTopOf="parent">
+
+              <TextView
+                android:id="@+id/allow_download_heading"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/add_profile_allow_download_heading"
+                android:textColor="@{viewModel.validPin ? @color/black : @color/grey}"
+                android:textStyle="bold" />
+
+              <TextView
+                android:id="@+id/allow_download_sub"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/add_profile_allow_download_sub" />
+            </LinearLayout>
+
+            <Switch
+              android:id="@+id/allow_download_switch"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
-              android:text="@string/add_profile_allow_download_heading"
-              android:textColor="@{viewModel.validPin ? @color/black : @color/grey}"
-              android:textStyle="bold" />
+              android:clickable="@{viewModel.validPin ? true : false}"
+              app:layout_constraintEnd_toEndOf="parent"
+              app:layout_constraintTop_toTopOf="parent" />
+          </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <TextView
-              android:id="@+id/allow_download_sub"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:text="@string/add_profile_allow_download_sub" />
-          </LinearLayout>
-
-          <Switch
-            android:id="@+id/allow_download_switch"
-            android:layout_width="wrap_content"
+          <org.oppia.app.profile.ProfileInputView
+            android:id="@+id/input_confirm_pin"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:clickable="@{viewModel.validPin ? true : false}"
+            android:layout_marginStart="32dp"
+            app:inputLength="3"
+            app:isPasswordInput="true"
+            app:label="@string/add_profile_input_confirm_pin"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/input_pin"
+            profile:error="@{viewModel.confirmPinErrorMsg}" />
+
+          <org.oppia.app.profile.ProfileInputView
+            android:id="@+id/input_pin"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="32dp"
+            android:visibility="visible"
+            app:inputLength="3"
+            app:isPasswordInput="true"
+            app:label="@string/add_profile_input_pin"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            profile:error="@{viewModel.pinErrorMsg}" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <org.oppia.app.profile.ProfileInputView
-          android:id="@+id/input_confirm_pin"
-          android:layout_width="match_parent"
+        <Button
+          android:id="@+id/create_button"
+          style="@style/StateButtonActive"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginStart="32dp"
-          app:inputLength="3"
-          app:isPasswordInput="true"
-          app:label="@string/add_profile_input_confirm_pin"
+          android:layout_marginTop="60dp"
+          android:layout_marginEnd="32dp"
+          android:background="@{viewModel.isButtonActive() ? @drawable/state_button_primary_background : @drawable/start_button_transparent_background}"
+          android:clickable="@{viewModel.isButtonActive()}"
+          android:text="@string/add_profile_create_btn"
+          android:textAllCaps="true"
+          android:textColor="@{viewModel.isButtonActive() ? @color/white : @color/submitButtonInactiveText }"
           app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@+id/input_pin"
-          profile:error="@{viewModel.confirmPinErrorMsg}" />
-
-        <org.oppia.app.profile.ProfileInputView
-          android:id="@+id/input_pin"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginStart="32dp"
-          android:visibility="visible"
-          app:inputLength="3"
-          app:isPasswordInput="true"
-          app:label="@string/add_profile_input_pin"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toTopOf="parent"
-          profile:error="@{viewModel.pinErrorMsg}" />
+          app:layout_constraintTop_toBottomOf="@+id/pin_container" />
       </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
 
-      <de.hdodenhof.circleimageview.CircleImageView
-        android:id="@+id/upload_image_button"
-        android:layout_width="136dp"
-        android:layout_height="136dp"
-        app:civ_circle_background_color="@color/grey"
-        android:paddingBottom="8dp"
-        android:src="@drawable/ic_default_avatar"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-      <org.oppia.app.profile.ProfileInputView
-        android:id="@+id/input_name"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:label="@string/add_profile_input_name"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/required_heading"
-        profile:error="@{viewModel.nameErrorMsg}" />
-
-      <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/edit_image_fab"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_edit"
-        app:backgroundTint="@color/white"
-        app:fabSize="mini"
-        app:layout_constraintBottom_toBottomOf="@+id/upload_image_button"
-        app:layout_constraintEnd_toEndOf="@+id/upload_image_button" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-  </ScrollView>
+    <View
+      android:layout_width="match_parent"
+      android:layout_height="6dp"
+      android:background="@drawable/toolbar_drop_shadow" />
+  </FrameLayout>
 </layout>

--- a/app/src/main/res/layout/add_profile_activity.xml
+++ b/app/src/main/res/layout/add_profile_activity.xml
@@ -12,166 +12,179 @@
       type="org.oppia.app.profile.AddProfileViewModel" />
   </data>
 
-  <ScrollView
-    android:id="@+id/scroll"
+  <FrameLayout
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/addProfileBackground">
+    android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <ScrollView
+      android:id="@+id/scroll"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:paddingTop="40dp"
-      android:paddingBottom="40dp">
-
-      <Button
-        android:id="@+id/create_button"
-        style="@style/StateButtonActive"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="60dp"
-        android:layout_marginEnd="32dp"
-        android:text="@string/add_profile_create_btn"
-        android:textAllCaps="true"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/pin_container" />
-
-      <CheckBox
-        android:id="@+id/checkbox_pin"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="24dp"
-        android:text="@string/add_profile_create_a_3_digit_pin"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/input_name" />
-
-      <ImageView
-        android:id="@+id/info_icon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:layout_marginEnd="40dp"
-        android:src="@drawable/ic_info_icon"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/checkbox_pin" />
-
-      <TextView
-        android:id="@+id/required_heading"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
-        android:layout_marginEnd="32dp"
-        android:text="@string/add_profile_required"
-        android:textSize="12sp"
-        app:layout_constraintTop_toBottomOf="@+id/upload_image_button" />
+      android:layout_height="match_parent"
+      android:background="@color/addProfileBackground">
 
       <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/pin_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:visibility="@{viewModel.createPin ? View.VISIBLE : View.GONE}"
-        app:layout_constraintTop_toBottomOf="@+id/checkbox_pin">
+        android:paddingTop="40dp"
+        android:paddingBottom="40dp">
+
+        <de.hdodenhof.circleimageview.CircleImageView
+          android:id="@+id/upload_image_button"
+          android:layout_width="136dp"
+          android:layout_height="136dp"
+          android:paddingBottom="8dp"
+          android:src="@drawable/ic_default_avatar"
+          app:civ_circle_background_color="@color/grey"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+          android:id="@+id/edit_image_fab"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:src="@drawable/ic_edit"
+          app:backgroundTint="@color/white"
+          app:fabSize="mini"
+          app:layout_constraintBottom_toBottomOf="@+id/upload_image_button"
+          app:layout_constraintEnd_toEndOf="@+id/upload_image_button" />
+
+        <org.oppia.app.profile.ProfileInputView
+          android:id="@+id/input_name"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          app:label="@string/add_profile_input_name"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@+id/required_heading"
+          profile:error="@{viewModel.nameErrorMsg}" />
+
+        <CheckBox
+          android:id="@+id/checkbox_pin"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginStart="24dp"
+          android:text="@string/add_profile_create_a_3_digit_pin"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@+id/input_name" />
+
+        <ImageView
+          android:id="@+id/info_icon"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginEnd="40dp"
+          android:src="@drawable/ic_info_icon"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toTopOf="@+id/checkbox_pin" />
+
+        <TextView
+          android:id="@+id/required_heading"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginStart="32dp"
+          android:layout_marginEnd="32dp"
+          android:text="@string/add_profile_required"
+          android:textSize="12sp"
+          app:layout_constraintTop_toBottomOf="@+id/upload_image_button" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
-          android:id="@+id/allow_download_container"
+          android:id="@+id/pin_container"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginStart="64dp"
-          android:layout_marginTop="32dp"
-          android:layout_marginEnd="32dp"
-          app:layout_constraintTop_toBottomOf="@+id/input_confirm_pin">
+          android:visibility="@{viewModel.createPin ? View.VISIBLE : View.GONE}"
+          app:layout_constraintTop_toBottomOf="@+id/checkbox_pin">
 
-          <LinearLayout
-            android:layout_width="0dp"
+          <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/allow_download_container"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginStart="64dp"
+            android:layout_marginTop="32dp"
             android:layout_marginEnd="32dp"
-            android:orientation="vertical"
-            app:layout_constraintEnd_toStartOf="@+id/allow_download_switch"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toBottomOf="@+id/input_confirm_pin">
 
-            <TextView
-              android:id="@+id/allow_download_heading"
+            <LinearLayout
+              android:layout_width="0dp"
+              android:layout_height="wrap_content"
+              android:layout_marginEnd="32dp"
+              android:orientation="vertical"
+              app:layout_constraintEnd_toStartOf="@+id/allow_download_switch"
+              app:layout_constraintStart_toStartOf="parent"
+              app:layout_constraintTop_toTopOf="parent">
+
+              <TextView
+                android:id="@+id/allow_download_heading"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/add_profile_allow_download_heading"
+                android:textColor="@{viewModel.validPin ? @color/black : @color/grey}"
+                android:textStyle="bold" />
+
+              <TextView
+                android:id="@+id/allow_download_sub"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/add_profile_allow_download_sub" />
+            </LinearLayout>
+
+            <Switch
+              android:id="@+id/allow_download_switch"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
-              android:text="@string/add_profile_allow_download_heading"
-              android:textColor="@{viewModel.validPin ? @color/black : @color/grey}"
-              android:textStyle="bold" />
+              android:clickable="@{viewModel.validPin ? true : false}"
+              app:layout_constraintEnd_toEndOf="parent"
+              app:layout_constraintTop_toTopOf="parent" />
+          </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <TextView
-              android:id="@+id/allow_download_sub"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:text="@string/add_profile_allow_download_sub" />
-          </LinearLayout>
-
-          <Switch
-            android:id="@+id/allow_download_switch"
-            android:layout_width="wrap_content"
+          <org.oppia.app.profile.ProfileInputView
+            android:id="@+id/input_confirm_pin"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:clickable="@{viewModel.validPin ? true : false}"
+            android:layout_marginStart="32dp"
+            app:inputLength="3"
+            app:isPasswordInput="true"
+            app:label="@string/add_profile_input_confirm_pin"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/input_pin"
+            profile:error="@{viewModel.confirmPinErrorMsg}" />
+
+          <org.oppia.app.profile.ProfileInputView
+            android:id="@+id/input_pin"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="32dp"
+            android:visibility="visible"
+            app:inputLength="3"
+            app:isPasswordInput="true"
+            app:label="@string/add_profile_input_pin"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            profile:error="@{viewModel.pinErrorMsg}" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <org.oppia.app.profile.ProfileInputView
-          android:id="@+id/input_confirm_pin"
-          android:layout_width="match_parent"
+        <Button
+          android:id="@+id/create_button"
+          style="@style/StateButtonActive"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginStart="32dp"
-          app:inputLength="3"
-          app:isPasswordInput="true"
-          app:label="@string/add_profile_input_confirm_pin"
+          android:layout_marginTop="60dp"
+          android:layout_marginEnd="32dp"
+          android:background="@{viewModel.isButtonActive() ? @drawable/state_button_primary_background : @drawable/start_button_transparent_background}"
+          android:clickable="@{viewModel.isButtonActive()}"
+          android:text="@string/add_profile_create_btn"
+          android:textAllCaps="true"
+          android:textColor="@{viewModel.isButtonActive() ? @color/white : @color/submitButtonInactiveText }"
           app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@+id/input_pin"
-          profile:error="@{viewModel.confirmPinErrorMsg}" />
-
-        <org.oppia.app.profile.ProfileInputView
-          android:id="@+id/input_pin"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginStart="32dp"
-          android:visibility="visible"
-          app:inputLength="3"
-          app:isPasswordInput="true"
-          app:label="@string/add_profile_input_pin"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toTopOf="parent"
-          profile:error="@{viewModel.pinErrorMsg}" />
+          app:layout_constraintTop_toBottomOf="@+id/pin_container" />
       </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
 
-      <de.hdodenhof.circleimageview.CircleImageView
-        android:id="@+id/upload_image_button"
-        android:layout_width="136dp"
-        android:layout_height="136dp"
-        app:civ_circle_background_color="@color/grey"
-        android:paddingBottom="8dp"
-        android:src="@drawable/ic_default_avatar"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-      <org.oppia.app.profile.ProfileInputView
-        android:id="@+id/input_name"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:label="@string/add_profile_input_name"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/required_heading"
-        profile:error="@{viewModel.nameErrorMsg}" />
-
-      <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/edit_image_fab"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_edit"
-        app:backgroundTint="@color/white"
-        app:fabSize="mini"
-        app:layout_constraintBottom_toBottomOf="@+id/upload_image_button"
-        app:layout_constraintEnd_toEndOf="@+id/upload_image_button" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-  </ScrollView>
+    <View
+      android:layout_width="match_parent"
+      android:layout_height="6dp"
+      android:background="@drawable/toolbar_drop_shadow" />
+  </FrameLayout>
 </layout>

--- a/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
@@ -8,15 +8,24 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.Resources
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.provider.MediaStore
+import android.view.View
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.PerformException
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
 import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.idling.CountingIdlingResource
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.Intents.intending
@@ -30,6 +39,8 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.util.HumanReadables
+import androidx.test.espresso.util.TreeIterables
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.BindsInstance
 import dagger.Component
@@ -54,6 +65,9 @@ import org.oppia.util.logging.GlobalLogLevel
 import org.oppia.util.logging.LogLevel
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
+import java.util.concurrent.AbstractExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -61,18 +75,21 @@ import javax.inject.Singleton
 @RunWith(AndroidJUnit4::class)
 class AddProfileActivityTest {
 
-  @Inject lateinit var context: Context
-  @Inject lateinit var profileTestHelper: ProfileTestHelper
+  @Inject
+  lateinit var context: Context
+  @Inject
+  lateinit var profileTestHelper: ProfileTestHelper
 
   @Before
-  @ExperimentalCoroutinesApi
   fun setUp() {
     Intents.init()
     setUpTestApplicationComponent()
+    IdlingRegistry.getInstance().register(MainThreadExecutor.countingResource)
   }
 
   @After
   fun tearDown() {
+    IdlingRegistry.getInstance().unregister(MainThreadExecutor.countingResource)
     Intents.release()
   }
 
@@ -89,7 +106,8 @@ class AddProfileActivityTest {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("test"), closeSoftKeyboard()
       )
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       intended(hasComponent(ProfileActivity::class.java.name))
     }
   }
@@ -98,10 +116,12 @@ class AddProfileActivityTest {
   fun testAddProfileActivity_changeConfiguration_inputName_clickCreate_checkOpensProfileActivity() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+      onView(allOf(withId(R.id.checkbox_pin))).perform(scrollTo())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(scrollTo()).perform(
         typeText("test"), closeSoftKeyboard()
       )
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       intended(hasComponent(ProfileActivity::class.java.name))
     }
   }
@@ -119,7 +139,8 @@ class AddProfileActivityTest {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(allOf(withId(R.id.checkbox_pin))).perform(scrollTo()).perform(click())
-      onView(withId(R.id.input_pin)).perform(scrollTo()).check(matches(isDisplayed()))
+      onView(withId(R.id.input_pin)).perform(scrollTo())
+      onView(withId(R.id.input_pin)).check(matches(isDisplayed()))
     }
   }
 
@@ -138,37 +159,52 @@ class AddProfileActivityTest {
     }
   }
 
+  //
+//  @Test
+//  fun testAddProfileActivity_inputName_inputPin_clickCreate_checkOpensProfileActivity() {
+//    launch(AddProfileActivity::class.java).use {
+//      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+//        typeText("test"),
+//        closeSoftKeyboard()
+//      )
+//      onView(withId(R.id.checkbox_pin)).perform(click())
+//      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
+//        typeText("123"),
+//        closeSoftKeyboard()
+//      )
+//      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+//      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
+//        typeText("123"),
+//        closeSoftKeyboard()
+//      )
+//      onView(withId(R.id.create_button)).perform(scrollTo())
+//      onView(withId(R.id.create_button)).perform(click())
+//      intended(hasComponent(ProfileActivity::class.java.name))
+//    }
+//  }
+//
   @Test
-  fun testAddProfileActivity_inputName_inputPin_clickCreate_checkOpensProfileActivity() {
+  fun testAddProfileActivity_changeConfiguration_inputName_inputPin_clickCreate_checkOpensProfileActivity() {
     launch(AddProfileActivity::class.java).use {
+      onView(isRoot()).perform(orientationLandscape())
+      onView(allOf(withId(R.id.checkbox_pin))).perform(scrollTo())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("test"),
         closeSoftKeyboard()
       )
-      onView(withId(R.id.checkbox_pin)).perform(click())
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
         typeText("123"),
         closeSoftKeyboard()
       )
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("123"), closeSoftKeyboard())
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
-      intended(hasComponent(ProfileActivity::class.java.name))
-    }
-  }
-
-  @Test
-  fun testAddProfileActivity_changeConfiguration_inputName_inputPin_clickCreate_checkOpensProfileActivity() {
-    launch(AddProfileActivity::class.java).use {
-      onView(isRoot()).perform(orientationLandscape())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(scrollTo())
-        .perform(typeText("test"), closeSoftKeyboard())
-      onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(typeText("123"), closeSoftKeyboard())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("123"), closeSoftKeyboard())
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
+        typeText("123"),
+        closeSoftKeyboard()
+      )
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       intended(hasComponent(ProfileActivity::class.java.name))
     }
   }
@@ -176,7 +212,8 @@ class AddProfileActivityTest {
   @Test
   fun testAddProfileActivity_checkCreateIsNotClickable() {
     launch(AddProfileActivity::class.java).use {
-      onView(withId(R.id.create_button)).perform(scrollTo()).check(matches(not(isClickable())))
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).check(matches(not(isClickable())))
     }
   }
 
@@ -184,7 +221,8 @@ class AddProfileActivityTest {
   fun testAddProfileActivity_changeConfiguration_checkCreateIsNotClickable() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
-      onView(withId(R.id.create_button)).perform(scrollTo()).check(matches(not(isClickable())))
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).check(matches(not(isClickable())))
     }
   }
 
@@ -196,7 +234,8 @@ class AddProfileActivityTest {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("Rajat"), closeSoftKeyboard()
       )
-      onView(withId(R.id.create_button)).perform(scrollTo()).check(matches(isClickable()))
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).check(matches(isClickable()))
     }
   }
 
@@ -221,7 +260,9 @@ class AddProfileActivityTest {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("Sean"), closeSoftKeyboard()
       )
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      waitForTheView(withId(R.id.create_button))
+      onView(withId(R.id.create_button)).perform(click())
       onView(
         allOf(
           withId(R.id.error_text),
@@ -237,10 +278,11 @@ class AddProfileActivityTest {
     profileTestHelper.initializeProfiles()
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(scrollTo()).perform(
         typeText("Sean"), closeSoftKeyboard()
       )
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       onView(
         allOf(
           withId(R.id.error_text),
@@ -258,7 +300,8 @@ class AddProfileActivityTest {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("Sean"), closeSoftKeyboard()
       )
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText(" "), closeSoftKeyboard()
       )
@@ -277,10 +320,14 @@ class AddProfileActivityTest {
     profileTestHelper.initializeProfiles()
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
+      waitForTheView(withId(R.id.checkbox_pin))
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(scrollTo()).perform(
         typeText("Sean"), closeSoftKeyboard()
       )
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(scrollTo())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText(" "), closeSoftKeyboard()
       )
@@ -299,7 +346,8 @@ class AddProfileActivityTest {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("123"), closeSoftKeyboard()
       )
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       onView(
         allOf(
           withId(R.id.error_text),
@@ -313,10 +361,12 @@ class AddProfileActivityTest {
   fun testAddProfileActivity_changeConfiguration_inputNameWithNumbers_clickCreate_checkNameOnlyLettersError() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("123"), closeSoftKeyboard()
       )
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       onView(
         allOf(
           withId(R.id.error_text),
@@ -332,7 +382,8 @@ class AddProfileActivityTest {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("123"), closeSoftKeyboard()
       )
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText(" "), closeSoftKeyboard()
       )
@@ -349,10 +400,12 @@ class AddProfileActivityTest {
   fun testAddProfileActivity_changeConfiguration_inputNameWithNumbers_clickCreate_inputName_checkErrorIsCleared() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(scrollTo()).perform(
         typeText("123"), closeSoftKeyboard()
       )
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(scrollTo())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText(" "), closeSoftKeyboard()
       )
@@ -375,7 +428,8 @@ class AddProfileActivityTest {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
         typeText("12"), closeSoftKeyboard()
       )
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       onView(
         allOf(
           withId(R.id.error_text),
@@ -389,13 +443,18 @@ class AddProfileActivityTest {
   fun testAddProfileActivity_changeConfiguration_inputShortPin_clickCreate_checkPinLengthError() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(scrollTo()).perform(
         typeText("test"), closeSoftKeyboard()
       )
-      onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
+      onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(typeText("12"), closeSoftKeyboard())
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
+        typeText("12"),
+        closeSoftKeyboard()
+      )
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       onView(
         allOf(
           withId(R.id.error_text),
@@ -412,8 +471,9 @@ class AddProfileActivityTest {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
         typeText("12"), closeSoftKeyboard()
       )
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo()).perform(
         typeText("3"), closeSoftKeyboard()
       )
       onView(allOf(withId(R.id.error_text), isDescendantOfA(withId(R.id.input_pin)))).check(
@@ -428,12 +488,19 @@ class AddProfileActivityTest {
   fun testAddProfileActivity_changeConfiguration_inputShortPin_clickCreate_inputPin_checkErrorIsCleared() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
-      onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(typeText("12"), closeSoftKeyboard())
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
+      waitForTheView(withId(R.id.checkbox_pin))
+      onView(withId(R.id.checkbox_pin)).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo()).perform(
+        typeText("12"),
+        closeSoftKeyboard()
+      )
       onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(typeText("3"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
+        typeText("3"),
+        closeSoftKeyboard()
+      )
       onView(allOf(withId(R.id.error_text), isDescendantOfA(withId(R.id.input_pin)))).check(
         matches(
           withText("")
@@ -453,8 +520,9 @@ class AddProfileActivityTest {
         typeText("123"), closeSoftKeyboard()
       )
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("12"))
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(typeText("12"))
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       onView(allOf(withId(R.id.error_text), isDescendantOfA(withId(R.id.input_confirm_pin)))).check(
         matches(
           withText(
@@ -469,21 +537,36 @@ class AddProfileActivityTest {
   fun testAddProfileActivity_changeConfiguration_inputWrongConfirmPin_checkConfirmWrongError() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(scrollTo()).perform(
         typeText("test"), closeSoftKeyboard()
       )
-      onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
+      onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(typeText("123"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
+        typeText("123"),
+        closeSoftKeyboard()
+      )
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("12"), closeSoftKeyboard())
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
+        typeText("12"),
+        closeSoftKeyboard()
+      )
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       onView(
         allOf(
           withId(R.id.error_text),
           isDescendantOfA(withId(R.id.input_confirm_pin))
         )
-      ).perform(scrollTo()).check(
+      ).perform(scrollTo())
+      onView(
+        allOf(
+          withId(R.id.error_text),
+          isDescendantOfA(withId(R.id.input_confirm_pin))
+        )
+      ).check(
         matches(
           withText(
             context.getString(R.string.add_profile_error_pin_confirm_wrong)
@@ -496,14 +579,25 @@ class AddProfileActivityTest {
   @Test
   fun testAddProfileActivity_inputWrongConfirmPin_inputConfirmPin_checkErrorIsCleared() {
     launch(AddProfileActivity::class.java).use {
-      onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
+      onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(typeText("123"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
+        typeText("123"),
+        closeSoftKeyboard()
+      )
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("12"), closeSoftKeyboard())
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
+        typeText("12"),
+        closeSoftKeyboard()
+      )
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("3"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
+        typeText("3"),
+        closeSoftKeyboard()
+      )
       onView(
         allOf(
           withId(R.id.error_text),
@@ -517,14 +611,23 @@ class AddProfileActivityTest {
   fun testAddProfileActivity_changeConfiguration_inputWrongConfirmPin_inputConfirmPin_checkErrorIsCleared() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
-      onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(typeText("123"), closeSoftKeyboard())
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
+      onView(withId(R.id.checkbox_pin)).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo()).perform(
+        typeText("123"),
+        closeSoftKeyboard()
+      )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo()).perform(
+        typeText("12"),
+        closeSoftKeyboard()
+      )
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("12"), closeSoftKeyboard())
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("3"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
+        typeText("3"),
+        closeSoftKeyboard()
+      )
       onView(
         allOf(
           withId(R.id.error_text),
@@ -550,8 +653,10 @@ class AddProfileActivityTest {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(typeText("123"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo()).perform(
+        typeText("123"),
+        closeSoftKeyboard()
+      )
       onView(withId(R.id.allow_download_switch)).check(matches(not(isClickable())))
     }
   }
@@ -565,7 +670,10 @@ class AddProfileActivityTest {
         closeSoftKeyboard()
       )
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("123"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
+        typeText("123"),
+        closeSoftKeyboard()
+      )
       onView(withId(R.id.allow_download_switch)).check(matches(isClickable()))
     }
   }
@@ -574,11 +682,19 @@ class AddProfileActivityTest {
   fun testAddProfileActivity_changeConfiguration_inputPin_inputConfirmPin_checkAllowDownloadClickable() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
-      onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
+      onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(typeText("123"), closeSoftKeyboard())
+      waitForTheView(withText(R.string.add_profile_input_name))
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
+        typeText("123"),
+        closeSoftKeyboard()
+      )
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("123"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
+        typeText("123"),
+        closeSoftKeyboard()
+      )
       onView(withId(R.id.allow_download_switch)).check(matches(isClickable()))
     }
   }
@@ -607,6 +723,7 @@ class AddProfileActivityTest {
     intending(expectedIntent).respondWith(activityResult)
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
+      onView(withId(R.id.upload_image_button)).perform(scrollTo())
       onView(withId(R.id.upload_image_button)).perform(click())
       intended(expectedIntent)
     }
@@ -636,6 +753,8 @@ class AddProfileActivityTest {
     intending(expectedIntent).respondWith(activityResult)
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
+      onView(withId(R.id.edit_image_fab)).perform(scrollTo())
+      waitForTheView(withId(R.id.edit_image_fab))
       onView(withId(R.id.edit_image_fab)).perform(click())
       intended(expectedIntent)
     }
@@ -671,9 +790,12 @@ class AddProfileActivityTest {
   @Test
   fun testAddProfileActivity_inputConfirmPin_changeConfiguration_checkConfirmPinIsDisplayed() {
     launch(AddProfileActivity::class.java).use {
-      onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("123"), closeSoftKeyboard())
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
+      onView(withId(R.id.checkbox_pin)).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo()).perform(
+        typeText("123"),
+        closeSoftKeyboard()
+      )
       onView(isRoot()).perform(orientationLandscape())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
         .check(matches(withText("123")))
@@ -692,14 +814,17 @@ class AddProfileActivityTest {
         typeText("123"), closeSoftKeyboard()
       )
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("123"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
+        typeText("123"),
+        closeSoftKeyboard()
+      )
       onView(isRoot()).perform(orientationLandscape())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(scrollTo())
-        .check(matches(withText("test")))
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).check(matches(withText("test")))
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .check(matches(withText("123")))
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).check(matches(withText("123")))
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .check(matches(withText("123")))
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).check(matches(withText("123")))
     }
   }
 
@@ -717,8 +842,10 @@ class AddProfileActivityTest {
       )
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
         .perform(typeText("123"), closeSoftKeyboard())
-      onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
+      onView(withId(R.id.checkbox_pin)).perform(click())
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       intended(hasComponent(ProfileActivity::class.java.name))
     }
   }
@@ -732,7 +859,8 @@ class AddProfileActivityTest {
         typeText("Sean"),
         closeSoftKeyboard()
       )
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       onView(isRoot()).perform(orientationLandscape())
       onView(
         allOf(
@@ -746,9 +874,11 @@ class AddProfileActivityTest {
   @Test
   fun testAddProfileActivity_selectCheckbox_changeConfiguration_checkboxIsSelected() {
     launch(AddProfileActivity::class.java).use {
-      onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
+      onView(withId(R.id.checkbox_pin)).perform(click())
       onView(isRoot()).perform(orientationLandscape())
-      onView(withId(R.id.checkbox_pin)).perform(scrollTo()).check(matches(isChecked()))
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
+      onView(withId(R.id.checkbox_pin)).check(matches(isChecked()))
     }
   }
 
@@ -761,12 +891,15 @@ class AddProfileActivityTest {
         closeSoftKeyboard()
       )
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("123"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
+        typeText("123"),
+        closeSoftKeyboard()
+      )
       onView(isRoot()).perform(orientationLandscape())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .check(matches(withText("123")))
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).check(matches(withText("123")))
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .check(matches(withText("123")))
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).check(matches(withText("123")))
     }
   }
 
@@ -783,15 +916,21 @@ class AddProfileActivityTest {
         closeSoftKeyboard()
       )
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("321"), closeSoftKeyboard())
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
+        typeText("321"),
+        closeSoftKeyboard()
+      )
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
       onView(isRoot()).perform(orientationLandscape())
+      onView(withId(R.id.checkbox_pin)).perform(scrollTo())
+      waitForTheView(withId(R.id.checkbox_pin))
       onView(
         allOf(
           withId(R.id.error_text),
           isDescendantOfA(withId(R.id.input_confirm_pin))
         )
-      ).perform(scrollTo()).check(
+      ).check(
         matches(
           withText(
             context.getString(R.string.add_profile_error_pin_confirm_wrong)
@@ -810,10 +949,15 @@ class AddProfileActivityTest {
         closeSoftKeyboard()
       )
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-        .perform(typeText("123"), closeSoftKeyboard())
-      onView(withId(R.id.allow_download_switch)).perform(scrollTo()).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
+        typeText("123"),
+        closeSoftKeyboard()
+      )
+      onView(withId(R.id.allow_download_switch)).perform(scrollTo())
+      onView(withId(R.id.allow_download_switch)).perform(click())
       onView(isRoot()).perform(orientationLandscape())
-      onView(withId(R.id.allow_download_switch)).perform(scrollTo()).check(matches(isChecked()))
+      onView(withId(R.id.allow_download_switch)).perform(scrollTo())
+      onView(withId(R.id.allow_download_switch)).check(matches(isChecked()))
     }
   }
 
@@ -847,7 +991,55 @@ class AddProfileActivityTest {
     return ActivityResult(RESULT_OK, resultIntent)
   }
 
-  @Qualifier annotation class TestDispatcher
+  private fun waitForTheView(viewMatcher: Matcher<View>): ViewInteraction {
+    return onView(isRoot()).perform(waitForMatch(viewMatcher, 30000L))
+  }
+
+  // TODO(#59): Remove these waits once we can ensure that the production executors are not depended on in tests.
+  //  Sleeping is really bad practice in Espresso tests, and can lead to test flakiness. It shouldn't be necessary if we
+  //  use a test executor service with a counting idle resource, but right now Gradle mixes dependencies such that both
+  //  the test and production blocking executors are being used. The latter cannot be updated to notify Espresso of any
+  //  active coroutines, so the test attempts to assert state before it's ready. This artificial delay in the Espresso
+  //  thread helps to counter that.
+  /**
+   * Perform action of waiting for a specific matcher to finish. Adapted from:
+   * https://stackoverflow.com/a/22563297/3689782.
+   */
+  private fun waitForMatch(viewMatcher: Matcher<View>, millis: Long): ViewAction {
+    return object : ViewAction {
+      override fun getDescription(): String {
+        return "wait for a specific view with matcher <$viewMatcher> during $millis millis."
+      }
+
+      override fun getConstraints(): Matcher<View> {
+        return isRoot()
+      }
+
+      override fun perform(uiController: UiController?, view: View?) {
+        checkNotNull(uiController)
+        uiController.loopMainThreadUntilIdle()
+        val startTime = System.currentTimeMillis()
+        val endTime = startTime + millis
+
+        do {
+          if (TreeIterables.breadthFirstViewTraversal(view).any { viewMatcher.matches(it) }) {
+            return
+          }
+          uiController.loopMainThreadForAtLeast(50)
+        } while (System.currentTimeMillis() < endTime)
+
+        // Couldn't match in time.
+        throw PerformException.Builder()
+          .withActionDescription(description)
+          .withViewDescription(HumanReadables.describe(view))
+          .withCause(TimeoutException())
+          .build()
+      }
+    }
+  }
+
+  @Qualifier
+  annotation class TestDispatcher
 
   @Module
   class TestModule {
@@ -906,5 +1098,46 @@ class AddProfileActivityTest {
     }
 
     fun inject(addProfileActivityTest: AddProfileActivityTest)
+  }
+
+  // TODO(#59): Move this to a general-purpose testing library that replaces all CoroutineExecutors with an
+  //  Espresso-enabled executor service. This service should also allow for background threads to run in both Espresso
+  //  and Robolectric to help catch potential race conditions, rather than forcing parallel execution to be sequential
+  //  and immediate.
+  //  NB: This also blocks on #59 to be able to actually create a test-only library.
+  /**
+   * An executor service that schedules all [Runnable]s to run asynchronously on the main thread. This is based on:
+   * https://android.googlesource.com/platform/packages/apps/TV/+/android-live-tv/src/com/android/tv/util/MainThreadExecutor.java.
+   */
+  private object MainThreadExecutor : AbstractExecutorService() {
+    override fun isTerminated(): Boolean = false
+
+    private val handler = Handler(Looper.getMainLooper())
+    val countingResource = CountingIdlingResource("main_thread_executor_counting_idling_resource")
+
+    override fun execute(command: Runnable?) {
+      countingResource.increment()
+      handler.post {
+        try {
+          command?.run()
+        } finally {
+          countingResource.decrement()
+        }
+      }
+    }
+
+    override fun shutdown() {
+      throw UnsupportedOperationException()
+    }
+
+    override fun shutdownNow(): MutableList<Runnable> {
+      throw UnsupportedOperationException()
+    }
+
+    override fun isShutdown(): Boolean = false
+
+    override fun awaitTermination(timeout: Long, unit: TimeUnit?): Boolean {
+      throw UnsupportedOperationException()
+    }
   }
 }

--- a/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
@@ -820,7 +820,7 @@ class AddProfileActivityTest {
   @Test
   fun testAddProfileActivity_clickInfo_checkInfoPopupIsDisplayed() {
     launch(AddProfileActivity::class.java).use {
-      onView(withId(R.id.app_info_image_view)).perform(click())
+      onView(withId(R.id.info_icon)).perform(click())
       onView(withText(context.getString(R.string.add_profile_pin_info))).check(matches(isDisplayed()))
     }
   }
@@ -828,19 +828,9 @@ class AddProfileActivityTest {
   @Test
   fun testAddProfileActivity_clickInfo_changeConfiguration_checkInfoPopupIsDisplayed() {
     launch(AddProfileActivity::class.java).use {
-      onView(withId(R.id.app_info_image_view)).perform(click())
+      onView(withId(R.id.info_icon)).perform(click())
       onView(isRoot()).perform(orientationLandscape())
       onView(withText(context.getString(R.string.add_profile_pin_info))).check(matches(isDisplayed()))
-    }
-  }
-
-  @Test
-  fun testAddProfileActivity_clickInfo_clickClose_checkInfoPopupIsDismissed() {
-    launch(AddProfileActivity::class.java).use {
-      onView(withId(R.id.app_info_image_view)).perform(click())
-      onView(withText(context.getString(R.string.add_profile_pin_info))).check(matches(isDisplayed()))
-      onView(withText(context.getString(R.string.add_profile_close))).perform(click())
-      onView(withText(context.getString(R.string.add_profile_pin_info))).check(matches(not(isDisplayed())))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
@@ -8,24 +8,15 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.Resources
 import android.net.Uri
-import android.os.Handler
-import android.os.Looper
 import android.provider.MediaStore
-import android.view.View
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.IdlingRegistry
-import androidx.test.espresso.PerformException
-import androidx.test.espresso.UiController
-import androidx.test.espresso.ViewAction
-import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
 import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.idling.CountingIdlingResource
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.Intents.intending
@@ -39,8 +30,6 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import androidx.test.espresso.util.HumanReadables
-import androidx.test.espresso.util.TreeIterables
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.BindsInstance
 import dagger.Component
@@ -65,9 +54,6 @@ import org.oppia.util.logging.GlobalLogLevel
 import org.oppia.util.logging.LogLevel
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
-import java.util.concurrent.AbstractExecutorService
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -75,21 +61,17 @@ import javax.inject.Singleton
 @RunWith(AndroidJUnit4::class)
 class AddProfileActivityTest {
 
-  @Inject
-  lateinit var context: Context
-  @Inject
-  lateinit var profileTestHelper: ProfileTestHelper
+  @Inject lateinit var context: Context
+  @Inject lateinit var profileTestHelper: ProfileTestHelper
 
   @Before
   fun setUp() {
     Intents.init()
     setUpTestApplicationComponent()
-    IdlingRegistry.getInstance().register(MainThreadExecutor.countingResource)
   }
 
   @After
   fun tearDown() {
-    IdlingRegistry.getInstance().unregister(MainThreadExecutor.countingResource)
     Intents.release()
   }
 
@@ -159,30 +141,29 @@ class AddProfileActivityTest {
     }
   }
 
-  //
-//  @Test
-//  fun testAddProfileActivity_inputName_inputPin_clickCreate_checkOpensProfileActivity() {
-//    launch(AddProfileActivity::class.java).use {
-//      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
-//        typeText("test"),
-//        closeSoftKeyboard()
-//      )
-//      onView(withId(R.id.checkbox_pin)).perform(click())
-//      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
-//        typeText("123"),
-//        closeSoftKeyboard()
-//      )
-//      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
-//      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-//        typeText("123"),
-//        closeSoftKeyboard()
-//      )
-//      onView(withId(R.id.create_button)).perform(scrollTo())
-//      onView(withId(R.id.create_button)).perform(click())
-//      intended(hasComponent(ProfileActivity::class.java.name))
-//    }
-//  }
-//
+  @Test
+  fun testAddProfileActivity_inputName_inputPin_clickCreate_checkOpensProfileActivity() {
+    launch(AddProfileActivity::class.java).use {
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+        typeText("test"),
+        closeSoftKeyboard()
+      )
+      onView(withId(R.id.checkbox_pin)).perform(click())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
+        typeText("123"),
+        closeSoftKeyboard()
+      )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
+        typeText("123"),
+        closeSoftKeyboard()
+      )
+      onView(withId(R.id.create_button)).perform(scrollTo())
+      onView(withId(R.id.create_button)).perform(click())
+      intended(hasComponent(ProfileActivity::class.java.name))
+    }
+  }
+
   @Test
   fun testAddProfileActivity_changeConfiguration_inputName_inputPin_clickCreate_checkOpensProfileActivity() {
     launch(AddProfileActivity::class.java).use {
@@ -261,7 +242,6 @@ class AddProfileActivityTest {
         typeText("Sean"), closeSoftKeyboard()
       )
       onView(withId(R.id.create_button)).perform(scrollTo())
-      waitForTheView(withId(R.id.create_button))
       onView(withId(R.id.create_button)).perform(click())
       onView(
         allOf(
@@ -321,7 +301,6 @@ class AddProfileActivityTest {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.checkbox_pin)).perform(scrollTo())
-      waitForTheView(withId(R.id.checkbox_pin))
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(scrollTo()).perform(
         typeText("Sean"), closeSoftKeyboard()
       )
@@ -489,7 +468,6 @@ class AddProfileActivityTest {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.checkbox_pin)).perform(scrollTo())
-      waitForTheView(withId(R.id.checkbox_pin))
       onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo()).perform(
         typeText("12"),
@@ -685,7 +663,6 @@ class AddProfileActivityTest {
       onView(withId(R.id.checkbox_pin)).perform(scrollTo())
       onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-      waitForTheView(withText(R.string.add_profile_input_name))
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
         typeText("123"),
         closeSoftKeyboard()
@@ -754,7 +731,6 @@ class AddProfileActivityTest {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.edit_image_fab)).perform(scrollTo())
-      waitForTheView(withId(R.id.edit_image_fab))
       onView(withId(R.id.edit_image_fab)).perform(click())
       intended(expectedIntent)
     }
@@ -924,7 +900,6 @@ class AddProfileActivityTest {
       onView(withId(R.id.create_button)).perform(click())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.checkbox_pin)).perform(scrollTo())
-      waitForTheView(withId(R.id.checkbox_pin))
       onView(
         allOf(
           withId(R.id.error_text),
@@ -991,55 +966,7 @@ class AddProfileActivityTest {
     return ActivityResult(RESULT_OK, resultIntent)
   }
 
-  private fun waitForTheView(viewMatcher: Matcher<View>): ViewInteraction {
-    return onView(isRoot()).perform(waitForMatch(viewMatcher, 30000L))
-  }
-
-  // TODO(#59): Remove these waits once we can ensure that the production executors are not depended on in tests.
-  //  Sleeping is really bad practice in Espresso tests, and can lead to test flakiness. It shouldn't be necessary if we
-  //  use a test executor service with a counting idle resource, but right now Gradle mixes dependencies such that both
-  //  the test and production blocking executors are being used. The latter cannot be updated to notify Espresso of any
-  //  active coroutines, so the test attempts to assert state before it's ready. This artificial delay in the Espresso
-  //  thread helps to counter that.
-  /**
-   * Perform action of waiting for a specific matcher to finish. Adapted from:
-   * https://stackoverflow.com/a/22563297/3689782.
-   */
-  private fun waitForMatch(viewMatcher: Matcher<View>, millis: Long): ViewAction {
-    return object : ViewAction {
-      override fun getDescription(): String {
-        return "wait for a specific view with matcher <$viewMatcher> during $millis millis."
-      }
-
-      override fun getConstraints(): Matcher<View> {
-        return isRoot()
-      }
-
-      override fun perform(uiController: UiController?, view: View?) {
-        checkNotNull(uiController)
-        uiController.loopMainThreadUntilIdle()
-        val startTime = System.currentTimeMillis()
-        val endTime = startTime + millis
-
-        do {
-          if (TreeIterables.breadthFirstViewTraversal(view).any { viewMatcher.matches(it) }) {
-            return
-          }
-          uiController.loopMainThreadForAtLeast(50)
-        } while (System.currentTimeMillis() < endTime)
-
-        // Couldn't match in time.
-        throw PerformException.Builder()
-          .withActionDescription(description)
-          .withViewDescription(HumanReadables.describe(view))
-          .withCause(TimeoutException())
-          .build()
-      }
-    }
-  }
-
-  @Qualifier
-  annotation class TestDispatcher
+  @Qualifier annotation class TestDispatcher
 
   @Module
   class TestModule {
@@ -1098,46 +1025,5 @@ class AddProfileActivityTest {
     }
 
     fun inject(addProfileActivityTest: AddProfileActivityTest)
-  }
-
-  // TODO(#59): Move this to a general-purpose testing library that replaces all CoroutineExecutors with an
-  //  Espresso-enabled executor service. This service should also allow for background threads to run in both Espresso
-  //  and Robolectric to help catch potential race conditions, rather than forcing parallel execution to be sequential
-  //  and immediate.
-  //  NB: This also blocks on #59 to be able to actually create a test-only library.
-  /**
-   * An executor service that schedules all [Runnable]s to run asynchronously on the main thread. This is based on:
-   * https://android.googlesource.com/platform/packages/apps/TV/+/android-live-tv/src/com/android/tv/util/MainThreadExecutor.java.
-   */
-  private object MainThreadExecutor : AbstractExecutorService() {
-    override fun isTerminated(): Boolean = false
-
-    private val handler = Handler(Looper.getMainLooper())
-    val countingResource = CountingIdlingResource("main_thread_executor_counting_idling_resource")
-
-    override fun execute(command: Runnable?) {
-      countingResource.increment()
-      handler.post {
-        try {
-          command?.run()
-        } finally {
-          countingResource.decrement()
-        }
-      }
-    }
-
-    override fun shutdown() {
-      throw UnsupportedOperationException()
-    }
-
-    override fun shutdownNow(): MutableList<Runnable> {
-      throw UnsupportedOperationException()
-    }
-
-    override fun isShutdown(): Boolean = false
-
-    override fun awaitTermination(timeout: Long, unit: TimeUnit?): Boolean {
-      throw UnsupportedOperationException()
-    }
   }
 }

--- a/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
@@ -817,6 +817,33 @@ class AddProfileActivityTest {
     }
   }
 
+  @Test
+  fun testAddProfileActivity_clickInfo_checkInfoPopupIsDisplayed() {
+    launch(AddProfileActivity::class.java).use {
+      onView(withId(R.id.app_info_image_view)).perform(click())
+      onView(withText(context.getString(R.string.add_profile_pin_info))).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testAddProfileActivity_clickInfo_changeConfiguration_checkInfoPopupIsDisplayed() {
+    launch(AddProfileActivity::class.java).use {
+      onView(withId(R.id.app_info_image_view)).perform(click())
+      onView(isRoot()).perform(orientationLandscape())
+      onView(withText(context.getString(R.string.add_profile_pin_info))).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testAddProfileActivity_clickInfo_clickClose_checkInfoPopupIsDismissed() {
+    launch(AddProfileActivity::class.java).use {
+      onView(withId(R.id.app_info_image_view)).perform(click())
+      onView(withText(context.getString(R.string.add_profile_pin_info))).check(matches(isDisplayed()))
+      onView(withText(context.getString(R.string.add_profile_close))).perform(click())
+      onView(withText(context.getString(R.string.add_profile_pin_info))).check(matches(not(isDisplayed())))
+    }
+  }
+
   private fun createGalleryPickActivityResultStub(): ActivityResult {
     val resources: Resources = context.resources
     val imageUri = Uri.parse(

--- a/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
@@ -9,7 +9,7 @@ import android.content.Intent
 import android.content.res.Resources
 import android.net.Uri
 import android.provider.MediaStore
-import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -61,10 +61,8 @@ import javax.inject.Singleton
 @RunWith(AndroidJUnit4::class)
 class AddProfileActivityTest {
 
-  @Inject
-  lateinit var context: Context
-  @Inject
-  lateinit var profileTestHelper: ProfileTestHelper
+  @Inject lateinit var context: Context
+  @Inject lateinit var profileTestHelper: ProfileTestHelper
 
   @Before
   @ExperimentalCoroutinesApi
@@ -87,7 +85,7 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_inputName_clickCreate_checkOpensProfileActivity() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("test"), closeSoftKeyboard()
       )
@@ -98,7 +96,7 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_changeConfiguration_inputName_clickCreate_checkOpensProfileActivity() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("test"), closeSoftKeyboard()
@@ -110,7 +108,7 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_clickOnCheckbox_createPin_checkIsDisplayed() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(allOf(withId(R.id.checkbox_pin))).perform(click())
       onView(withId(R.id.input_pin)).check(matches(isDisplayed()))
     }
@@ -118,7 +116,7 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_changeConfiguration_clickOnCheckbox_createPin_checkIsDisplayed() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(allOf(withId(R.id.checkbox_pin))).perform(scrollTo()).perform(click())
       onView(withId(R.id.input_pin)).perform(scrollTo()).check(matches(isDisplayed()))
@@ -127,14 +125,14 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_createPin_checkNotVisible() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.input_pin)).check(matches(not(isDisplayed())))
     }
   }
 
   @Test
   fun testAddProfileActivity_changeConfiguration_createPin_checkNotVisible() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.input_pin)).check(matches(not(isDisplayed())))
     }
@@ -142,21 +140,18 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_inputName_inputPin_clickCreate_checkOpensProfileActivity() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("test"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
-        typeText("123"), closeSoftKeyboard()
+        typeText("123"),
+        closeSoftKeyboard()
       )
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      )
-        .perform(
-          typeText("123"), closeSoftKeyboard()
-        )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+        .perform(typeText("123"), closeSoftKeyboard())
       onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
       intended(hasComponent(ProfileActivity::class.java.name))
     }
@@ -164,50 +159,57 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_changeConfiguration_inputName_inputPin_clickCreate_checkOpensProfileActivity() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
-      onView(
-        allOf(
-          withId(R.id.input),
-          isDescendantOfA(withId(R.id.input_name))
-        )
-      ).perform(scrollTo())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(scrollTo())
         .perform(typeText("test"), closeSoftKeyboard())
       onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
         .perform(typeText("123"), closeSoftKeyboard())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      ).perform(typeText("123"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+        .perform(typeText("123"), closeSoftKeyboard())
       onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
       intended(hasComponent(ProfileActivity::class.java.name))
     }
   }
 
   @Test
-  fun testAddProfileActivity_clickCreate_checkNameEmptyError() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
-      onView(
-        allOf(
-          withId(R.id.error_text),
-          isDescendantOfA(withId(R.id.input_name))
-        )
-      ).check(matches(withText(context.getString(R.string.add_profile_error_name_empty))))
+  fun testAddProfileActivity_checkCreateIsNotClickable() {
+    launch(AddProfileActivity::class.java).use {
+      onView(withId(R.id.create_button)).perform(scrollTo()).check(matches(not(isClickable())))
     }
   }
 
   @Test
-  fun testAddProfileActivity_changeConfiguration_clickCreate_checkNameEmptyError() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+  fun testAddProfileActivity_changeConfiguration_checkCreateIsNotClickable() {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
-      onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
-      onView(
-        allOf(
-          withId(R.id.error_text),
-          isDescendantOfA(withId(R.id.input_name))
-        )
-      ).check(matches(withText(context.getString(R.string.add_profile_error_name_empty))))
+      onView(withId(R.id.create_button)).perform(scrollTo()).check(matches(not(isClickable())))
+    }
+  }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testAddProfileActivity_inputName_checkCreateIsClickable() {
+    profileTestHelper.initializeProfiles()
+    launch(AddProfileActivity::class.java).use {
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+        typeText("Rajat"), closeSoftKeyboard()
+      )
+      onView(withId(R.id.create_button)).perform(scrollTo()).check(matches(isClickable()))
+    }
+  }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testAddProfileActivity_inputName_changeConfiguration_checkCreateIsClickable() {
+    profileTestHelper.initializeProfiles()
+    launch(AddProfileActivity::class.java).use {
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+        typeText("Rajat"), closeSoftKeyboard()
+      )
+      onView(isRoot()).perform(orientationLandscape())
+      onView(withId(R.id.create_button)).perform(scrollTo()).check(matches(isClickable()))
     }
   }
 
@@ -215,7 +217,7 @@ class AddProfileActivityTest {
   @ExperimentalCoroutinesApi
   fun testAddProfileActivity_inputNotUniqueName_clickCreate_checkNameNotUniqueError() {
     profileTestHelper.initializeProfiles()
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("Sean"), closeSoftKeyboard()
       )
@@ -233,7 +235,7 @@ class AddProfileActivityTest {
   @ExperimentalCoroutinesApi
   fun testAddProfileActivity_changeConfiguration_inputNotUniqueName_clickCreate_checkNameNotUniqueError() {
     profileTestHelper.initializeProfiles()
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("Sean"), closeSoftKeyboard()
@@ -252,7 +254,7 @@ class AddProfileActivityTest {
   @ExperimentalCoroutinesApi
   fun testAddProfileActivity_inputNotUniqueName_clickCreate_inputName_checkErrorIsCleared() {
     profileTestHelper.initializeProfiles()
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("Sean"), closeSoftKeyboard()
       )
@@ -273,7 +275,7 @@ class AddProfileActivityTest {
   @ExperimentalCoroutinesApi
   fun testAddProfileActivity_changeConfiguration_inputNotUniqueName_clickCreate_inputName_checkErrorIsCleared() {
     profileTestHelper.initializeProfiles()
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("Sean"), closeSoftKeyboard()
@@ -293,7 +295,7 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_inputNameWithNumbers_clickCreate_checkNameOnlyLettersError() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("123"), closeSoftKeyboard()
       )
@@ -309,7 +311,7 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_changeConfiguration_inputNameWithNumbers_clickCreate_checkNameOnlyLettersError() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("123"), closeSoftKeyboard()
@@ -326,7 +328,7 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_inputNameWithNumbers_clickCreate_inputName_checkErrorIsCleared() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("123"), closeSoftKeyboard()
       )
@@ -345,7 +347,7 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_changeConfiguration_inputNameWithNumbers_clickCreate_inputName_checkErrorIsCleared() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("123"), closeSoftKeyboard()
@@ -365,7 +367,10 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_inputShortPin_clickCreate_checkPinLengthError() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+        typeText("test"), closeSoftKeyboard()
+      )
       onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
         typeText("12"), closeSoftKeyboard()
@@ -382,13 +387,14 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_changeConfiguration_inputShortPin_clickCreate_checkPinLengthError() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+        typeText("test"), closeSoftKeyboard()
+      )
       onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(
-          typeText("12"), closeSoftKeyboard()
-        )
+        .perform(typeText("12"), closeSoftKeyboard())
       onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
       onView(
         allOf(
@@ -401,7 +407,7 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_inputShortPin_clickCreate_inputPin_checkErrorIsCleared() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
         typeText("12"), closeSoftKeyboard()
@@ -420,18 +426,14 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_changeConfiguration_inputShortPin_clickCreate_inputPin_checkErrorIsCleared() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(
-          typeText("12"), closeSoftKeyboard()
-        )
+        .perform(typeText("12"), closeSoftKeyboard())
       onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(
-          typeText("3"), closeSoftKeyboard()
-        )
+        .perform(typeText("3"), closeSoftKeyboard())
       onView(allOf(withId(R.id.error_text), isDescendantOfA(withId(R.id.input_pin)))).check(
         matches(
           withText("")
@@ -442,14 +444,15 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_inputWrongConfirmPin_checkConfirmWrongError() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+        typeText("test"), closeSoftKeyboard()
+      )
       onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
         typeText("123"), closeSoftKeyboard()
       )
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
         .perform(typeText("12"))
       onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
       onView(allOf(withId(R.id.error_text), isDescendantOfA(withId(R.id.input_confirm_pin)))).check(
@@ -464,16 +467,15 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_changeConfiguration_inputWrongConfirmPin_checkConfirmWrongError() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+        typeText("test"), closeSoftKeyboard()
+      )
       onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(
-          typeText("123"), closeSoftKeyboard()
-        )
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      )
+        .perform(typeText("123"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
         .perform(typeText("12"), closeSoftKeyboard())
       onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
       onView(
@@ -493,17 +495,15 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_inputWrongConfirmPin_inputConfirmPin_checkErrorIsCleared() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
         .perform(typeText("123"), closeSoftKeyboard())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      ).perform(typeText("12"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+        .perform(typeText("12"), closeSoftKeyboard())
       onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      ).perform(typeText("3"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+        .perform(typeText("3"), closeSoftKeyboard())
       onView(
         allOf(
           withId(R.id.error_text),
@@ -515,23 +515,16 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_changeConfiguration_inputWrongConfirmPin_inputConfirmPin_checkErrorIsCleared() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(
-          typeText("123"), closeSoftKeyboard()
-        )
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      )
+        .perform(typeText("123"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
         .perform(typeText("12"), closeSoftKeyboard())
       onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      ).perform(
-        typeText("3"), closeSoftKeyboard()
-      )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+        .perform(typeText("3"), closeSoftKeyboard())
       onView(
         allOf(
           withId(R.id.error_text),
@@ -543,7 +536,7 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_inputPin_checkAllowDownloadNotClickable() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
         typeText("123"), closeSoftKeyboard()
@@ -554,27 +547,24 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_changeConfiguration_inputPin_checkAllowDownloadNotClickable() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(
-          typeText("123"), closeSoftKeyboard()
-        )
+        .perform(typeText("123"), closeSoftKeyboard())
       onView(withId(R.id.allow_download_switch)).check(matches(not(isClickable())))
     }
   }
 
   @Test
   fun testAddProfileActivity_inputPin_inputConfirmPin_checkAllowDownloadClickable() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
-        typeText("123"), closeSoftKeyboard()
+        typeText("123"),
+        closeSoftKeyboard()
       )
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
         .perform(typeText("123"), closeSoftKeyboard())
       onView(withId(R.id.allow_download_switch)).check(matches(isClickable()))
     }
@@ -582,16 +572,12 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_changeConfiguration_inputPin_inputConfirmPin_checkAllowDownloadClickable() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
-        .perform(
-          typeText("123"), closeSoftKeyboard()
-        )
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      )
+        .perform(typeText("123"), closeSoftKeyboard())
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
         .perform(typeText("123"), closeSoftKeyboard())
       onView(withId(R.id.allow_download_switch)).check(matches(isClickable()))
     }
@@ -605,7 +591,7 @@ class AddProfileActivityTest {
     )
     val activityResult = createGalleryPickActivityResultStub()
     intending(expectedIntent).respondWith(activityResult)
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.upload_image_button)).perform(click())
       intended(expectedIntent)
     }
@@ -619,7 +605,7 @@ class AddProfileActivityTest {
     )
     val activityResult = createGalleryPickActivityResultStub()
     intending(expectedIntent).respondWith(activityResult)
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.upload_image_button)).perform(click())
       intended(expectedIntent)
@@ -634,7 +620,7 @@ class AddProfileActivityTest {
     )
     val activityResult = createGalleryPickActivityResultStub()
     intending(expectedIntent).respondWith(activityResult)
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.edit_image_fab)).perform(click())
       intended(expectedIntent)
     }
@@ -648,75 +634,55 @@ class AddProfileActivityTest {
     )
     val activityResult = createGalleryPickActivityResultStub()
     intending(expectedIntent).respondWith(activityResult)
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.edit_image_fab)).perform(click())
       intended(expectedIntent)
     }
   }
 
-  private fun createGalleryPickActivityResultStub(): ActivityResult {
-    val resources: Resources = context.resources
-    val imageUri = Uri.parse(
-      ContentResolver.SCHEME_ANDROID_RESOURCE + "://" +
-          resources.getResourcePackageName(R.mipmap.ic_launcher) + '/' +
-          resources.getResourceTypeName(R.mipmap.ic_launcher) + '/' +
-          resources.getResourceEntryName(R.mipmap.ic_launcher)
-    )
-    val resultIntent = Intent()
-    resultIntent.setData(imageUri)
-    return ActivityResult(RESULT_OK, resultIntent)
-  }
-
   @Test
   fun testAddProfileActivity_inputName_changeConfiguration_checkNameIsDisplayed() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("test"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
-        scrollTo()
-      )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(scrollTo())
         .check(matches(withText("test")))
     }
   }
 
   @Test
   fun testAddProfileActivity_inputPin_changeConfiguration_checkPinIsDisplayed() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
-        typeText("123"), closeSoftKeyboard()
+        typeText("123"),
+        closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
-        scrollTo()
-      )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
         .check(matches(withText("123")))
     }
   }
 
   @Test
   fun testAddProfileActivity_inputConfirmPin_changeConfiguration_checkConfirmPinIsDisplayed() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      ).perform(
-        typeText("123"), closeSoftKeyboard()
-      )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+        .perform(typeText("123"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      ).check(matches(withText("123")))
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+        .check(matches(withText("123")))
     }
   }
 
   @Test
   fun testAddProfileActivity_inputName_inputPin_inputConfirmPin_changeConfiguration_checkName_checkPin_checkConfirmPin_IsDisplayed() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("test"),
         closeSoftKeyboard()
@@ -725,45 +691,32 @@ class AddProfileActivityTest {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
         typeText("123"), closeSoftKeyboard()
       )
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      )
-        .perform(
-          typeText("123"), closeSoftKeyboard()
-        )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+        .perform(typeText("123"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
-        scrollTo()
-      )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(scrollTo())
         .check(matches(withText("test")))
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
-        scrollTo()
-      )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
         .check(matches(withText("123")))
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
         .check(matches(withText("123")))
     }
   }
 
   @Test
   fun testAddProfileActivity_inputName_inputPin_inputConfirmPin_deselectPIN_clickCreate_checkOpensProfileActivity() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("test"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
-        typeText("123"), closeSoftKeyboard()
+        typeText("123"),
+        closeSoftKeyboard()
       )
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      )
-        .perform(
-          typeText("123"), closeSoftKeyboard()
-        )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+        .perform(typeText("123"), closeSoftKeyboard())
       onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
       onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
       intended(hasComponent(ProfileActivity::class.java.name))
@@ -774,7 +727,7 @@ class AddProfileActivityTest {
   @ExperimentalCoroutinesApi
   fun testAddProfileActivity_inputNotUniqueName_clickCreate_changeConfiguration_checkErrorMessageDisplayed() {
     profileTestHelper.initializeProfiles()
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
         typeText("Sean"),
         closeSoftKeyboard()
@@ -792,7 +745,7 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_selectCheckbox_changeConfiguration_checkboxIsSelected() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.checkbox_pin)).perform(scrollTo()).perform(click())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.checkbox_pin)).perform(scrollTo()).check(matches(isChecked()))
@@ -801,38 +754,36 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_inputPin_inputConfirmPin_changeConfiguration_checkPin_checkConfirmPin_IsDisplayed() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
-        typeText("123"), closeSoftKeyboard()
+        typeText("123"),
+        closeSoftKeyboard()
       )
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      ).perform(
-        typeText("123"), closeSoftKeyboard()
-      )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+        .perform(typeText("123"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
-        scrollTo()
-      ).check(matches(withText("123")))
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      ).check(matches(withText("123")))
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(scrollTo())
+        .check(matches(withText("123")))
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+        .check(matches(withText("123")))
     }
   }
 
   @Test
   fun testAddProfileActivity_inputPin_inputDifferentConfirmPin_clickCreate_changeConfiguration_checkErrorMessageDisplayed() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).perform(
+        typeText("test"),
+        closeSoftKeyboard()
+      )
       onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
-        typeText("123"), closeSoftKeyboard()
+        typeText("123"),
+        closeSoftKeyboard()
       )
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      ).perform(
-        typeText("321"), closeSoftKeyboard()
-      )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+        .perform(typeText("321"), closeSoftKeyboard())
       onView(withId(R.id.create_button)).perform(scrollTo()).perform(click())
       onView(isRoot()).perform(orientationLandscape())
       onView(
@@ -852,24 +803,34 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_inputPin_inputConfirmPin_turnOnDownloadAccessSwitch_changeConfiguration_checkDownloadAccessSwitchIsOn() {
-    ActivityScenario.launch(AddProfileActivity::class.java).use {
+    launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.checkbox_pin)).perform(click())
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
-        typeText("123"), closeSoftKeyboard()
+        typeText("123"),
+        closeSoftKeyboard()
       )
-      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(
-        scrollTo()
-      ).perform(
-        typeText("123"), closeSoftKeyboard()
-      )
+      onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_confirm_pin)))).perform(scrollTo())
+        .perform(typeText("123"), closeSoftKeyboard())
       onView(withId(R.id.allow_download_switch)).perform(scrollTo()).perform(click())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.allow_download_switch)).perform(scrollTo()).check(matches(isChecked()))
     }
   }
 
-  @Qualifier
-  annotation class TestDispatcher
+  private fun createGalleryPickActivityResultStub(): ActivityResult {
+    val resources: Resources = context.resources
+    val imageUri = Uri.parse(
+      ContentResolver.SCHEME_ANDROID_RESOURCE + "://" +
+        resources.getResourcePackageName(R.mipmap.ic_launcher) + '/' +
+        resources.getResourceTypeName(R.mipmap.ic_launcher) + '/' +
+        resources.getResourceEntryName(R.mipmap.ic_launcher)
+    )
+    val resultIntent = Intent()
+    resultIntent.data = imageUri
+    return ActivityResult(RESULT_OK, resultIntent)
+  }
+
+  @Qualifier annotation class TestDispatcher
 
   @Module
   class TestModule {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes part of #931 

While working on the highfi part of the `AddProfileActivity` I noticed that `Create` button is active and deactive based on user edittext and earlier it was always active. Now because of this the implementation change and so did the test cases. This PR deals with that lowfi change.

Mock: https://xd.adobe.com/view/0687f00c-695b-437a-79a6-688e7f4f7552-70b6/screen/60506b8a-25e6-4435-a660-bb62bc389d4c/PC-MP-Add-Profile-Empty-6/

All test cases pass for `AddProfileActivityTest`

## Screenshots for landscape
![Screenshot_1585737803](https://user-images.githubusercontent.com/9396084/78128604-d42b8f00-7433-11ea-8908-14df1b7d4d60.png)
![Screenshot_1585737810](https://user-images.githubusercontent.com/9396084/78128623-d988d980-7433-11ea-8130-f9c3c95a9fb4.png)
![Screenshot_1585737812](https://user-images.githubusercontent.com/9396084/78128632-db529d00-7433-11ea-9027-53dbeb3fa389.png)
![Screenshot_1585737819](https://user-images.githubusercontent.com/9396084/78128635-dbeb3380-7433-11ea-9983-f32a2b9840df.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
