### PR TITLE
hifi profile chooser portrait mode

### DIFF
--- a/app/src/main/res/layout/profile_chooser_fragment.xml
+++ b/app/src/main/res/layout/profile_chooser_fragment.xml
@@ -9,7 +9,7 @@
       type="org.oppia.app.profile.ProfileChooserViewModel" />
   </data>
 
-  <FrameLayout
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -26,11 +26,38 @@
         android:layout_height="match_parent">
 
         <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:fontFamily="sans-serif"
+          android:gravity="center"
+          android:minHeight="48dp"
+          android:paddingTop="20dp"
+          android:text="@string/profile_chooser_language"
+          android:textColor="@color/profileChooserGreyTextColor"
+          android:textSize="16sp"
+          android:visibility="gone"
+          app:layout_constraintEnd_toStartOf="@+id/profile_chooser_language_icon"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+          android:id="@+id/profile_chooser_language_icon"
+          android:layout_width="48dp"
+          android:layout_height="48dp"
+          android:layout_marginEnd="36dp"
+          android:paddingStart="4dp"
+          android:paddingTop="20dp"
+          android:paddingEnd="20dp"
+          android:src="@drawable/ic_language_icon_grey_24dp"
+          android:visibility="gone"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
           android:id="@+id/profile_select_text"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginStart="36dp"
-          android:layout_marginTop="60dp"
+          android:layout_marginTop="64dp"
           android:layout_marginEnd="36dp"
           android:fontFamily="sans-serif"
           android:text="@string/profile_chooser_select"
@@ -63,41 +90,38 @@
       </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>
 
-    <LinearLayout
+    <View
       android:layout_width="match_parent"
-      android:layout_height="128dp"
-      android:layout_gravity="bottom"
-      android:background="@drawable/admin_controls_gradient"
-      android:gravity="bottom"
-      android:orientation="horizontal"
-      android:paddingStart="20dp"
-      android:paddingEnd="20dp"
-      android:paddingBottom="24dp">
+      android:layout_height="96dp"
+      android:background="@drawable/profile_chooser_gradient"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent" />
 
-      <LinearLayout
-        android:id="@+id/administrator_controls_linear_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:onClick="@{(v) -> viewModel.onAdministratorControlsButtonClicked()}"
-        android:orientation="horizontal">
+    <TextView
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="24dp"
+      android:fontFamily="sans-serif"
+      android:gravity="center"
+      android:minHeight="48dp"
+      android:text="@string/profile_chooser_administrator_controls"
+      android:textColor="@color/profileChooserGreyTextColor"
+      android:textSize="16sp"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toStartOf="@+id/profile_chooser_setting_icon" />
 
