### PR TITLE
Fix #1348: Topic Size issue fixed

### DIFF
--- a/app/src/main/java/org/oppia/app/topic/info/TopicInfoFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/topic/info/TopicInfoFragmentPresenter.kt
@@ -82,6 +82,7 @@ class TopicInfoFragmentPresenter @Inject constructor(
             fragment.requireView().findViewById(R.id.topic_description_text_view)
           )
         )
+        topicInfoViewModel.calculateTopicSizeWithUnit()
         controlSeeMoreTextVisibility()
       }
     )

--- a/app/src/main/java/org/oppia/app/topic/info/TopicInfoViewModel.kt
+++ b/app/src/main/java/org/oppia/app/topic/info/TopicInfoViewModel.kt
@@ -16,15 +16,14 @@ class TopicInfoViewModel @Inject constructor(
 ) : ObservableViewModel() {
 
   val topic = ObservableField<Topic>(Topic.getDefaultInstance())
+  val topicSize = ObservableField<String>("")
   val topicDescription = ObservableField<CharSequence>("")
   var downloadStatusIndicatorDrawableResourceId =
     ObservableField(R.drawable.ic_available_offline_primary_24dp)
   val isDescriptionExpanded = ObservableField<Boolean>(true)
-  val isSeeMoreVisible = ObservableField<Boolean>(true)
 
-  /** Returns the space this topic requires on disk, formatted for display. */
-  fun getTopicSizeWithUnit(): String {
-    return topic.get()?.let { topic ->
+  fun calculateTopicSizeWithUnit() {
+    val sizeWithUnit = topic.get()?.let { topic ->
       val sizeInBytes: Int = topic.diskSizeBytes.toInt()
       val sizeInKb = sizeInBytes / 1024
       val sizeInMb = sizeInKb / 1024
@@ -36,7 +35,10 @@ class TopicInfoViewModel @Inject constructor(
         else -> context.getString(R.string.size_bytes, roundUpToHundreds(sizeInBytes))
       }
     } ?: context.getString(R.string.unknown_size)
+    topicSize.set(sizeWithUnit)
   }
+
+  val isSeeMoreVisible = ObservableField<Boolean>(true)
 
   private fun roundUpToHundreds(intValue: Int): Int {
     return ((intValue + 9) / 10) * 10

--- a/app/src/main/java/org/oppia/app/topic/info/TopicInfoViewModel.kt
+++ b/app/src/main/java/org/oppia/app/topic/info/TopicInfoViewModel.kt
@@ -21,6 +21,7 @@ class TopicInfoViewModel @Inject constructor(
   var downloadStatusIndicatorDrawableResourceId =
     ObservableField(R.drawable.ic_available_offline_primary_24dp)
   val isDescriptionExpanded = ObservableField<Boolean>(true)
+  val isSeeMoreVisible = ObservableField<Boolean>(true)
 
   fun calculateTopicSizeWithUnit() {
     val sizeWithUnit = topic.get()?.let { topic ->
@@ -37,8 +38,6 @@ class TopicInfoViewModel @Inject constructor(
     } ?: context.getString(R.string.unknown_size)
     topicSize.set(sizeWithUnit)
   }
-
-  val isSeeMoreVisible = ObservableField<Boolean>(true)
 
   private fun roundUpToHundreds(intValue: Int): Int {
     return ((intValue + 9) / 10) * 10

--- a/app/src/main/res/layout-land/topic_info_fragment.xml
+++ b/app/src/main/res/layout-land/topic_info_fragment.xml
@@ -126,7 +126,7 @@
         android:layout_marginStart="8dp"
         android:layout_marginEnd="72dp"
         android:fontFamily="sans-serif"
-        android:text="@{String.format(@string/topic_download_text, viewModel.getTopicSizeWithUnit())}"
+        android:text="@{String.format(@string/topic_download_text, viewModel.topicSize)}"
         android:textColor="@color/oppiaPrimaryText"
         android:textSize="18sp"
         android:textStyle="italic"

--- a/app/src/main/res/layout/topic_info_fragment.xml
+++ b/app/src/main/res/layout/topic_info_fragment.xml
@@ -144,7 +144,7 @@
         android:layout_marginStart="8dp"
         android:layout_marginEnd="32dp"
         android:fontFamily="sans-serif"
-        android:text="@{String.format(@string/topic_download_text, viewModel.getTopicSizeWithUnit())}"
+        android:text="@{String.format(@string/topic_download_text, viewModel.topicSize)}"
         android:textColor="@color/oppiaPrimaryText"
         android:textSize="18sp"
         android:textStyle="italic"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #1348 

Currently in develop, `TopicInfoFragment` displays `0 Bytes` as topic size. This is fixed in this PR.
Note that the topic size can be calculated only for those topics which are coming from json files and therefore `First Topic` and `Second Topic` will still show topic size as `0 bytes`.

![Screenshot_1592444820](https://user-images.githubusercontent.com/9396084/84968274-b8cb4880-b133-11ea-879e-4dff6ab16def.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
