### PR TITLE
Fix #1398: Set minimum image size to 48dp

### DIFF
--- a/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
@@ -13,6 +13,7 @@ import android.view.ViewTreeObserver
 import android.widget.TextView
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
+import org.oppia.util.R
 import javax.inject.Inject
 
 // TODO(#169): Replace this with exploration asset downloader.
@@ -69,8 +70,18 @@ class UrlImageParser private constructor(
       val drawable = drawableFactory(resource)
       htmlContentTextView.post {
         htmlContentTextView.width {
-          val drawableHeight = drawable.intrinsicHeight
-          val drawableWidth = drawable.intrinsicWidth
+          var drawableHeight = drawable.intrinsicHeight
+          var drawableWidth = drawable.intrinsicWidth
+          val minimumImageSize = context.resources.getDimensionPixelSize(R.dimen.minimum_image_size)
+          if (drawableHeight <= minimumImageSize || drawableWidth <= minimumImageSize) {
+            val multipleFactor = if (drawableHeight <= drawableWidth) {
+              (minimumImageSize.toDouble() / drawableHeight.toDouble())
+            } else {
+              (minimumImageSize.toDouble() / drawableWidth.toDouble())
+            }
+            drawableHeight = (drawableHeight.toDouble() * multipleFactor).toInt()
+            drawableWidth = (drawableWidth.toDouble() * multipleFactor).toInt()
+          }
           val initialDrawableMargin = if (imageCenterAlign) {
             calculateInitialMargin(it, drawableWidth)
           } else {

--- a/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
@@ -74,9 +74,15 @@ class UrlImageParser private constructor(
           var drawableWidth = drawable.intrinsicWidth
           val minimumImageSize = context.resources.getDimensionPixelSize(R.dimen.minimum_image_size)
           if (drawableHeight <= minimumImageSize || drawableWidth <= minimumImageSize) {
+            // The multipleFactor value is used to make sure that the aspect ratio of the image remains the same.
+            // Example: Height is 90, width is 60 and minimumImageSize is 120.
+            // Then multipleFactor will be 2 (120/60).
+            // The new height will be 180 and new width will be 120.
             val multipleFactor = if (drawableHeight <= drawableWidth) {
+              // If height is less then the multipleFactor, value is determined by height.
               (minimumImageSize.toDouble() / drawableHeight.toDouble())
             } else {
+              // If width is less then the multipleFactor, value is determined by width.
               (minimumImageSize.toDouble() / drawableWidth.toDouble())
             }
             drawableHeight = (drawableHeight.toDouble() * multipleFactor).toInt()

--- a/utility/src/main/res/values/dimens.xml
+++ b/utility/src/main/res/values/dimens.xml
@@ -4,4 +4,5 @@
   <dimen name="bullet_gap_width">16dp</dimen>
   <dimen name="bullet_y_offset">2dp</dimen>
   <dimen name="bullet_leading_margin">24dp</dimen>
+  <dimen name="minimum_image_size">48dp</dimen>
 </resources>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #1398

This PR makes sure that the image size in rich-text is atleast 48dpx48dp while maintaining its original aspect ratio.

## Before
![Screenshot_1592995063](https://user-images.githubusercontent.com/9396084/85541775-f3eae180-b635-11ea-97a9-3c26e4f05f49.png)


## After
![Screenshot_1592995342](https://user-images.githubusercontent.com/9396084/85541786-f8af9580-b635-11ea-99e8-0ef7ea4fb60a.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
