### PR TITLE
Fix part of #1088: Topic download milestone 1

### DIFF
--- a/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
@@ -96,7 +96,6 @@ class TopicListController @Inject constructor(
   private val dataProviders: DataProviders,
   private val jsonAssetRetriever: JsonAssetRetriever,
   private val topicController: TopicController,
-  private val topicRepository: TopicRepository,
   private val storyProgressController: StoryProgressController,
   private val explorationRetriever: ExplorationRetriever,
   @BackgroundDispatcher private val backgroundDispatcher: CoroutineDispatcher,

--- a/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
@@ -32,7 +32,6 @@ import org.oppia.app.model.Topic
 import org.oppia.app.model.TopicList
 import org.oppia.app.model.TopicProgress
 import org.oppia.app.model.TopicSummary
-import org.oppia.app.model.TopicSummaryListView
 import org.oppia.app.model.Voiceover
 import org.oppia.app.model.VoiceoverMapping
 import org.oppia.domain.exploration.ExplorationRetriever
@@ -157,8 +156,8 @@ class TopicListController @Inject constructor(
    * Returns the list of [TopicSummary]s currently tracked by the app, possibly up to
    * [EVICTION_TIME_MILLIS] old.
    */
-  fun getTopicList(): LiveData<AsyncResult<TopicSummaryListView>> {
-    return dataProviders.convertToLiveData(topicRepository.getTopicSummaryListDataProvider())
+  fun getTopicList(): LiveData<AsyncResult<TopicList>> {
+    return MutableLiveData(AsyncResult.success(createTopicList()))
   }
 
   /**

--- a/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
@@ -32,6 +32,7 @@ import org.oppia.app.model.Topic
 import org.oppia.app.model.TopicList
 import org.oppia.app.model.TopicProgress
 import org.oppia.app.model.TopicSummary
+import org.oppia.app.model.TopicSummaryListView
 import org.oppia.app.model.Voiceover
 import org.oppia.app.model.VoiceoverMapping
 import org.oppia.domain.exploration.ExplorationRetriever
@@ -96,6 +97,7 @@ class TopicListController @Inject constructor(
   private val dataProviders: DataProviders,
   private val jsonAssetRetriever: JsonAssetRetriever,
   private val topicController: TopicController,
+  private val topicRepository: TopicRepository,
   private val storyProgressController: StoryProgressController,
   private val explorationRetriever: ExplorationRetriever,
   @BackgroundDispatcher private val backgroundDispatcher: CoroutineDispatcher,
@@ -155,8 +157,8 @@ class TopicListController @Inject constructor(
    * Returns the list of [TopicSummary]s currently tracked by the app, possibly up to
    * [EVICTION_TIME_MILLIS] old.
    */
-  fun getTopicList(): LiveData<AsyncResult<TopicList>> {
-    return MutableLiveData(AsyncResult.success(createTopicList()))
+  fun getTopicList(): LiveData<AsyncResult<TopicSummaryListView>> {
+    return dataProviders.convertToLiveData(topicRepository.getTopicSummaryListDataProvider())
   }
 
   /**

--- a/domain/src/main/java/org/oppia/domain/topic/TopicRepository.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicRepository.kt
@@ -1,0 +1,853 @@
+package org.oppia.domain.topic
+
+import androidx.lifecycle.LiveData
+import kotlinx.coroutines.Deferred
+import org.json.JSONArray
+import org.json.JSONObject
+import org.oppia.app.model.ChapterPlayState
+import org.oppia.app.model.ChapterSummary
+import org.oppia.app.model.ChapterSummaryDatabase
+import org.oppia.app.model.ChapterSummaryDomain
+import org.oppia.app.model.LessonThumbnail
+import org.oppia.app.model.LessonThumbnailGraphic
+import org.oppia.app.model.RevisionCard
+import org.oppia.app.model.SkillSummary
+import org.oppia.app.model.SkillSummaryDatabase
+import org.oppia.app.model.SkillSummaryDomain
+import org.oppia.app.model.StorySummary
+import org.oppia.app.model.StorySummaryDatabase
+import org.oppia.app.model.StorySummaryDomain
+import org.oppia.app.model.SubtitledHtml
+import org.oppia.app.model.Subtopic
+import org.oppia.app.model.SubtopicDatabase
+import org.oppia.app.model.SubtopicDomain
+import org.oppia.app.model.TopicBackend
+import org.oppia.app.model.TopicDatabase
+import org.oppia.app.model.TopicDomain
+import org.oppia.app.model.TopicSummaryListView
+import org.oppia.app.model.TopicSummaryView
+import org.oppia.data.persistence.PersistentCacheStore
+import org.oppia.domain.util.JsonAssetRetriever
+import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProvider
+import org.oppia.util.data.DataProviders
+import org.oppia.util.logging.Logger
+import javax.inject.Inject
+import javax.inject.Singleton
+
+val TOPIC_JSON_FILE_ASSOCIATIONS = mapOf(
+  FRACTIONS_TOPIC_ID to listOf(
+    "fractions_exploration0.json",
+    "fractions_exploration1.json",
+    "fractions_questions.json",
+    "fractions_skills.json",
+    "fractions_stories.json",
+    "fractions_subtopics.json",
+    "fractions_topic.json"
+  ),
+  RATIOS_TOPIC_ID to listOf(
+    "ratios_exploration0.json",
+    "ratios_exploration1.json",
+    "ratios_exploration2.json",
+    "ratios_exploration3.json",
+    "ratios_questions.json",
+    "ratios_skills.json",
+    "ratios_stories.json",
+    "ratios_topic.json"
+  )
+)
+
+private const val ADD_TOPIC_TRANSFORMED_PROVIDER_ID = "add_topic_transformed_id"
+private const val ADD_SUBTOPIC_LIST_TRANSFORMED_PROVIDER_ID = "add_subtopic_list_transformed_id"
+private const val ADD_STORY_SUMMARY_LIST_TRANSFORMED_PROVIDER_ID = "add_story_list_transformed_id"
+private const val ADD_SKILL_SUMMARY_LIST_TRANSFORMED_PROVIDER_ID = "add_skill_list_transformed_id"
+private const val ADD_CHAPTER_SUMMARY_LIST_TRANSFORMED_PROVIDER_ID =
+  "add_chapter_list_transformed_id"
+private const val GET_ALL_TOPICS_TRANSFORMED_PROVIDER_ID = "get_all_topics_transformed_id"
+private const val GET_TOPIC_LIST_TRANSFORMED_PROVIDER_ID = "get_topic_list_transformed_id"
+private const val GET_TOPIC_TRANSFORMED_PROVIDER_ID = "get_topic_transformed_id"
+private const val COMBINE_TOPIC_AND_CHAPTER_SUMMARY = "combine_topic_and_chapter_summary"
+
+/** Controller for retrieving all aspects of a topic. */
+@Singleton
+class TopicRepository @Inject constructor(
+  cacheStoreFactory: PersistentCacheStore.Factory,
+  private val dataProviders: DataProviders,
+  private val jsonAssetRetriever: JsonAssetRetriever,
+  private val logger: Logger
+) {
+
+  /** Indicates that the given chapter already exists. */
+  class ChapterSummaryAlreadyExistsException(msg: String) : Exception(msg)
+
+  /** Indicates that the given chapter is not found. */
+  class ChapterSummaryNotFoundException(msg: String) : Exception(msg)
+
+  /** Indicates that the given skill summary already exists. */
+  class SkillSummaryAlreadyExistsException(msg: String) : Exception(msg)
+
+  /** Indicates that the given skill summary is not found. */
+  class SkillSummaryNotFoundException(msg: String) : Exception(msg)
+
+  /** Indicates that the given story summary already exists. */
+  class StorySummaryAlreadyExistsException(msg: String) : Exception(msg)
+
+  /** Indicates that the given story summary is not found. */
+  class StorySummaryNotFoundException(msg: String) : Exception(msg)
+
+  /** Indicates that the given subtopic already exists. */
+  class SubtopicAlreadyExistsException(msg: String) : Exception(msg)
+
+  /** Indicates that the given subtopic is not found. */
+  class SubtopicNotFoundException(msg: String) : Exception(msg)
+
+  /** Indicates that the given topic already exists. */
+  class TopicAlreadyExistsException(msg: String) : Exception(msg)
+
+  /** Indicates that the given topic is not found. */
+  class TopicNotFoundException(msg: String) : Exception(msg)
+
+  /**
+   * These statuses correspond to the exceptions above such that if the deferred contains
+   * CHAPTER_SUMMARY_ALREADY_FOUND, the [ChapterSummaryAlreadyExistsException] will be passed to a failed AsyncResult.
+   *
+   * SUCCESS corresponds to a successful AsyncResult.
+   */
+  private enum class ChapterSummaryActionStatus {
+    SUCCESS,
+    CHAPTER_SUMMARY_ALREADY_EXISTS,
+    CHAPTER_SUMMARY_NOT_FOUND
+  }
+
+  /**
+   * These statuses correspond to the exceptions above such that if the deferred contains
+   * SKILL_SUMMARY_ALREADY_FOUND, the [SkillSummaryAlreadyExistsException] will be passed to a failed AsyncResult.
+   *
+   * SUCCESS corresponds to a successful AsyncResult.
+   */
+  private enum class SkillSummaryActionStatus {
+    SUCCESS,
+    SKILL_SUMMARY_ALREADY_EXISTS,
+    SKILL_SUMMARY_NOT_FOUND
+  }
+
+  /**
+   * These statuses correspond to the exceptions above such that if the deferred contains
+   * STORY_SUMMARY_ALREADY_FOUND, the [StorySummaryAlreadyExistsException] will be passed to a failed AsyncResult.
+   *
+   * SUCCESS corresponds to a successful AsyncResult.
+   */
+  private enum class StorySummaryActionStatus {
+    SUCCESS,
+    STORY_SUMMARY_ALREADY_EXISTS,
+    STORY_SUMMARY_NOT_FOUND
+  }
+
+  /**
+   * These statuses correspond to the exceptions above such that if the deferred contains
+   * SUBTOPIC_ALREADY_FOUND, the [SubtopicAlreadyExistsException] will be passed to a failed AsyncResult.
+   *
+   * SUCCESS corresponds to a successful AsyncResult.
+   */
+  private enum class SubtopicActionStatus {
+    SUCCESS,
+    SUBTOPIC_ALREADY_EXISTS,
+    SUBTOPIC_NOT_FOUND
+  }
+
+  /**
+   * These statuses correspond to the exceptions above such that if the deferred contains
+   * TOPIC_ALREADY_FOUND, the [TopicAlreadyExistsException] will be passed to a failed AsyncResult.
+   *
+   * SUCCESS corresponds to a successful AsyncResult.
+   */
+  private enum class TopicActionStatus {
+    SUCCESS,
+    TOPIC_ALREADY_EXISTS,
+    TOPIC_NOT_FOUND
+  }
+
+  private val chapterSummaryDataStore =
+    cacheStoreFactory.create(
+      "chapter_summary_database",
+      ChapterSummaryDatabase.getDefaultInstance()
+    )
+
+  private val skillSummaryDataStore =
+    cacheStoreFactory.create(
+      "skill_summary_database",
+      SkillSummaryDatabase.getDefaultInstance()
+    )
+
+  private val storySummaryDataStore =
+    cacheStoreFactory.create(
+      "story_summary_database",
+      StorySummaryDatabase.getDefaultInstance()
+    )
+
+  private val subtopicDataStore =
+    cacheStoreFactory.create("subtopic_database", SubtopicDatabase.getDefaultInstance())
+
+  private val topicDataStore =
+    cacheStoreFactory.create("topic_database", TopicDatabase.getDefaultInstance())
+
+  // TODO(#272): Remove init block when storeDataAsync is fixed
+  init {
+    chapterSummaryDataStore.primeCacheAsync().invokeOnCompletion {
+      it?.let {
+        logger.e(
+          "DOMAIN",
+          "Failed to prime cache chapterSummaryDataStore ahead of LiveData conversion for TopicRepository.",
+          it
+        )
+      }
+    }
+    skillSummaryDataStore.primeCacheAsync().invokeOnCompletion {
+      it?.let {
+        logger.e(
+          "DOMAIN",
+          "Failed to prime cache skillSummaryDataStore ahead of LiveData conversion for TopicRepository.",
+          it
+        )
+      }
+    }
+    storySummaryDataStore.primeCacheAsync().invokeOnCompletion {
+      it?.let {
+        logger.e(
+          "DOMAIN",
+          "Failed to prime cache storySummaryDataStore ahead of LiveData conversion for TopicRepository.",
+          it
+        )
+      }
+    }
+    subtopicDataStore.primeCacheAsync().invokeOnCompletion {
+      it?.let {
+        logger.e(
+          "DOMAIN",
+          "Failed to prime cache subtopicDataStore ahead of LiveData conversion for TopicRepository.",
+          it
+        )
+      }
+    }
+    topicDataStore.primeCacheAsync().invokeOnCompletion {
+      it?.let {
+        logger.e(
+          "DOMAIN",
+          "Failed to prime cache topicDataStore ahead of LiveData conversion for TopicRepository.",
+          it
+        )
+      }
+    }
+  }
+
+  fun loadAllTopics() {
+    TOPIC_JSON_FILE_ASSOCIATIONS.keys.forEach { topicId ->
+      val topicBackend = retrieveTopicFromJSON(topicId)
+      addTopic(topicBackend)
+      addSubTopicList(topicBackend)
+      addSkillSummary(topicBackend)
+      addStorySummary(topicBackend)
+      addChapterSummary(topicBackend)
+    }
+  }
+
+  /** Returns a [TopicSummaryListView] [DataProvider]. */
+  internal fun getTopicSummaryListDataProvider(): DataProvider<TopicSummaryListView> {
+    val topicListDataProvider = getTopicListDataProvider()
+    val chapterSummaryListDataProvider = getChapterSummaryListDataProvider()
+    return dataProviders.combine(
+      COMBINE_TOPIC_AND_CHAPTER_SUMMARY,
+      topicListDataProvider,
+      chapterSummaryListDataProvider,
+      ::combineTopicListAndChapterSummaryList
+    )
+  }
+
+  fun getTopic(topicId: String): DataProvider<TopicDomain> {
+    return dataProviders.transformAsync<TopicDatabase, TopicDomain>(
+      GET_TOPIC_TRANSFORMED_PROVIDER_ID,
+      topicDataStore
+    ) {
+      val topicDomain = it.topicDatabaseMap[topicId]
+      AsyncResult.success(topicDomain ?: TopicDomain.getDefaultInstance())
+    }
+  }
+
+  private fun getTopicListDataProvider(): DataProvider<List<TopicDomain>> {
+    return dataProviders.transformAsync<TopicDatabase, List<TopicDomain>>(
+      GET_TOPIC_TRANSFORMED_PROVIDER_ID,
+      topicDataStore
+    ) {
+      AsyncResult.success(it.topicDatabaseMap.values.toList())
+    }
+  }
+
+  private fun getChapterSummaryListDataProvider(): DataProvider<List<ChapterSummaryDomain>> {
+    return dataProviders.transformAsync<ChapterSummaryDatabase, List<ChapterSummaryDomain>>(
+      GET_TOPIC_TRANSFORMED_PROVIDER_ID,
+      chapterSummaryDataStore
+    ) {
+      AsyncResult.success(it.chapterSummaryDatabaseMap.values.toList())
+    }
+  }
+
+  private fun combineTopicListAndChapterSummaryList(
+    topicDomainList: List<TopicDomain>,
+    chapterSummaryDomainList: List<ChapterSummaryDomain>
+  ): TopicSummaryListView {
+    val topicSummaryListView = TopicSummaryListView.newBuilder()
+    topicDomainList.forEach { topicDomain ->
+      val topicSummaryView = convertTopicDomainToTopicSummaryView(topicDomain)
+      val chapterCount =
+        chapterSummaryDomainList.filter { chapterSummaryDomain ->
+          chapterSummaryDomain.topicId == topicDomain.topicId
+        }.size
+      topicSummaryListView.addTopicSummary(
+        topicSummaryView.toBuilder().setTotalChapterCount(
+          chapterCount
+        ).build()
+      )
+    }
+    return topicSummaryListView.build()
+  }
+
+  /**
+   * Adds a topic to offline storage.
+   *
+   * @param topicBackend TopicBackend which needs to be saved offline.
+   * @return a [LiveData] that indicates the success/failure of this add operation.
+   */
+  private fun addTopic(topicBackend: TopicBackend): DataProvider<Any?> {
+    val deferred = topicDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
+      val topicDomain = convertTopicBackendToTopicDomain(topicBackend)
+      val topicDatabaseBuilder = it.toBuilder().putTopicDatabase(topicBackend.topicId, topicDomain)
+      Pair(topicDatabaseBuilder.build(), TopicActionStatus.SUCCESS)
+    }
+    return dataProviders.createInMemoryDataProviderAsync(ADD_TOPIC_TRANSFORMED_PROVIDER_ID) {
+      return@createInMemoryDataProviderAsync getDeferredResultForTopic(
+        topicBackend.topicId,
+        deferred
+      )
+    }
+  }
+
+  /**
+   * Adds a list of subtopic to offline storage linked to a particular topic.
+   *
+   * @param topicBackend TopicBackend which needs to be saved offline.
+   * @return a [LiveData] that indicates the success/failure of this add operation.
+   */
+  private fun addSubTopicList(topicBackend: TopicBackend): DataProvider<Any?> {
+    val deferred =
+      subtopicDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
+        val subtopicListDomainList = convertTopicBackendToSubtopicListDomain(topicBackend)
+        val subtopicDatabaseBuilder = it.toBuilder()
+        subtopicListDomainList.forEach { subtopicDomain ->
+          subtopicDatabaseBuilder.putSubtopicDatabase(
+            subtopicDomain.subtopicId,
+            subtopicDomain
+          )
+        }
+        Pair(subtopicDatabaseBuilder.build(), SubtopicActionStatus.SUCCESS)
+      }
+    return dataProviders.createInMemoryDataProviderAsync(ADD_SUBTOPIC_LIST_TRANSFORMED_PROVIDER_ID) {
+      return@createInMemoryDataProviderAsync getDeferredResultForSubtopic(
+        topicBackend.topicId,
+        deferred
+      )
+    }
+  }
+
+  /**
+   * Adds a list of skills to offline storage linked to a particular topic.
+   *
+   * @param topicBackend TopicBackend which needs to be saved offline.
+   * @return a [LiveData] that indicates the success/failure of this add operation.
+   */
+  private fun addSkillSummary(topicBackend: TopicBackend): DataProvider<Any?> {
+    val deferred =
+      skillSummaryDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
+        val skillSummaryDomainList = convertTopicBackendToSkillSummaryDomain(topicBackend)
+        val skillSummaryDatabaseBuilder = it.toBuilder()
+        skillSummaryDomainList.forEach { skillSummaryDomain ->
+          skillSummaryDatabaseBuilder.putSkillSummaryDatabase(
+            skillSummaryDomain.skillId,
+            skillSummaryDomain
+          )
+        }
+        Pair(skillSummaryDatabaseBuilder.build(), SkillSummaryActionStatus.SUCCESS)
+      }
+    return dataProviders.createInMemoryDataProviderAsync(
+      ADD_SKILL_SUMMARY_LIST_TRANSFORMED_PROVIDER_ID
+    ) {
+      return@createInMemoryDataProviderAsync getDeferredResultForSkillSummary(
+        topicBackend.topicId,
+        deferred
+      )
+    }
+  }
+
+  /**
+   * Adds a list of stories to offline storage linked to a particular topic.
+   *
+   * @param topicBackend TopicBackend which needs to be saved offline.
+   * @return a [LiveData] that indicates the success/failure of this add operation.
+   */
+  private fun addStorySummary(topicBackend: TopicBackend): DataProvider<Any?> {
+    val deferred =
+      storySummaryDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
+        val storySummaryDomainList = convertTopicBackendToStorySummaryDomain(topicBackend)
+        val storySummaryDatabaseBuilder = it.toBuilder()
+        storySummaryDomainList.forEach { storySummaryDomain ->
+          storySummaryDatabaseBuilder.putStorySummaryDatabase(
+            storySummaryDomain.storyId,
+            storySummaryDomain
+          )
+        }
+        Pair(storySummaryDatabaseBuilder.build(), StorySummaryActionStatus.SUCCESS)
+      }
+    return dataProviders.createInMemoryDataProviderAsync(
+      ADD_STORY_SUMMARY_LIST_TRANSFORMED_PROVIDER_ID
+    ) {
+      return@createInMemoryDataProviderAsync getDeferredResultForStorySummary(
+        topicBackend.topicId,
+        deferred
+      )
+    }
+  }
+
+  /**
+   * Adds a list of stories to offline storage linked to a particular topic.
+   *
+   * @param topicBackend TopicBackend which needs to be saved offline.
+   * @return a [LiveData] that indicates the success/failure of this add operation.
+   */
+  private fun addChapterSummary(topicBackend: TopicBackend): DataProvider<Any?> {
+    val deferred =
+      chapterSummaryDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
+        val chapterSummaryDomainList = convertTopicToChapterSummaryList(topicBackend)
+        val chapterSummaryDatabaseBuilder = it.toBuilder()
+        chapterSummaryDomainList.forEach { chapterSummaryDomain ->
+          chapterSummaryDatabaseBuilder.putChapterSummaryDatabase(
+            chapterSummaryDomain.explorationId,
+            chapterSummaryDomain
+          )
+        }
+        Pair(chapterSummaryDatabaseBuilder.build(), ChapterSummaryActionStatus.SUCCESS)
+      }
+    return dataProviders.createInMemoryDataProviderAsync(
+      ADD_CHAPTER_SUMMARY_LIST_TRANSFORMED_PROVIDER_ID
+    ) {
+      return@createInMemoryDataProviderAsync getDeferredResultForChapterSummary(
+        topicBackend.topicId,
+        deferred
+      )
+    }
+  }
+
+  private fun convertTopicBackendToTopicDomain(topicBackend: TopicBackend): TopicDomain {
+    return TopicDomain.newBuilder()
+      .setTopicId(topicBackend.topicId)
+      .setName(topicBackend.name)
+      .setDescription(topicBackend.description)
+      .setTopicThumbnail(TOPIC_THUMBNAILS.getValue(topicBackend.topicId))
+      .setDiskSizeBytes(topicBackend.diskSizeBytes)
+      .build()
+  }
+
+  private fun convertTopicBackendToSkillSummaryDomain(topicBackend: TopicBackend): List<SkillSummaryDomain> {
+    val skillSummaryDomainList = ArrayList<SkillSummaryDomain>()
+    topicBackend.skillList.forEach { skillSummary ->
+      val skillSummaryDomain = convertSkillSummaryToSkillSummaryDomain(skillSummary)
+      skillSummaryDomainList.add(skillSummaryDomain)
+    }
+    return skillSummaryDomainList
+  }
+
+  private fun convertTopicToChapterSummaryList(topicBackend: TopicBackend): List<ChapterSummaryDomain> {
+    val chapterSummaryList = ArrayList<ChapterSummaryDomain>()
+    topicBackend.storyList.forEach { storySummary ->
+      storySummary.chapterList.forEach { chapterSummary ->
+        val chapterSummaryDomain = convertChapterSummaryToChapterSummaryDomain(
+          topicBackend.topicId,
+          storySummary.storyId,
+          chapterSummary
+        )
+        chapterSummaryList.add(chapterSummaryDomain)
+      }
+    }
+    return chapterSummaryList
+  }
+
+  private fun convertChapterSummaryToChapterSummaryDomain(
+    topicId: String,
+    storyId: String,
+    chapterSummary: ChapterSummary
+  ): ChapterSummaryDomain {
+    return ChapterSummaryDomain.newBuilder()
+      .setTopicId(topicId)
+      .setStoryId(storyId)
+      .setExplorationId(chapterSummary.explorationId)
+      .setName(chapterSummary.name)
+      .setSummary(chapterSummary.summary)
+      .setChapterPlayState(ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES)
+      .setChapterThumbnail(chapterSummary.chapterThumbnail)
+      .build()
+  }
+
+  private fun convertSkillSummaryToSkillSummaryDomain(skillSummary: SkillSummary): SkillSummaryDomain {
+    return SkillSummaryDomain.newBuilder()
+      .setSkillId(skillSummary.skillId)
+      .setDescription(skillSummary.description)
+      .setThumbnailUrl(skillSummary.thumbnailUrl)
+      .setSkillThumbnail(skillSummary.skillThumbnail)
+      .build()
+  }
+
+  private fun convertTopicBackendToStorySummaryDomain(topicBackend: TopicBackend): List<StorySummaryDomain> {
+    val storySummaryDomainList = ArrayList<StorySummaryDomain>()
+    topicBackend.storyList.forEach { storySummary ->
+      val storySummaryDomain =
+        convertStorySummaryToStorySummaryDomain(topicBackend.topicId, storySummary)
+      storySummaryDomainList.add(storySummaryDomain)
+    }
+    return storySummaryDomainList
+  }
+
+  private fun convertStorySummaryToStorySummaryDomain(
+    topicId: String,
+    storySummary: StorySummary
+  ): StorySummaryDomain {
+    return StorySummaryDomain.newBuilder()
+      .setTopicId(topicId)
+      .setStoryId(storySummary.storyId)
+      .setStoryName(storySummary.storyName)
+      .setStoryThumbnail(storySummary.storyThumbnail)
+      .build()
+  }
+
+  private fun convertTopicBackendToSubtopicListDomain(topicBackend: TopicBackend): List<SubtopicDomain> {
+    val subtopicDomainList = ArrayList<SubtopicDomain>()
+    topicBackend.subtopicList.forEach { subtopic ->
+      val subtopicDomain = convertSubtopicToSubtopicDomain(topicBackend.topicId, subtopic)
+      subtopicDomainList.add(subtopicDomain)
+    }
+    return subtopicDomainList
+  }
+
+  private fun convertSubtopicToSubtopicDomain(topicId: String, subtopic: Subtopic): SubtopicDomain {
+    return SubtopicDomain.newBuilder()
+      .setTopicId(topicId)
+      .setSubtopicId(subtopic.subtopicId)
+      .setTitle(subtopic.title)
+      .setSubtopicThumbnail(subtopic.subtopicThumbnail)
+      .setThumbnailUrl(subtopic.thumbnailUrl)
+      .addAllSkillIds(subtopic.skillIdsList)
+      .build()
+  }
+
+  private fun convertTopicDomainToTopicSummaryView(topicDomain: TopicDomain): TopicSummaryView {
+    return TopicSummaryView.newBuilder()
+      .setTopicId(topicDomain.topicId)
+      .setName(topicDomain.name)
+      .setVersion(1)
+      .setTopicThumbnail(TOPIC_THUMBNAILS.getValue(topicDomain.topicId))
+      .build()
+  }
+
+  private suspend fun getDeferredResultForChapterSummary(
+    topicId: String,
+    deferred: Deferred<ChapterSummaryActionStatus>
+  ): AsyncResult<Any?> {
+    return when (deferred.await()) {
+      ChapterSummaryActionStatus.SUCCESS -> AsyncResult.success(null)
+      ChapterSummaryActionStatus.CHAPTER_SUMMARY_ALREADY_EXISTS -> AsyncResult.failed(
+        ChapterSummaryAlreadyExistsException("Chapter summary list for topic $topicId is already present.")
+      )
+      ChapterSummaryActionStatus.CHAPTER_SUMMARY_NOT_FOUND -> AsyncResult.failed(
+        ChapterSummaryNotFoundException("Chapter summary list for topic $topicId not found.")
+      )
+    }
+  }
+
+  private suspend fun getDeferredResultForSkillSummary(
+    topicId: String,
+    deferred: Deferred<SkillSummaryActionStatus>
+  ): AsyncResult<Any?> {
+    return when (deferred.await()) {
+      SkillSummaryActionStatus.SUCCESS -> AsyncResult.success(null)
+      SkillSummaryActionStatus.SKILL_SUMMARY_ALREADY_EXISTS -> AsyncResult.failed(
+        SkillSummaryAlreadyExistsException("Skill summary list for topic $topicId is already present.")
+      )
+      SkillSummaryActionStatus.SKILL_SUMMARY_NOT_FOUND -> AsyncResult.failed(
+        SkillSummaryNotFoundException("Skill summary list for topic $topicId not found.")
+      )
+    }
+  }
+
+  private suspend fun getDeferredResultForStorySummary(
+    topicId: String,
+    deferred: Deferred<StorySummaryActionStatus>
+  ): AsyncResult<Any?> {
+    return when (deferred.await()) {
+      StorySummaryActionStatus.SUCCESS -> AsyncResult.success(null)
+      StorySummaryActionStatus.STORY_SUMMARY_ALREADY_EXISTS -> AsyncResult.failed(
+        StorySummaryAlreadyExistsException("Story summary list for topic $topicId is already present.")
+      )
+      StorySummaryActionStatus.STORY_SUMMARY_NOT_FOUND -> AsyncResult.failed(
+        StorySummaryNotFoundException("Story summary list for topic $topicId not found.")
+      )
+    }
+  }
+
+  private suspend fun getDeferredResultForSubtopic(
+    topicId: String,
+    deferred: Deferred<SubtopicActionStatus>
+  ): AsyncResult<Any?> {
+    return when (deferred.await()) {
+      SubtopicActionStatus.SUCCESS -> AsyncResult.success(null)
+      SubtopicActionStatus.SUBTOPIC_ALREADY_EXISTS -> AsyncResult.failed(
+        SubtopicAlreadyExistsException("Subtopic list for topic $topicId is already present.")
+      )
+      SubtopicActionStatus.SUBTOPIC_NOT_FOUND -> AsyncResult.failed(
+        SubtopicNotFoundException("Subtopic list for topic $topicId not found.")
+      )
+    }
+  }
+
+  private suspend fun getDeferredResultForTopic(
+    topicId: String,
+    deferred: Deferred<TopicActionStatus>
+  ): AsyncResult<Any?> {
+    return when (deferred.await()) {
+      TopicActionStatus.SUCCESS -> AsyncResult.success(null)
+      TopicActionStatus.TOPIC_ALREADY_EXISTS -> AsyncResult.failed(
+        TopicAlreadyExistsException("Topic for topicId $topicId is already present.")
+      )
+      TopicActionStatus.TOPIC_NOT_FOUND -> AsyncResult.failed(
+        TopicNotFoundException("Topic for topicId $topicId not found.")
+      )
+    }
+  }
+
+  private fun retrieveTopicFromJSON(topicId: String): TopicBackend {
+    return when (topicId) {
+      FRACTIONS_TOPIC_ID -> createTopicFromJson(
+        "fractions_topic.json", "fractions_skills.json", "fractions_stories.json"
+      )
+      RATIOS_TOPIC_ID -> createTopicFromJson(
+        "ratios_topic.json", "ratios_skills.json", "ratios_stories.json"
+      )
+      else -> throw IllegalArgumentException("Invalid topic ID: $topicId")
+    }
+  }
+
+  internal fun retrieveStory(storyId: String): StorySummary {
+    return when (storyId) {
+      FRACTIONS_STORY_ID_0 -> createStoryFromJsonFile("fractions_stories.json", /* index= */ 0)
+      RATIOS_STORY_ID_0 -> createStoryFromJsonFile("ratios_stories.json", /* index= */ 0)
+      RATIOS_STORY_ID_1 -> createStoryFromJsonFile("ratios_stories.json", /* index= */ 1)
+      else -> throw IllegalArgumentException("Invalid story ID: $storyId")
+    }
+  }
+
+  // TODO(#45): Expose this as a data provider, or omit if it's not needed.
+  private fun retrieveReviewCard(topicId: String, subtopicId: String): RevisionCard {
+    return when (subtopicId) {
+      FRACTIONS_SUBTOPIC_ID_1 -> createSubtopicFromJson(
+        "fractions_subtopics.json"
+      )
+      FRACTIONS_SUBTOPIC_ID_2 -> createSubtopicFromJson(
+        "fractions_subtopics.json"
+      )
+      FRACTIONS_SUBTOPIC_ID_3 -> createSubtopicFromJson(
+        "fractions_subtopics.json"
+      )
+      else -> throw IllegalArgumentException("Invalid topic Name: $topicId")
+    }
+  }
+
+  /**
+   * Creates topic from its json representation. The json file is expected to have
+   * a key called 'topic' that holds the topic data.
+   */
+  private fun createTopicFromJson(
+    topicFileName: String,
+    skillFileName: String,
+    storyFileName: String
+  ): TopicBackend {
+    val topicData = jsonAssetRetriever.loadJsonFromAsset(topicFileName)?.getJSONObject("topic")!!
+    val subtopicList: List<Subtopic> =
+      createSubtopicListFromJsonArray(topicData.optJSONArray("subtopics"))
+    val topicId = topicData.getString("id")
+    return TopicBackend.newBuilder()
+      .setTopicId(topicId)
+      .setName(topicData.getString("name"))
+      .setDescription(topicData.getString("description"))
+      .addAllSkill(createSkillsFromJson(skillFileName))
+      .addAllStory(createStoriesFromJson(storyFileName))
+      .setTopicThumbnail(TOPIC_THUMBNAILS.getValue(topicId))
+      .setDiskSizeBytes(computeTopicSizeBytes(TOPIC_FILE_ASSOCIATIONS.getValue(topicId)))
+      .addAllSubtopic(subtopicList)
+      .build()
+  }
+
+  /** Creates a sub-topic from its json representation. */
+  private fun createSubtopicFromJson(topicFileName: String): RevisionCard {
+    val subtopicData =
+      jsonAssetRetriever.loadJsonFromAsset(topicFileName)?.getJSONObject("page_contents")!!
+    val subtopicTitle =
+      jsonAssetRetriever.loadJsonFromAsset(topicFileName)?.getString("subtopic_title")!!
+    return RevisionCard.newBuilder()
+      .setSubtopicTitle(subtopicTitle)
+      .setPageContents(
+        SubtitledHtml.newBuilder()
+          .setHtml(subtopicData.getJSONObject("subtitled_html").getString("html"))
+          .setContentId(subtopicData.getJSONObject("subtitled_html").getString("content_id")).build()
+      )
+      .build()
+  }
+
+  /**
+   * Creates the subtopic list of a topic from its json representation. The json file is expected to have
+   * a key called 'subtopic' that contains an array of skill Ids,subtopic_id and title.
+   */
+  private fun createSubtopicListFromJsonArray(subtopicJsonArray: JSONArray?): List<Subtopic> {
+    val subtopicList = mutableListOf<Subtopic>()
+
+    for (i in 0 until subtopicJsonArray!!.length()) {
+      val skillIdList = ArrayList<String>()
+
+      val currentSubtopicJsonObject = subtopicJsonArray.optJSONObject(i)
+      val skillJsonArray = currentSubtopicJsonObject.optJSONArray("skill_ids")
+
+      for (j in 0 until skillJsonArray.length()) {
+        skillIdList.add(skillJsonArray.optString(j))
+      }
+      val subtopic = Subtopic.newBuilder().setSubtopicId(currentSubtopicJsonObject.optString("id"))
+        .setTitle(currentSubtopicJsonObject.optString("title"))
+        .setSubtopicThumbnail(createSubtopicThumbnail(currentSubtopicJsonObject.optString("id")))
+        .addAllSkillIds(skillIdList).build()
+      subtopicList.add(subtopic)
+    }
+    return subtopicList
+  }
+
+  private fun computeTopicSizeBytes(constituentFiles: List<String>): Long {
+    // TODO(#169): Compute this based on protos & the combined topic package.
+    // TODO(#386): Incorporate audio & image files in this computation.
+    return constituentFiles.map(jsonAssetRetriever::getAssetSize).map(Int::toLong)
+      .reduceRight(Long::plus)
+  }
+
+  /**
+   * Creates a list of skill for topic from its json representation. The json file is expected to have
+   * a key called 'skill_list' that contains an array of skill objects, each with the key 'skill'.
+   */
+  private fun createSkillsFromJson(fileName: String): List<SkillSummary> {
+    val skillList = mutableListOf<SkillSummary>()
+    val skillData = jsonAssetRetriever.loadJsonFromAsset(fileName)?.getJSONArray("skill_list")!!
+    for (i in 0 until skillData.length()) {
+      skillList.add(createSkillFromJson(skillData.getJSONObject(i).getJSONObject("skill")))
+    }
+    return skillList
+  }
+
+  private fun createSkillFromJson(skillData: JSONObject): SkillSummary {
+    return SkillSummary.newBuilder()
+      .setSkillId(skillData.getString("id"))
+      .setDescription(skillData.getString("description"))
+      .setSkillThumbnail(createSkillThumbnail(skillData.getString("id")))
+      .build()
+  }
+
+  /**
+   * Creates a list of [StorySummary]s for topic from its json representation. The json file is expected to have
+   * a key called 'story_list' that contains an array of story objects, each with the key 'story'.
+   */
+  private fun createStoriesFromJson(fileName: String): List<StorySummary> {
+    val storyList = mutableListOf<StorySummary>()
+    val storyData = jsonAssetRetriever.loadJsonFromAsset(fileName)?.getJSONArray("story_list")!!
+    for (i in 0 until storyData.length()) {
+      storyList.add(createStoryFromJson(storyData.getJSONObject(i).getJSONObject("story")))
+    }
+    return storyList
+  }
+
+  /** Creates a list of [StorySummary]s for topic given its json representation and the index of the story in json. */
+  private fun createStoryFromJsonFile(fileName: String, index: Int): StorySummary {
+    val storyData = jsonAssetRetriever.loadJsonFromAsset(fileName)?.getJSONArray("story_list")!!
+    if (storyData.length() < index) {
+      return StorySummary.getDefaultInstance()
+    }
+    return createStoryFromJson(storyData.getJSONObject(index).getJSONObject("story"))
+  }
+
+  private fun createStoryFromJson(storyData: JSONObject): StorySummary {
+    val storyId = storyData.getString("id")
+    return StorySummary.newBuilder()
+      .setStoryId(storyId)
+      .setStoryName(storyData.getString("title"))
+      .setStoryThumbnail(STORY_THUMBNAILS.getValue(storyId))
+      .addAllChapter(createChaptersFromJson(storyData.getJSONObject("story_contents").getJSONArray("nodes")))
+      .build()
+  }
+
+  private fun createChaptersFromJson(chapterData: JSONArray): List<ChapterSummary> {
+    val chapterList = mutableListOf<ChapterSummary>()
+
+    for (i in 0 until chapterData.length()) {
+      val chapter = chapterData.getJSONObject(i)
+      val explorationId = chapter.getString("exploration_id")
+      chapterList.add(
+        ChapterSummary.newBuilder()
+          .setExplorationId(explorationId)
+          .setName(chapter.getString("title"))
+          .setChapterPlayState(ChapterPlayState.COMPLETION_STATUS_UNSPECIFIED)
+          .setChapterThumbnail(EXPLORATION_THUMBNAILS.getValue(explorationId))
+          .build()
+      )
+    }
+    return chapterList
+  }
+
+  private fun createSkillThumbnail(skillId: String): LessonThumbnail {
+    return when (skillId) {
+      FRACTIONS_SKILL_ID_0 -> LessonThumbnail.newBuilder()
+        .setThumbnailGraphic(LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION)
+        .build()
+      FRACTIONS_SKILL_ID_1 -> LessonThumbnail.newBuilder()
+        .setThumbnailGraphic(LessonThumbnailGraphic.WRITING_FRACTIONS)
+        .build()
+      FRACTIONS_SKILL_ID_2 -> LessonThumbnail.newBuilder()
+        .setThumbnailGraphic(LessonThumbnailGraphic.MIXED_NUMBERS_AND_IMPROPER_FRACTIONS)
+        .build()
+      RATIOS_SKILL_ID_0 -> LessonThumbnail.newBuilder()
+        .setThumbnailGraphic(LessonThumbnailGraphic.DERIVE_A_RATIO)
+        .build()
+      else -> LessonThumbnail.newBuilder()
+        .setThumbnailGraphic(LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION)
+        .build()
+    }
+  }
+
+  private fun createSubtopicThumbnail(subtopicId: String): LessonThumbnail {
+    return when (subtopicId) {
+      FRACTIONS_SUBTOPIC_ID_1 -> LessonThumbnail.newBuilder()
+        .setThumbnailGraphic(LessonThumbnailGraphic.WHAT_IS_A_FRACTION)
+        .build()
+      FRACTIONS_SUBTOPIC_ID_2 -> LessonThumbnail.newBuilder()
+        .setThumbnailGraphic(LessonThumbnailGraphic.FRACTION_OF_A_GROUP)
+        .build()
+      FRACTIONS_SUBTOPIC_ID_3 -> LessonThumbnail.newBuilder()
+        .setThumbnailGraphic(LessonThumbnailGraphic.MIXED_NUMBERS)
+        .build()
+      FRACTIONS_SUBTOPIC_ID_4 -> LessonThumbnail.newBuilder()
+        .setThumbnailGraphic(LessonThumbnailGraphic.ADDING_FRACTIONS)
+        .build()
+      else -> LessonThumbnail.newBuilder()
+        .setThumbnailGraphic(LessonThumbnailGraphic.THE_NUMBER_LINE)
+        .build()
+    }
+  }
+}

