### PR TITLE
Fix part of #1248: High-fi profile chooser portrait mode

### DIFF
--- a/app/src/main/java/org/oppia/app/databinding/MarginBindingAdapters.kt
+++ b/app/src/main/java/org/oppia/app/databinding/MarginBindingAdapters.kt
@@ -1,0 +1,45 @@
+package org.oppia.app.databinding
+
+import android.view.View
+import android.view.ViewGroup.MarginLayoutParams
+import androidx.databinding.BindingAdapter
+
+/** Used to set a margin-start for profile chooser items. */
+@BindingAdapter("app:profile_chooser_marginStart")
+fun setLayoutMarginStart(view: View, marginStart: Float) {
+  if (view.layoutParams is MarginLayoutParams) {
+    val params = view.layoutParams as MarginLayoutParams
+    params.setMargins(marginStart.toInt(), params.topMargin, params.marginEnd, params.bottomMargin)
+    view.requestLayout()
+  }
+}
+
+/** Used to set a margin-end for profile chooser items. */
+@BindingAdapter("app:profile_chooser_marginEnd")
+fun setLayoutMarginEnd(view: View, marginEnd: Float) {
+  if (view.layoutParams is MarginLayoutParams) {
+    val params = view.layoutParams as MarginLayoutParams
+    params.setMargins(params.marginStart, params.topMargin, marginEnd.toInt(), params.bottomMargin)
+    view.requestLayout()
+  }
+}
+
+/** Used to set a margin-top for profile chooser items. */
+@BindingAdapter("app:profile_chooser_marginTop")
+fun setLayoutMarginTop(view: View, marginTop: Float) {
+  if (view.layoutParams is MarginLayoutParams) {
+    val params = view.layoutParams as MarginLayoutParams
+    params.setMargins(params.marginStart, marginTop.toInt(), params.marginEnd, params.bottomMargin)
+    view.requestLayout()
+  }
+}
+
+/** Used to set a margin-bottom for profile chooser items. */
+@BindingAdapter("app:profile_chooser_marginBottom")
+fun setLayoutMarginBottom(view: View, marginBottom: Float) {
+  if (view.layoutParams is MarginLayoutParams) {
+    val params = view.layoutParams as MarginLayoutParams
+    params.setMargins(params.marginStart, params.topMargin, params.marginEnd, marginBottom.toInt())
+    view.requestLayout()
+  }
+}

--- a/app/src/main/java/org/oppia/app/databinding/MarginBindingAdapters.kt
+++ b/app/src/main/java/org/oppia/app/databinding/MarginBindingAdapters.kt
@@ -5,7 +5,7 @@ import android.view.ViewGroup.MarginLayoutParams
 import androidx.databinding.BindingAdapter
 
 /** Used to set a margin-start for profile chooser items. */
