### PR TITLE
Fix #1278: Highfi issue fix for Reset Pin screen

### DIFF
--- a/app/src/main/res/layout-land/profile_reset_pin_activity.xml
+++ b/app/src/main/res/layout-land/profile_reset_pin_activity.xml
@@ -53,6 +53,8 @@
         android:layout_height="wrap_content"
         android:overScrollMode="never"
         android:scrollbars="none"
+        android:paddingBottom="168dp"
+        android:clipToPadding="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -60,7 +62,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:background="@color/white"
+          android:background="@drawable/general_item_background_border"
           android:paddingBottom="108dp">
 
           <TextView


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #1278 

Mock: https://xd.adobe.com/view/ee9e607b-dbd6-4372-48dc-b687d32af3da-98af/screen/6f83fcd9-e72d-4941-a16f-6754a869e083/RG-MN-Register-Empty-37

Two minor issue fixed:
1. Border around the white layout which contains UI.
2. The grey extra padding at the bottom of the screen is added.

## Old UI:
![Screenshot_1591691309](https://user-images.githubusercontent.com/9396084/84124880-69ad5580-aa59-11ea-9ccf-4e5e9b91c3b8.png)

## New UI:
![Screenshot_1591691859](https://user-images.githubusercontent.com/9396084/84125991-f4428480-aa5a-11ea-999c-8b6dc0e4d385.png)



## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
