### PR TITLE
Fix #1003: Pin verification hifi

### DIFF
--- a/app/src/main/res/layout-land/pin_password_activity.xml
+++ b/app/src/main/res/layout-land/pin_password_activity.xml
@@ -105,9 +105,11 @@
 
     <LinearLayout
       android:id="@+id/show_pin"
-      android:layout_width="48dp"
-      android:layout_height="48dp"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
       android:layout_marginStart="12dp"
+      android:minWidth="48dp"
+      android:minHeight="48dp"
       android:orientation="vertical"
       app:layout_constraintBottom_toBottomOf="@+id/input_pin"
       app:layout_constraintStart_toEndOf="@+id/input_pin"

--- a/app/src/main/res/layout-land/pin_password_activity.xml
+++ b/app/src/main/res/layout-land/pin_password_activity.xml
@@ -128,7 +128,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="center_horizontal"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="4dp"
         android:fontFamily="sans-serif"
         android:text="@{viewModel.showPassword ? @string/pin_password_hide : @string/pin_password_show}"
         android:textAllCaps="true"

--- a/app/src/main/res/layout-land/pin_password_activity.xml
+++ b/app/src/main/res/layout-land/pin_password_activity.xml
@@ -17,7 +17,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/oppiaLightGreen"
-    android:paddingTop="96dp">
+    android:paddingTop="48dp"
+    android:paddingBottom="76dp">
 
     <TextView
       android:id="@+id/hello_text_view"

--- a/app/src/main/res/layout-land/pin_password_activity.xml
+++ b/app/src/main/res/layout-land/pin_password_activity.xml
@@ -54,7 +54,7 @@
       android:layout_height="wrap_content"
       android:layout_marginTop="24dp"
       android:text="@string/pin_password_incorrect_pin"
-      android:textColor="@color/oppiaBrown"
+      android:textColor="@color/editTextError"
       android:textSize="16sp"
       android:visibility="@{viewModel.showError ? View.VISIBLE : View.INVISIBLE}"
       app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/pin_password_activity.xml
+++ b/app/src/main/res/layout/pin_password_activity.xml
@@ -53,7 +53,7 @@
       android:layout_height="wrap_content"
       android:layout_marginTop="24dp"
       android:text="@string/pin_password_incorrect_pin"
-      android:textColor="@color/oppiaBrown"
+      android:textColor="@color/editTextError"
       android:textSize="16sp"
       android:visibility="@{viewModel.showError ? View.VISIBLE : View.INVISIBLE}"
       app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/pin_password_activity.xml
+++ b/app/src/main/res/layout/pin_password_activity.xml
@@ -127,7 +127,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="center_horizontal"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="4dp"
         android:fontFamily="sans-serif"
         android:text="@{viewModel.showPassword ? @string/pin_password_hide : @string/pin_password_show}"
         android:textAllCaps="true"

--- a/app/src/main/res/layout/pin_password_activity.xml
+++ b/app/src/main/res/layout/pin_password_activity.xml
@@ -104,9 +104,11 @@
 
     <LinearLayout
       android:id="@+id/show_pin"
-      android:layout_width="48dp"
-      android:layout_height="48dp"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
       android:layout_marginStart="12dp"
+      android:minWidth="48dp"
+      android:minHeight="48dp"
       android:orientation="vertical"
       app:layout_constraintBottom_toBottomOf="@+id/input_pin"
       app:layout_constraintStart_toEndOf="@+id/input_pin"


### PR DESCRIPTION
## Explanation
Pin verification landscape and general hifi

## Mocks
Portrait 
https://xd.adobe.com/view/0687f00c-695b-437a-79a6-688e7f4f7552-70b6/screen/afb412a3-db42-4538-bbdd-7d38c84d963e/PC-NP-Shake-Error- 
Lanscape 
https://xd.adobe.com/view/ee9e607b-dbd6-4372-48dc-b687d32af3da-98af/screen/6722d327-0ea3-4a80-8370-69ce85f308f5/RG-MN-Register-Empty-22

## Screenshots
![Screenshot_20200420-154559](https://user-images.githubusercontent.com/54615666/79741213-7eede980-831e-11ea-8187-46cd28889828.png)
![Screenshot_20200420-154530 (1)](https://user-images.githubusercontent.com/54615666/79741221-81504380-831e-11ea-8f9a-31ab96359936.png)

## Accessibility test result
![Screenshot_20200420-154621](https://user-images.githubusercontent.com/54615666/79741310-a775e380-831e-11ea-96cc-f184b2558bf2.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
