### PR TITLE
Fix #1248: High profile chooser landscape

### DIFF
--- a/app/src/main/res/layout-land/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout-land/profile_chooser_add_view.xml
@@ -26,12 +26,12 @@
     <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:layout_marginStart="16dp"
+      android:layout_marginEnd="16dp"
       android:layout_marginBottom="24dp"
       android:gravity="center_horizontal"
       android:orientation="vertical"
       app:profileChooserMarginBottom="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_20 : @dimen/margin_28}"
-      app:profileChooserMarginStart="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_20 : @dimen/margin_44}"
-      app:profileChooserMarginEnd="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_72}"
       app:profileChooserMarginTop="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_24}">
 
       <de.hdodenhof.circleimageview.CircleImageView
@@ -49,6 +49,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:fontFamily="sans-serif-medium"
+        android:gravity="center"
         android:text="@{presenter.wasProfileEverBeenAddedValue ? @string/profile_chooser_add : @string/set_up_multiple_profiles}"
         android:textColor="@color/white"
         android:textSize="14sp" />

--- a/app/src/main/res/layout-land/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout-land/profile_chooser_add_view.xml
@@ -28,13 +28,17 @@
       android:layout_height="wrap_content"
       android:layout_marginBottom="24dp"
       android:gravity="center_horizontal"
-      android:orientation="vertical">
+      android:orientation="vertical"
+      app:profileChooserMarginBottom="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_20 : @dimen/margin_28}"
+      app:profileChooserMarginStart="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_20 : @dimen/margin_44}"
+      app:profileChooserMarginEnd="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_72}"
+      app:profileChooserMarginTop="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_24}">
 
       <de.hdodenhof.circleimageview.CircleImageView
         android:id="@+id/profile_add_button"
         android:layout_width="72dp"
         android:layout_height="72dp"
-        android:layout_marginBottom="12dp"
+        android:layout_marginBottom="8dp"
         android:src="@drawable/ic_add_profile"
         app:civ_border_color="@color/avatarBorder"
         app:civ_border_width="1dp" />
@@ -42,29 +46,23 @@
       <TextView
         android:id="@+id/add_profile_text"
         android:layout_width="wrap_content"
-        android:layout_gravity="center"
         android:layout_height="wrap_content"
+        android:layout_gravity="center"
         android:fontFamily="sans-serif-medium"
         android:text="@{presenter.wasProfileEverBeenAddedValue ? @string/profile_chooser_add : @string/set_up_multiple_profiles}"
-        android:paddingStart="8dp"
-        android:paddingEnd="8dp"
         android:textColor="@color/white"
         android:textSize="14sp" />
 
       <TextView
         android:id="@+id/add_profile_description_text"
         android:layout_width="wrap_content"
-        android:layout_gravity="center"
         android:layout_height="wrap_content"
-        android:fontFamily="sans-serif-medium"
-        android:paddingStart="8dp"
-        android:paddingEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
+        android:layout_gravity="center"
+        android:fontFamily="sans-serif"
         android:gravity="center"
         android:text="@string/set_up_multiple_profiles_description"
         android:textColor="@color/white"
-        android:textSize="14sp"
+        android:textSize="12sp"
         android:visibility="@{presenter.wasProfileEverBeenAddedValue ? View.GONE : View.VISIBLE}" />
     </LinearLayout>
   </LinearLayout>

--- a/app/src/main/res/layout-land/profile_chooser_fragment.xml
+++ b/app/src/main/res/layout-land/profile_chooser_fragment.xml
@@ -25,6 +25,19 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <ImageView
+          android:id="@+id/profile_chooser_language_icon"
+          android:layout_width="48dp"
+          android:layout_height="48dp"
+          android:layout_marginEnd="36dp"
+          android:paddingStart="4dp"
+          android:paddingTop="20dp"
+          android:paddingEnd="20dp"
+          android:src="@drawable/ic_language_icon_grey_24dp"
+          android:visibility="gone"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toTopOf="parent" />
+
         <TextView
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
@@ -33,23 +46,10 @@
           android:minHeight="48dp"
           android:paddingTop="20dp"
           android:text="@string/profile_chooser_language"
