### PR TITLE
Fix #854: Question Player Input Interactions And Submitted Answer content items hifi

### DIFF
--- a/app/src/main/java/org/oppia/app/player/state/StatePlayerRecyclerViewAssembler.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StatePlayerRecyclerViewAssembler.kt
@@ -78,7 +78,6 @@ import org.oppia.app.utility.LifecycleSafeTimerFactory
 import org.oppia.util.parser.HtmlParser
 import org.oppia.util.threading.BackgroundDispatcher
 import javax.inject.Inject
-import org.oppia.app.topic.questionplayer.QuestionPlayerFragment
 
 private const val DELAY_SHOW_INITIAL_HINT_MS = 60_000L
 private const val DELAY_SHOW_ADDITIONAL_HINTS_MS = 30_000L

--- a/app/src/main/java/org/oppia/app/player/state/itemviewmodel/SubmittedAnswerViewModel.kt
+++ b/app/src/main/java/org/oppia/app/player/state/itemviewmodel/SubmittedAnswerViewModel.kt
@@ -1,8 +1,11 @@
 package org.oppia.app.player.state.itemviewmodel
 
+import androidx.databinding.ObservableField
 import org.oppia.app.model.UserAnswer
 
 /** [StateItemViewModel] for previously submitted answers. */
 class SubmittedAnswerViewModel(
   val submittedUserAnswer: UserAnswer, val gcsEntityId: String
-): StateItemViewModel(ViewType.SUBMITTED_ANSWER)
+) : StateItemViewModel(ViewType.SUBMITTED_ANSWER) {
+  val isCorrectAnswer = ObservableField<Boolean>(false)
+}

