### PR TITLE
Fix #899: Highfi Navigation Drawer 

### DIFF
--- a/app/src/main/java/org/oppia/app/drawer/NavigationDrawerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/drawer/NavigationDrawerFragmentPresenter.kt
@@ -1,5 +1,6 @@
 package org.oppia.app.drawer
 
+import android.os.Build
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
@@ -61,6 +62,10 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
     binding.fragmentDrawerNavView.setNavigationItemSelectedListener(this)
 
     fragment.setHasOptionsMenu(true)
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      binding.fragmentDrawerNavView.setElevation(0f);
+    }
 
     internalProfileId = activity.intent.getIntExtra(KEY_NAVIGATION_PROFILE_ID, -1)
     profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()

--- a/app/src/main/res/layout/drawer_fragment.xml
+++ b/app/src/main/res/layout/drawer_fragment.xml
@@ -8,42 +8,74 @@
       type="org.oppia.app.drawer.NavigationDrawerFooterViewModel" />
   </data>
   <com.google.android.material.navigation.NavigationView
-    android:id="@+id/fragment_drawer_nav_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="start"
-    android:fitsSystemWindows="true"
-    app:itemBackground="@android:color/transparent"
-    app:itemIconTint="@color/drawer_item"
-    app:itemTextColor="@color/drawer_item"
-    app:menu="@menu/navigation_drawer_menu">
+    android:fitsSystemWindows="true">
 
-    <LinearLayout
-      android:id="@+id/administrator_controls_linear_layout"
+    <androidx.core.widget.NestedScrollView
+      android:id="@+id/nestedscrollview"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_gravity="bottom"
-      android:orientation="horizontal"
-      android:padding="16dp"
-      android:visibility="@{footerViewModel.isAdmin ? View.VISIBLE : View.GONE}">
+      android:layout_height="match_parent"
+      android:fillViewport="true"
+      android:scrollbars="vertical">
 
-      <ImageView
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:layout_gravity="center_vertical"
-        android:layout_margin="4dp"
-        android:src="@drawable/ic_admin_settings_icon_brown_24dp" />
-
-      <TextView
+      <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:layout_marginStart="32dp"
-        android:layout_marginEnd="32dp"
-        android:fontFamily="sans-serif-medium"
-        android:text="@string/administrator_controls"
-        android:textColor="@color/highlightedNavMenuItem"
-        android:textSize="14sp" />
-    </LinearLayout>
+        android:orientation="vertical">
+
+        <com.google.android.material.navigation.NavigationView
+          android:id="@+id/fragment_drawer_nav_view"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_gravity="start"
+          android:background="@android:color/transparent"
+          android:fitsSystemWindows="true"
+          app:itemBackground="@android:color/transparent"
+          app:itemIconTint="@color/drawer_item"
+          app:itemTextColor="@color/drawer_item"
+          app:menu="@menu/navigation_drawer_menu"
+          android:overScrollMode="never"/>
+
+        <Button
+          android:id="@+id/menu_footer_separator"
+          android:layout_width="match_parent"
+          android:layout_height="0dp"
+          android:layout_weight="1"
+          android:clickable="false"
+          android:background="@android:color/transparent" />
+
+        <LinearLayout
+          android:id="@+id/administrator_controls_linear_layout"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_gravity="bottom"
+          android:orientation="horizontal"
+          android:padding="16dp"
+          android:visibility="@{footerViewModel.isAdmin ? View.VISIBLE : View.GONE}">
+
+          <ImageView
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_gravity="center_vertical"
+            android:layout_margin="4dp"
+            android:src="@drawable/ic_admin_settings_icon_brown_24dp" />
+
+          <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="32dp"
+            android:layout_marginEnd="32dp"
+            android:fontFamily="sans-serif-medium"
+            android:text="@string/administrator_controls"
+            android:textColor="@color/highlightedNavMenuItem"
+            android:textSize="14sp" />
+        </LinearLayout>
+
+
+      </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
   </com.google.android.material.navigation.NavigationView>
 </layout>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  --> Fixes #899
Fixed the landscape orientation of the Navigation Drawer and added the test cases. Navigation Footer used to overlap the menu in landscape orientation.

Navigation Drawer behaves exactly as seen in the mock.
Mock: https://xd.adobe.com/view/0687f00c-695b-437a-79a6-688e7f4f7552-70b6/screen/79c56b13-218b-48fc-a403-b085d46953f3/Settings-Side-Menu-1

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
