### PR TITLE
Fixes #1416: NavigationDrawer width in tablet portrait mode

### DIFF
--- a/app/src/main/res/layout-sw600dp-port/home_activity.xml
+++ b/app/src/main/res/layout-sw600dp-port/home_activity.xml
@@ -1,0 +1,33 @@
+<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/home_activity_drawer_layout"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  tools:context=".home.HomeActivity">
+
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include
+      android:id="@+id/home_activity_toolbar"
+      layout="@layout/toolbar" />
+
+    <FrameLayout
+      android:id="@+id/home_fragment_placeholder"
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1" />
+  </LinearLayout>
+
+  <fragment
+    android:id="@+id/home_activity_fragment_navigation_drawer"
+    android:name="org.oppia.app.drawer.NavigationDrawerFragment"
+    android:layout_width="304dp"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    app:layout="@layout/drawer_fragment"
+    tools:layout="@layout/drawer_fragment" />
+</androidx.drawerlayout.widget.DrawerLayout>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
- Fixed the width of the **NavigationDrawer** in tablet portrait mode
- Fixes #1416 
- Mocks: https://xd.adobe.com/view/d405de00-a871-4f0f-73a0-f8acef30349b-a234/screen/3a43a3ce-597a-4e4b-b509-3eafd4249528/
## Screenshots
### Before
![screenshot-2020-06-26_21 25 44 457](https://user-images.githubusercontent.com/8533363/85894411-fe070e80-b7f4-11ea-8c9d-576cdaee87b1.png)
### After
![screenshot-2020-06-26_21 26 42 41](https://user-images.githubusercontent.com/8533363/85894429-07907680-b7f5-11ea-99e5-f4b9d7a7986a.png)
## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
