### PR TITLE
Fix #1042 Status bar color for pre-lollipop versions

### DIFF
--- a/app/src/main/java/org/oppia/app/drawer/NavigationDrawerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/drawer/NavigationDrawerFragmentPresenter.kt
@@ -253,13 +253,13 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
         override fun onDrawerOpened(drawerView: View) {
           super.onDrawerOpened(drawerView)
           fragment.activity!!.invalidateOptionsMenu()
-          StatusBarColor.statusBarColorUpdate(R.color.slideDrawerOpenStatusBar, activity, false)
+          StatusBarColor.statusBarColorUpdate(R.color.slideDrawerOpenStatusBar, activity,binding.statusBarBackground, false)
         }
 
         override fun onDrawerClosed(drawerView: View) {
           super.onDrawerClosed(drawerView)
           fragment.activity!!.invalidateOptionsMenu()
-          StatusBarColor.statusBarColorUpdate(R.color.colorPrimaryDark, activity, false)
+          StatusBarColor.statusBarColorUpdate(R.color.colorPrimaryDark, activity,binding.statusBarBackground, false)
         }
       }
       drawerLayout.setDrawerListener(drawerToggle)
@@ -279,13 +279,13 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
         override fun onDrawerOpened(drawerView: View) {
           super.onDrawerOpened(drawerView)
           fragment.activity!!.invalidateOptionsMenu()
-          StatusBarColor.statusBarColorUpdate(R.color.slideDrawerOpenStatusBar, activity, false)
+          StatusBarColor.statusBarColorUpdate(R.color.slideDrawerOpenStatusBar, activity,binding.statusBarBackground, false)
         }
 
         override fun onDrawerClosed(drawerView: View) {
           super.onDrawerClosed(drawerView)
           fragment.activity!!.invalidateOptionsMenu()
-          StatusBarColor.statusBarColorUpdate(R.color.colorPrimaryDark, activity, false)
+          StatusBarColor.statusBarColorUpdate(R.color.colorPrimaryDark, activity,binding.statusBarBackground, false)
         }
       }
       drawerLayout.setDrawerListener(drawerToggle)

