### PR TITLE
Fix #988: Enable Profile Image Update Multiple times.

### DIFF
--- a/domain/src/main/java/org/oppia/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/domain/profile/ProfileManagementController.kt
@@ -55,8 +55,6 @@ private const val UPDATE_APP_LANGUAGE_TRANSFORMED_PROVIDER_ID = "update_app_lang
 private const val UPDATE_AUDIO_LANGUAGE_TRANSFORMED_PROVIDER_ID =
   "update_audio_language_transformed_id"
 
-const val PROFILE_AVATAR_FILE_NAME = "profile_avatar.png"
-
 /** Controller for retrieving, adding, updating, and deleting profiles. */
 @Singleton
 class ProfileManagementController @Inject constructor(
@@ -731,7 +729,8 @@ class ProfileManagementController @Inject constructor(
 
   private fun saveImageToInternalStorage(avatarImagePath: Uri, profileDir: File): String? {
     val bitmap = MediaStore.Images.Media.getBitmap(context.contentResolver, avatarImagePath)
-    val imageFile = File(profileDir, PROFILE_AVATAR_FILE_NAME)
+    val fileName = avatarImagePath.pathSegments.last()
+    val imageFile = File(profileDir, fileName)
     try {
       FileOutputStream(imageFile).use { fos ->
         rotateAndCompressBitmap(avatarImagePath, bitmap, /* cropSize= */ 300)


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #988 

In current develop, if you go to `Navigation Drawer -> Profile Progress` and update the profile image multiple times, you will notice that after 1/2 attempts the profile image will not get updated. This is because the image is getting saved in the database with same name and we have caching enabled in our project and therefore the view keeps the old reference. 

So as a solution to that, we just need to make sure that everytime the image is saved, the name is different.

For testing this you might need your real device.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x]  The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