--- a/app/src/main/java/org/oppia/app/topic/questionplayer/QuestionPlayerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/topic/questionplayer/QuestionPlayerFragmentPresenter.kt
@@ -175,6 +175,7 @@ class QuestionPlayerFragmentPresenter @Inject constructor(
     answerOutcomeLiveData.observe(
       fragment,
       Observer<AnsweredQuestionOutcome> { result ->
+        recyclerViewAssembler.isCorrectAnswer.set(result.isCorrectAnswer)
         if (result.isCorrectAnswer) {
           recyclerViewAssembler.showCongratulationMessageOnCorrectAnswer()
         }

--- a/app/src/main/res/drawable/ic_check_primary.xml
+++ b/app/src/main/res/drawable/ic_check_primary.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24">
+  <path
+    android:fillColor="#00645C"
+    android:pathData="M9,16.17L5.53,12.7c-0.39,-0.39 -1.02,-0.39 -1.41,0 -0.39,0.39 -0.39,1.02 0,1.41l4.18,4.18c0.39,0.39 1.02,0.39 1.41,0L20.29,7.71c0.39,-0.39 0.39,-1.02 0,-1.41 -0.39,-0.39 -1.02,-0.39 -1.41,0L9,16.17z" />
+</vector>

--- a/app/src/main/res/drawable/rounded_rect_white_background.xml
+++ b/app/src/main/res/drawable/rounded_rect_white_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+  <corners android:radius="4dp" />
+  <solid android:color="@color/white" />
+</shape>

--- a/app/src/main/res/layout/previous_responses_header_item.xml
+++ b/app/src/main/res/layout/previous_responses_header_item.xml
@@ -12,14 +12,13 @@
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="16dp"
+    android:layout_marginTop="@dimen/divider_margin_top"
     android:clickable="true"
     android:focusable="true"
     android:minHeight="48dp"
-    android:paddingTop="16dp"
-    android:paddingBottom="16dp"
-    android:paddingStart="20dp"
-    android:paddingEnd="16dp"
+    android:paddingBottom="28dp"
+    android:paddingStart="28dp"
+    android:paddingEnd="28dp"
     android:onClick="@{(v) -> viewModel.onResponsesHeaderClicked()}">
 
     <FrameLayout

--- a/app/src/main/res/layout/question_player_feedback_item.xml
+++ b/app/src/main/res/layout/question_player_feedback_item.xml
@@ -1,0 +1,27 @@
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <data>
+
+    <variable
+      name="htmlContent"
+      type="CharSequence" />
+  </data>
+
+  <FrameLayout
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="28dp"
+    android:layout_marginTop="28dp"
+    android:layout_marginEnd="28dp"
+    android:layout_marginBottom="28dp">
+
+    <TextView
+      android:id="@+id/question_player_feedback_text_view"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fontFamily="sans-serif"
+      android:text="@{htmlContent}"
+      android:textColor="@color/oppiaPrimaryText"
+      android:textSize="16sp" />
+  </FrameLayout>
+</layout>

--- a/app/src/main/res/layout/question_player_selection_interaction_item.xml
+++ b/app/src/main/res/layout/question_player_selection_interaction_item.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools">
+
+  <data>
+
+    <variable
+      name="viewModel"
+      type="org.oppia.app.player.state.itemviewmodel.SelectionInteractionViewModel" />
+  </data>
+
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="28dp"
+    android:layout_marginTop="@dimen/divider_margin_top"
+    android:layout_marginEnd="28dp"
+    android:layout_marginBottom="@dimen/divider_margin_bottom"
+    android:background="@drawable/rounded_rect_white_background"
+    android:descendantFocusability="beforeDescendants"
+    android:focusableInTouchMode="true"
+    android:orientation="vertical"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:layout_editor_absoluteX="8dp">
+
+    <org.oppia.app.player.state.SelectionInteractionView
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="12dp"
+      android:layout_marginTop="@dimen/divider_margin_top"
+      android:layout_marginEnd="12dp"
+      android:layout_marginBottom="@dimen/divider_margin_bottom"
+      android:divider="@android:color/transparent"
+      app:allOptionsItemInputType="@{viewModel.getSelectionItemInputType()}"
+      app:data="@{viewModel.choiceItems}"
+      app:entityId="@{viewModel.entityId}"
+      app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+  </LinearLayout>
+</layout>

--- a/app/src/main/res/layout/question_player_submitted_answer_item.xml
+++ b/app/src/main/res/layout/question_player_submitted_answer_item.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <data>
+
+    <import type="android.view.View" />
+
+    <variable
+      name="submittedAnswer"
+      type="CharSequence" />
+
+    <variable
+      name="viewModel"
+      type="org.oppia.app.player.state.itemviewmodel.SubmittedAnswerViewModel" />
+  </data>
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="28dp"
+    android:layout_marginTop="@dimen/divider_margin_top"
+    android:layout_marginEnd="28dp"
+    android:layout_marginBottom="@dimen/divider_margin_bottom">
+
+    <TextView
+      android:id="@+id/question_player_submitted_answer_text_view"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:background="@drawable/submitted_answer_background"
+      android:paddingStart="12dp"
+      android:paddingTop="8dp"
+      android:paddingEnd="12dp"
+      android:paddingBottom="8dp"
+      android:text="@{submittedAnswer}"
+      android:textAlignment="viewStart"
+      android:textColor="@color/oppiaPrimaryText"
+      android:textSize="16sp"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      app:layout_constraintWidth_max="wrap"
+      app:layout_constraintWidth_percent=".87" />
+
+    <ImageView
+      android:id="@+id/question_player_answer_tick"
+      android:layout_width="24dp"
+      android:layout_height="24dp"
+      android:layout_marginStart="8dp"
+      android:layout_marginEnd="8dp"
+      android:src="@drawable/ic_check_primary"
+      android:visibility="@{viewModel.isCorrectAnswer ? View.VISIBLE : View.GONE}"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintStart_toEndOf="@+id/question_player_submitted_answer_text_view"
+      app:layout_constraintTop_toTopOf="parent" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -36,6 +36,7 @@
   <color name="oppiaTextShadow">#1F000000</color>
   <color name="oppiaGreyBorder">#DDDDDD</color>
   <color name="oppiaDashedDivider">#80707070</color>
+  <color name="oppiaSubmittedAnswerTextColor">#777777</color>
   <color name="oppiaBackgroundYellowIvory">#FFFFF0</color>
   <color name="oppiaFAQDivider">#707070</color>
   <color name="oppiaProfileChooserDivider">#707070</color>


### PR DESCRIPTION
## Explanation
Duplicate of #945 
PR includes hifi of the below

- Input interactions items 
- Feedback item
- Previous response item
- Submitted answer item

For checking multiple choice please refer: https://gist.github.com/nikitamarysolomanpvt/40b46c066db14c76febb986d33af3381 
As there are some ambiguity in alignments in mock please follow :
https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/91c4a1ac-dbfe-4616-80b1-f77b82bb5f41/PM-Q6-Text-Input-w-Units-Inputted-Answer-2-
For knowing the branches of Question Player hifi please refer: https://docs.google.com/document/d/1hUCHfKeJePvYaYlwhg23JZ-H85fz1wi00Y42N7w854U/edit?usp=sharing

## Mock

https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/91c4a1ac-dbfe-4616-80b1-f77b82bb5f41/PM-Q6-Text-Input-w-Units-Inputted-Answer-2-

https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/eeed0f6c-54ca-4371-ab23-5199abd87f28/PM-Q2-Text-Input-Keyboard-1-

https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/bed05d74-07dd-475b-abbe-295709b6c7ed/PM-Q2-Text-Input-Continue- 

https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/825e927e-66ee-4268-84f0-126e0eb3a187/PM-Q4-Checkboxes-Checkbox-2-


https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/b749c7eb-156a-47f4-86f1-2e51a5d43b82/PM-Q4-Checkboxes-Continue-/

## Screen shot

<img width="392" alt="small" src="https://user-images.githubusercontent.com/54615666/77428611-5c8bad80-6dfe-11ea-8a0e-5b4cd32f9178.png">
<img width="384" alt="small" src="https://user-images.githubusercontent.com/54615666/77947664-e5fd1d00-72e1-11ea-96de-9720498e6f45.png">
<img width="342" alt="s1" src="https://user-images.githubusercontent.com/54615666/77947672-e990a400-72e1-11ea-8784-2e3637961806.png">


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.


## Known issues 
bulletted Submitted answer content yet to fix would be fixed by rajat in explorations
(Specially the one with image).

##  Accessibility Scanner Results
![Screenshot_20200406-163521](https://user-images.githubusercontent.com/54615666/78552412-19313600-7825-11ea-9410-cc3e771c0bc4.png)