-        <TextView
-          android:layout_width="0dp"
-          android:layout_height="wrap_content"
-          android:layout_marginEnd="8dp"
-          android:layout_marginBottom="2dp"
-          android:layout_weight="1"
-          android:fontFamily="sans-serif-medium"
-          android:gravity="end"
-          android:text="@string/administrator_controls"
-          android:textColor="@color/oppiaProgressChapterNotFinished"
-          android:textSize="14sp" />
-
-        <ImageView
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:src="@drawable/ic_admin_settings_icon_grey_24dp" />
-      </LinearLayout>
-    </LinearLayout>
-  </FrameLayout>
+    <ImageView
+      android:id="@+id/profile_chooser_setting_icon"
+      android:layout_width="48dp"
+      android:layout_height="48dp"
+      android:layout_marginEnd="4dp"
+      android:layout_marginBottom="24dp"
+      android:paddingStart="8dp"
+      android:paddingTop="12dp"
+      android:paddingEnd="16dp"
+      android:paddingBottom="12dp"
+      android:src="@drawable/ic_settings_grey_48dp"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/test/java/org/oppia/app/testing/ProfileChooserSpanTest.kt
+++ b/app/src/test/java/org/oppia/app/testing/ProfileChooserSpanTest.kt
@@ -32,8 +32,6 @@ class ProfileChooserSpanTest {
   @ExperimentalCoroutinesApi
   fun setUp() {
     Intents.init()
-    ApplicationProvider.getApplicationContext<Context>().resources.configuration.orientation =
-      Configuration.ORIENTATION_LANDSCAPE
   }
 
   @After

--- a/app/src/test/java/org/oppia/app/testing/ProfileChooserSpanTest.kt
+++ b/app/src/test/java/org/oppia/app/testing/ProfileChooserSpanTest.kt
@@ -50,6 +50,75 @@ class ProfileChooserSpanTest {
   }
 
   @Test
+  fun testProfileChooserFragmentRecyclerView_hasCorrectSpanCount() {
+    launch(ProfileChooserFragmentTestActivity::class.java).use { scenario ->
+      scenario.onActivity { activity ->
+        assertThat(getProfileRecyclerViewGridLayoutManager(activity).spanCount).isEqualTo(2)
+      }
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "port-ldpi")
+  fun testProfileChooserFragmentRecyclerView_ldpi_hasCorrectSpanCount() {
+    launch(ProfileChooserFragmentTestActivity::class.java).use { scenario ->
+      scenario.onActivity { activity ->
+        assertThat(getProfileRecyclerViewGridLayoutManager(activity).spanCount).isEqualTo(2)
+      }
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "port-mdpi")
+  fun testProfileChooserFragmentRecyclerView_mdpi_hasCorrectSpanCount() {
+    launch(ProfileChooserFragmentTestActivity::class.java).use { scenario ->
+      scenario.onActivity { activity ->
+        assertThat(getProfileRecyclerViewGridLayoutManager(activity).spanCount).isEqualTo(2)
+      }
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "port-hdpi")
+  fun testProfileChooserFragmentRecyclerView_hdpi_hasCorrectSpanCount() {
+    launch(ProfileChooserFragmentTestActivity::class.java).use { scenario ->
+      scenario.onActivity { activity ->
+        assertThat(getProfileRecyclerViewGridLayoutManager(activity).spanCount).isEqualTo(2)
+      }
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "port-xhdpi")
+  fun testProfileChooserFragmentRecyclerView_xhdpi_hasCorrectSpanCount() {
+    launch(ProfileChooserFragmentTestActivity::class.java).use { scenario ->
+      scenario.onActivity { activity ->
+        assertThat(getProfileRecyclerViewGridLayoutManager(activity).spanCount).isEqualTo(2)
+      }
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "port-xxhdpi")
+  fun testProfileChooserFragmentRecyclerView_xxhdpi_hasCorrectSpanCount() {
+    launch(ProfileChooserFragmentTestActivity::class.java).use { scenario ->
+      scenario.onActivity { activity ->
+        assertThat(getProfileRecyclerViewGridLayoutManager(activity).spanCount).isEqualTo(2)
+      }
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "port-xxxhdpi")
+  fun testProfileChooserFragmentRecyclerView_xxxhdpi_hasCorrectSpanCount() {
+    launch(ProfileChooserFragmentTestActivity::class.java).use { scenario ->
+      scenario.onActivity { activity ->
+        assertThat(getProfileRecyclerViewGridLayoutManager(activity).spanCount).isEqualTo(2)
+      }
+    }
+  }
+
+  @Test
   @Config(qualifiers = "land-ldpi")
   fun testProfileChooserFragmentRecyclerView_landscape_ldpi_hasCorrectSpanCount() {
     launch(ProfileChooserFragmentTestActivity::class.java).use { scenario ->


### PR DESCRIPTION
## Explanation 
This PR contain UI changes for portrait mode only with test cases.

## Mock Link

https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/18e69208-8528-424a-a368-b2c5d530d235/PC-SP-Profile-Chooser-

## Checklist
- [x] Add Administration Controls
- [x] App Language
- [x] Test cases
- [x] Accessibility Test
##  Accessibility Scanner Results
org.oppia.app:id/add_profile_text
The item's text contrast ratio is 1.53. This ratio is based on an estimated foreground color of #404040 and an estimated background color of #222222. Consider using colors that result in a contrast ratio greater than 4.50 for small text, or 3.00 for large text.
![screenshot_Oppia_2020-04-06-16_09_25](https://user-images.githubusercontent.com/54615666/78550726-2dbfff00-7822-11ea-9121-c9ae3130bd1c.png)

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.