--- a/app/src/main/java/org/oppia/app/home/topiclist/TopicListAdapter.kt
+++ b/app/src/main/java/org/oppia/app/home/topiclist/TopicListAdapter.kt
@@ -151,7 +151,7 @@ class TopicListAdapter(
        */
       val snapHelper = StartSnapHelper()
       binding.promotedStoryListRecyclerView.layoutManager = horizontalLayoutManager
-      binding.promotedStoryListRecyclerView.setOnFlingListener(null)
+      binding.promotedStoryListRecyclerView.onFlingListener = null
       snapHelper.attachToRecyclerView(binding.promotedStoryListRecyclerView)
 
       val paddingEnd = if (orientation == Configuration.ORIENTATION_PORTRAIT) {

--- a/app/src/main/java/org/oppia/app/onboarding/OnboardingFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/onboarding/OnboardingFragmentPresenter.kt
@@ -68,11 +68,11 @@ class OnboardingFragmentPresenter @Inject constructor(
 
   private fun onboardingStatusBarColorUpdate(position: Int) {
     when (position) {
-      0 -> StatusBarColor.statusBarColorUpdate(R.color.onboarding1StatusBar, activity, false)
-      1 -> StatusBarColor.statusBarColorUpdate(R.color.onboarding2StatusBar, activity, false)
-      2 -> StatusBarColor.statusBarColorUpdate(R.color.onboarding3StatusBar, activity, false)
-      3 -> StatusBarColor.statusBarColorUpdate(R.color.onboarding4StatusBar, activity, false)
-      else -> StatusBarColor.statusBarColorUpdate(R.color.colorPrimaryDark, activity, false)
+      0 -> StatusBarColor.statusBarColorUpdate(R.color.onboarding1StatusBar, activity,binding.statusBarBackground, false)
+      1 -> StatusBarColor.statusBarColorUpdate(R.color.onboarding2StatusBar, activity,binding.statusBarBackground, false)
+      2 -> StatusBarColor.statusBarColorUpdate(R.color.onboarding3StatusBar, activity,binding.statusBarBackground, false)
+      3 -> StatusBarColor.statusBarColorUpdate(R.color.onboarding4StatusBar, activity,binding.statusBarBackground, false)
+      else -> StatusBarColor.statusBarColorUpdate(R.color.colorPrimaryDark, activity,binding.statusBarBackground, false)
     }
   }
 

--- a/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
@@ -184,7 +184,7 @@ class StateFragmentPresenter @Inject constructor(
         if (bottom < oldBottom) {
           binding.stateRecyclerView.postDelayed({
             binding.stateRecyclerView.scrollToPosition(
-              stateRecyclerViewAdapter.getItemCount() - 1
+              stateRecyclerViewAdapter.itemCount - 1
             )
           }, 100)
         }
@@ -545,7 +545,7 @@ class StateFragmentPresenter @Inject constructor(
   }
 
   private fun showCongratulationMessageOnCorrectAnswer() {
-    binding.congratulationTextview.setVisibility(View.VISIBLE)
+    binding.congratulationTextview.visibility = View.VISIBLE
 
     val fadeIn = AlphaAnimation(0f, 1f)
     fadeIn.interpolator = DecelerateInterpolator() //add this
@@ -559,7 +559,7 @@ class StateFragmentPresenter @Inject constructor(
     val animation = AnimationSet(false) //change to false
     animation.addAnimation(fadeIn)
     animation.addAnimation(fadeOut)
-    binding.congratulationTextview.setAnimation(animation)
+    binding.congratulationTextview.animation = animation
 
     Handler().postDelayed({
       binding.congratulationTextview.clearAnimation()

--- a/app/src/main/java/org/oppia/app/profile/PinPasswordActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/profile/PinPasswordActivityPresenter.kt
@@ -40,7 +40,6 @@ class PinPasswordActivityPresenter @Inject constructor(
 
   @ExperimentalCoroutinesApi
   fun handleOnCreate() {
-    StatusBarColor.statusBarColorUpdate(R.color.pinInputStatusBar, activity, true)
     val adminPin = activity.intent.getStringExtra(KEY_PIN_PASSWORD_ADMIN_PIN)
     profileId = activity.intent.getIntExtra(KEY_PIN_PASSWORD_PROFILE_ID, -1)
     val binding = DataBindingUtil.setContentView<PinPasswordActivityBinding>(activity, R.layout.pin_password_activity)
@@ -49,7 +48,7 @@ class PinPasswordActivityPresenter @Inject constructor(
       lifecycleOwner = activity
       viewModel = pinViewModel
     }
-
+    StatusBarColor.statusBarColorUpdate(R.color.pinInputStatusBar, activity,binding.statusBarBackground, true)
     binding.showPin.setOnClickListener {
       pinViewModel.showPassword.set(!pinViewModel.showPassword.get()!!)
     }

--- a/app/src/main/java/org/oppia/app/profile/ProfileChooserFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/profile/ProfileChooserFragmentPresenter.kt
@@ -3,9 +3,13 @@ package org.oppia.app.profile
 import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Resources
+import android.os.Build
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.databinding.ObservableField
@@ -78,12 +82,12 @@ class ProfileChooserFragmentPresenter @Inject constructor(
 
   /** Binds ViewModel and sets up RecyclerView Adapter. */
   fun handleCreateView(inflater: LayoutInflater, container: ViewGroup?): View? {
-    StatusBarColor.statusBarColorUpdate(R.color.profileStatusBar, activity, false)
     binding = ProfileChooserFragmentBinding.inflate(inflater, container, /* attachToRoot= */ false)
     binding.apply {
       viewModel = chooserViewModel
       lifecycleOwner = fragment
     }
+    StatusBarColor.statusBarColorUpdate(R.color.profileStatusBar, activity,  binding.statusBarBackground, false)
     binding.profileRecyclerView.isNestedScrollingEnabled = false
     subscribeToWasProfileEverBeenAdded()
     binding.profileRecyclerView.apply {

--- a/app/src/main/java/org/oppia/app/profileprogress/ProfilePictureActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/profileprogress/ProfilePictureActivityPresenter.kt
@@ -28,7 +28,6 @@ class ProfilePictureActivityPresenter @Inject constructor(
   private lateinit var profileId: ProfileId
 
   fun handleOnCreate(internalProfileId: Int) {
-    StatusBarColor.statusBarColorUpdate(R.color.profileStatusBar, activity, false)
     val binding = DataBindingUtil.setContentView<ProfilePictureActivityBinding>(activity, R.layout.profile_picture_activity)
     profilePictureActivityViewModel = ProfilePictureActivityViewModel()
 
@@ -36,6 +35,7 @@ class ProfilePictureActivityPresenter @Inject constructor(
       viewModel = profilePictureActivityViewModel
       lifecycleOwner = activity
     }
+    StatusBarColor.statusBarColorUpdate(R.color.profileStatusBar, activity,binding.statusBarBackground, false)
     profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
 
     subscribeToProfileLiveData()

--- a/app/src/main/java/org/oppia/app/profileprogress/ProfileProgressViewModel.kt
+++ b/app/src/main/java/org/oppia/app/profileprogress/ProfileProgressViewModel.kt
@@ -97,7 +97,7 @@ class ProfileProgressViewModel @Inject constructor(
       ongoingStoryList.recentStoryList
     }
     itemViewModelList.addAll(itemList.map { story ->
-      RecentlyPlayedStorySummaryViewModel(story) as ProfileProgressItemViewModel
+      RecentlyPlayedStorySummaryViewModel(story)
     })
     return itemViewModelList
   }

--- a/app/src/main/java/org/oppia/app/recyclerview/BindableAdapter.kt
+++ b/app/src/main/java/org/oppia/app/recyclerview/BindableAdapter.kt
@@ -33,7 +33,6 @@ class BindableAdapter<T : Any> internal constructor(
   private val dataList: MutableList<T> = ArrayList()
 
   // TODO(#170): Introduce support for stable IDs.
-
   /** Sets the data of this adapter. This is expected to be called by Android via data-binding. */
   private fun setData(newDataList: List<T>) {
     dataList.clear()

--- a/app/src/main/java/org/oppia/app/testing/InputInteractionViewTestActivity.kt
+++ b/app/src/main/java/org/oppia/app/testing/InputInteractionViewTestActivity.kt
@@ -60,9 +60,6 @@ class InputInteractionViewTestActivity : AppCompatActivity(), StateKeyboardButto
   override fun onPendingAnswerError(
     pendingAnswerError: String?
   ) {
-    if (pendingAnswerError != null)
-      binding.submitButton.isEnabled = false
-    else
-      binding.submitButton.isEnabled = true
+    binding.submitButton.isEnabled = pendingAnswerError == null
   }
 }

--- a/app/src/main/java/org/oppia/app/topic/practice/TopicPracticeViewModel.kt
+++ b/app/src/main/java/org/oppia/app/topic/practice/TopicPracticeViewModel.kt
@@ -58,7 +58,7 @@ class TopicPracticeViewModel @Inject constructor(
     itemViewModelList.add(TopicPracticeHeaderViewModel() as TopicPracticeItemViewModel)
 
     itemViewModelList.addAll(topic.subtopicList.map { subtopic ->
-      TopicPracticeSubtopicViewModel(subtopic) as TopicPracticeItemViewModel
+      TopicPracticeSubtopicViewModel(subtopic)
     })
 
     itemViewModelList.add(TopicPracticeFooterViewModel() as TopicPracticeItemViewModel)

--- a/app/src/main/java/org/oppia/app/walkthrough/WalkthroughActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/walkthrough/WalkthroughActivityPresenter.kt
@@ -29,7 +29,7 @@ class WalkthroughActivityPresenter @Inject constructor(
       presenter = this@WalkthroughActivityPresenter
       lifecycleOwner = activity
     }
-    StatusBarColor.statusBarColorUpdate(R.color.walkthroughStatusBar, activity, true)
+    StatusBarColor.statusBarColorUpdate(R.color.walkthroughStatusBar, activity,binding.statusBarBackground, true)
     val currentFragmentIndex = getWalkthroughViewModel().currentProgress.get()?.minus(1)
 
     if (currentFragmentIndex == -1 && getWalkthroughWelcomeFragment() == null) {

--- a/app/src/main/res/layout-land/onboarding_fragment.xml
+++ b/app/src/main/res/layout-land/onboarding_fragment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto">
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools">
 
   <data>
 
@@ -19,6 +20,11 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/oppiaBackgroundYellowIvory">
+    <View
+      android:id="@+id/statusBarBackground"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.viewpager.widget.ViewPager
       android:id="@+id/onboarding_slide_view_pager"

--- a/app/src/main/res/layout-land/pin_password_activity.xml
+++ b/app/src/main/res/layout-land/pin_password_activity.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto">
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools">
 
   <data>
 
@@ -19,6 +20,12 @@
     android:background="@color/oppiaLightGreen"
     android:paddingTop="48dp"
     android:paddingBottom="76dp">
+
+    <View
+      android:id="@+id/statusBarBackground"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
       android:id="@+id/hello_text_view"

--- a/app/src/main/res/layout-land/profile_chooser_fragment.xml
+++ b/app/src/main/res/layout-land/profile_chooser_fragment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto">
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools">
 
   <data>
 
@@ -24,7 +25,12 @@
         android:id="@+id/profile_chooser_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-
+        <View
+          android:id="@+id/statusBarBackground"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          app:layout_constraintTop_toTopOf="parent"
+          tools:layout_editor_absoluteX="-16dp" />
         <TextView
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"

--- a/app/src/main/res/layout-land/profile_picture_activity.xml
+++ b/app/src/main/res/layout-land/profile_picture_activity.xml
@@ -15,6 +15,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <View
+      android:id="@+id/statusBarBackground"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:layout_constraintTop_toTopOf="parent"
+      />
+
     <ImageView
       android:id="@+id/profile_picture_image_view"
       android:layout_width="0dp"

--- a/app/src/main/res/layout/drawer_fragment.xml
+++ b/app/src/main/res/layout/drawer_fragment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto">
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools">
 
   <data>
 
@@ -14,7 +15,6 @@
   <com.google.android.material.navigation.NavigationView
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-
     <androidx.core.widget.NestedScrollView
       android:id="@+id/drawer_nested_scroll_view"
       android:layout_width="match_parent"
@@ -26,7 +26,13 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
-
+        <View
+          android:id="@+id/statusBarBackground"
+          android:layout_width="match_parent"
+          android:layout_height="0dp"
+          android:visibility="invisible"
+          app:layout_constraintTop_toTopOf="parent"
+          />
         <com.google.android.material.navigation.NavigationView
           android:id="@+id/fragment_drawer_nav_view"
           android:layout_width="match_parent"

--- a/app/src/main/res/layout/onboarding_fragment.xml
+++ b/app/src/main/res/layout/onboarding_fragment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto">
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools">
 
   <data>
 
@@ -19,7 +20,11 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/oppiaBackgroundYellowIvory">
-
+    <View
+      android:id="@+id/statusBarBackground"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:layout_constraintTop_toTopOf="parent" />
     <androidx.viewpager.widget.ViewPager
       android:id="@+id/onboarding_slide_view_pager"
       android:layout_width="match_parent"

--- a/app/src/main/res/layout/pin_password_activity.xml
+++ b/app/src/main/res/layout/pin_password_activity.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto">
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools">
 
   <data>
 
@@ -18,6 +19,12 @@
     android:layout_height="match_parent"
     android:background="@color/oppiaLightGreen"
     android:paddingTop="96dp">
+
+    <View
+      android:id="@+id/statusBarBackground"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:layout_constraintTop_toTopOf="parent"/>
 
     <TextView
       android:id="@+id/hello_text_view"

--- a/app/src/main/res/layout/profile_chooser_fragment.xml
+++ b/app/src/main/res/layout/profile_chooser_fragment.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:tools="http://schemas.android.com/tools"
+  xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <data>
@@ -13,6 +14,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+
     <androidx.core.widget.NestedScrollView
       android:layout_width="match_parent"
       android:layout_height="match_parent"
@@ -24,6 +26,13 @@
         android:id="@+id/profile_chooser_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
+
+        <View
+          android:id="@+id/statusBarBackground"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          app:layout_constraintTop_toTopOf="parent"
+          tools:layout_editor_absoluteX="-16dp" />
 
         <ImageView
           android:id="@+id/profile_chooser_language_icon"

--- a/app/src/main/res/layout/profile_picture_activity.xml
+++ b/app/src/main/res/layout/profile_picture_activity.xml
@@ -15,6 +15,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <View
+      android:id="@+id/statusBarBackground"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:layout_constraintTop_toTopOf="parent"
+      />
+
     <ImageView
       android:id="@+id/profile_picture_image_view"
       android:layout_width="0dp"

--- a/app/src/main/res/layout/walkthrough_activity.xml
+++ b/app/src/main/res/layout/walkthrough_activity.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto">
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools">
 
   <data>
 
@@ -18,6 +19,12 @@
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+    <View
+      android:id="@+id/statusBarBackground"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:layout_constraintTop_toTopOf="parent"
+       />
 
     <FrameLayout
       android:id="@+id/walkthrough_fragment_placeholder"

--- a/app/src/sharedTest/java/org/oppia/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -288,7 +288,7 @@ class AdministratorControlsActivityTest {
         try
         {
           val nestedScrollView = findFirstParentLayoutOfClass(view, NestedScrollView::class.java) as NestedScrollView
-          nestedScrollView.scrollTo(0, view.getTop())
+          nestedScrollView.scrollTo(0, view.top)
         }
         catch (e:Exception) {
           throw PerformException.Builder()
@@ -303,7 +303,7 @@ class AdministratorControlsActivityTest {
   }
 
   private fun findFirstParentLayoutOfClass(view: View, parentClass:Class<out View>): View {
-    var parent : ViewParent = FrameLayout(view.getContext())
+    var parent : ViewParent = FrameLayout(view.context)
     lateinit var incrementView: ViewParent
     var i = 0
     while (!(parent.javaClass === parentClass))
@@ -322,10 +322,10 @@ class AdministratorControlsActivityTest {
     return parent as View
   }
   private fun findParent(view: View): ViewParent {
-    return view.getParent()
+    return view.parent
   }
   private fun findParent(view: ViewParent): ViewParent {
-    return view.getParent()
+    return view.parent
   }
 
   @Qualifier

--- a/app/src/sharedTest/java/org/oppia/app/testing/NavigationDrawerTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/testing/NavigationDrawerTestActivityTest.kt
@@ -400,7 +400,7 @@ class NavigationDrawerTestActivityTest {
         try
         {
           val nestedScrollView = findFirstParentLayoutOfClass(view, NestedScrollView::class.java) as NestedScrollView
-          nestedScrollView.scrollTo(0, view.getTop())
+          nestedScrollView.scrollTo(0, view.top)
         }
         catch (e:Exception) {
           throw PerformException.Builder()
@@ -415,7 +415,7 @@ class NavigationDrawerTestActivityTest {
   }
 
   private fun findFirstParentLayoutOfClass(view: View, parentClass:Class<out View>): View {
-    var parent : ViewParent = FrameLayout(view.getContext())
+    var parent : ViewParent = FrameLayout(view.context)
     lateinit var incrementView: ViewParent
     var i = 0
     while (!(parent.javaClass === parentClass))
@@ -434,10 +434,10 @@ class NavigationDrawerTestActivityTest {
     return parent as View
   }
   private fun findParent(view: View): ViewParent {
-    return view.getParent()
+    return view.parent
   }
   private fun findParent(view: ViewParent): ViewParent {
-    return view.getParent()
+    return view.parent
   }
 
 

--- a/app/src/sharedTest/java/org/oppia/app/topic/info/TopicInfoFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/info/TopicInfoFragmentTest.kt
@@ -43,7 +43,7 @@ private const val DUMMY_TOPIC_DESCRIPTION_LONG = "Lorem Ipsum is simply dummy te
   "Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and " +
   "scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, " +
   "remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, " +
-  "and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.";
+  "and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
 
 // NOTE TO DEVELOPERS: this test must be annotated with @LooperMode(LooperMode.MODE.PAUSED) to pass on Robolectric.
 /** Tests for [TopicInfoFragment]. */

--- a/utility/src/main/java/org/oppia/util/statusbar/StatusBarColor.kt
+++ b/utility/src/main/java/org/oppia/util/statusbar/StatusBarColor.kt
@@ -1,7 +1,9 @@
 package org.oppia.util.statusbar
 
+import android.content.res.Resources
 import android.os.Build
 import android.view.View
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 
@@ -14,13 +16,29 @@ class StatusBarColor {
      * @param activity the reference of the activity from which this method is called.
      * @param statusBarLight passed Boolean true if the status bar theme is light, else passed Boolean false
      */
-    fun statusBarColorUpdate(colorId: Int, activity: AppCompatActivity, statusBarLight: Boolean) {
+    fun statusBarColorUpdate(colorId: Int, activity: AppCompatActivity, statusBar:View?, statusBarLight: Boolean) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
         if (statusBarLight && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
           activity.window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
         }
         activity.window.statusBarColor = ContextCompat.getColor(activity, colorId)
       }
+      else{
+        activity.window.setFlags(
+            WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS,
+            WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
+        val statusBarHeight=getStatusBarHeight(activity.resources)
+        statusBar!!.layoutParams.height=statusBarHeight
+        statusBar.setBackgroundColor(colorId)
+      }
+    }
+    private fun getStatusBarHeight(resources: Resources):Int{
+      var statusBarHeight=0
+      val id=resources.getIdentifier("status_bar_height","dimen","android")
+      if(id>0){
+        statusBarHeight=resources.getDimensionPixelSize(id)
+      }
+      return statusBarHeight
     }
   }
 }

--- a/utility/src/main/java/org/oppia/util/statusbar/StatusBarColor.kt
+++ b/utility/src/main/java/org/oppia/util/statusbar/StatusBarColor.kt
@@ -16,27 +16,33 @@ class StatusBarColor {
      * @param activity the reference of the activity from which this method is called.
      * @param statusBarLight passed Boolean true if the status bar theme is light, else passed Boolean false
      */
-    fun statusBarColorUpdate(colorId: Int, activity: AppCompatActivity, statusBar:View?, statusBarLight: Boolean) {
+    fun statusBarColorUpdate(
+      colorId: Int,
+      activity: AppCompatActivity,
+      statusBar: View?,
+      statusBarLight: Boolean
+    ) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
         if (statusBarLight && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
           activity.window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
         }
         activity.window.statusBarColor = ContextCompat.getColor(activity, colorId)
-      }
-      else{
+      } else {
         activity.window.setFlags(
-            WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS,
-            WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
-        val statusBarHeight=getStatusBarHeight(activity.resources)
-        statusBar!!.layoutParams.height=statusBarHeight
+          WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS,
+          WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS
+        )
+        val statusBarHeight = getStatusBarHeight(activity.resources)
+        statusBar!!.layoutParams.height = statusBarHeight
         statusBar.setBackgroundColor(colorId)
       }
     }
-    private fun getStatusBarHeight(resources: Resources):Int{
-      var statusBarHeight=0
-      val id=resources.getIdentifier("status_bar_height","dimen","android")
-      if(id>0){
-        statusBarHeight=resources.getDimensionPixelSize(id)
+
+    private fun getStatusBarHeight(resources: Resources): Int {
+      var statusBarHeight = 0
+      val id = resources.getIdentifier("status_bar_height", "dimen", "android")
+      if (id > 0) {
+        statusBarHeight = resources.getDimensionPixelSize(id)
       }
       return statusBarHeight
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation

 I have made change to the util.statusbarcolor file. I have also added a view in the xml files of the fragments that require to change status bar color. Also I have passed the view in the change status bar color function in the presenters of the above mentioned fragments. I inspected the code with android studio and the rest are the changes from that process.
  

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [ ] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
