### PR TITLE
Fix part of # 42: Highfi Exploration Toolbar [Landscape + Portrait]

### DIFF
--- a/app/src/main/res/layout/exploration_activity.xml
+++ b/app/src/main/res/layout/exploration_activity.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout>
+
   <data>
+
     <import type="android.view.View" />
+
     <variable
       name="viewModel"
       type="org.oppia.app.player.exploration.ExplorationViewModel" />
   </data>
+
   <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -24,19 +28,21 @@
         android:id="@+id/exploration_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_gravity="end"
         android:background="@color/colorPrimary"
         android:minHeight="?attr/actionBarSize"
-        android:layout_gravity="end"
         android:theme="@style/Widget.AppCompat.ActionBar"
+        app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white">
+
         <ImageView
           android:id="@+id/action_audio_player"
           android:layout_width="48dp"
           android:layout_height="48dp"
           android:layout_gravity="end"
           android:scaleType="center"
-          android:visibility="@{viewModel.showAudioButton ? View.VISIBLE : View.GONE}"
-          android:src="@{viewModel.isAudioStreamingOn ? @drawable/ic_audio_streaming_on_24dp :  @drawable/ic_audio_streaming_off_24dp}" />
+          android:src="@{viewModel.isAudioStreamingOn ? @drawable/ic_audio_streaming_on_24dp :  @drawable/ic_audio_streaming_off_24dp}"
+          android:visibility="@{viewModel.showAudioButton ? View.VISIBLE : View.GONE}" />
       </androidx.appcompat.widget.Toolbar>
     </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

This PR focuses on the high-fi part of toolbar in exploration player.

Mock Link: https://xd.adobe.com/view/ee9e607b-dbd6-4372-48dc-b687d32af3da-98af/screen/a0cd1cb3-1b6b-4951-942e-4e46cacde6fe/UP-User-Profile-28
https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/4744bfae-84be-44fa-a27d-9a252fdfc2f9/LM-Q1-Fraction-Input-No-Answer-

## TextSize issue
The mocks shows that the toolbar title text size is `18sp` but despite that we are using `20sp` in our code because all other screens in the app is following `20sp` and we need to keep toolbar consistent across the app and it should be though from default-android design perspective instead of mock perspective. So even if we want to keep it `18sp` that's fine but we need to keep it consistent for other screens too.

Accessibility test check has not been done as it will be a separate milestone.

## Screenshots
![Screenshot_1591681150](https://user-images.githubusercontent.com/9396084/84110033-ac633380-aa41-11ea-8860-772f455a312f.png)
![Screenshot_1591681153](https://user-images.githubusercontent.com/9396084/84110041-af5e2400-aa41-11ea-8206-84a217df62c9.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
