### PR TITLE
Fix #1256: Error fix for profile chooser

### DIFF
--- a/domain/src/main/java/org/oppia/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/domain/profile/ProfileManagementController.kt
@@ -29,6 +29,7 @@ import java.io.FileOutputStream
 import java.util.*
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.sign
 
 private const val TRANSFORMED_GET_PROFILES_PROVIDER_ID = "transformed_get_profiles_provider_id"
 private const val TRANSFORMED_GET_PROFILE_PROVIDER_ID = "transformed_get_profile_provider_id"
@@ -216,7 +217,7 @@ class ProfileManagementController @Inject constructor(
         newProfileBuilder.avatar = ProfileAvatar.newBuilder().setAvatarColorRgb(colorRgb).build()
       }
 
-      val wasProfileEverAdded = !it.wasProfileEverAdded && !isAdmin
+      val wasProfileEverAdded = it.profilesCount >0
 
       val profileDatabaseBuilder =
         it.toBuilder()


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #1256 

In some cases the application was showing this UI, which should never happen:

![Screenshot_1591353372](https://user-images.githubusercontent.com/9396084/83867551-3ad86c00-a747-11ea-82d4-d834b5786c53.png)

Mock 1: https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/8cdde1f8-daae-438c-8fdd-084e5d227080/

Mock 2: https://xd.adobe.com/view/0687f00c-695b-437a-79a6-688e7f4f7552-70b6/screen/ad1de6e2-1d5d-4ac3-888c-58d036c7ede4/


**Mock 1** should be visible only in one case, when the application has never added even a single profile (except default admin profile). 
**Mock 2*8 is visible if in the past atleast one profile has been added (except for the default first profile).

Different scenario to understand this more clearly:
1. If you install fresh copy of app and never add any new profile, **Mock 1** should appear.
2. If you add one new profile which is not admin, now everytime after this **Mock 2** should appear.
3. If you go to `Administrator Settings` -> `Edit Profiles` and delete all profiles except the admin profile, the profile chooser should show **Mock 2**, as in past atleast one profile was added we just deleted it.

## Steps to reproduce current bug:
1. Install fresh copy from develop.
2. Add a new profile, check UI.
3. Add another profile, check UI.
4. Add another profile, check UI.

You will notice that for every odd number of profiles the UI issue occurs as shown above in screenshot.



In some cases the application was showing this UI, which should never happen:

![Screenshot_1591353372](https://user-images.githubusercontent.com/9396084/83867551-3ad86c00-a747-11ea-82d4-d834b5786c53.png)

Mock 1: https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/8cdde1f8-daae-438c-8fdd-084e5d227080/

Mock 2: https://xd.adobe.com/view/0687f00c-695b-437a-79a6-688e7f4f7552-70b6/screen/ad1de6e2-1d5d-4ac3-888c-58d036c7ede4/


**Mock 1** should be visible only in one case, when the application has never added even a single profile (except default admin profile). 
**Mock 2*8 is visible if in the past atleast one profile has been added (except for the default first profile).

Different scenario to understand this more clearly:
1. If you install fresh copy of app and never add any new profile, **Mock 1** should appear.
2. If you add one new profile which is not admin, now everytime after this **Mock 2** should appear.
3. If you go to `Administrator Settings` -> `Edit Profiles` and delete all profiles except the admin profile, the profile chooser should show **Mock 2**, as in past atleast one profile was added we just deleted it.

## Steps to reproduce current bug:
1. Install fresh copy from develop.
2. Add a new profile, check UI.
3. Add another profile, check UI.
4. Add another profile, check UI.

You will notice that for every odd number of profiles the UI issue occurs as shown above in screenshot.



In some cases the application was showing this UI, which should never happen:

![Screenshot_1591353372](https://user-images.githubusercontent.com/9396084/83867551-3ad86c00-a747-11ea-82d4-d834b5786c53.png)

Mock 1: https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/8cdde1f8-daae-438c-8fdd-084e5d227080/

Mock 2: https://xd.adobe.com/view/0687f00c-695b-437a-79a6-688e7f4f7552-70b6/screen/ad1de6e2-1d5d-4ac3-888c-58d036c7ede4/


**Mock 1** should be visible only in one case, when the application has never added even a single profile (except default admin profile). 
**Mock 2*8 is visible if in the past atleast one profile has been added (except for the default first profile).

Different scenario to understand this more clearly:
1. If you install fresh copy of app and never add any new profile, **Mock 1** should appear.
2. If you add one new profile which is not admin, now everytime after this **Mock 2** should appear.
3. If you go to `Administrator Settings` -> `Edit Profiles` and delete all profiles except the admin profile, the profile chooser should show **Mock 2**, as in past atleast one profile was added we just deleted it.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
