### PR TITLE
Revert "Fix #1398: Set minimum image size to 48dp"

### DIFF
--- a/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
@@ -13,7 +13,6 @@ import android.view.ViewTreeObserver
 import android.widget.TextView
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
-import org.oppia.util.R
 import javax.inject.Inject
 
 // TODO(#169): Replace this with exploration asset downloader.
@@ -70,24 +69,8 @@ class UrlImageParser private constructor(
       val drawable = drawableFactory(resource)
       htmlContentTextView.post {
         htmlContentTextView.width {
-          var drawableHeight = drawable.intrinsicHeight
-          var drawableWidth = drawable.intrinsicWidth
-          val minimumImageSize = context.resources.getDimensionPixelSize(R.dimen.minimum_image_size)
-          if (drawableHeight <= minimumImageSize || drawableWidth <= minimumImageSize) {
-            // The multipleFactor value is used to make sure that the aspect ratio of the image remains the same.
-            // Example: Height is 90, width is 60 and minimumImageSize is 120.
-            // Then multipleFactor will be 2 (120/60).
-            // The new height will be 180 and new width will be 120.
-            val multipleFactor = if (drawableHeight <= drawableWidth) {
-              // If height is less then the multipleFactor, value is determined by height.
-              (minimumImageSize.toDouble() / drawableHeight.toDouble())
-            } else {
-              // If width is less then the multipleFactor, value is determined by width.
-              (minimumImageSize.toDouble() / drawableWidth.toDouble())
-            }
-            drawableHeight = (drawableHeight.toDouble() * multipleFactor).toInt()
-            drawableWidth = (drawableWidth.toDouble() * multipleFactor).toInt()
-          }
+          val drawableHeight = drawable.intrinsicHeight
+          val drawableWidth = drawable.intrinsicWidth
           val initialDrawableMargin = if (imageCenterAlign) {
             calculateInitialMargin(it, drawableWidth)
           } else {

--- a/utility/src/main/res/values/dimens.xml
+++ b/utility/src/main/res/values/dimens.xml
@@ -4,5 +4,4 @@
   <dimen name="bullet_gap_width">16dp</dimen>
   <dimen name="bullet_y_offset">2dp</dimen>
   <dimen name="bullet_leading_margin">24dp</dimen>
-  <dimen name="minimum_image_size">48dp</dimen>
 </resources>


### PR DESCRIPTION
Reverts oppia/oppia-android#1393

The number of this issue was incorrect because of which other PR got closed which is #1398 and therefore reverting this PR.