### PR TITLE
Fix part of #972: Enable kotlin linting to the data module in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,8 +61,8 @@ jobs:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle" }}
       - run:
-          name: Utility module linting
-          command: ./ktlint utility/src/**/java && echo "Lint completed successfully"
+          name: Kotlin tests - Data, Utility
+          command: ./ktlint utility/**/*.kt data/**/*.kt && echo "Lint completed successfully"
       - store_artifacts:
           path: app/build/reports
           destination: reports


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
We fixed all kotlin lint issues in the data module in #996 
Now we would like to enable the lint check for the module in circleci to avoid future linting errors
Fixes part of #972 

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR is made from a branch that is up-to-date with "develop".
- [ ] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
