### PR TITLE
Fix #1344: Submit button active/deactive in Question Player

### DIFF
--- a/app/src/main/java/org/oppia/app/topic/questionplayer/QuestionPlayerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/topic/questionplayer/QuestionPlayerFragmentPresenter.kt
@@ -171,9 +171,9 @@ class QuestionPlayerFragmentPresenter @Inject constructor(
    * error state.
    */
   fun updateSubmitButton(pendingAnswerError: String?, inputAnswerAvailable: Boolean) {
-    if(inputAnswerAvailable){
+    if (inputAnswerAvailable) {
       questionViewModel.setCanSubmitAnswer(pendingAnswerError == null)
-    } else{
+    } else {
       questionViewModel.setCanSubmitAnswer(canSubmitAnswer = false)
     }
   }
@@ -257,7 +257,7 @@ class QuestionPlayerFragmentPresenter @Inject constructor(
           recyclerViewAssembler.stopHintsFromShowing()
           questionViewModel.setHintBulbVisibility(false)
           recyclerViewAssembler.showCongratulationMessageOnCorrectAnswer()
-        } else{
+        } else {
           questionViewModel.setCanSubmitAnswer(canSubmitAnswer = false)
         }
       }

--- a/app/src/main/java/org/oppia/app/topic/questionplayer/QuestionPlayerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/topic/questionplayer/QuestionPlayerFragmentPresenter.kt
@@ -171,7 +171,11 @@ class QuestionPlayerFragmentPresenter @Inject constructor(
    * error state.
    */
   fun updateSubmitButton(pendingAnswerError: String?, inputAnswerAvailable: Boolean) {
-    questionViewModel.setCanSubmitAnswer(pendingAnswerError == null)
+    if(inputAnswerAvailable){
+      questionViewModel.setCanSubmitAnswer(pendingAnswerError == null)
+    } else{
+      questionViewModel.setCanSubmitAnswer(canSubmitAnswer = false)
+    }
   }
 
   fun handleKeyboardAction() = onSubmitButtonClicked()
@@ -253,6 +257,8 @@ class QuestionPlayerFragmentPresenter @Inject constructor(
           recyclerViewAssembler.stopHintsFromShowing()
           questionViewModel.setHintBulbVisibility(false)
           recyclerViewAssembler.showCongratulationMessageOnCorrectAnswer()
+        } else{
+          questionViewModel.setCanSubmitAnswer(canSubmitAnswer = false)
         }
       }
     )
@@ -343,6 +349,7 @@ class QuestionPlayerFragmentPresenter @Inject constructor(
   }
 
   private fun moveToNextState() {
+    questionViewModel.setCanSubmitAnswer(canSubmitAnswer = false)
     questionAssessmentProgressController.moveToNextQuestion()
   }
 

--- a/app/src/main/java/org/oppia/app/topic/questionplayer/QuestionPlayerViewModel.kt
+++ b/app/src/main/java/org/oppia/app/topic/questionplayer/QuestionPlayerViewModel.kt
@@ -18,7 +18,7 @@ class QuestionPlayerViewModel @Inject constructor() : ObservableViewModel() {
   val currentQuestion = ObservableField(0)
   val progressPercentage = ObservableField(0)
   val isAtEndOfSession = ObservableBoolean(false)
-  private val canSubmitAnswer = ObservableField(true)
+  private val canSubmitAnswer = ObservableField(false)
 
   var newAvailableHintIndex = -1
   var allHintsExhausted = false


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fix #1344

The `Submit` button in Question player should be correctly controlled for active/deactive state.

This PR mainly controls the `Submit` button state under various conditions.

As a reviewer, you should focus on following manual test cases in Fractions QuestionPlayer.

Follow these steps for testing:
1. In `develop`, run the app and check `submit` button in QuestionPlayer (Fractions Topic -> Practice -> Select Skills -> Start). You will notice that the submit button is always active.
2. Now switch to this branch and check the submit button under various conditions.

The Submit button should be inactive by default.
In all EditText related input interaction, if there is no text available, the submit button should be disabled.
In all EditText related input interaction, if there is error, the submit button should be disabled.
If the learner enters an incorrect answer, clicks submit then after that the submit button should be disabled.

The test cases will be covered as a part of https://github.com/oppia/oppia-android/issues/503 as similar test cases have already been finished in `StateFragmentTest`.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
