### PR TITLE
Fix #1437 : Onboarding swipe back to prev page crash #1437

### DIFF
--- a/app/src/main/java/org/oppia/app/onboarding/OnboardingPagerAdapter.kt
+++ b/app/src/main/java/org/oppia/app/onboarding/OnboardingPagerAdapter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ScrollView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.viewpager.widget.PagerAdapter
 import org.oppia.app.databinding.OnboardingSlideBinding
@@ -48,6 +49,10 @@ class OnboardingPagerAdapter(
   }
 
   override fun destroyItem(container: ViewGroup, position: Int, `object`: Any) {
-    container.removeView(`object` as ConstraintLayout)
+    if(`object` is ConstraintLayout){
+      container.removeView(`object`)
+    } else if (`object` is ScrollView) {
+      container.removeView(`object`)
+    }
   }
 }

--- a/app/src/main/java/org/oppia/app/onboarding/OnboardingPagerAdapter.kt
+++ b/app/src/main/java/org/oppia/app/onboarding/OnboardingPagerAdapter.kt
@@ -49,10 +49,6 @@ class OnboardingPagerAdapter(
   }
 
   override fun destroyItem(container: ViewGroup, position: Int, `object`: Any) {
-    if (`object` is ConstraintLayout) {
-      container.removeView(`object`)
-    } else if (`object` is ScrollView) {
-      container.removeView(`object`)
-    }
+    container.removeView(`object` as ScrollView)
   }
 }

