### PR TITLE
Fix #555: Create one central utility file from where we should access date format or even convert date timestamp to string from that file.

### DIFF
--- a/app/src/main/java/org/oppia/app/administratorcontrols/appversion/AppVersionViewModel.kt
+++ b/app/src/main/java/org/oppia/app/administratorcontrols/appversion/AppVersionViewModel.kt
@@ -6,7 +6,7 @@ import org.oppia.app.BuildConfig
 import org.oppia.app.fragment.FragmentScope
 import org.oppia.app.viewmodel.ObservableViewModel
 import org.oppia.util.system.OppiaDateTimeFormatter
-import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 
 /** [ViewModel] for [AppVersionFragment]*/

--- a/app/src/main/java/org/oppia/app/administratorcontrols/appversion/AppVersionViewModel.kt
+++ b/app/src/main/java/org/oppia/app/administratorcontrols/appversion/AppVersionViewModel.kt
@@ -22,13 +22,11 @@ class AppVersionViewModel @Inject constructor(
     fragment.activity!!.packageManager.getPackageInfo(fragment.activity!!.packageName, /* flags= */ 0).lastUpdateTime
   val lastUpdateDate = ObservableField<String>(getDateTime(lastUpdateDateTime))
 
-  // TODO(#555): Create one central utility file from where we should access date format or even convert date timestamp to string from that file.
-  private fun getDateTime(l: Long): String? {
-    val dateTime = oppiaDateTimeFormatter.formatDateFromDateString(
-      oppiaDateTimeFormatter.dd_MMMM_yyyy,
-      l,
+  private fun getDateTime(lastUpdateTime: Long): String? {
+    return oppiaDateTimeFormatter.formatDateFromDateString(
+      OppiaDateTimeFormatter.DD_MMM_YYYY,
+      lastUpdateTime,
       Locale.US
     )
-    return dateTime
   }
 }

--- a/app/src/main/java/org/oppia/app/administratorcontrols/appversion/AppVersionViewModel.kt
+++ b/app/src/main/java/org/oppia/app/administratorcontrols/appversion/AppVersionViewModel.kt
@@ -5,14 +5,15 @@ import androidx.fragment.app.Fragment
 import org.oppia.app.BuildConfig
 import org.oppia.app.fragment.FragmentScope
 import org.oppia.app.viewmodel.ObservableViewModel
-import java.text.SimpleDateFormat
+import org.oppia.util.system.OppiaDateTimeFormatter
 import java.util.*
 import javax.inject.Inject
 
 /** [ViewModel] for [AppVersionFragment]*/
 @FragmentScope
 class AppVersionViewModel @Inject constructor(
-  fragment: Fragment
+  fragment: Fragment,
+  private val oppiaDateTimeFormatter: OppiaDateTimeFormatter
 ) : ObservableViewModel() {
 
   val versionName = ObservableField<String>(BuildConfig.VERSION_NAME)
@@ -23,12 +24,11 @@ class AppVersionViewModel @Inject constructor(
 
   // TODO(#555): Create one central utility file from where we should access date format or even convert date timestamp to string from that file.
   private fun getDateTime(l: Long): String? {
-    return try {
-      val sdf = SimpleDateFormat("dd MMMM yyyy", Locale.US)
-      val netDate = Date(l)
-      sdf.format(netDate)
-    } catch (e: Exception) {
-      e.toString()
-    }
+    val dateTime = oppiaDateTimeFormatter.formatDateFromDateString(
+      oppiaDateTimeFormatter.dd_MMMM_yyyy,
+      l,
+      Locale.US
+    )
+    return dateTime
   }
 }

--- a/app/src/main/java/org/oppia/app/databinding/TextViewBindingAdapters.kt
+++ b/app/src/main/java/org/oppia/app/databinding/TextViewBindingAdapters.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import org.oppia.app.R
+import org.oppia.util.system.OppiaDateTimeFormatter
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -11,8 +12,11 @@ import java.util.*
 @BindingAdapter("profile:created")
 fun setProfileDataText(textView: TextView, timestamp: Long) {
   // TODO(#555): Create one central utility file from where we should access date format or even convert date timestamp to string from that file.
-  val sdf = SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
-  val time = sdf.format(Date(timestamp))
+  val oppiaDateTimeFormatter = OppiaDateTimeFormatter()
+  val time = oppiaDateTimeFormatter.formatDateFromDateString(
+    oppiaDateTimeFormatter.dd_MMMM_yyyy,
+    timestamp
+  )
   textView.text = String.format(textView.context.getString(R.string.profile_edit_created, time))
 }
 
@@ -34,18 +38,14 @@ private const val HOUR_MILLIS = 60 * MINUTE_MILLIS
 private const val DAY_MILLIS = 24 * HOUR_MILLIS
 
 // TODO(#555): Shift this logic to central utility file for date-time related conversions.
-fun currentDate(): Date {
-  val calendar = Calendar.getInstance()
-  return calendar.time
-}
 
 fun getTimeAgo(lastVisitedTimeStamp: Long, context: Context): String {
-  var timeStamp = lastVisitedTimeStamp
-  if (timeStamp < 1000000000000L)
-  // If timestamp is given in seconds, convert that to milliseconds.
-    timeStamp *= 1000
 
-  val now = currentDate().time
+  val oppiaDateTimeFormatter = OppiaDateTimeFormatter()
+  val timeStamp =
+    oppiaDateTimeFormatter.checkAndConvertTimestampToMilliseconds(lastVisitedTimeStamp)
+  val now = oppiaDateTimeFormatter.currentDate().time
+
   if (timeStamp > now || timeStamp <= 0) return ""
 
   val res = context.resources

--- a/app/src/main/java/org/oppia/app/databinding/TextViewBindingAdapters.kt
+++ b/app/src/main/java/org/oppia/app/databinding/TextViewBindingAdapters.kt
@@ -5,8 +5,6 @@ import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import org.oppia.app.R
 import org.oppia.util.system.OppiaDateTimeFormatter
-import java.text.SimpleDateFormat
-import java.util.*
 
 /** Binds date text with relative time. */
 @BindingAdapter("profile:created")
@@ -14,7 +12,7 @@ fun setProfileDataText(textView: TextView, timestamp: Long) {
   // TODO(#555): Create one central utility file from where we should access date format or even convert date timestamp to string from that file.
   val oppiaDateTimeFormatter = OppiaDateTimeFormatter()
   val time = oppiaDateTimeFormatter.formatDateFromDateString(
-    oppiaDateTimeFormatter.dd_MMMM_yyyy,
+    OppiaDateTimeFormatter.DD_MMM_YYYY,
     timestamp
   )
   textView.text = String.format(textView.context.getString(R.string.profile_edit_created, time))

--- a/app/src/main/java/org/oppia/app/databinding/TextViewBindingAdapters.kt
+++ b/app/src/main/java/org/oppia/app/databinding/TextViewBindingAdapters.kt
@@ -9,7 +9,6 @@ import org.oppia.util.system.OppiaDateTimeFormatter
 /** Binds date text with relative time. */
 @BindingAdapter("profile:created")
 fun setProfileDataText(textView: TextView, timestamp: Long) {
-  // TODO(#555): Create one central utility file from where we should access date format or even convert date timestamp to string from that file.
   val oppiaDateTimeFormatter = OppiaDateTimeFormatter()
   val time = oppiaDateTimeFormatter.formatDateFromDateString(
     OppiaDateTimeFormatter.DD_MMM_YYYY,
@@ -20,8 +19,7 @@ fun setProfileDataText(textView: TextView, timestamp: Long) {
 
 @BindingAdapter("profile:lastVisited")
 fun setProfileLastVisitedText(textView: TextView, timestamp: Long) {
-  // TODO(#555): Create one central utility file from where we should access date format or even convert date timestamp to string from that file.
-  textView.text =
+   textView.text =
     String.format(
       textView.context.getString(R.string.profile_last_used) + " " + getTimeAgo(
         timestamp,
@@ -34,8 +32,6 @@ private const val SECOND_MILLIS = 1000
 private const val MINUTE_MILLIS = 60 * SECOND_MILLIS
 private const val HOUR_MILLIS = 60 * MINUTE_MILLIS
 private const val DAY_MILLIS = 24 * HOUR_MILLIS
-
-// TODO(#555): Shift this logic to central utility file for date-time related conversions.
 
 fun getTimeAgo(lastVisitedTimeStamp: Long, context: Context): String {
 

--- a/app/src/sharedTest/java/org/oppia/app/administratorcontrols/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/administratorcontrols/AppVersionActivityTest.kt
@@ -35,7 +35,7 @@ import org.oppia.app.utility.OrientationChangeAction.Companion.orientationLandsc
 import org.oppia.util.system.OppiaDateTimeFormatter
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
-import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -126,7 +126,6 @@ class AppVersionActivityTest {
     }
   }
 
-  // TODO(#555): Create one central utility file from where we should access date format or even convert date timestamp to string from that file.
   private fun getDateTime(dateTimeTimestamp: Long): String? {
     return oppiaDateTimeFormatter.formatDateFromDateString(
       OppiaDateTimeFormatter.DD_MMM_YYYY,

--- a/app/src/sharedTest/java/org/oppia/app/administratorcontrols/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/administratorcontrols/AppVersionActivityTest.kt
@@ -32,6 +32,7 @@ import org.oppia.app.BuildConfig
 import org.oppia.app.R
 import org.oppia.app.administratorcontrols.appversion.AppVersionActivity
 import org.oppia.app.utility.OrientationChangeAction.Companion.orientationLandscape
+import org.oppia.util.system.OppiaDateTimeFormatter
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import java.text.SimpleDateFormat
@@ -44,6 +45,7 @@ import javax.inject.Singleton
 class AppVersionActivityTest {
 
   @Inject lateinit var context: Context
+  @Inject lateinit var oppiaDateTimeFormatter: OppiaDateTimeFormatter
   private lateinit var lastUpdateDate: String
 
   @Before
@@ -127,13 +129,12 @@ class AppVersionActivityTest {
 
   // TODO(#555): Create one central utility file from where we should access date format or even convert date timestamp to string from that file.
   private fun getDateTime(l: Long): String? {
-    return try {
-      val sdf = SimpleDateFormat("dd MMMM yyyy", Locale.US)
-      val netDate = Date(l)
-      sdf.format(netDate)
-    } catch (e: Exception) {
-      e.toString()
-    }
+    val dateTime = oppiaDateTimeFormatter.formatDateFromDateString(
+      oppiaDateTimeFormatter.dd_MMMM_yyyy,
+      l,
+      Locale.US
+    )
+    return dateTime
   }
 
   private fun launchAppVersionActivityIntent(): ActivityScenario<AppVersionActivity> {

--- a/app/src/sharedTest/java/org/oppia/app/administratorcontrols/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/administratorcontrols/AppVersionActivityTest.kt
@@ -35,7 +35,6 @@ import org.oppia.app.utility.OrientationChangeAction.Companion.orientationLandsc
 import org.oppia.util.system.OppiaDateTimeFormatter
 import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
-import java.text.SimpleDateFormat
 import java.util.*
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/app/src/sharedTest/java/org/oppia/app/administratorcontrols/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/administratorcontrols/AppVersionActivityTest.kt
@@ -128,13 +128,12 @@ class AppVersionActivityTest {
   }
 
   // TODO(#555): Create one central utility file from where we should access date format or even convert date timestamp to string from that file.
-  private fun getDateTime(l: Long): String? {
-    val dateTime = oppiaDateTimeFormatter.formatDateFromDateString(
-      oppiaDateTimeFormatter.dd_MMMM_yyyy,
-      l,
+  private fun getDateTime(dateTimeTimestamp: Long): String? {
+    return oppiaDateTimeFormatter.formatDateFromDateString(
+      OppiaDateTimeFormatter.DD_MMM_YYYY,
+      dateTimeTimestamp,
       Locale.US
     )
-    return dateTime
   }
 
   private fun launchAppVersionActivityIntent(): ActivityScenario<AppVersionActivity> {

--- a/utility/src/main/java/org/oppia/util/system/OppiaDateTimeFormatter.kt
+++ b/utility/src/main/java/org/oppia/util/system/OppiaDateTimeFormatter.kt
@@ -1,7 +1,9 @@
 package org.oppia.util.system
 
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/utility/src/main/java/org/oppia/util/system/OppiaDateTimeFormatter.kt
+++ b/utility/src/main/java/org/oppia/util/system/OppiaDateTimeFormatter.kt
@@ -11,10 +11,9 @@ import javax.inject.Singleton
 @Singleton
 class OppiaDateTimeFormatter @Inject constructor() {
 
-  val dd_MMM_yyyy = "dd MMM yyyy"
-  val hh_mm_a = "hh:mm a"
-  val dd_MMMM_yyyy = "dd MMMM yyyy"
-  val dd_MMMM_yyyy_zzzz = "dd MMMM yyyy zzzz"
+  companion object{
+    val DD_MMM_YYYY = "dd MMMM yyyy"
+  }
 
   fun formatDateFromDateString(
     inputDateFormat: String,
@@ -37,9 +36,10 @@ class OppiaDateTimeFormatter @Inject constructor() {
 
   fun checkAndConvertTimestampToMilliseconds(lastVisitedTimeStamp: Long): Long {
     var timeStamp = lastVisitedTimeStamp
-    if (timeStamp < 1000000000000L)
-    // If timestamp is given in seconds, convert that to milliseconds.
+    if (timeStamp < 1000000000000L) {
+      // If timestamp is given in seconds, convert that to milliseconds.
       timeStamp *= 1000
+    }
     return timeStamp
   }
 }

--- a/utility/src/main/java/org/oppia/util/system/OppiaDateTimeFormatter.kt
+++ b/utility/src/main/java/org/oppia/util/system/OppiaDateTimeFormatter.kt
@@ -1,0 +1,43 @@
+package org.oppia.util.system
+
+import java.text.SimpleDateFormat
+import java.util.*
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Utility to format date to text or parse text to date. */
+@Singleton
+class OppiaDateTimeFormatter @Inject constructor() {
+
+  val dd_MMM_yyyy = "dd MMM yyyy"
+  val hh_mm_a = "hh:mm a"
+  val dd_MMMM_yyyy = "dd MMMM yyyy"
+  val dd_MMMM_yyyy_zzzz = "dd MMMM yyyy zzzz"
+
+  fun formatDateFromDateString(
+    inputDateFormat: String,
+    timestamp: Long,
+    locale: Locale = Locale.getDefault()
+  ): String {
+    return try {
+      val sdf = SimpleDateFormat(inputDateFormat, locale)
+      val dateTime = Date(timestamp)
+      sdf.format(dateTime)
+    } catch (e: Exception) {
+      e.toString()
+    }
+  }
+
+  fun currentDate(): Date {
+    val calendar = Calendar.getInstance()
+    return calendar.time
+  }
+
+  fun checkAndConvertTimestampToMilliseconds(lastVisitedTimeStamp: Long): Long {
+    var timeStamp = lastVisitedTimeStamp
+    if (timeStamp < 1000000000000L)
+    // If timestamp is given in seconds, convert that to milliseconds.
+      timeStamp *= 1000
+    return timeStamp
+  }
+}

--- a/utility/src/main/java/org/oppia/util/system/OppiaDateTimeFormatter.kt
+++ b/utility/src/main/java/org/oppia/util/system/OppiaDateTimeFormatter.kt
@@ -12,7 +12,7 @@ import javax.inject.Singleton
 class OppiaDateTimeFormatter @Inject constructor() {
 
   companion object {
-    val DD_MMM_YYYY = "dd MMMM yyyy"
+    const val DD_MMM_YYYY = "dd MMMM yyyy"
   }
 
   fun formatDateFromDateString(

--- a/utility/src/main/java/org/oppia/util/system/OppiaDateTimeFormatter.kt
+++ b/utility/src/main/java/org/oppia/util/system/OppiaDateTimeFormatter.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 @Singleton
 class OppiaDateTimeFormatter @Inject constructor() {
 
-  companion object{
+  companion object {
     val DD_MMM_YYYY = "dd MMMM yyyy"
   }
 

--- a/utility/src/test/java/org/oppia/util/system/OppiaDateTimeFormatterTest.kt
+++ b/utility/src/test/java/org/oppia/util/system/OppiaDateTimeFormatterTest.kt
@@ -9,19 +9,17 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import javax.inject.Inject
-import javax.inject.Singleton
 
 // Time: Wed Apr 24 2019 08:22:00
 private const val MORNING_TIMESTAMP = 1556094120000
-
 // Time: Formatted time for 1556094120000 timestamp
 private const val MORNING_FORMATTED_TIME = "24 April 2019"
-
 private const val MILLISECONDS = 1586774460000
 private const val TIMESTAMP_IN_SECONDS = 1586774460L
 

--- a/utility/src/test/java/org/oppia/util/system/OppiaDateTimeFormatterTest.kt
+++ b/utility/src/test/java/org/oppia/util/system/OppiaDateTimeFormatterTest.kt
@@ -47,7 +47,7 @@ class OppiaDateTimeFormatterTest {
   fun testFormatDateFromDateString_successFormatToString() {
     assertThat(
       oppiaDateTimeFormatter.formatDateFromDateString(
-        oppiaDateTimeFormatter.dd_MMMM_yyyy,
+        OppiaDateTimeFormatter.DD_MMM_YYYY,
         MORNING_TIMESTAMP
       )
     ).isEqualTo(MORNING_FORMATTED_TIME)

--- a/utility/src/test/java/org/oppia/util/system/OppiaDateTimeFormatterTest.kt
+++ b/utility/src/test/java/org/oppia/util/system/OppiaDateTimeFormatterTest.kt
@@ -1,0 +1,92 @@
+package org.oppia.util.system
+
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import dagger.BindsInstance
+import dagger.Component
+import dagger.Module
+import dagger.Provides
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// Time: Wed Apr 24 2019 08:22:00
+private const val MORNING_TIMESTAMP = 1556094120000
+
+// Time: Formatted time for 1556094120000 timestamp
+private const val MORNING_FORMATTED_TIME = "24 April 2019"
+
+private const val MILLISECONDS = 1586774460000
+private const val TIMESTAMP_IN_SECONDS = 1586774460L
+
+/** Tests for [OppiaDateTimeFormatter]. */
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class OppiaDateTimeFormatterTest {
+
+  @Inject
+  lateinit var oppiaDateTimeFormatter: OppiaDateTimeFormatter
+
+  @Before
+  fun setUp() {
+    setUpTestApplicationComponent()
+  }
+
+  private fun setUpTestApplicationComponent() {
+    DaggerOppiaDateTimeFormatterTest_TestApplicationComponent.builder()
+      .setApplication(ApplicationProvider.getApplicationContext())
+      .build()
+      .inject(this)
+  }
+
+  @Test
+  fun testFormatDateFromDateString_successFormatToString() {
+    assertThat(
+      oppiaDateTimeFormatter.formatDateFromDateString(
+        oppiaDateTimeFormatter.dd_MMMM_yyyy,
+        MORNING_TIMESTAMP
+      )
+    ).isEqualTo(MORNING_FORMATTED_TIME)
+  }
+
+  @Test
+  fun testCheckAndConvertTimestampToMilliseconds_successConvertedToMilliseconds() {
+    assertThat(
+      oppiaDateTimeFormatter.checkAndConvertTimestampToMilliseconds(
+        TIMESTAMP_IN_SECONDS
+      )
+    ).isEqualTo(MILLISECONDS)
+  }
+
+  // TODO(#89): Move this to a common test application component.
+  @Module
+  class TestModule {
+
+    @Provides
+    @Singleton
+    fun provideContext(application: Application): Context {
+      return application
+    }
+  }
+
+  // TODO(#89): Move this to a common test application component.
+  @Singleton
+  @Component(modules = [TestModule::class])
+  interface TestApplicationComponent {
+    @Component.Builder
+    interface Builder {
+      @BindsInstance
+      fun setApplication(application: Application): Builder
+
+      fun build(): TestApplicationComponent
+    }
+
+    fun inject(oppiaTimeFormatterTest: OppiaDateTimeFormatterTest)
+  }
+}


### PR DESCRIPTION
## Explanation
Fixes #555 This PR adds the central utility file for date format

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