-@BindingAdapter("app:profile_chooser_marginStart")
+@BindingAdapter("app:profileChooserMarginStart")
 fun setLayoutMarginStart(view: View, marginStart: Float) {
   if (view.layoutParams is MarginLayoutParams) {
     val params = view.layoutParams as MarginLayoutParams
@@ -15,7 +15,7 @@ fun setLayoutMarginStart(view: View, marginStart: Float) {
 }
 
 /** Used to set a margin-end for profile chooser items. */
-@BindingAdapter("app:profile_chooser_marginEnd")
+@BindingAdapter("app:profileChooserMarginEnd")
 fun setLayoutMarginEnd(view: View, marginEnd: Float) {
   if (view.layoutParams is MarginLayoutParams) {
     val params = view.layoutParams as MarginLayoutParams
@@ -25,7 +25,7 @@ fun setLayoutMarginEnd(view: View, marginEnd: Float) {
 }
 
 /** Used to set a margin-top for profile chooser items. */
-@BindingAdapter("app:profile_chooser_marginTop")
+@BindingAdapter("app:profileChooserMarginTop")
 fun setLayoutMarginTop(view: View, marginTop: Float) {
   if (view.layoutParams is MarginLayoutParams) {
     val params = view.layoutParams as MarginLayoutParams
@@ -35,7 +35,7 @@ fun setLayoutMarginTop(view: View, marginTop: Float) {
 }
 
 /** Used to set a margin-bottom for profile chooser items. */
-@BindingAdapter("app:profile_chooser_marginBottom")
+@BindingAdapter("app:profileChooserMarginBottom")
 fun setLayoutMarginBottom(view: View, marginBottom: Float) {
   if (view.layoutParams is MarginLayoutParams) {
     val params = view.layoutParams as MarginLayoutParams

--- a/app/src/main/res/layout/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout/profile_chooser_add_view.xml
@@ -14,7 +14,6 @@
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="24dp"
     android:gravity="center_horizontal"
     android:orientation="vertical">
 
@@ -23,44 +22,53 @@
       android:layout_width="match_parent"
       android:layout_height="0.5dp"
       android:layout_marginBottom="24dp"
-      android:visibility="@{presenter.wasProfileEverBeenAddedValue ? View.GONE : View.VISIBLE}"
-      android:background="@color/oppiaProfileChooserDivider" />
-
-    <de.hdodenhof.circleimageview.CircleImageView
-      android:id="@+id/profile_add_button"
-      android:layout_width="72dp"
-      android:layout_height="72dp"
-      android:layout_marginBottom="12dp"
-      android:src="@drawable/ic_add_profile"
-      app:civ_border_color="@color/avatarBorder"
-      app:civ_border_width="1dp" />
-
-    <TextView
-      android:id="@+id/add_profile_text"
-      android:layout_width="wrap_content"
-      android:layout_gravity="center"
-      android:layout_height="wrap_content"
-      android:fontFamily="sans-serif-medium"
-      android:text="@{presenter.wasProfileEverBeenAddedValue ? @string/profile_chooser_add : @string/set_up_multiple_profiles}"
-      android:paddingStart="8dp"
-      android:paddingEnd="8dp"
-      android:textColor="@color/white"
-      android:textSize="14sp" />
-
-    <TextView
-      android:id="@+id/add_profile_description_text"
-      android:layout_width="wrap_content"
-      android:layout_gravity="center"
-      android:layout_height="wrap_content"
-      android:fontFamily="sans-serif-medium"
-      android:paddingStart="8dp"
-      android:paddingEnd="8dp"
-      android:layout_marginStart="8dp"
-      android:layout_marginEnd="8dp"
-      android:gravity="center"
-      android:text="@string/set_up_multiple_profiles_description"
-      android:textColor="@color/white"
-      android:textSize="14sp"
+      android:background="@color/oppiaProfileChooserDivider"
       android:visibility="@{presenter.wasProfileEverBeenAddedValue ? View.GONE : View.VISIBLE}" />
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:gravity="center_vertical"
+      android:orientation="@{presenter.wasProfileEverBeenAddedValue ? LinearLayout.VERTICAL : LinearLayout.HORIZONTAL}"
+      app:profile_chooser_marginEnd="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_20}"
+      app:profile_chooser_marginStart="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_20}"
+      app:profile_chooser_marginTop="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_0 : @dimen/margin_24}">
+
+      <de.hdodenhof.circleimageview.CircleImageView
+        android:id="@+id/profile_add_button"
+        android:layout_width="72dp"
+        android:layout_height="72dp"
+        android:src="@drawable/ic_add_profile"
+        app:civ_border_color="@color/avatarBorder"
+        app:civ_border_width="1dp" />
+
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:orientation="vertical">
+
+        <TextView
+          android:id="@+id/add_profile_text"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:fontFamily="sans-serif-medium"
+          android:text="@{presenter.wasProfileEverBeenAddedValue ? @string/profile_chooser_add : @string/set_up_multiple_profiles}"
+          android:textColor="@color/white"
+          android:textSize="14sp" />
+
+        <TextView
+          android:id="@+id/add_profile_description_text"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center"
+          android:layout_marginTop="4dp"
+          android:fontFamily="sans-serif"
+          android:text="@string/set_up_multiple_profiles_description"
+          android:textColor="@color/white"
+          android:textSize="12sp"
+          android:visibility="@{presenter.wasProfileEverBeenAddedValue ? View.GONE : View.VISIBLE}" />
+      </LinearLayout>
+    </LinearLayout>
   </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout/profile_chooser_add_view.xml
@@ -4,6 +4,10 @@
 
   <data>
 
+    <import type="android.widget.LinearLayout" />
+
+    <import type="android.view.Gravity" />
+
     <import type="android.view.View" />
 
     <variable
@@ -21,18 +25,18 @@
       android:id="@+id/add_profile_divider_view"
       android:layout_width="match_parent"
       android:layout_height="0.5dp"
-      android:layout_marginBottom="24dp"
+      android:layout_marginBottom="60dp"
       android:background="@color/oppiaProfileChooserDivider"
       android:visibility="@{presenter.wasProfileEverBeenAddedValue ? View.GONE : View.VISIBLE}" />
 
     <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:gravity="center_vertical"
+      android:gravity="@{presenter.wasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
       android:orientation="@{presenter.wasProfileEverBeenAddedValue ? LinearLayout.VERTICAL : LinearLayout.HORIZONTAL}"
-      app:profile_chooser_marginEnd="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_20}"
-      app:profile_chooser_marginStart="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_20}"
-      app:profile_chooser_marginTop="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_0 : @dimen/margin_24}">
+      app:profileChooserMarginEnd="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_20}"
+      app:profileChooserMarginStart="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_20}"
+      app:profileChooserMarginTop="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_0 : @dimen/margin_24}">
 
       <de.hdodenhof.circleimageview.CircleImageView
         android:id="@+id/profile_add_button"
@@ -45,8 +49,10 @@
       <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="24dp"
-        android:orientation="vertical">
+        android:gravity="@{presenter.wasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
+        android:orientation="vertical"
+        app:profileChooserMarginTop="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_8 : @dimen/margin_0}"
+        app:profileChooserMarginStart="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_0 : @dimen/margin_24}">
 
         <TextView
           android:id="@+id/add_profile_text"

--- a/app/src/main/res/layout/profile_chooser_fragment.xml
+++ b/app/src/main/res/layout/profile_chooser_fragment.xml
@@ -70,9 +70,9 @@
           android:id="@+id/profile_recycler_view"
           android:layout_width="match_parent"
           android:layout_height="match_parent"
-          android:layout_marginStart="36dp"
+          android:layout_marginStart="32dp"
           android:layout_marginTop="36dp"
-          android:layout_marginEnd="36dp"
+          android:layout_marginEnd="32dp"
           android:clipToPadding="false"
           android:fadingEdge="horizontal"
           android:fadingEdgeLength="72dp"
@@ -90,9 +90,10 @@
 
     <View
       android:layout_width="match_parent"
-      android:layout_height="96dp"
+      android:layout_height="128dp"
       android:background="@drawable/profile_chooser_gradient"
       app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintEnd_toEndOf="parent" />
 
     <LinearLayout
@@ -100,7 +101,6 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:onClick="@{(v) -> viewModel.onAdministratorControlsButtonClicked()}"
-      android:background="@drawable/profile_chooser_gradient"
       android:orientation="horizontal"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent">

--- a/app/src/main/res/layout/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout/profile_chooser_profile_view.xml
@@ -7,6 +7,8 @@
 
     <import type="android.widget.LinearLayout" />
 
+    <import type="android.view.Gravity" />
+
     <import type="android.view.View" />
 
     <variable
@@ -22,16 +24,17 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="center_horizontal"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    app:profileChooserMarginBottom="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_20 : @dimen/margin_0}">
 
     <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:gravity="center_vertical"
+      android:gravity="@{presenter.wasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
       android:orientation="@{presenter.wasProfileEverBeenAddedValue ? LinearLayout.VERTICAL : LinearLayout.HORIZONTAL}"
-      app:profile_chooser_marginEnd="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_28}"
-      app:profile_chooser_marginStart="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_28}"
-      app:profile_chooser_marginTop="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_0 : @dimen/margin_24}">
+      app:profileChooserMarginEnd="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_28}"
+      app:profileChooserMarginStart="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_28}"
+      app:profileChooserMarginTop="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_0 : @dimen/margin_24}">
 
       <de.hdodenhof.circleimageview.CircleImageView
         android:id="@+id/profile_avatar_img"
@@ -44,8 +47,10 @@
       <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:orientation="vertical">
+        android:gravity="@{presenter.wasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
+        android:orientation="vertical"
+        app:profileChooserMarginTop="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_8 : @dimen/margin_0}"
+        app:profileChooserMarginStart="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_0 : @dimen/margin_20}">
 
         <TextView
           android:id="@+id/profile_name_text"
@@ -64,7 +69,6 @@
           android:id="@+id/profile_last_visited"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
           android:fontFamily="sans-serif-light"
           android:textColor="@color/white"
           android:textSize="12sp"
@@ -76,7 +80,6 @@
           android:id="@+id/profile_is_admin_text"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="2dp"
           android:fontFamily="sans-serif-light"
           android:gravity="center"
           android:text="@string/profile_chooser_admin"

--- a/app/src/main/res/layout/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout/profile_chooser_profile_view.xml
@@ -5,6 +5,8 @@
 
   <data>
 
+    <import type="android.widget.LinearLayout" />
+
     <import type="android.view.View" />
 
     <variable
@@ -20,66 +22,77 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="center_horizontal"
-    android:layout_marginBottom="24dp"
     android:orientation="vertical">
 
-    <de.hdodenhof.circleimageview.CircleImageView
-      android:id="@+id/profile_avatar_img"
-      android:layout_width="72dp"
-      android:layout_height="72dp"
-      android:layout_marginBottom="8dp"
-      app:civ_border_color="@color/avatarBorder"
-      app:civ_border_width="1dp"
-      profile:src="@{viewModel.profile.avatar}" />
-
-    <TextView
-      android:id="@+id/profile_name_text"
-      android:layout_width="wrap_content"
+    <LinearLayout
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:ellipsize="end"
-      android:fontFamily="sans-serif-medium"
-      android:gravity="center"
-      android:maxLines="2"
-      android:paddingStart="8dp"
-      android:paddingEnd="8dp"
-      android:singleLine="false"
-      android:text="@{viewModel.profile.name}"
-      android:textColor="@color/white"
-      android:textSize="14sp" />
+      android:gravity="center_vertical"
+      android:orientation="@{presenter.wasProfileEverBeenAddedValue ? LinearLayout.VERTICAL : LinearLayout.HORIZONTAL}"
+      app:profile_chooser_marginEnd="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_28}"
+      app:profile_chooser_marginStart="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_28}"
+      app:profile_chooser_marginTop="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_0 : @dimen/margin_24}">
 
-    <TextView
-      android:id="@+id/profile_last_visited"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="2dp"
-      android:fontFamily="sans-serif-light"
-      android:textColor="@color/white"
-      android:textSize="12sp"
-      android:textStyle="italic"
-      android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
-      profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
+      <de.hdodenhof.circleimageview.CircleImageView
+        android:id="@+id/profile_avatar_img"
+        android:layout_width="72dp"
+        android:layout_height="72dp"
+        app:civ_border_color="@color/avatarBorder"
+        app:civ_border_width="1dp"
+        profile:src="@{viewModel.profile.avatar}" />
 
-    <TextView
-      android:id="@+id/profile_is_admin_text"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="2dp"
-      android:fontFamily="sans-serif-light"
-      android:gravity="center"
-      android:paddingStart="8dp"
-      android:paddingEnd="8dp"
-      android:text="@string/profile_chooser_admin"
-      android:textColor="@color/white"
-      android:textSize="12sp"
-      android:textStyle="italic"
-      android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}" />
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        android:orientation="vertical">
+
+        <TextView
+          android:id="@+id/profile_name_text"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:ellipsize="end"
+          android:fontFamily="sans-serif-medium"
+          android:gravity="center"
+          android:maxLines="2"
+          android:singleLine="false"
+          android:text="@{viewModel.profile.name}"
+          android:textColor="@color/white"
+          android:textSize="14sp" />
+
+        <TextView
+          android:id="@+id/profile_last_visited"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:fontFamily="sans-serif-light"
+          android:textColor="@color/white"
+          android:textSize="12sp"
+          android:textStyle="italic"
+          android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
+          profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
+
+        <TextView
+          android:id="@+id/profile_is_admin_text"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="2dp"
+          android:fontFamily="sans-serif-light"
+          android:gravity="center"
+          android:text="@string/profile_chooser_admin"
+          android:textColor="@color/white"
+          android:textSize="12sp"
+          android:textStyle="italic"
+          android:visibility="@{viewModel.profile.isAdmin &amp;&amp; presenter.wasProfileEverBeenAddedValue ? View.VISIBLE : View.GONE}" />
+      </LinearLayout>
+    </LinearLayout>
 
     <View
       android:id="@+id/add_profile_divider_view"
       android:layout_width="match_parent"
       android:layout_height="0.5dp"
-      android:layout_marginTop="24dp"
-      android:visibility="@{presenter.wasProfileEverBeenAddedValue ? View.GONE : View.VISIBLE}"
-      android:background="@color/oppiaProfileChooserDivider" />
+      android:layout_marginTop="60dp"
+      android:background="@color/oppiaProfileChooserDivider"
+      android:visibility="@{presenter.wasProfileEverBeenAddedValue ? View.GONE : View.VISIBLE}" />
   </LinearLayout>
 </layout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -27,9 +27,12 @@
   <dimen name="margin_36">36dp</dimen>
   <dimen name="margin_32">32dp</dimen>
   <dimen name="margin_28">28dp</dimen>
+  <dimen name="margin_24">24dp</dimen>
+  <dimen name="margin_20">20dp</dimen>
   <dimen name="margin_16">16dp</dimen>
   <dimen name="margin_12">12dp</dimen>
   <dimen name="margin_8">8dp</dimen>
+  <dimen name="margin_0">0dp</dimen>
   <dimen name="dot_width_height">12dp</dimen>
   <dimen name="dot_gap">12dp</dimen>
   <dimen name="enter_text_view_padding_start">60dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,7 +155,7 @@
   <string name="profile_chooser_select">Select your profile</string>
   <string name="profile_chooser_add">Add Profile</string>
   <string name="set_up_multiple_profiles">Set up Multiple Profiles</string>
-  <string name="set_up_multiple_profiles_description">Add up to 10 users to your account.Perfect for families and classrooms.</string>
+  <string name="set_up_multiple_profiles_description">Add up to 10 users to your account. Perfect for families and classrooms.</string>
   <string name="profile_chooser_administrator_controls">Administrator Controls</string>
   <string name="profile_chooser_language">Language</string>
   <!-- AdminAuthActivity -->


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes portrait part of https://github.com/oppia/oppia-android/issues/1248

First-Time: https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/8cdde1f8-daae-438c-8fdd-084e5d227080/PC-SP-Profile-Chooser-v2

Regular: https://xd.adobe.com/view/0687f00c-695b-437a-79a6-688e7f4f7552-70b6/screen/ad1de6e2-1d5d-4ac3-888c-58d036c7ede4/PC-MP-Profile-Chooser-/

This PR is typical because the padding and margin varies depending upon the regular and first-time view. So I have introduced data-binding-adapter to control the margin accordingly.

Also, the margin between few texts (name and last-used text and administrator tag) was `1dp` and `2dp` and if I keep that margin in code the gap between the text looks more and if I remove that then the gap looks much more similar to the mocks and therefore I have removed such margins for better mock resemblance.

Once this PR is approved then I will create PR for landscape as most of this code will be used in that.

_NOTE: You might see that the UI is acting weirdly when the items are in odd number. This has not been solved in this as mostly it is related to domain or low-fi. So I will create a separate PR for that but for now if you face some difficulties like that, just open the `HomeActivity` and logout to go to main screen and it will work correctly._ (https://github.com/oppia/oppia-android/pull/1257)

This PR does not check the accessibility test as it was discussed earlier that it would be separate milestone later in the project.

## Screenshots

![Screenshot_1591351547](https://user-images.githubusercontent.com/9396084/83865619-1202a780-a744-11ea-969f-5cbe823951bf.png)
![Screenshot_1591351557](https://user-images.githubusercontent.com/9396084/83865623-1333d480-a744-11ea-88b7-af464458b84d.png)
![Screenshot_1591351563](https://user-images.githubusercontent.com/9396084/83865624-13cc6b00-a744-11ea-8dbb-2211d0b44790.png)
![Screenshot_1591351622](https://user-images.githubusercontent.com/9396084/83865626-14650180-a744-11ea-8301-342806fcbc25.png)
![Screenshot_1591351658](https://user-images.githubusercontent.com/9396084/83865627-14fd9800-a744-11ea-9ecb-6798c3600918.png)
![Screenshot_1591351768](https://user-images.githubusercontent.com/9396084/83865628-14fd9800-a744-11ea-964f-a9338344b692.png)
![Screenshot_1591351770](https://user-images.githubusercontent.com/9396084/83865630-15962e80-a744-11ea-8de7-e4d961f99673.png)
![Screenshot_1591351804](https://user-images.githubusercontent.com/9396084/83865632-15962e80-a744-11ea-9848-21306aa4964f.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
