### PR TITLE
Fix #847: Question player progress-bar hifi

### DIFF
--- a/app/src/main/res/drawable/progress_bar.xml
+++ b/app/src/main/res/drawable/progress_bar.xml
@@ -4,7 +4,9 @@
     <shape>
       <corners android:radius="8dp" />
       <solid android:color="@color/white" />
-      <stroke android:width="1dp" android:color="@color/colorPrimary" />
+      <stroke
+        android:width="1dp"
+        android:color="@color/colorPrimary" />
     </shape>
   </item>
   <item android:id="@+id/progress">

--- a/app/src/main/res/layout/question_player_fragment.xml
+++ b/app/src/main/res/layout/question_player_fragment.xml
@@ -119,5 +119,11 @@
         android:textSize="20sp"
         android:visibility="invisible" />
     </FrameLayout>
+
+    <View
+      android:id="@+id/question_player_toolbar_shadow_view"
+      android:layout_width="match_parent"
+      android:layout_height="6dp"
+      android:background="@drawable/toolbar_drop_shadow" />
   </FrameLayout>
 </layout>

--- a/app/src/main/res/layout/question_player_fragment.xml
+++ b/app/src/main/res/layout/question_player_fragment.xml
@@ -55,6 +55,7 @@
         android:divider="@android:color/transparent"
         android:dividerHeight="8dp"
         android:overScrollMode="never"
+        android:padding="16dp"
         app:data="@{viewModel.itemList}"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintBottom_toTopOf="@id/question_progress_bar"
@@ -66,10 +67,10 @@
         android:id="@+id/question_progress_bar"
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="30dp"
-        android:layout_marginEnd="30dp"
-        android:layout_marginBottom="5dp"
+        android:layout_height="12dp"
+        android:layout_marginStart="32dp"
+        android:layout_marginEnd="32dp"
+        android:layout_marginBottom="8dp"
         android:max="100"
         android:progress="@{viewModel.progressPercentage}"
         android:progressDrawable="@drawable/progress_bar"
@@ -81,9 +82,12 @@
         android:id="@+id/question_progress_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="30dp"
-        android:layout_marginBottom="20dp"
+        android:layout_marginEnd="32dp"
+        android:layout_marginBottom="12dp"
+        android:fontFamily="sans-serif"
         android:text="@{viewModel.isAtEndOfSession ? @string/question_training_session_progress_finished : @string/question_training_session_progress(viewModel.currentQuestion, viewModel.questionCount)}"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="12sp"
         android:textStyle="italic"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
@@ -115,11 +119,5 @@
         android:textSize="20sp"
         android:visibility="invisible" />
     </FrameLayout>
-
-    <View
-      android:id="@+id/question_player_toolbar_shadow_view"
-      android:layout_width="match_parent"
-      android:layout_height="6dp"
-      android:background="@drawable/toolbar_drop_shadow" />
   </FrameLayout>
 </layout>


### PR DESCRIPTION
## Explanation
question-player progress-bar hifi
duplicate of #853

## Mock
https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/4d4e4bd8-3755-41fc-bf83-3dcff5d5eee1/PM-Q2-Text-Input-No-Answer-

## Screen shot
<img width="388" alt="small" src="https://user-images.githubusercontent.com/54615666/77277052-22c58480-6ce2-11ea-8f8a-93a0dc02d2de.png">


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