-          android:visibility="gone"
           android:textColor="@color/profileChooserGreyTextColor"
           android:textSize="16sp"
-          app:layout_constraintEnd_toStartOf="@+id/profile_chooser_language_icon"
-          app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageView
-          android:id="@+id/profile_chooser_language_icon"
-          android:layout_width="48dp"
-          android:layout_height="48dp"
-          android:layout_marginEnd="36dp"
           android:visibility="gone"
-          android:paddingStart="4dp"
-          android:paddingTop="20dp"
-          android:paddingEnd="20dp"
-          android:src="@drawable/ic_language_icon_grey_24dp"
-          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintEnd_toStartOf="@+id/profile_chooser_language_icon"
           app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
@@ -71,7 +71,7 @@
           android:layout_width="match_parent"
           android:layout_height="match_parent"
           android:layout_marginStart="16dp"
-          android:layout_marginTop="16dp"
+          android:layout_marginTop="12dp"
           android:layout_marginEnd="16dp"
           android:clipToPadding="false"
           android:fadingEdge="horizontal"
@@ -93,6 +93,7 @@
       android:layout_height="96dp"
       android:background="@drawable/profile_chooser_gradient"
       app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintEnd_toEndOf="parent" />
 
     <LinearLayout
@@ -100,7 +101,6 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:onClick="@{(v) -> viewModel.onAdministratorControlsButtonClicked()}"
-      android:background="@drawable/profile_chooser_gradient"
       android:orientation="horizontal"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent">

--- a/app/src/main/res/layout-land/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-land/profile_chooser_profile_view.xml
@@ -28,12 +28,12 @@
     <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:layout_marginStart="16dp"
+      android:layout_marginEnd="16dp"
       android:gravity="center_horizontal"
       android:orientation="vertical"
-      app:profileChooserMarginStart="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_20 : @dimen/margin_72}"
-      app:profileChooserMarginEnd="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_20 : @dimen/margin_44}"
-      app:profileChooserMarginTop="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_24}"
-      app:profileChooserMarginBottom="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_28}">
+      app:profileChooserMarginBottom="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_28}"
+      app:profileChooserMarginTop="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_24}">
 
       <de.hdodenhof.circleimageview.CircleImageView
         android:id="@+id/profile_avatar_img"
@@ -62,6 +62,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:fontFamily="sans-serif-light"
+        android:gravity="center"
         android:textColor="@color/white"
         android:textSize="12sp"
         android:textStyle="italic"

--- a/app/src/main/res/layout-land/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-land/profile_chooser_profile_view.xml
@@ -5,6 +5,10 @@
 
   <data>
 
+    <import type="android.widget.LinearLayout" />
+
+    <import type="android.view.Gravity" />
+
     <import type="android.view.View" />
 
     <variable
@@ -25,8 +29,11 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:gravity="center_horizontal"
-      android:layout_marginBottom="24dp"
-      android:orientation="vertical">
+      android:orientation="vertical"
+      app:profileChooserMarginStart="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_20 : @dimen/margin_72}"
+      app:profileChooserMarginEnd="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_20 : @dimen/margin_44}"
+      app:profileChooserMarginTop="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_24}"
+      app:profileChooserMarginBottom="@{presenter.wasProfileEverBeenAddedValue ? @dimen/margin_16 : @dimen/margin_28}">
 
       <de.hdodenhof.circleimageview.CircleImageView
         android:id="@+id/profile_avatar_img"
@@ -45,8 +52,6 @@
         android:fontFamily="sans-serif-medium"
         android:gravity="center"
         android:maxLines="2"
-        android:paddingStart="8dp"
-        android:paddingEnd="8dp"
         android:singleLine="false"
         android:text="@{viewModel.profile.name}"
         android:textColor="@color/white"
