### PR TITLE
Fixes part of #1168: Topic-revision - Tablet (Portrait) (Lowfi)

### DIFF
--- a/app/src/main/res/layout-sw600dp-port/topic_revision_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-port/topic_revision_fragment.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <data>
+    <variable
+      name="viewModel"
+      type="org.oppia.app.topic.revision.TopicRevisionViewModel" />
+  </data>
+
+  <FrameLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/oppiaBackground">
+
+    <androidx.recyclerview.widget.RecyclerView
+      android:id="@+id/revision_recycler_view"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:clipToPadding="false"
+      android:overScrollMode="never"
+      android:paddingStart="20dp"
+      android:paddingTop="20dp"
+      android:paddingEnd="20dp"
+      android:paddingBottom="144dp"
+      android:scrollbars="none"
+      app:data="@{viewModel.subtopicLiveData}"/>
+  </FrameLayout>
+</layout>

--- a/app/src/main/res/layout-sw600dp-port/topic_revision_summary_view.xml
+++ b/app/src/main/res/layout-sw600dp-port/topic_revision_summary_view.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <data>
+    <import type="android.view.View"/>
+    <import type="org.oppia.app.model.Subtopic"/>
+    <variable
+      name="viewModel"
+      type="org.oppia.app.topic.revision.revisionitemviewmodel.TopicRevisionItemViewModel" />
+
+  </data>
+
+  <com.google.android.material.card.MaterialCardView
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="12dp"
+    android:layout_marginEnd="8dp"
+    android:layout_marginBottom="12dp"
+    android:clipToPadding="true"
+    app:cardBackgroundColor="@color/white"
+    app:cardCornerRadius="4dp"
+    app:cardElevation="4dp"
+    app:cardMaxElevation="4dp"
+    android:onClick="@{(v) -> viewModel.onRevisionItemPressed.onTopicRevisionSummaryClicked(viewModel.subtopic)}">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content">
+
+      <ImageView
+        android:id="@+id/subtopic_image_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@color/white"
+        android:importantForAccessibility="no"
+        android:scaleType="centerInside"
+        android:src="@{viewModel.subtopic.subtopicThumbnail.thumbnailGraphic}"
+        app:layout_constraintDimensionRatio="H,4:3"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+      <TextView
+        android:id="@+id/subtopic_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/oppiaBrownDark"
+        android:ellipsize="end"
+        android:fontFamily="sans-serif"
+        android:textStyle="bold"
+        android:maxLines="3"
+        android:minLines="3"
+        android:paddingStart="8dp"
+        android:paddingTop="8dp"
+        android:paddingEnd="8dp"
+        android:paddingBottom="16dp"
+        android:text="@{viewModel.subtopic.title}"
+        android:textColor="@color/white"
+        android:textSize="14sp"
+        app:layout_constraintTop_toBottomOf="@id/subtopic_image_view" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+  </com.google.android.material.card.MaterialCardView>
+</layout>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->
## Note
This PR only fixes part of its issue because it only adds `xml` files. The `span_count` value will be updated in another PR that will fix the span count for both `landscape` and `portrait` modes.  
That `span_count` PR will also contain `RobolectricTests` for the `span_count` in the whole `TopicRevisionFragment`
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
- Fixes part of #1168 
- Implemented low-fi UI for **Topic-Revision** for tablet - portrait mode
## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
