### PR TITLE
Fix part of #1028: Add ProfileProgress app tests to the non-flaky queue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
       - restore_cache:
           <<: *restore_cache
       - run:
-          name: App -  FAQ, Help, Mydownloads, Parser,Profileprogress, RecyclerView, Story, Utility tests
+          name: App -  FAQ, Help, Mydownloads, Parser, Profileprogress, RecyclerView, Story, Utility tests
           command: ./.circleci/gradle/gradlew -i :app:testDebugUnitTest --tests org.oppia.app.faq* --tests org.oppia.app.help* --tests org.oppia.app.mydownloads*
             --tests org.oppia.app.parser* --tests org.oppia.app.profileprogress* --tests org.oppia.app.recyclerview* --tests org.oppia.app.story* --tests org.oppia.app.utility*
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,9 +133,9 @@ jobs:
       - restore_cache:
           <<: *restore_cache
       - run:
-          name: App -  FAQ, Help, Mydownloads, Parser, RecyclerView, Story, Utility tests
+          name: App -  FAQ, Help, Mydownloads, Parser,Profileprogress, RecyclerView, Story, Utility tests
           command: ./.circleci/gradle/gradlew -i :app:testDebugUnitTest --tests org.oppia.app.faq* --tests org.oppia.app.help* --tests org.oppia.app.mydownloads*
-            --tests org.oppia.app.parser* --tests org.oppia.app.recyclerview* --tests org.oppia.app.story* --tests org.oppia.app.utility*
+            --tests org.oppia.app.parser* --tests org.oppia.app.profileprogress* --tests org.oppia.app.recyclerview* --tests org.oppia.app.story* --tests org.oppia.app.utility*
       - run:
           name: Save test results
           command: |


### PR DESCRIPTION
## Explanation
This PR adds tests in the ProfileProgress directories of the app module to the non-flaky queue
Fixes part of #1028