### PR TITLE
Fix #823: Question content item Hi-fi

### DIFF
--- a/app/src/main/res/layout/question_player_content_item.xml
+++ b/app/src/main/res/layout/question_player_content_item.xml
@@ -1,0 +1,30 @@
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <data>
+
+    <import type="android.view.View" />
+
+    <variable
+      name="htmlContent"
+      type="CharSequence" />
+  </data>
+
+  <FrameLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="28dp"
+    android:layout_marginTop="36dp"
+    android:layout_marginEnd="28dp"
+    android:layout_marginBottom="28dp">
+
+    <TextView
+      android:id="@+id/question_player_content_text_view"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fontFamily="sans-serif"
+      android:text="@{htmlContent}"
+      android:textColor="@color/oppiaPrimaryText"
+      android:textSize="16sp"
+      android:visibility="@{htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}" />
+  </FrameLayout>
+</layout>

--- a/app/src/main/res/layout/question_player_fragment.xml
+++ b/app/src/main/res/layout/question_player_fragment.xml
@@ -23,8 +23,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="28dp"
-        android:layout_marginEnd="28dp"
         android:layout_marginTop="28dp"
+        android:layout_marginEnd="28dp"
         android:fontFamily="sans-serif"
         android:text="@string/question_training_session_finished_header"
         android:textColor="@color/oppiaPrimaryText"
@@ -38,8 +38,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="28dp"
-        android:layout_marginEnd="28dp"
         android:layout_marginTop="8dp"
+        android:layout_marginEnd="28dp"
         android:fontFamily="sans-serif"
         android:text="@string/question_training_session_finished_message"
         android:textColor="@color/oppiaPrimaryText"
@@ -54,7 +54,6 @@
         android:layout_height="0dp"
         android:divider="@android:color/transparent"
         android:dividerHeight="8dp"
-        android:padding="16dp"
         android:overScrollMode="never"
         app:data="@{viewModel.itemList}"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
@@ -98,8 +97,8 @@
       android:layout_marginTop="8dp"
       android:layout_marginEnd="28dp"
       android:layout_marginBottom="16dp"
-      android:translationZ="4dp"
-      android:elevation="8dp">
+      android:elevation="8dp"
+      android:translationZ="4dp">
 
       <TextView
         android:id="@+id/congratulations_text_view"
@@ -116,8 +115,9 @@
         android:textSize="20sp"
         android:visibility="invisible" />
     </FrameLayout>
+
     <View
-      android:id="@+id/toolbar_shadow_view"
+      android:id="@+id/question_player_toolbar_shadow_view"
       android:layout_width="match_parent"
       android:layout_height="6dp"
       android:background="@drawable/toolbar_drop_shadow" />


### PR DESCRIPTION
## Explanation
Question Player Content item UI update -Hi-fi.
Duplicate of #889, changes in alignment with respect to recycler-view.
## Mock
https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/8fbb663a-39aa-4be1-83bd-73bde6f85dcc/PM-Q1-Fraction-Input-No-Answer-
## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
