### PR TITLE
Fix #986: Fixed crash in ProfileResetPinActivityPresenter

### DIFF
--- a/app/src/main/java/org/oppia/app/settings/profile/ProfileResetPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/settings/profile/ProfileResetPinActivityPresenter.kt
@@ -41,7 +41,7 @@ class ProfileResetPinActivityPresenter @Inject constructor(
     resetViewModel.isAdmin.set(isAdmin)
 
     binding.profileResetPinToolbar.setNavigationOnClickListener {
-      (activity as ProfileRenameActivity).finish()
+      (activity as ProfileResetPinActivity).finish()
     }
 
     binding.apply {


### PR DESCRIPTION
## Explanation

This Pr fixes crash on click of navigation back button in Profile Reset Pin.