--- a/domain/src/test/java/org/oppia/domain/topic/TopicRepositoryTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicRepositoryTest.kt
@@ -1,0 +1,850 @@
+package org.oppia.domain.topic
+
+import android.app.Application
+import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import dagger.BindsInstance
+import dagger.Component
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.Mockito.atLeastOnce
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnit
+import org.mockito.junit.MockitoRule
+import org.oppia.app.model.ChapterPlayState
+import org.oppia.app.model.ChapterSummaryDomain
+import org.oppia.app.model.LessonThumbnail
+import org.oppia.app.model.LessonThumbnailGraphic
+import org.oppia.app.model.RevisionCardDomain
+import org.oppia.app.model.RevisionCardView
+import org.oppia.app.model.SkillSummaryDomain
+import org.oppia.app.model.SkillSummaryView
+import org.oppia.app.model.StorySummaryDomain
+import org.oppia.app.model.StorySummaryView
+import org.oppia.app.model.SubtitledHtml
+import org.oppia.app.model.SubtopicDomain
+import org.oppia.app.model.SubtopicView
+import org.oppia.app.model.TopicDomain
+import org.oppia.app.model.TopicSummaryListView
+import org.oppia.app.model.TopicView
+import org.oppia.util.caching.CacheAssetsLocally
+import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders
+import org.oppia.util.logging.EnableConsoleLog
+import org.oppia.util.logging.EnableFileLog
+import org.oppia.util.logging.GlobalLogLevel
+import org.oppia.util.logging.LogLevel
+import org.oppia.util.threading.BackgroundDispatcher
+import org.oppia.util.threading.BlockingDispatcher
+import org.robolectric.annotation.Config
+import javax.inject.Inject
+import javax.inject.Qualifier
+import javax.inject.Singleton
+import kotlin.coroutines.EmptyCoroutineContext
+
+private const val DUMMY_DESCRIPTION_TEXT = "dummy_description_text"
+private const val DUMMY_TITLE_TEXT = "dummy_title_text"
+private const val DUMMY_THUMBNAIL_URL = "dummy_thumbnail_url"
+private const val TEST_SUBTOPIC_ID_0 = "test_subtopic_id_0"
+private const val TEST_SUBTOPIC_ID_1 = "test_subtopic_id_1"
+private const val TEST_CONTENT_ID = "test_content_id"
+private const val TEST_HTML_TEXT = "test_html_text"
+
+/** Tests for [TopicRepository]. */
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class TopicRepositoryTest {
+
+  @Rule
+  @JvmField
+  val mockitoRule: MockitoRule = MockitoJUnit.rule()
+
+  @Rule
+  @JvmField
+  val executorRule = InstantTaskExecutorRule()
+
+  @Inject
+  lateinit var topicRepository: TopicRepository
+
+  @Mock
+  lateinit var mockRevisionCardViewObserver: Observer<AsyncResult<RevisionCardView>>
+  @Captor
+  lateinit var revisionCardViewResultCaptor: ArgumentCaptor<AsyncResult<RevisionCardView>>
+
+  @Mock
+  lateinit var mockSkillSummaryViewObserver: Observer<AsyncResult<SkillSummaryView>>
+  @Captor
+  lateinit var skillSummaryViewResultCaptor: ArgumentCaptor<AsyncResult<SkillSummaryView>>
+
+  @Mock
+  lateinit var mockStorySummaryViewListObserver: Observer<AsyncResult<List<StorySummaryView>>>
+  @Captor
+  lateinit var storySummaryViewListResultCaptor: ArgumentCaptor<AsyncResult<List<StorySummaryView>>>
+
+  @Mock
+  lateinit var mockStorySummaryViewObserver: Observer<AsyncResult<StorySummaryView>>
+  @Captor
+  lateinit var storySummaryViewResultCaptor: ArgumentCaptor<AsyncResult<StorySummaryView>>
+
+  @Mock
+  lateinit var mockSubtopicViewListObserver: Observer<AsyncResult<List<SubtopicView>>>
+  @Captor
+  lateinit var subtopicViewListResultCaptor: ArgumentCaptor<AsyncResult<List<SubtopicView>>>
+
+  @Mock
+  lateinit var mockSubtopicViewObserver: Observer<AsyncResult<SubtopicView>>
+  @Captor
+  lateinit var subtopicViewResultCaptor: ArgumentCaptor<AsyncResult<SubtopicView>>
+
+  @Mock
+  lateinit var mockTopicSummaryListViewObserver: Observer<AsyncResult<TopicSummaryListView>>
+  @Captor
+  lateinit var topicSummaryListViewResultCaptor: ArgumentCaptor<AsyncResult<TopicSummaryListView>>
+
+  @Mock
+  lateinit var mockTopicViewObserver: Observer<AsyncResult<TopicView>>
+  @Captor
+  lateinit var topicViewResultCaptor: ArgumentCaptor<AsyncResult<TopicView>>
+
+  @Inject
+  lateinit var dataProviders: DataProviders
+
+  @Inject
+  @field:TestDispatcher
+  lateinit var testDispatcher: CoroutineDispatcher
+
+  private val coroutineContext by lazy {
+    EmptyCoroutineContext + testDispatcher
+  }
+
+  // https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/
+  @ObsoleteCoroutinesApi
+  private val testThread = newSingleThreadContext("TestMain")
+
+  @Before
+  @ExperimentalCoroutinesApi
+  @ObsoleteCoroutinesApi
+  fun setUp() {
+    Dispatchers.setMain(testThread)
+    setUpTestApplicationComponent()
+  }
+
+  @After
+  @ExperimentalCoroutinesApi
+  @ObsoleteCoroutinesApi
+  fun tearDown() {
+    Dispatchers.resetMain()
+    testThread.close()
+  }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testRevisionCard_addRevisionCardList_getRevisionCard0_correctRevisionCardData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.addRevisionCardList(createRevisionCardList())
+      advanceUntilIdle()
+
+      val revisionCardDataProvider = topicRepository.getRevisionCardDataProvider(DUMMY_TITLE_TEXT)
+      dataProviders.convertToLiveData(revisionCardDataProvider)
+        .observeForever(mockRevisionCardViewObserver)
+      advanceUntilIdle()
+
+      verifyGetRevisionCardViewSucceeded()
+      val revisionCardView = revisionCardViewResultCaptor.value.getOrThrow()
+      assertThat(revisionCardView.subtopicTitle).isEqualTo(DUMMY_TITLE_TEXT)
+      assertThat(revisionCardView.pageContents.contentId).isEqualTo(TEST_CONTENT_ID)
+      assertThat(revisionCardView.pageContents.html).isEqualTo(TEST_HTML_TEXT)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun tesSkillSummary_addSkillSummaryList_getSkillSummary0_correctSkillSummaryData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.addSkillSummaryList(createSkillSummaryList())
+      advanceUntilIdle()
+
+      val skillSummaryDataProvider = topicRepository.getSkillSummaryDataProvider(TEST_SKILL_ID_0)
+      dataProviders.convertToLiveData(skillSummaryDataProvider)
+        .observeForever(mockSkillSummaryViewObserver)
+      advanceUntilIdle()
+
+      verifyGetSkillSummaryViewSucceeded()
+      val skillSummaryView = skillSummaryViewResultCaptor.value.getOrThrow()
+      assertThat(skillSummaryView.skillId).isEqualTo(TEST_SKILL_ID_0)
+      assertThat(skillSummaryView.description).isEqualTo(DUMMY_DESCRIPTION_TEXT)
+      assertThat(skillSummaryView.thumbnailUrl).isEqualTo(DUMMY_THUMBNAIL_URL)
+      assertThat(skillSummaryView.skillThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun tesSkillSummary_addSkillSummaryList_getSkillSummary1_correctSkillSummaryData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.addSkillSummaryList(createSkillSummaryList())
+      advanceUntilIdle()
+
+      val skillSummaryDataProvider = topicRepository.getSkillSummaryDataProvider(TEST_SKILL_ID_1)
+      dataProviders.convertToLiveData(skillSummaryDataProvider)
+        .observeForever(mockSkillSummaryViewObserver)
+      advanceUntilIdle()
+
+      verifyGetSkillSummaryViewSucceeded()
+      val skillSummaryView = skillSummaryViewResultCaptor.value.getOrThrow()
+      assertThat(skillSummaryView.skillId).isEqualTo(TEST_SKILL_ID_1)
+      assertThat(skillSummaryView.description).isEqualTo(DUMMY_DESCRIPTION_TEXT)
+      assertThat(skillSummaryView.thumbnailUrl).isEqualTo(DUMMY_THUMBNAIL_URL)
+      assertThat(skillSummaryView.skillThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun tesStorySummary_addStorySummaryList_getStorySummary0_correctStorySummaryData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.addStorySummaryList(createStorySummaryList())
+      advanceUntilIdle()
+
+      val storySummaryDataProvider = topicRepository.getStorySummaryDataProvider(TEST_STORY_ID_0)
+      dataProviders.convertToLiveData(storySummaryDataProvider)
+        .observeForever(mockStorySummaryViewObserver)
+      advanceUntilIdle()
+
+      verifyGetStorySummaryViewSucceeded()
+      val storySummaryView = storySummaryViewResultCaptor.value.getOrThrow()
+      assertThat(storySummaryView.storyId).isEqualTo(TEST_STORY_ID_0)
+      assertThat(storySummaryView.storyName).isEqualTo("First story")
+      assertThat(storySummaryView.storyThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS)
+      assertThat(storySummaryView.chapterCount).isEqualTo(0)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun tesStorySummaryAndChapterSummary_addStorySummaryList_addChapterSummaryList_getStorySummary0_correctStorySummaryAndChapterSummaryData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.addStorySummaryList(createStorySummaryList())
+      advanceUntilIdle()
+
+      topicRepository.addChapterSummaryList(createChapterSummaryList())
+      advanceUntilIdle()
+
+      val storySummaryDataProvider = topicRepository.getStorySummaryDataProvider(TEST_STORY_ID_0)
+      dataProviders.convertToLiveData(storySummaryDataProvider)
+        .observeForever(mockStorySummaryViewObserver)
+      advanceUntilIdle()
+
+      verifyGetStorySummaryViewSucceeded()
+      val storySummaryView = storySummaryViewResultCaptor.value.getOrThrow()
+      assertThat(storySummaryView.storyId).isEqualTo(TEST_STORY_ID_0)
+      assertThat(storySummaryView.storyName).isEqualTo("First story")
+      assertThat(storySummaryView.storyThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS)
+      assertThat(storySummaryView.chapterCount).isEqualTo(1)
+
+      val chapterSummaryView = storySummaryView.chapterList[0]
+      assertThat(chapterSummaryView.explorationId).isEqualTo(TEST_EXPLORATION_ID_0)
+      assertThat(chapterSummaryView.name).isEqualTo(DUMMY_TITLE_TEXT)
+      assertThat(chapterSummaryView.summary).isEqualTo(DUMMY_DESCRIPTION_TEXT)
+      assertThat(chapterSummaryView.chapterThumbnail.thumbnailGraphic).isEqualTo(
+        LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS
+      )
+      assertThat(chapterSummaryView.chapterPlayState).isEqualTo(ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun tesStorySummary_addStorySummaryList_getStorySummary1_correctStorySummaryData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.addStorySummaryList(createStorySummaryList())
+      advanceUntilIdle()
+
+      val storySummaryDataProvider = topicRepository.getStorySummaryDataProvider(TEST_STORY_ID_1)
+      dataProviders.convertToLiveData(storySummaryDataProvider)
+        .observeForever(mockStorySummaryViewObserver)
+      advanceUntilIdle()
+
+      verifyGetStorySummaryViewSucceeded()
+      val storySummaryView = storySummaryViewResultCaptor.value.getOrThrow()
+      assertThat(storySummaryView.storyId).isEqualTo(TEST_STORY_ID_1)
+      assertThat(storySummaryView.storyName).isEqualTo("Second story")
+      assertThat(storySummaryView.storyThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION)
+      assertThat(storySummaryView.chapterCount).isEqualTo(0)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun tesStorySummaryAndChapterSummary_addStorySummaryList_addChapterSummaryList_getStorySummary1_correctStorySummaryAndChapterSummaryData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.addStorySummaryList(createStorySummaryList())
+      advanceUntilIdle()
+
+      topicRepository.addChapterSummaryList(createChapterSummaryList())
+      advanceUntilIdle()
+
+      val storySummaryDataProvider = topicRepository.getStorySummaryDataProvider(TEST_STORY_ID_1)
+      dataProviders.convertToLiveData(storySummaryDataProvider)
+        .observeForever(mockStorySummaryViewObserver)
+      advanceUntilIdle()
+
+      verifyGetStorySummaryViewSucceeded()
+      val storySummaryView = storySummaryViewResultCaptor.value.getOrThrow()
+      assertThat(storySummaryView.storyId).isEqualTo(TEST_STORY_ID_1)
+      assertThat(storySummaryView.storyName).isEqualTo("Second story")
+      assertThat(storySummaryView.storyThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION)
+      assertThat(storySummaryView.chapterCount).isEqualTo(1)
+
+      val chapterSummaryView = storySummaryView.chapterList[0]
+      assertThat(chapterSummaryView.explorationId).isEqualTo(TEST_EXPLORATION_ID_1)
+      assertThat(chapterSummaryView.name).isEqualTo(DUMMY_TITLE_TEXT)
+      assertThat(chapterSummaryView.summary).isEqualTo(DUMMY_DESCRIPTION_TEXT)
+      assertThat(chapterSummaryView.chapterThumbnail.thumbnailGraphic).isEqualTo(
+        LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION
+      )
+      assertThat(chapterSummaryView.chapterPlayState).isEqualTo(ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun tesStorySummary_addStorySummaryList_getStorySummaryList_correctStorySummaryData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.addStorySummaryList(createStorySummaryList())
+      advanceUntilIdle()
+
+      val storySummaryListDataProvider =
+        topicRepository.getStorySummaryListDataProvider(TEST_TOPIC_ID_0)
+      dataProviders.convertToLiveData(storySummaryListDataProvider)
+        .observeForever(mockStorySummaryViewListObserver)
+      advanceUntilIdle()
+
+      verifyGetStorySummaryViewListSucceeded()
+      val storySummaryViewList = storySummaryViewListResultCaptor.value.getOrThrow()
+      assertThat(storySummaryViewList.size).isEqualTo(2)
+
+      val storySummaryView0 = storySummaryViewList[0]
+      assertThat(storySummaryView0.storyId).isEqualTo(TEST_STORY_ID_0)
+      assertThat(storySummaryView0.storyName).isEqualTo("First story")
+      assertThat(storySummaryView0.storyThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS)
+      assertThat(storySummaryView0.chapterCount).isEqualTo(0)
+
+      val storySummaryView1 = storySummaryViewList[1]
+      assertThat(storySummaryView1.storyId).isEqualTo(TEST_STORY_ID_1)
+      assertThat(storySummaryView1.storyName).isEqualTo("Second story")
+      assertThat(storySummaryView1.storyThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION)
+      assertThat(storySummaryView1.chapterCount).isEqualTo(0)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun tesStorySummaryAndChapterSummary_addStorySummaryList_getStorySummaryList_correctStorySummaryAndChapterSummaryData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.addStorySummaryList(createStorySummaryList())
+      advanceUntilIdle()
+
+      topicRepository.addChapterSummaryList(createChapterSummaryList())
+      advanceUntilIdle()
+
+      val storySummaryListDataProvider =
+        topicRepository.getStorySummaryListDataProvider(TEST_TOPIC_ID_0)
+      dataProviders.convertToLiveData(storySummaryListDataProvider)
+        .observeForever(mockStorySummaryViewListObserver)
+      advanceUntilIdle()
+
+      verifyGetStorySummaryViewListSucceeded()
+      val storySummaryViewList = storySummaryViewListResultCaptor.value.getOrThrow()
+      assertThat(storySummaryViewList.size).isEqualTo(2)
+
+      val storySummaryView0 = storySummaryViewList[0]
+      assertThat(storySummaryView0.storyId).isEqualTo(TEST_STORY_ID_0)
+      assertThat(storySummaryView0.storyName).isEqualTo("First story")
+      assertThat(storySummaryView0.storyThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS)
+      assertThat(storySummaryView0.chapterCount).isEqualTo(1)
+
+      val chapterSummaryView0 = storySummaryView0.chapterList[0]
+      assertThat(chapterSummaryView0.explorationId).isEqualTo(TEST_EXPLORATION_ID_0)
+      assertThat(chapterSummaryView0.name).isEqualTo(DUMMY_TITLE_TEXT)
+      assertThat(chapterSummaryView0.summary).isEqualTo(DUMMY_DESCRIPTION_TEXT)
+      assertThat(chapterSummaryView0.chapterThumbnail.thumbnailGraphic).isEqualTo(
+        LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS
+      )
+      assertThat(chapterSummaryView0.chapterPlayState).isEqualTo(ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES)
+
+      val storySummaryView1 = storySummaryViewList[1]
+      assertThat(storySummaryView1.storyId).isEqualTo(TEST_STORY_ID_1)
+      assertThat(storySummaryView1.storyName).isEqualTo("Second story")
+      assertThat(storySummaryView1.storyThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION)
+      assertThat(storySummaryView1.chapterCount).isEqualTo(1)
+
+      val chapterSummaryView1 = storySummaryView1.chapterList[0]
+      assertThat(chapterSummaryView1.explorationId).isEqualTo(TEST_EXPLORATION_ID_1)
+      assertThat(chapterSummaryView1.name).isEqualTo(DUMMY_TITLE_TEXT)
+      assertThat(chapterSummaryView1.summary).isEqualTo(DUMMY_DESCRIPTION_TEXT)
+      assertThat(chapterSummaryView1.chapterThumbnail.thumbnailGraphic).isEqualTo(
+        LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION
+      )
+      assertThat(chapterSummaryView1.chapterPlayState).isEqualTo(ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testSubtopic_addSubtopicList_getSubtopic0_correctSubtopicData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.addSubTopicList(createSubtopicList())
+      advanceUntilIdle()
+
+      val subtopicDataProvider = topicRepository.getSubtopicDataProvider(TEST_SUBTOPIC_ID_0)
+      dataProviders.convertToLiveData(subtopicDataProvider)
+        .observeForever(mockSubtopicViewObserver)
+      advanceUntilIdle()
+
+      verifyGetSubtopicViewSucceeded()
+      val subtopicView = subtopicViewResultCaptor.value.getOrThrow()
+      assertThat(subtopicView.subtopicId).isEqualTo(TEST_SUBTOPIC_ID_0)
+      assertThat(subtopicView.title).isEqualTo(DUMMY_TITLE_TEXT)
+      assertThat(subtopicView.skillIdsList.size).isEqualTo(createSkillIdsList().size)
+      assertThat(subtopicView.thumbnailUrl).isEqualTo(DUMMY_THUMBNAIL_URL)
+      assertThat(subtopicView.subtopicThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testSubtopic_addSubtopicList_getSubtopic1_correctSubtopicData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.addSubTopicList(createSubtopicList())
+      advanceUntilIdle()
+
+      val subtopicDataProvider = topicRepository.getSubtopicDataProvider(TEST_SUBTOPIC_ID_1)
+      dataProviders.convertToLiveData(subtopicDataProvider)
+        .observeForever(mockSubtopicViewObserver)
+      advanceUntilIdle()
+
+      verifyGetSubtopicViewSucceeded()
+      val subtopicView = subtopicViewResultCaptor.value.getOrThrow()
+      assertThat(subtopicView.subtopicId).isEqualTo(TEST_SUBTOPIC_ID_1)
+      assertThat(subtopicView.title).isEqualTo(DUMMY_TITLE_TEXT)
+      assertThat(subtopicView.skillIdsList.size).isEqualTo(createSkillIdsList().size)
+      assertThat(subtopicView.thumbnailUrl).isEqualTo(DUMMY_THUMBNAIL_URL)
+      assertThat(subtopicView.subtopicThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testSubtopic_addSubtopicList_getSubtopicList_correctSubtopicData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.addSubTopicList(createSubtopicList())
+      advanceUntilIdle()
+
+      val subtopicListDataProvider = topicRepository.getSubtopicListDataProvider(TEST_TOPIC_ID_0)
+      dataProviders.convertToLiveData(subtopicListDataProvider)
+        .observeForever(mockSubtopicViewListObserver)
+      advanceUntilIdle()
+
+      verifyGetSubtopicViewListSucceeded()
+      val subtopicViewList = subtopicViewListResultCaptor.value.getOrThrow()
+      assertThat(subtopicViewList.size).isEqualTo(2)
+
+      val subtopicView0 = subtopicViewList[0]
+      assertThat(subtopicView0.subtopicId).isEqualTo(TEST_SUBTOPIC_ID_0)
+      assertThat(subtopicView0.title).isEqualTo(DUMMY_TITLE_TEXT)
+      assertThat(subtopicView0.skillIdsList.size).isEqualTo(createSkillIdsList().size)
+      assertThat(subtopicView0.thumbnailUrl).isEqualTo(DUMMY_THUMBNAIL_URL)
+      assertThat(subtopicView0.subtopicThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS)
+
+      val subtopicView1 = subtopicViewList[1]
+      assertThat(subtopicView1.subtopicId).isEqualTo(TEST_SUBTOPIC_ID_1)
+      assertThat(subtopicView1.title).isEqualTo(DUMMY_TITLE_TEXT)
+      assertThat(subtopicView1.skillIdsList.size).isEqualTo(createSkillIdsList().size)
+      assertThat(subtopicView1.thumbnailUrl).isEqualTo(DUMMY_THUMBNAIL_URL)
+      assertThat(subtopicView1.subtopicThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testTopic_addTopic0_getTopic0_correctTopicData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.addTopic(createTopic0())
+      advanceUntilIdle()
+
+      val topicDataProvider = topicRepository.getTopicDataProvider(TEST_TOPIC_ID_0)
+      dataProviders.convertToLiveData(topicDataProvider)
+        .observeForever(mockTopicViewObserver)
+      advanceUntilIdle()
+
+      verifyGetTopicViewSucceeded()
+      val topicView = topicViewResultCaptor.value.getOrThrow()
+      assertThat(topicView.topicId).isEqualTo(TEST_TOPIC_ID_0)
+      assertThat(topicView.name).isEqualTo(DUMMY_TITLE_TEXT)
+      assertThat(topicView.description).isEqualTo(DUMMY_DESCRIPTION_TEXT)
+      assertThat(topicView.diskSizeBytes).isEqualTo(1024)
+      assertThat(topicView.topicThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testTopic_addTopic1_getTopic1_correctTopicData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.addTopic(createTopic1())
+      advanceUntilIdle()
+
+      val topicDataProvider = topicRepository.getTopicDataProvider(TEST_TOPIC_ID_1)
+      dataProviders.convertToLiveData(topicDataProvider)
+        .observeForever(mockTopicViewObserver)
+      advanceUntilIdle()
+
+      verifyGetTopicViewSucceeded()
+      val topicView = topicViewResultCaptor.value.getOrThrow()
+      assertThat(topicView.topicId).isEqualTo(TEST_TOPIC_ID_1)
+      assertThat(topicView.name).isEqualTo(DUMMY_TITLE_TEXT)
+      assertThat(topicView.description).isEqualTo(DUMMY_DESCRIPTION_TEXT)
+      assertThat(topicView.diskSizeBytes).isEqualTo(2048)
+      assertThat(topicView.topicThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION)
+    }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun testTopic_addTopics_getTopicSummaryList_correctTopicSummaryListData() =
+    runBlockingTest(coroutineContext) {
+      topicRepository.initialiseAllTopics()
+      advanceUntilIdle()
+
+      val topicSummaryListViewDataProvider = topicRepository.getTopicSummaryListDataProvider()
+      dataProviders.convertToLiveData(topicSummaryListViewDataProvider)
+        .observeForever(mockTopicSummaryListViewObserver)
+      advanceUntilIdle()
+
+      verifyGetTopicSummaryListViewSucceeded()
+      val topicSummaryListView = topicSummaryListViewResultCaptor.value.getOrThrow()
+      assertThat(topicSummaryListView.topicSummaryCount).isEqualTo(2)
+
+      val topicSummaryView0 = topicSummaryListView.getTopicSummary(0)
+      assertThat(topicSummaryView0.topicId).isEqualTo(FRACTIONS_TOPIC_ID)
+      assertThat(topicSummaryView0.name).isEqualTo("Fractions")
+      assertThat(topicSummaryView0.totalChapterCount).isEqualTo(1)
+      assertThat(topicSummaryView0.topicThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.CHILD_WITH_FRACTIONS_HOMEWORK)
+
+      val topicSummaryView1 = topicSummaryListView.getTopicSummary(1)
+      assertThat(topicSummaryView1.topicId).isEqualTo(RATIOS_TOPIC_ID)
+      assertThat(topicSummaryView1.name).isEqualTo("Ratios and Proportional Reasoning")
+      assertThat(topicSummaryView1.totalChapterCount).isEqualTo(2)
+      assertThat(topicSummaryView1.topicThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.DUCK_AND_CHICKEN)
+    }
+
+  private fun setUpTestApplicationComponent() {
+    DaggerTopicRepositoryTest_TestApplicationComponent.builder()
+      .setApplication(ApplicationProvider.getApplicationContext())
+      .build()
+      .inject(this)
+  }
+
+  private fun verifyGetRevisionCardViewSucceeded() {
+    verify(
+      mockRevisionCardViewObserver,
+      atLeastOnce()
+    ).onChanged(revisionCardViewResultCaptor.capture())
+    assertThat(revisionCardViewResultCaptor.value.isSuccess()).isTrue()
+  }
+
+  private fun verifyGetSkillSummaryViewSucceeded() {
+    verify(
+      mockSkillSummaryViewObserver,
+      atLeastOnce()
+    ).onChanged(skillSummaryViewResultCaptor.capture())
+    assertThat(skillSummaryViewResultCaptor.value.isSuccess()).isTrue()
+  }
+
+  private fun verifyGetStorySummaryViewListSucceeded() {
+    verify(
+      mockStorySummaryViewListObserver,
+      atLeastOnce()
+    ).onChanged(storySummaryViewListResultCaptor.capture())
+    assertThat(storySummaryViewListResultCaptor.value.isSuccess()).isTrue()
+  }
+
+  private fun verifyGetStorySummaryViewSucceeded() {
+    verify(
+      mockStorySummaryViewObserver,
+      atLeastOnce()
+    ).onChanged(storySummaryViewResultCaptor.capture())
+    assertThat(storySummaryViewResultCaptor.value.isSuccess()).isTrue()
+  }
+
+  private fun verifyGetSubtopicViewListSucceeded() {
+    verify(
+      mockSubtopicViewListObserver,
+      atLeastOnce()
+    ).onChanged(subtopicViewListResultCaptor.capture())
+    assertThat(subtopicViewListResultCaptor.value.isSuccess()).isTrue()
+  }
+
+  private fun verifyGetSubtopicViewSucceeded() {
+    verify(mockSubtopicViewObserver, atLeastOnce()).onChanged(subtopicViewResultCaptor.capture())
+    assertThat(subtopicViewResultCaptor.value.isSuccess()).isTrue()
+  }
+
+  private fun verifyGetTopicSummaryListViewSucceeded() {
+    verify(mockTopicSummaryListViewObserver, atLeastOnce()).onChanged(
+      topicSummaryListViewResultCaptor.capture()
+    )
+    assertThat(topicSummaryListViewResultCaptor.value.isSuccess()).isTrue()
+  }
+
+  private fun verifyGetTopicViewSucceeded() {
+    verify(mockTopicViewObserver, atLeastOnce()).onChanged(topicViewResultCaptor.capture())
+    assertThat(topicViewResultCaptor.value.isSuccess()).isTrue()
+  }
+
+  private fun createChapterSummaryList(): List<ChapterSummaryDomain> {
+    val chapterSummaryDomainList = mutableListOf<ChapterSummaryDomain>()
+    chapterSummaryDomainList.add(createStory0ChapterSummary0())
+    chapterSummaryDomainList.add(createStory1ChapterSummary0())
+    return chapterSummaryDomainList
+  }
+
+  private fun createStory0ChapterSummary0(): ChapterSummaryDomain {
+    return ChapterSummaryDomain.newBuilder()
+      .setStoryId(TEST_STORY_ID_0)
+      .setTopicId(TEST_TOPIC_ID_0)
+      .setExplorationId(TEST_EXPLORATION_ID_0)
+      .setName(DUMMY_TITLE_TEXT)
+      .setSummary(DUMMY_DESCRIPTION_TEXT)
+      .setChapterPlayState(ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES)
+      .setChapterThumbnail(createThumbnail0())
+      .build()
+  }
+
+  private fun createStory1ChapterSummary0(): ChapterSummaryDomain {
+    return ChapterSummaryDomain.newBuilder()
+      .setStoryId(TEST_STORY_ID_1)
+      .setTopicId(TEST_TOPIC_ID_0)
+      .setExplorationId(TEST_EXPLORATION_ID_1)
+      .setName(DUMMY_TITLE_TEXT)
+      .setSummary(DUMMY_DESCRIPTION_TEXT)
+      .setChapterPlayState(ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES)
+      .setChapterThumbnail(createThumbnail1())
+      .build()
+  }
+
+  private fun createRevisionCardList(): List<RevisionCardDomain> {
+    val revisionCardDomainList = mutableListOf<RevisionCardDomain>()
+    revisionCardDomainList.add(createRevisionCard0())
+    return revisionCardDomainList
+  }
+
+  private fun createRevisionCard0(): RevisionCardDomain {
+    return RevisionCardDomain.newBuilder()
+      .setSubtopicTitle(DUMMY_TITLE_TEXT)
+      .setPageContents(createRevisionCardPageContent0())
+      .build()
+  }
+
+  private fun createRevisionCardPageContent0(): SubtitledHtml {
+    return SubtitledHtml.newBuilder()
+      .setContentId(TEST_CONTENT_ID)
+      .setHtml(TEST_HTML_TEXT)
+      .build()
+  }
+
+  private fun createSkillSummaryList(): List<SkillSummaryDomain> {
+    val skillSummaryDomainList = mutableListOf<SkillSummaryDomain>()
+    skillSummaryDomainList.add(createSkillSummary0())
+    skillSummaryDomainList.add(createSkillSummary1())
+    return skillSummaryDomainList
+  }
+
+  private fun createSkillSummary0(): SkillSummaryDomain {
+    return SkillSummaryDomain.newBuilder()
+      .setSkillId(TEST_SKILL_ID_0)
+      .setDescription(DUMMY_DESCRIPTION_TEXT)
+      .setSkillThumbnail(createThumbnail0())
+      .setThumbnailUrl(DUMMY_THUMBNAIL_URL)
+      .build()
+  }
+
+  private fun createSkillSummary1(): SkillSummaryDomain {
+    return SkillSummaryDomain.newBuilder()
+      .setSkillId(TEST_SKILL_ID_1)
+      .setDescription(DUMMY_DESCRIPTION_TEXT)
+      .setSkillThumbnail(createThumbnail1())
+      .setThumbnailUrl(DUMMY_THUMBNAIL_URL)
+      .build()
+  }
+
+  private fun createStorySummaryList(): List<StorySummaryDomain> {
+    val storySummaryDomainList = mutableListOf<StorySummaryDomain>()
+    storySummaryDomainList.add(createStorySummary0())
+    storySummaryDomainList.add(createStorySummary1())
+    return storySummaryDomainList
+  }
+
+  private fun createStorySummary0(): StorySummaryDomain {
+    return StorySummaryDomain.newBuilder()
+      .setStoryId(TEST_STORY_ID_0)
+      .setStoryName("First story")
+      .setTopicId(TEST_TOPIC_ID_0)
+      .setStoryThumbnail(createThumbnail0())
+      .build()
+  }
+
+  private fun createStorySummary1(): StorySummaryDomain {
+    return StorySummaryDomain.newBuilder()
+      .setStoryId(TEST_STORY_ID_1)
+      .setStoryName("Second story")
+      .setTopicId(TEST_TOPIC_ID_0)
+      .setStoryThumbnail(createThumbnail1())
+      .build()
+  }
+
+  private fun createSubtopicList(): List<SubtopicDomain> {
+    val subtopicDomainList = mutableListOf<SubtopicDomain>()
+    subtopicDomainList.add(createSubtopic0())
+    subtopicDomainList.add(createSubtopic1())
+    return subtopicDomainList
+  }
+
+  private fun createSubtopic0(): SubtopicDomain {
+    return SubtopicDomain.newBuilder()
+      .setSubtopicId(TEST_SUBTOPIC_ID_0)
+      .setTopicId(TEST_TOPIC_ID_0)
+      .setTitle(DUMMY_TITLE_TEXT)
+      .setSubtopicThumbnail(createThumbnail0())
+      .setThumbnailUrl(DUMMY_THUMBNAIL_URL)
+      .addAllSkillIds(createSkillIdsList())
+      .build()
+  }
+
+  private fun createSubtopic1(): SubtopicDomain {
+    return SubtopicDomain.newBuilder()
+      .setSubtopicId(TEST_SUBTOPIC_ID_1)
+      .setTopicId(TEST_TOPIC_ID_0)
+      .setTitle(DUMMY_TITLE_TEXT)
+      .setSubtopicThumbnail(createThumbnail1())
+      .setThumbnailUrl(DUMMY_THUMBNAIL_URL)
+      .addAllSkillIds(createSkillIdsList())
+      .build()
+  }
+
+  private fun createTopic0(): TopicDomain {
+    return TopicDomain.newBuilder()
+      .setTopicId(TEST_TOPIC_ID_0)
+      .setName(DUMMY_TITLE_TEXT)
+      .setDescription(DUMMY_DESCRIPTION_TEXT)
+      .setDiskSizeBytes(1024)
+      .setTopicThumbnail(createThumbnail0())
+      .build()
+  }
+
+  private fun createTopic1(): TopicDomain {
+    return TopicDomain.newBuilder()
+      .setTopicId(TEST_TOPIC_ID_1)
+      .setName(DUMMY_TITLE_TEXT)
+      .setDescription(DUMMY_DESCRIPTION_TEXT)
+      .setDiskSizeBytes(2048)
+      .setTopicThumbnail(createThumbnail1())
+      .build()
+  }
+
+  private fun createThumbnail0(): LessonThumbnail {
+    return LessonThumbnail.newBuilder()
+      .setThumbnailGraphic(LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS)
+      .build()
+  }
+
+  private fun createThumbnail1(): LessonThumbnail {
+    return LessonThumbnail.newBuilder()
+      .setThumbnailGraphic(LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION)
+      .build()
+  }
+
+  private fun createSkillIdsList(): List<String> {
+    val skillIdsList = mutableListOf<String>()
+    skillIdsList.add(TEST_SKILL_ID_0)
+    skillIdsList.add(TEST_SKILL_ID_1)
+    skillIdsList.add(TEST_SKILL_ID_2)
+    return skillIdsList
+  }
+
+  @Qualifier
+  annotation class TestDispatcher
+
+  // TODO(#89): Move this to a common test application component.
+  @Module
+  class TestModule {
+    @Provides
+    @Singleton
+    fun provideContext(application: Application): Context {
+      return application
+    }
+
+    @ExperimentalCoroutinesApi
+    @Singleton
+    @Provides
+    @TestDispatcher
+    fun provideTestDispatcher(): CoroutineDispatcher {
+      return TestCoroutineDispatcher()
+    }
+
+    @Singleton
+    @Provides
+    @BackgroundDispatcher
+    fun provideBackgroundDispatcher(@TestDispatcher testDispatcher: CoroutineDispatcher): CoroutineDispatcher {
+      return testDispatcher
+    }
+
+    @Singleton
+    @Provides
+    @BlockingDispatcher
+    fun provideBlockingDispatcher(@TestDispatcher testDispatcher: CoroutineDispatcher): CoroutineDispatcher {
+      return testDispatcher
+    }
+
+    // TODO(#59): Either isolate these to their own shared test module, or use the real logging
+    // module in tests to avoid needing to specify these settings for tests.
+    @EnableConsoleLog
+    @Provides
+    fun provideEnableConsoleLog(): Boolean = true
+
+    @EnableFileLog
+    @Provides
+    fun provideEnableFileLog(): Boolean = false
+
+    @GlobalLogLevel
+    @Provides
+    fun provideGlobalLogLevel(): LogLevel = LogLevel.VERBOSE
+
+    @CacheAssetsLocally
+    @Provides
+    fun provideCacheAssetsLocally(): Boolean = false
+  }
+
+  // TODO(#89): Move this to a common test application component.
+  @Singleton
+  @Component(modules = [TestModule::class])
+  interface TestApplicationComponent {
+    @Component.Builder
+    interface Builder {
+      @BindsInstance
+      fun setApplication(application: Application): Builder
+
+      fun build(): TestApplicationComponent
+    }
+
+    fun inject(topicRepositoryTest: TopicRepositoryTest)
+  }
+}

--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -439,6 +439,47 @@ message SubtopicView {
   LessonThumbnail subtopic_thumbnail = 5;
 }
 
+// Top level proto used to store revision card content.
+message RevisionCardDatabase{
+  // Subtopic title to subtopic content mapping.
+  map<string, RevisionCardDomain> subtopic_content_database = 1;
+}
+
+// Corresponds to a revision card that is stored in database.
+message RevisionCardDomain {
+  // The title corresponding to the subtopic.
+  string subtopic_title = 1;
+
+  // The core explanation of the subtopic being revised.
+  SubtitledHtml page_contents = 2;
+}
+
+// Corresponds to a revision card that can be displayed for a specific subtopic.
+message RevisionCardView {
+  // The title corresponding to the subtopic.
+  string subtopic_title = 1;
+
+  // The core explanation of the subtopic being revised.
+  SubtitledHtml page_contents = 2;
+}
+
+// Corresponds to a revision card that can be displayed for a specific subtopic.
+message SubtopicContentView {
+  // The title corresponding to the subtopic.
+  string subtopic_title = 1;
+
+  // The core explanation of the subtopic being revised.
+  SubtitledHtml page_contents = 2;
+
+  // Mapping from content_id to a VoiceoverMapping for each SubtitledHtml in this revision card that has corresponding
+  // recorded audio to play.
+  map<string, VoiceoverMapping> recorded_voiceover = 3;
+
+  // Mapping from content_id to a TranslationMapping for each SubtitledHtml in this revision card that has corresponding
+  // translations.
+  map<string, TranslationMapping> written_translation = 4;
+}
+
 // Top level proto used to store skill summaries.
 message SkillSummaryDatabase{
   // Skill id to skill summary map.

--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -324,3 +324,272 @@ message RevisionCard {
   // translations.
   map<string, TranslationMapping> written_translation = 6;
 }
+
+// Corresponds to a single topic that can be read, played, trained, or reviewed.
+message TopicBackend {
+  // The ID corresponding to the topic.
+  string topic_id = 1;
+
+  // The topic's name.
+  string name = 2;
+
+  // A brief description of the topic.
+  string description = 3;
+
+  // A list of summarized stories contained within this topic.
+  repeated StorySummary story = 4;
+
+  // A list of summarized skills contained within this topic.
+  repeated SkillSummary skill = 5;
+
+  // The thumbnail corresponding to this topic.
+  LessonThumbnail topic_thumbnail = 6;
+
+  // The number of on-disk bytes this topic consumes.
+  int64 disk_size_bytes = 7;
+
+  // A list of subtopic contained within this topic.
+  repeated Subtopic subtopic = 8;
+}
+
+message TopicDatabase{
+    map<string, TopicDomain> topic_database = 1;
+}
+
+// Corresponds to a single topic that can be read, played, trained, or reviewed.
+message TopicDomain{
+  // The ID corresponding to the topic.
+  string topic_id = 1;
+
+  // The topic's name.
+  string name = 2;
+
+  // A brief description of the topic.
+  string description = 3;
+
+  // The thumbnail corresponding to this topic.
+  LessonThumbnail topic_thumbnail = 4;
+
+  // The number of on-disk bytes this topic consumes.
+  int64 disk_size_bytes = 5;
+}
+
+// Corresponds to a single topic that can be read, played, trained, or reviewed.
+message TopicView {
+  // The ID corresponding to the topic.
+  string topic_id = 1;
+
+  // The topic's name.
+  string name = 2;
+
+  // A brief description of the topic.
+  string description = 3;
+
+  // A list of subtopic contained within this topic.
+  repeated SubtopicView subtopic = 4;
+
+  // A list of summarized stories contained within this topic.
+  repeated StorySummaryView story = 5;
+
+  // A list of summarized skills contained within this topic.
+  repeated SkillSummaryView skill = 6;
+
+  // The thumbnail corresponding to this topic.
+  LessonThumbnail topic_thumbnail = 7;
+
+  // The number of on-disk bytes this topic consumes.
+  int64 disk_size_bytes = 8;
+}
+
+// Top level proto used to store subtopic summaries.
+message SubtopicDatabase{
+  // Subtopic ID to subtopic summary mapping.
+  map<string, SubtopicDomain> subtopic_database = 1;
+}
+
+// Corresponds to a single subtopic.
+message SubtopicDomain {
+  // The topic ID associated with this subtopic.
+  string topic_id = 1;
+
+  // The ID of the subtopic.
+  string subtopic_id = 2;
+
+  // The title of the subtopic.
+  string title = 3;
+
+  // The list of skill ids associated with the subtopic.
+  repeated string skill_ids = 4;
+
+  // A URL corresponding to a thumbnail associated with this subtopic. If this is absent, the UI should show a reasonable
+  // alternative.
+  string thumbnail_url = 5;
+
+  // The thumbnail corresponding to this subtopic.
+  LessonThumbnail subtopic_thumbnail = 6;
+}
+
+// Corresponds to a single subtopic.
+message SubtopicView {
+  // The ID of the subtopic.
+  string subtopic_id = 1;
+
+  // The title of the subtopic.
+  string title = 2;
+
+  // The list of skill ids associated with the subtopic.
+  repeated string skill_ids = 3;
+
+  // A URL corresponding to a thumbnail associated with this subtopic. If this is absent, the UI should show a reasonable
+  // alternative.
+  string thumbnail_url = 4;
+
+  // The thumbnail corresponding to this subtopic.
+  LessonThumbnail subtopic_thumbnail = 5;
+}
+
+// Top level proto used to store skill summaries.
+message SkillSummaryDatabase{
+  // Skill id to skill summary map.
+  map<string, SkillSummaryDomain> skill_summary_database = 1;
+}
+
+// A summary of a skill that can be trained or reviewed by the player.
+message SkillSummaryDomain {
+  // The ID of the skill.
+  string skill_id = 1;
+
+  // A brief description of the skill.
+  string description = 2;
+
+  // A URL corresponding to a thumbnail associated with this skill. If this is absent, the UI should show a reasonable
+  // alternative.
+  string thumbnail_url = 3;
+
+  // The thumbnail corresponding to this skill.
+  LessonThumbnail skill_thumbnail = 4;
+}
+
+// A summary of a skill that can be trained or reviewed by the player.
+message SkillSummaryView {
+  // The ID of the skill.
+  string skill_id = 1;
+
+  // A brief description of the skill.
+  string description = 2;
+
+  // A URL corresponding to a thumbnail associated with this skill. If this is absent, the UI should show a reasonable
+  // alternative.
+  string thumbnail_url = 3;
+
+  // The thumbnail corresponding to this skill.
+  LessonThumbnail skill_thumbnail = 4;
+}
+
+// Top level proto used to store story summaries.
+message StorySummaryDatabase{
+  // Story ID to story summary map.
+  map<string, StorySummaryDomain> story_summary_database = 1;
+}
+
+// A summary of a story that can be played within a topic.
+message StorySummaryDomain {
+  // The topic ID associated with this story.
+  string topic_id = 1;
+
+  // The ID of the story.
+  string story_id = 2;
+
+  // The name of the story.
+  string story_name = 3;
+
+  // The thumbnail corresponding to this story.
+  LessonThumbnail story_thumbnail = 4;
+}
+
+// Top level proto used to store chapter summaries.
+message ChapterSummaryDatabase{
+  // Exploration ID to chapter summary map.
+  map<string, ChapterSummaryDomain> chapter_summary_database = 1;
+}
+
+// A summary of a chapter/exploration that can be played.
+message ChapterSummaryDomain {
+  // The topic ID associated with this chapter.
+  string topic_id = 1;
+
+  // The story ID associated with this chapter.
+  string story_id = 2;
+
+  // The exploration ID associated with this chapter.
+  string exploration_id = 3;
+
+  // The chapter's name (which is the same as the exploration's title).
+  string name = 4;
+
+  // Summary of this chapter.
+  string summary = 5;
+
+  // Indicates the playable state of the current chapter, including whether it's already been completed.
+  ChapterPlayState chapter_play_state = 6;
+
+  // The thumbnail corresponding to this chapter.
+  LessonThumbnail chapter_thumbnail = 7;
+}
+
+// A summary of a story that can be played within a topic.
+message StorySummaryView {
+  // The ID of the story.
+  string story_id = 1;
+
+  // The name of the story.
+  string story_name = 2;
+
+  // The thumbnail corresponding to this story.
+  LessonThumbnail story_thumbnail = 3;
+
+  // A list of summarized chapters/explorations that can be played within the story.
+  repeated ChapterSummary chapter = 4;
+}
+
+// A summary of a chapter/exploration that can be played.
+message ChapterSummaryView {
+  // The exploration ID associated with this chapter.
+  string exploration_id = 1;
+
+  // The chapter's name (which is the same as the exploration's title).
+  string name = 2;
+
+  // Summary of this chapter.
+  string summary = 3;
+
+  // Indicates the playable state of the current chapter, including whether it's already been completed.
+  ChapterPlayState chapter_play_state = 4;
+
+  // The thumbnail corresponding to this chapter.
+  LessonThumbnail chapter_thumbnail = 5;
+}
+
+// Corresponds to the list of topics that can be shown on the homescreen.
+message TopicSummaryListView {
+  // All topics that are available to the player.
+  repeated TopicSummaryView topic_summary = 2;
+}
+
+// A homescreen summary of a topic.
+message TopicSummaryView {
+  // The ID of the topic.
+  string topic_id = 1;
+
+  // The name of the topic.
+  string name = 2;
+
+  // The associated thumbnail that should be displayed with this topic summary.
+  LessonThumbnail topic_thumbnail = 3;
+
+  // The structural version of the topic.
+  int32 version = 4;
+
+  // The total number of lessons associated with this topic.
+  int32 total_chapter_count = 5;
+}

--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -385,20 +385,11 @@ message TopicView {
   // A brief description of the topic.
   string description = 3;
 
-  // A list of subtopic contained within this topic.
-  repeated SubtopicView subtopic = 4;
-
-  // A list of summarized stories contained within this topic.
-  repeated StorySummaryView story = 5;
-
-  // A list of summarized skills contained within this topic.
-  repeated SkillSummaryView skill = 6;
-
   // The thumbnail corresponding to this topic.
-  LessonThumbnail topic_thumbnail = 7;
+  LessonThumbnail topic_thumbnail = 4;
 
   // The number of on-disk bytes this topic consumes.
-  int64 disk_size_bytes = 8;
+  int64 disk_size_bytes = 5;
 }
 
 // Top level proto used to store subtopic summaries.
@@ -549,7 +540,7 @@ message StorySummaryView {
   LessonThumbnail story_thumbnail = 3;
 
   // A list of summarized chapters/explorations that can be played within the story.
-  repeated ChapterSummary chapter = 4;
+  repeated ChapterSummaryView chapter = 4;
 }
 
 // A summary of a chapter/exploration that can be played.

--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -325,33 +325,6 @@ message RevisionCard {
   map<string, TranslationMapping> written_translation = 6;
 }
 
-// Corresponds to a single topic that can be read, played, trained, or reviewed.
-message TopicBackend {
-  // The ID corresponding to the topic.
-  string topic_id = 1;
-
-  // The topic's name.
-  string name = 2;
-
-  // A brief description of the topic.
-  string description = 3;
-
-  // A list of summarized stories contained within this topic.
-  repeated StorySummary story = 4;
-
-  // A list of summarized skills contained within this topic.
-  repeated SkillSummary skill = 5;
-
-  // The thumbnail corresponding to this topic.
-  LessonThumbnail topic_thumbnail = 6;
-
-  // The number of on-disk bytes this topic consumes.
-  int64 disk_size_bytes = 7;
-
-  // A list of subtopic contained within this topic.
-  repeated Subtopic subtopic = 8;
-}
-
 message TopicDatabase{
     map<string, TopicDomain> topic_database = 1;
 }


### PR DESCRIPTION
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes part of #1088 

This PR introduces TopicRepository which saves json data in proto-database and introduce functions which can be used to fetch data from this database.

This PR uses 3 types of suffix for different protos:
***Database** -> To define the top level proto-database. We could have used Domain for this too but that would easily create confusion. So I have kept it Database for top level proto and all child protos contains **Domain**.
***Domain** -> In general these are getting used in the entire domain layer. Currently json files are getting converted to these types of protos and then they are saved to database. 
***View** -> All those protos which will be finally be used in **app** module are using this suffix.

## NOTE
This PR is currently under development. All the important functions have been introduced but the documentation (comments) and test cases is pending for this PR.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR is made from a branch that is up-to-date with "develop".
- [ ] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