@@ -56,7 +61,6 @@
         android:id="@+id/profile_last_visited"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="2dp"
         android:fontFamily="sans-serif-light"
         android:textColor="@color/white"
         android:textSize="12sp"
@@ -68,11 +72,8 @@
         android:id="@+id/profile_is_admin_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="2dp"
         android:fontFamily="sans-serif-light"
         android:gravity="center"
-        android:paddingStart="8dp"
-        android:paddingEnd="8dp"
         android:text="@string/profile_chooser_admin"
         android:textColor="@color/white"
         android:textSize="12sp"
@@ -84,7 +85,7 @@
       android:id="@+id/add_profile_divider_view"
       android:layout_width="0.5dp"
       android:layout_height="match_parent"
-      android:visibility="@{presenter.wasProfileEverBeenAddedValue ? View.GONE : View.VISIBLE}"
-      android:background="@color/oppiaProfileChooserDivider" />
+      android:background="@color/oppiaProfileChooserDivider"
+      android:visibility="@{presenter.wasProfileEverBeenAddedValue ? View.GONE : View.VISIBLE}" />
   </LinearLayout>
 </layout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -26,6 +26,7 @@
   <dimen name="margin_152">152dp</dimen>
   <dimen name="margin_120">120dp</dimen>
   <dimen name="margin_72">72dp</dimen>
+  <dimen name="margin_44">44dp</dimen>
   <dimen name="margin_36">36dp</dimen>
   <dimen name="margin_32">32dp</dimen>
   <dimen name="margin_28">28dp</dimen>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Mocks: 
https://xd.adobe.com/view/ee9e607b-dbd6-4372-48dc-b687d32af3da-98af/screen/80891ce5-a7ce-405f-a882-b27ccfc0030b/

https://xd.adobe.com/view/ee9e607b-dbd6-4372-48dc-b687d32af3da-98af/screen/1fc109c3-31f3-4743-bd3b-76be39c0049a/

https://xd.adobe.com/view/ee9e607b-dbd6-4372-48dc-b687d32af3da-98af/screen/4ae1ae9d-9ae9-4cd3-a15a-6c2a7a23b8be/PC-MP-Profile-Created-Visible-


This PR does not contain the exact margins mentioned in the mocks because if we use those exact margins the implementation done by @nikitamarysolomanpvt which manages type number of items based on the screen size will fail and looks much worse.
So all the margins have been modified in such a way that it can work on Nexus S as well as Pixel 3 at the same time. Right now we are not focused on Nexus S but I did try this app on that and because of the the UI approach was getting affected and therefore I had to take that into consideration.

## One of the incorrect mocks if I use exact margins:
![Screenshot_1591612718](https://user-images.githubusercontent.com/9396084/84022195-7a9b8f80-a9a3-11ea-80d7-27b0935459ac.png)


## Screenshots
![Screenshot_1591612475](https://user-images.githubusercontent.com/9396084/84022249-930baa00-a9a3-11ea-9998-ffbe32cf8fe8.png)
![Screenshot_1591612895](https://user-images.githubusercontent.com/9396084/84022254-96069a80-a9a3-11ea-9619-94daf32c0419.png)
![Screenshot_1591612920](https://user-images.githubusercontent.com/9396084/84022256-969f3100-a9a3-11ea-9896-78ccead3997b.png)
![Screenshot_1591612949](https://user-images.githubusercontent.com/9396084/84022257-9737c780-a9a3-11ea-9e23-add7db3be2bc.png)
![Screenshot_1591613034](https://user-images.githubusercontent.com/9396084/84022258-9737c780-a9a3-11ea-9d3c-e88a4880f171.png)
![Screenshot_1591613120](https://user-images.githubusercontent.com/9396084/84022260-97d05e00-a9a3-11ea-9643-c6975f4dd7b9.png)

Also, accessibility tests have not been taken into consideration as that would be separate milestone later this year.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