--- a/app/src/main/java/org/oppia/app/onboarding/OnboardingPagerAdapter.kt
+++ b/app/src/main/java/org/oppia/app/onboarding/OnboardingPagerAdapter.kt
@@ -49,7 +49,7 @@ class OnboardingPagerAdapter(
   }
 
   override fun destroyItem(container: ViewGroup, position: Int, `object`: Any) {
-    if(`object` is ConstraintLayout){
+    if (`object` is ConstraintLayout) {
       container.removeView(`object`)
     } else if (`object` is ScrollView) {
       container.removeView(`object`)

--- a/app/src/main/java/org/oppia/app/onboarding/OnboardingPagerAdapter.kt
+++ b/app/src/main/java/org/oppia/app/onboarding/OnboardingPagerAdapter.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.viewpager.widget.PagerAdapter
 import org.oppia.app.databinding.OnboardingSlideBinding
 import org.oppia.app.databinding.OnboardingSlideFinalBinding

--- a/app/src/main/res/layout-land/onboarding_slide.xml
+++ b/app/src/main/res/layout-land/onboarding_slide.xml
@@ -9,56 +9,65 @@
       type="org.oppia.app.onboarding.OnboardingSlideViewModel" />
   </data>
 
-  <androidx.constraintlayout.widget.ConstraintLayout
+  <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="horizontal">
+    android:clipToPadding="false"
+    android:fillViewport="true"
+    android:overScrollMode="never"
+    android:scrollbars="none">
 
-    <ImageView
-      android:id="@+id/slide_image_view"
-      android:layout_width="0dp"
-      android:layout_height="0dp"
-      android:adjustViewBounds="true"
-      android:contentDescription="@{viewModel.contentDescription}"
-      android:scaleType="fitXY"
-      android:src="@{viewModel.slideImage}"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintDimensionRatio="H, 10:9"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-      android:id="@+id/slide_title_text_view"
-      android:layout_width="0dp"
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginStart="8dp"
-      android:layout_marginTop="80dp"
-      android:layout_marginEnd="28dp"
-      android:fontFamily="sans-serif-medium"
-      android:gravity="center_horizontal"
-      android:text="@{viewModel.title}"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="24sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintHorizontal_bias="1.0"
-      app:layout_constraintStart_toEndOf="@+id/slide_image_view"
-      app:layout_constraintTop_toTopOf="parent" />
+      android:orientation="horizontal">
 
-    <TextView
-      android:id="@+id/slide_description_text_view"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="20dp"
-      android:layout_marginTop="16dp"
-      android:layout_marginEnd="40dp"
-      android:fontFamily="sans-serif"
-      android:gravity="center_horizontal"
-      android:text="@{viewModel.description}"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="16sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintHorizontal_bias="0.0"
-      app:layout_constraintStart_toEndOf="@+id/slide_image_view"
-      app:layout_constraintTop_toBottomOf="@+id/slide_title_text_view" />
-  </androidx.constraintlayout.widget.ConstraintLayout>
+      <ImageView
+        android:id="@+id/slide_image_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:adjustViewBounds="true"
+        android:contentDescription="@{viewModel.contentDescription}"
+        android:scaleType="fitXY"
+        android:src="@{viewModel.slideImage}"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="H, 10:9"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+      <TextView
+        android:id="@+id/slide_title_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="80dp"
+        android:layout_marginEnd="28dp"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center_horizontal"
+        android:text="@{viewModel.title}"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="24sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toEndOf="@+id/slide_image_view"
+        app:layout_constraintTop_toTopOf="parent" />
+
+      <TextView
+        android:id="@+id/slide_description_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="40dp"
+        android:fontFamily="sans-serif"
+        android:gravity="center_horizontal"
+        android:text="@{viewModel.description}"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toEndOf="@+id/slide_image_view"
+        app:layout_constraintTop_toBottomOf="@+id/slide_title_text_view" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+  </ScrollView>
 </layout>

--- a/app/src/main/res/layout-land/onboarding_slide_final.xml
+++ b/app/src/main/res/layout-land/onboarding_slide_final.xml
@@ -9,74 +9,83 @@
       type="org.oppia.app.onboarding.OnboardingSlideFinalViewModel" />
   </data>
 
-  <androidx.constraintlayout.widget.ConstraintLayout
+  <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="horizontal">
+    android:clipToPadding="false"
+    android:fillViewport="true"
+    android:overScrollMode="never"
+    android:scrollbars="none">
 
-    <ImageView
-      android:id="@+id/slide_image_view"
-      android:layout_width="0dp"
-      android:layout_height="0dp"
-      android:contentDescription="@string/onboarding_slide_3_title"
-      android:adjustViewBounds="true"
-      android:scaleType="fitXY"
-      android:src="@drawable/ic_landscape_onboarding_3"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintDimensionRatio="H, 10:9"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-      android:id="@+id/slide_title_text_view"
-      android:layout_width="0dp"
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginStart="8dp"
-      android:layout_marginTop="80dp"
-      android:layout_marginEnd="28dp"
-      android:fontFamily="sans-serif-medium"
-      android:gravity="center_horizontal"
-      android:text="@string/onboarding_slide_3_title"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="24sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintHorizontal_bias="1.0"
-      app:layout_constraintStart_toEndOf="@+id/slide_image_view"
-      app:layout_constraintTop_toTopOf="parent" />
+      android:orientation="horizontal">
 
-    <TextView
-      android:id="@+id/slide_description_text_view"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="20dp"
-      android:layout_marginTop="16dp"
-      android:layout_marginEnd="40dp"
-      android:fontFamily="sans-serif"
-      android:gravity="center_horizontal"
-      android:text="@string/onboarding_slide_3_description"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="16sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintHorizontal_bias="0.0"
-      app:layout_constraintStart_toEndOf="@+id/slide_image_view"
-      app:layout_constraintTop_toBottomOf="@+id/slide_title_text_view" />
+      <ImageView
+        android:id="@+id/slide_image_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/onboarding_slide_3_title"
+        android:scaleType="fitXY"
+        android:src="@drawable/ic_landscape_onboarding_3"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="H, 10:9"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-    <Button
-      android:id="@+id/get_started_button"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="24dp"
-      android:layout_marginStart="28dp"
-      android:layout_marginEnd="52dp"
-      android:background="@drawable/primary_rounded_button"
-      android:fontFamily="sans-serif-medium"
-      android:minHeight="48dp"
-      android:onClick="@{(v) -> viewModel.clickOnGetStarted()}"
-      android:text="@string/get_started"
-      android:textColor="@color/white"
-      android:textSize="14sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toEndOf="@+id/slide_image_view"
-      app:layout_constraintTop_toBottomOf="@id/slide_description_text_view" />
-  </androidx.constraintlayout.widget.ConstraintLayout>
+      <TextView
+        android:id="@+id/slide_title_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="80dp"
+        android:layout_marginEnd="28dp"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center_horizontal"
+        android:text="@string/onboarding_slide_3_title"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="24sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toEndOf="@+id/slide_image_view"
+        app:layout_constraintTop_toTopOf="parent" />
+
+      <TextView
+        android:id="@+id/slide_description_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="40dp"
+        android:fontFamily="sans-serif"
+        android:gravity="center_horizontal"
+        android:text="@string/onboarding_slide_3_description"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toEndOf="@+id/slide_image_view"
+        app:layout_constraintTop_toBottomOf="@+id/slide_title_text_view" />
+
+      <Button
+        android:id="@+id/get_started_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="28dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="52dp"
+        android:background="@drawable/primary_rounded_button"
+        android:fontFamily="sans-serif-medium"
+        android:minHeight="48dp"
+        android:onClick="@{(v) -> viewModel.clickOnGetStarted()}"
+        android:text="@string/get_started"
+        android:textColor="@color/white"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/slide_image_view"
+        app:layout_constraintTop_toBottomOf="@id/slide_description_text_view" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+  </ScrollView>
 </layout>

--- a/app/src/main/res/layout-sw600dp-land/onboarding_slide.xml
+++ b/app/src/main/res/layout-sw600dp-land/onboarding_slide.xml
@@ -9,71 +9,80 @@
       type="org.oppia.app.onboarding.OnboardingSlideViewModel" />
   </data>
 
-  <androidx.constraintlayout.widget.ConstraintLayout
+  <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="horizontal">
+    android:clipToPadding="false"
+    android:fillViewport="true"
+    android:overScrollMode="never"
+    android:scrollbars="none">
 
-    <ImageView
-      android:id="@+id/slide_image_view"
-      android:layout_width="0dp"
-      android:layout_height="0dp"
-      android:adjustViewBounds="true"
-      android:contentDescription="@{viewModel.contentDescription}"
-      android:src="@{viewModel.slideImage}"
-      app:layout_constraintDimensionRatio="40:39"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-      android:id="@+id/slide_title_text_view"
-      android:layout_width="0dp"
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginBottom="12dp"
-      android:fontFamily="sans-serif-medium"
-      android:gravity="center_horizontal"
-      android:text="@{viewModel.title}"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="32sp"
-      app:layout_constraintBottom_toTopOf="@+id/guideline"
-      app:layout_constraintEnd_toStartOf="@+id/guideline5"
-      app:layout_constraintStart_toStartOf="@+id/guideline7" />
+      android:orientation="horizontal">
 
-    <TextView
-      android:id="@+id/slide_description_text_view"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="12dp"
-      android:fontFamily="sans-serif"
-      android:gravity="center_horizontal"
-      android:text="@{viewModel.description}"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="24sp"
-      app:layout_constraintEnd_toEndOf="@+id/slide_title_text_view"
-      app:layout_constraintHorizontal_bias="0.0"
-      app:layout_constraintStart_toStartOf="@+id/slide_title_text_view"
-      app:layout_constraintTop_toTopOf="@+id/guideline" />
+      <ImageView
+        android:id="@+id/slide_image_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:adjustViewBounds="true"
+        android:contentDescription="@{viewModel.contentDescription}"
+        android:src="@{viewModel.slideImage}"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="40:39"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-    <androidx.constraintlayout.widget.Guideline
-      android:id="@+id/guideline"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal"
-      app:layout_constraintGuide_percent="0.5" />
+      <TextView
+        android:id="@+id/slide_title_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center_horizontal"
+        android:text="@{viewModel.title}"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="32sp"
+        app:layout_constraintBottom_toTopOf="@+id/guideline"
+        app:layout_constraintEnd_toStartOf="@+id/guideline5"
+        app:layout_constraintStart_toStartOf="@+id/guideline7" />
 
-    <androidx.constraintlayout.widget.Guideline
-      android:id="@+id/guideline5"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:orientation="vertical"
-      app:layout_constraintGuide_percent="0.90625" />
+      <TextView
+        android:id="@+id/slide_description_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:fontFamily="sans-serif"
+        android:gravity="center_horizontal"
+        android:text="@{viewModel.description}"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="24sp"
+        app:layout_constraintEnd_toEndOf="@+id/slide_title_text_view"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="@+id/slide_title_text_view"
+        app:layout_constraintTop_toTopOf="@+id/guideline" />
 
-    <androidx.constraintlayout.widget.Guideline
-      android:id="@+id/guideline7"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:orientation="vertical"
-      app:layout_constraintGuide_percent="0.5546" />
-  </androidx.constraintlayout.widget.ConstraintLayout>
+      <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.5" />
+
+      <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline5"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.90625" />
+
+      <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline7"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.5546" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+  </ScrollView>
 </layout>

--- a/app/src/main/res/layout-sw600dp-land/onboarding_slide_final.xml
+++ b/app/src/main/res/layout-sw600dp-land/onboarding_slide_final.xml
@@ -9,87 +9,96 @@
       type="org.oppia.app.onboarding.OnboardingSlideFinalViewModel" />
   </data>
 
-  <androidx.constraintlayout.widget.ConstraintLayout
+  <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="horizontal">
+    android:clipToPadding="false"
+    android:fillViewport="true"
+    android:overScrollMode="never"
+    android:scrollbars="none">
 
-    <ImageView
-      android:id="@+id/slide_image_view"
-      android:layout_width="0dp"
-      android:layout_height="0dp"
-      android:adjustViewBounds="true"
-      android:contentDescription="@string/onboarding_slide_3_title"
-      android:src="@drawable/ic_landscape_onboarding_3_tablet"
-      app:layout_constraintDimensionRatio="40:39"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-      android:id="@+id/slide_title_text_view"
-      android:layout_width="0dp"
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginBottom="12dp"
-      android:fontFamily="sans-serif-medium"
-      android:gravity="center_horizontal"
-      android:text="@string/onboarding_slide_3_title"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="32sp"
-      app:layout_constraintBottom_toTopOf="@+id/guideline2"
-      app:layout_constraintEnd_toEndOf="@+id/slide_description_text_view"
-      app:layout_constraintHorizontal_bias="1.0"
-      app:layout_constraintStart_toStartOf="@+id/slide_description_text_view" />
+      android:orientation="horizontal">
 
-    <TextView
-      android:id="@+id/slide_description_text_view"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="12dp"
-      android:fontFamily="sans-serif"
-      android:gravity="center_horizontal"
-      android:text="@string/onboarding_slide_3_description"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="24sp"
-      app:layout_constraintEnd_toStartOf="@+id/guideline3"
-      app:layout_constraintStart_toStartOf="@+id/guideline4"
-      app:layout_constraintTop_toTopOf="@+id/guideline2" />
+      <ImageView
+        android:id="@+id/slide_image_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/onboarding_slide_3_title"
+        android:src="@drawable/ic_landscape_onboarding_3_tablet"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="40:39"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-    <Button
-      android:id="@+id/get_started_button"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="40dp"
-      android:background="@drawable/primary_rounded_button"
-      android:fontFamily="sans-serif-medium"
-      android:minHeight="48dp"
-      android:onClick="@{(v) -> viewModel.clickOnGetStarted()}"
-      android:text="@string/get_started"
-      android:textColor="@color/white"
-      android:textSize="14sp"
-      app:layout_constraintEnd_toEndOf="@+id/slide_title_text_view"
-      app:layout_constraintStart_toStartOf="@+id/slide_title_text_view"
-      app:layout_constraintTop_toBottomOf="@id/slide_description_text_view" />
+      <TextView
+        android:id="@+id/slide_title_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center_horizontal"
+        android:text="@string/onboarding_slide_3_title"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="32sp"
+        app:layout_constraintBottom_toTopOf="@+id/guideline2"
+        app:layout_constraintEnd_toEndOf="@+id/slide_description_text_view"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="@+id/slide_description_text_view" />
 
-    <androidx.constraintlayout.widget.Guideline
-      android:id="@+id/guideline2"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal"
-      app:layout_constraintGuide_percent="0.5" />
+      <TextView
+        android:id="@+id/slide_description_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:fontFamily="sans-serif"
+        android:gravity="center_horizontal"
+        android:text="@string/onboarding_slide_3_description"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="24sp"
+        app:layout_constraintEnd_toStartOf="@+id/guideline3"
+        app:layout_constraintStart_toStartOf="@+id/guideline4"
+        app:layout_constraintTop_toTopOf="@+id/guideline2" />
 
-    <androidx.constraintlayout.widget.Guideline
-      android:id="@+id/guideline3"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:orientation="vertical"
-      app:layout_constraintGuide_percent="0.90625" />
+      <Button
+        android:id="@+id/get_started_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="40dp"
+        android:background="@drawable/primary_rounded_button"
+        android:fontFamily="sans-serif-medium"
+        android:minHeight="48dp"
+        android:onClick="@{(v) -> viewModel.clickOnGetStarted()}"
+        android:text="@string/get_started"
+        android:textColor="@color/white"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="@+id/slide_title_text_view"
+        app:layout_constraintStart_toStartOf="@+id/slide_title_text_view"
+        app:layout_constraintTop_toBottomOf="@id/slide_description_text_view" />
 
-    <androidx.constraintlayout.widget.Guideline
-      android:id="@+id/guideline4"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:orientation="vertical"
-      app:layout_constraintGuide_percent="0.5546" />
-  </androidx.constraintlayout.widget.ConstraintLayout>
+      <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.5" />
+
+      <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.90625" />
+
+      <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline4"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.5546" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+  </ScrollView>
 </layout>

--- a/app/src/main/res/layout-sw600dp-port/onboarding_slide.xml
+++ b/app/src/main/res/layout-sw600dp-port/onboarding_slide.xml
@@ -9,55 +9,64 @@
       type="org.oppia.app.onboarding.OnboardingSlideViewModel" />
   </data>
 
-  <androidx.constraintlayout.widget.ConstraintLayout
+  <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:clipToPadding="false"
+    android:fillViewport="true"
+    android:overScrollMode="never"
+    android:scrollbars="none">
 
-    <ImageView
-      android:id="@+id/slide_image_view"
-      android:layout_width="0dp"
-      android:layout_height="0dp"
-      android:contentDescription="@{viewModel.contentDescription}"
-      android:src="@{viewModel.slideImage}"
-      app:layout_constraintDimensionRatio="5:4"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-      android:id="@+id/slide_title_text_view"
-      android:layout_width="0dp"
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginStart="160dp"
-      android:layout_marginTop="48dp"
-      android:layout_marginEnd="160dp"
-      android:fontFamily="sans-serif-medium"
-      android:gravity="center_horizontal"
-      android:maxLines="1"
-      android:text="@{viewModel.title}"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="32sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/slide_image_view" />
+      android:orientation="vertical">
 
-    <TextView
-      android:id="@+id/slide_description_text_view"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="192dp"
-      android:layout_marginTop="24dp"
-      android:layout_marginEnd="192dp"
-      android:fontFamily="sans-serif"
-      android:gravity="center_horizontal"
-      android:maxLines="2"
-      android:minLines="2"
-      android:text="@{viewModel.description}"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="24sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/slide_title_text_view" />
-  </androidx.constraintlayout.widget.ConstraintLayout>
+      <ImageView
+        android:id="@+id/slide_image_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@{viewModel.contentDescription}"
+        android:src="@{viewModel.slideImage}"
+        app:layout_constraintDimensionRatio="5:4"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+      <TextView
+        android:id="@+id/slide_title_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="160dp"
+        android:layout_marginTop="48dp"
+        android:layout_marginEnd="160dp"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center_horizontal"
+        android:maxLines="1"
+        android:text="@{viewModel.title}"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="32sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/slide_image_view" />
+
+      <TextView
+        android:id="@+id/slide_description_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="192dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="192dp"
+        android:fontFamily="sans-serif"
+        android:gravity="center_horizontal"
+        android:maxLines="2"
+        android:minLines="2"
+        android:text="@{viewModel.description}"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="24sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/slide_title_text_view" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+  </ScrollView>
 </layout>

--- a/app/src/main/res/layout-sw600dp-port/onboarding_slide_final.xml
+++ b/app/src/main/res/layout-sw600dp-port/onboarding_slide_final.xml
@@ -9,73 +9,82 @@
       type="org.oppia.app.onboarding.OnboardingSlideFinalViewModel" />
   </data>
 
-  <androidx.constraintlayout.widget.ConstraintLayout
+  <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:clipToPadding="false"
+    android:fillViewport="true"
+    android:overScrollMode="never"
+    android:scrollbars="none">
 
-    <ImageView
-      android:id="@+id/slide_image_view"
-      android:layout_width="0dp"
-      android:layout_height="0dp"
-      android:contentDescription="@string/onboarding_slide_3_title"
-      android:src="@drawable/ic_portrait_onboarding_3"
-      app:layout_constraintDimensionRatio="5:4"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-      android:id="@+id/slide_title_text_view"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="160dp"
-      android:layout_marginTop="48dp"
-      android:layout_marginEnd="160dp"
-      android:fontFamily="sans-serif-medium"
-      android:gravity="center_horizontal"
-      android:maxLines="1"
-      android:text="@string/onboarding_slide_3_title"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="32sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/slide_image_view" />
-
-    <TextView
-      android:id="@+id/slide_description_text_view"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="192dp"
-      android:layout_marginTop="24dp"
-      android:layout_marginEnd="192dp"
-      android:fontFamily="sans-serif"
-      android:gravity="center_horizontal"
-      android:maxLines="2"
-      android:minLines="2"
-      android:text="@string/onboarding_slide_3_description"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="24sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/slide_title_text_view" />
-
-    <Button
-      android:id="@+id/get_started_button"
+    <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginStart="204dp"
-      android:layout_marginTop="24dp"
-      android:layout_marginEnd="204dp"
-      android:background="@drawable/primary_rounded_button"
-      android:fontFamily="sans-serif-medium"
-      android:minHeight="48dp"
-      android:onClick="@{(v) -> viewModel.clickOnGetStarted()}"
-      android:text="@string/get_started"
-      android:textColor="@color/white"
-      android:textSize="20sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/slide_description_text_view" />
-  </androidx.constraintlayout.widget.ConstraintLayout>
+      android:orientation="vertical">
+
+      <ImageView
+        android:id="@+id/slide_image_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@string/onboarding_slide_3_title"
+        android:src="@drawable/ic_portrait_onboarding_3"
+        app:layout_constraintDimensionRatio="5:4"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+      <TextView
+        android:id="@+id/slide_title_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="160dp"
+        android:layout_marginTop="48dp"
+        android:layout_marginEnd="160dp"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center_horizontal"
+        android:maxLines="1"
+        android:text="@string/onboarding_slide_3_title"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="32sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/slide_image_view" />
+
+      <TextView
+        android:id="@+id/slide_description_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="192dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="192dp"
+        android:fontFamily="sans-serif"
+        android:gravity="center_horizontal"
+        android:maxLines="2"
+        android:minLines="2"
+        android:text="@string/onboarding_slide_3_description"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="24sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/slide_title_text_view" />
+
+      <Button
+        android:id="@+id/get_started_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="204dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="204dp"
+        android:background="@drawable/primary_rounded_button"
+        android:fontFamily="sans-serif-medium"
+        android:minHeight="48dp"
+        android:onClick="@{(v) -> viewModel.clickOnGetStarted()}"
+        android:text="@string/get_started"
+        android:textColor="@color/white"
+        android:textSize="20sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/slide_description_text_view" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+  </ScrollView>
 </layout>

--- a/app/src/main/res/layout/onboarding_slide.xml
+++ b/app/src/main/res/layout/onboarding_slide.xml
@@ -9,56 +9,65 @@
       type="org.oppia.app.onboarding.OnboardingSlideViewModel" />
   </data>
 
-  <androidx.constraintlayout.widget.ConstraintLayout
+  <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:clipToPadding="false"
+    android:fillViewport="true"
+    android:overScrollMode="never"
+    android:scrollbars="none">
 
-    <ImageView
-      android:id="@+id/slide_image_view"
-      android:layout_width="0dp"
-      android:layout_height="0dp"
-      android:contentDescription="@{viewModel.contentDescription}"
-      android:src="@{viewModel.slideImage}"
-      app:layout_constraintDimensionRatio="5:4"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-      android:id="@+id/slide_title_text_view"
-      android:layout_width="0dp"
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginStart="28dp"
-      android:layout_marginTop="40dp"
-      android:layout_marginEnd="28dp"
-      android:layout_marginBottom="16dp"
-      android:fontFamily="sans-serif-medium"
-      android:gravity="center_horizontal"
-      android:maxLines="1"
-      android:text="@{viewModel.title}"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="24sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/slide_image_view" />
+      android:orientation="vertical">
 
-    <TextView
-      android:id="@+id/slide_description_text_view"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="48dp"
-      android:layout_marginTop="16dp"
-      android:layout_marginEnd="48dp"
-      android:fontFamily="sans-serif"
-      android:gravity="center_horizontal"
-      android:maxLines="2"
-      android:minLines="2"
-      android:text="@{viewModel.description}"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="16sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/slide_title_text_view" />
-  </androidx.constraintlayout.widget.ConstraintLayout>
+      <ImageView
+        android:id="@+id/slide_image_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@{viewModel.contentDescription}"
+        android:src="@{viewModel.slideImage}"
+        app:layout_constraintDimensionRatio="5:4"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+      <TextView
+        android:id="@+id/slide_title_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="28dp"
+        android:layout_marginTop="40dp"
+        android:layout_marginEnd="28dp"
+        android:layout_marginBottom="16dp"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center_horizontal"
+        android:maxLines="1"
+        android:text="@{viewModel.title}"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="24sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/slide_image_view" />
+
+      <TextView
+        android:id="@+id/slide_description_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="48dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="48dp"
+        android:fontFamily="sans-serif"
+        android:gravity="center_horizontal"
+        android:maxLines="2"
+        android:minLines="2"
+        android:text="@{viewModel.description}"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/slide_title_text_view" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+  </ScrollView>
 </layout>

--- a/app/src/main/res/layout/onboarding_slide_final.xml
+++ b/app/src/main/res/layout/onboarding_slide_final.xml
@@ -19,7 +19,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
+      android:layout_height="wrap_content"
       android:orientation="vertical"
       android:overScrollMode="always">
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #1437 

Earlier when we get [this](https://github.com/oppia/oppia-android/issues/1255) error where we need to scroll the onboarding screen as the user screen size is small enough to fit, we solved by adding `ScrollView`. 
Now, in this PR we are putting just a check when the `PagerAdapter` calls `destroyItem` it sees what is the object it is removing from the view, And we have both `ConstraintLayout` and `ScrollView` as Parent in our different screen size layout. 

Although the other solution to solve this is to make all parent `ScrollView`. Any Suggestions? 
What I think is to go for making all parent same `ScrollView` rather than making the change in code and putting checks as if in future our design changes and some other parent arrives, we need to update here again.  

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
