### PR TITLE
Fixes part of #1460: Shift test topics to json files

### DIFF
--- a/app/src/main/java/org/oppia/app/player/state/testing/StateFragmentTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/state/testing/StateFragmentTestActivityPresenter.kt
@@ -10,7 +10,7 @@ import org.oppia.app.databinding.StateFragmentTestActivityBinding
 import org.oppia.app.player.state.StateFragment
 import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.exploration.ExplorationDataController
-import org.oppia.domain.exploration.TEST_EXPLORATION_ID_30
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_2
 import org.oppia.domain.topic.TEST_STORY_ID_0
 import org.oppia.domain.topic.TEST_TOPIC_ID_0
 import org.oppia.util.data.AsyncResult
@@ -41,7 +41,7 @@ class StateFragmentTestActivityPresenter @Inject constructor(
     val topicId = activity.intent.getStringExtra(TEST_ACTIVITY_TOPIC_ID_EXTRA) ?: TEST_TOPIC_ID_0
     val storyId = activity.intent.getStringExtra(TEST_ACTIVITY_STORY_ID_EXTRA) ?: TEST_STORY_ID_0
     val explorationId =
-      activity.intent.getStringExtra(TEST_ACTIVITY_EXPLORATION_ID_EXTRA) ?: TEST_EXPLORATION_ID_30
+      activity.intent.getStringExtra(TEST_ACTIVITY_EXPLORATION_ID_EXTRA) ?: TEST_EXPLORATION_ID_2
     activity.findViewById<Button>(R.id.play_test_exploration_button)?.setOnClickListener {
       startPlayingExploration(profileId, topicId, storyId, explorationId)
     }

--- a/app/src/main/java/org/oppia/app/testing/ExplorationTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/testing/ExplorationTestActivityPresenter.kt
@@ -7,7 +7,7 @@ import org.oppia.app.R
 import org.oppia.app.activity.ActivityScope
 import org.oppia.app.home.RouteToExplorationListener
 import org.oppia.domain.exploration.ExplorationDataController
-import org.oppia.domain.exploration.TEST_EXPLORATION_ID_5
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_2
 import org.oppia.domain.topic.TEST_STORY_ID_0
 import org.oppia.domain.topic.TEST_TOPIC_ID_0
 import org.oppia.util.data.AsyncResult
@@ -17,7 +17,7 @@ import javax.inject.Inject
 private const val INTERNAL_PROFILE_ID = 0
 private const val TOPIC_ID = TEST_TOPIC_ID_0
 private const val STORY_ID = TEST_STORY_ID_0
-private const val EXPLORATION_ID = TEST_EXPLORATION_ID_5
+private const val EXPLORATION_ID = TEST_EXPLORATION_ID_2
 private const val TAG_EXPLORATION_TEST_ACTIVITY = "ExplorationTestActivity"
 
 /** The presenter for [ExplorationTestActivityPresenter]. */

--- a/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
@@ -378,7 +378,7 @@ class HomeActivityTest {
       )
       onView(atPositionOnView(R.id.home_recycler_view, 3, R.id.topic_name_text_view)).check(
         matches(
-          withText(containsString("First Topic"))
+          withText(containsString("First Test Topic"))
         )
       )
     }
@@ -411,7 +411,7 @@ class HomeActivityTest {
       )
       onView(atPositionOnView(R.id.home_recycler_view, 4, R.id.topic_name_text_view)).check(
         matches(
-          withText(containsString("Second Topic"))
+          withText(containsString("Second Test Topic"))
         )
       )
     }

--- a/app/src/sharedTest/java/org/oppia/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/exploration/ExplorationActivityTest.kt
@@ -54,13 +54,13 @@ import org.oppia.app.testing.ExplorationInjectionActivity
 import org.oppia.app.utility.EspressoTestsMatchers.withDrawable
 import org.oppia.app.utility.OrientationChangeAction.Companion.orientationLandscape
 import org.oppia.domain.exploration.ExplorationDataController
-import org.oppia.domain.exploration.TEST_EXPLORATION_ID_30
 import org.oppia.domain.topic.FRACTIONS_EXPLORATION_ID_0
 import org.oppia.domain.topic.FRACTIONS_STORY_ID_0
 import org.oppia.domain.topic.FRACTIONS_TOPIC_ID
 import org.oppia.domain.topic.RATIOS_EXPLORATION_ID_0
 import org.oppia.domain.topic.RATIOS_STORY_ID_0
 import org.oppia.domain.topic.RATIOS_TOPIC_ID
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_2
 import org.oppia.domain.topic.TEST_STORY_ID_0
 import org.oppia.domain.topic.TEST_TOPIC_ID_0
 import org.oppia.util.networking.NetworkConnectionUtil
@@ -114,13 +114,13 @@ class ExplorationActivityTest {
 
   @Test
   fun testExploration_toolbarTitle_isDisplayedSuccessfully() {
-    getApplicationDependencies(TEST_EXPLORATION_ID_30)
+    getApplicationDependencies(TEST_EXPLORATION_ID_2)
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
         internalProfileId,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
-        TEST_EXPLORATION_ID_30
+        TEST_EXPLORATION_ID_2
       )
     ).use {
       waitForTheView(withText("Prototype Exploration"))
@@ -132,13 +132,13 @@ class ExplorationActivityTest {
 
   @Test
   fun testExploration_configurationChange_toolbarTitle_isDisplayedSuccessfully() {
-    getApplicationDependencies(TEST_EXPLORATION_ID_30)
+    getApplicationDependencies(TEST_EXPLORATION_ID_2)
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
         internalProfileId,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
-        TEST_EXPLORATION_ID_30
+        TEST_EXPLORATION_ID_2
       )
     ).use {
       onView(isRoot()).perform(orientationLandscape())
@@ -151,13 +151,13 @@ class ExplorationActivityTest {
 
   @Test
   fun testAudioWithNoVoiceover_openPrototypeExploration_checkAudioButtonIsHidden() {
-    getApplicationDependencies(TEST_EXPLORATION_ID_30)
+    getApplicationDependencies(TEST_EXPLORATION_ID_2)
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
         internalProfileId,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
-        TEST_EXPLORATION_ID_30
+        TEST_EXPLORATION_ID_2
       )
     ).use {
       onView(withId(R.id.action_audio_player)).check(matches(not(isDisplayed())))
@@ -167,13 +167,13 @@ class ExplorationActivityTest {
 
   @Test
   fun testAudioWithNoVoiceover_openPrototypeExploration_configurationChange_checkAudioButtonIsHidden() { // ktlint-disable max-line-length
-    getApplicationDependencies(TEST_EXPLORATION_ID_30)
+    getApplicationDependencies(TEST_EXPLORATION_ID_2)
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
         internalProfileId,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
-        TEST_EXPLORATION_ID_30
+        TEST_EXPLORATION_ID_2
       )
     ).use {
       onView(isRoot()).perform(orientationLandscape())

--- a/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
@@ -55,10 +55,10 @@ import org.oppia.app.utility.CustomGeneralLocation
 import org.oppia.app.utility.DragViewAction
 import org.oppia.app.utility.OrientationChangeAction.Companion.orientationLandscape
 import org.oppia.app.utility.RecyclerViewCoordinatesProvider
-import org.oppia.domain.exploration.TEST_EXPLORATION_ID_30
-import org.oppia.domain.exploration.TEST_EXPLORATION_ID_5
-import org.oppia.domain.exploration.TEST_EXPLORATION_ID_8
 import org.oppia.domain.profile.ProfileTestHelper
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_0
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_2
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_4
 import org.oppia.domain.topic.TEST_STORY_ID_0
 import org.oppia.domain.topic.TEST_TOPIC_ID_0
 import org.oppia.testing.TestLogReportingModule
@@ -116,7 +116,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_explorationLoads() {
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       // Due to the exploration activity loading, the play button should no longer be visible.
       onView(withId(R.id.play_test_exploration_button)).check(matches(not(isDisplayed())))
@@ -125,7 +125,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_explorationLoads_changeConfiguration_buttonIsNotVisible() {
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(isRoot()).perform(orientationLandscape())
       // Due to the exploration activity loading, the play button should no longer be visible.
@@ -135,7 +135,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_explorationHasContinueButton() {
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(withId(R.id.continue_button)).check(matches(isDisplayed()))
     }
@@ -143,7 +143,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_changeConfiguration_explorationHasContinueButton() {
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.continue_button)).check(matches(isDisplayed()))
@@ -152,7 +152,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_secondState_hasSubmitButton() {
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(withId(R.id.continue_button)).perform(click())
       onView(withId(R.id.submit_answer_button)).check(
@@ -164,7 +164,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_changeConfiguration_secondState_hasSubmitButton() {
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.continue_button)).perform(click())
@@ -177,7 +177,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_secondState_submitAnswer_submitChangesToContinueButton() {
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(withId(R.id.continue_button)).perform(click())
       onView(withId(R.id.fraction_input_interaction_view)).perform(
@@ -195,7 +195,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_changeConfiguration_secondState_submitAnswer_submitChangesToContinueButton() { // ktlint-disable max-line-length
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.state_recycler_view)).perform(scrollToPosition<RecyclerView.ViewHolder>(1))
@@ -214,7 +214,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_secondState_submitInvalidAnswer_disablesSubmitAndShowsError() {
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(withId(R.id.continue_button)).perform(click())
 
@@ -233,7 +233,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_changeConfiguration_secondState_submitInvalidAnswer_disablesSubmitAndShowsError() { // ktlint-disable max-line-length
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.continue_button)).perform(click())
@@ -255,7 +255,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_secondState_invalidAnswer_updated_reenabledSubmitButton() {
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(withId(R.id.continue_button)).perform(click())
       onView(withId(R.id.fraction_input_interaction_view)).perform(
@@ -279,7 +279,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_changeConfiguration_secondState_invalidAnswer_updated_reenabledSubmitButton() { // ktlint-disable max-line-length
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.continue_button)).perform(click())
@@ -303,7 +303,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_firstState_previousAndNextButtonIsNotDisplayed() {
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
 
       onView(withId(R.id.previous_state_navigation_button)).check(matches(not(isDisplayed())))
@@ -313,7 +313,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadDragDropExp_mergeFirstTwoItems_worksCorrectly() {
-    launchForExploration(TEST_EXPLORATION_ID_8).use {
+    launchForExploration(TEST_EXPLORATION_ID_4).use {
       startPlayingExploration()
 
       onView(
@@ -335,7 +335,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadDragDropExp_mergeFirstTwoItems_invalidAnswer_correctItemCount() {
-    launchForExploration(TEST_EXPLORATION_ID_8).use {
+    launchForExploration(TEST_EXPLORATION_ID_4).use {
       startPlayingExploration()
 
       onView(
@@ -359,7 +359,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadDragDropExp_mergeFirstTwoItems_dragItem_worksCorrectly() {
-    launchForExploration(TEST_EXPLORATION_ID_8).use {
+    launchForExploration(TEST_EXPLORATION_ID_4).use {
       startPlayingExploration()
 
       onView(
@@ -394,7 +394,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadDragDropExp_mergeFirstTwoItems_unlinkFirstItem_worksCorrectly() {
-    launchForExploration(TEST_EXPLORATION_ID_8).use {
+    launchForExploration(TEST_EXPLORATION_ID_4).use {
       startPlayingExploration()
 
       onView(
@@ -423,7 +423,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_changeConfiguration_firstState_previousAndNextButtonIsNotDisplayed() { // ktlint-disable max-line-length
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.previous_state_navigation_button)).check(matches(not(isDisplayed())))
@@ -433,7 +433,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_submitAnswer_clickContinueButton_previousButtonIsDisplayed() {
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
 
       onView(withId(R.id.continue_button)).perform(click())
@@ -445,7 +445,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_changeConfiguration_submitAnswer_clickContinueButton_previousButtonIsDisplayed() { // ktlint-disable max-line-length
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.continue_button)).perform(click())
@@ -457,7 +457,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_submitAnswer_clickContinueThenPrevious_onlyNextButtonIsShown() {
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(withId(R.id.continue_button)).perform(click())
 
@@ -472,7 +472,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_changeConfiguration_submitAnswer_clickContinueThenPrevious_onlyNextButtonIsShown() { // ktlint-disable max-line-length
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.continue_button)).perform(click())
@@ -488,7 +488,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_submitAnswer_clickContinueThenPreviousThenNext_prevAndSubmitShown() { // ktlint-disable max-line-length
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(withId(R.id.continue_button)).perform(click())
 
@@ -505,7 +505,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_changeConfiguration_submitAnswer_clickContinueThenPreviousThenNext_prevAndSubmitShown() { // ktlint-disable max-line-length
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       onView(withId(R.id.continue_button)).perform(click())
 
@@ -522,7 +522,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_continueToEndExploration_hasReturnToTopicButton() {
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
 
       playThroughPrototypeExploration()
@@ -536,7 +536,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_changeConfiguration_continueToEndExploration_hasReturnToTopicButton() { // ktlint-disable max-line-length
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
 
       playThroughPrototypeExploration()
@@ -550,7 +550,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_continueToEndExploration_clickReturnToTopic_destroysActivity() {
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       playThroughPrototypeExploration()
 
@@ -563,7 +563,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadExp_changeConfiguration_continueToEndExploration_clickReturnToTopic_destroysActivity() { // ktlint-disable max-line-length
-    launchForExploration(TEST_EXPLORATION_ID_30).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       playThroughPrototypeExploration()
 
@@ -576,7 +576,7 @@ class StateFragmentTest {
 
   @Test
   fun testContentCard_forDemoExploration_withCustomOppiaTags_displaysParsedHtml() {
-    launchForExploration(TEST_EXPLORATION_ID_5).use {
+    launchForExploration(TEST_EXPLORATION_ID_0).use {
       startPlayingExploration()
 
       val htmlResult =
@@ -593,7 +593,7 @@ class StateFragmentTest {
 
   @Test
   fun testContentCard_forDemoExploration_changeConfiguration_withCustomOppiaTags_displaysParsedHtml() { // ktlint-disable max-line-length
-    launchForExploration(TEST_EXPLORATION_ID_5).use {
+    launchForExploration(TEST_EXPLORATION_ID_0).use {
       startPlayingExploration()
 
       val htmlResult =

--- a/app/src/test/java/org/oppia/app/player/exploration/ExplorationActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/app/player/exploration/ExplorationActivityLocalTest.kt
@@ -32,8 +32,8 @@ import org.oppia.domain.classify.rules.numberwithunits.NumberWithUnitsRuleModule
 import org.oppia.domain.classify.rules.numericinput.NumericInputRuleModule
 import org.oppia.domain.classify.rules.textinput.TextInputRuleModule
 import org.oppia.domain.exploration.ExplorationDataController
-import org.oppia.domain.exploration.TEST_EXPLORATION_ID_30
 import org.oppia.domain.question.QuestionModule
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_2
 import org.oppia.domain.topic.TEST_STORY_ID_0
 import org.oppia.domain.topic.TEST_TOPIC_ID_0
 import org.oppia.testing.FakeEventLogger
@@ -77,13 +77,13 @@ class ExplorationActivityLocalTest {
 
   @Test
   fun testExploration_onLaunch_logsEvent() {
-    getApplicationDependencies(TEST_EXPLORATION_ID_30)
+    getApplicationDependencies(TEST_EXPLORATION_ID_2)
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
         internalProfileId,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
-        TEST_EXPLORATION_ID_30
+        TEST_EXPLORATION_ID_2
       )
     ).use {
 
@@ -92,7 +92,7 @@ class ExplorationActivityLocalTest {
       assertThat(event.context.activityContextCase).isEqualTo(EXPLORATION_CONTEXT)
       assertThat(event.actionName).isEqualTo(EventLog.EventAction.OPEN_EXPLORATION_ACTIVITY)
       assertThat(event.priority).isEqualTo(EventLog.Priority.ESSENTIAL)
-      assertThat(event.context.explorationContext.explorationId).matches(TEST_EXPLORATION_ID_30)
+      assertThat(event.context.explorationContext.explorationId).matches(TEST_EXPLORATION_ID_2)
       assertThat(event.context.explorationContext.topicId).matches(TEST_TOPIC_ID_0)
       assertThat(event.context.explorationContext.storyId).matches(TEST_STORY_ID_0)
     }

--- a/app/src/test/java/org/oppia/app/testing/player/state/StateFragmentAccessibilityTest.kt
+++ b/app/src/test/java/org/oppia/app/testing/player/state/StateFragmentAccessibilityTest.kt
@@ -40,9 +40,9 @@ import org.oppia.domain.classify.rules.multiplechoiceinput.MultipleChoiceInputMo
 import org.oppia.domain.classify.rules.numberwithunits.NumberWithUnitsRuleModule
 import org.oppia.domain.classify.rules.numericinput.NumericInputRuleModule
 import org.oppia.domain.classify.rules.textinput.TextInputRuleModule
-import org.oppia.domain.exploration.TEST_EXPLORATION_ID_8
 import org.oppia.domain.profile.ProfileTestHelper
 import org.oppia.domain.question.QuestionModule
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_4
 import org.oppia.domain.topic.TEST_STORY_ID_0
 import org.oppia.domain.topic.TEST_TOPIC_ID_0
 import org.oppia.testing.TestAccessibilityModule
@@ -88,7 +88,7 @@ class StateFragmentAccessibilityTest {
   @InternalCoroutinesApi
   @ExperimentalCoroutinesApi
   fun testStateFragment_loadDragDropExp_moveDownWithAccessibility() {
-    launchForExploration(TEST_EXPLORATION_ID_8).use {
+    launchForExploration(TEST_EXPLORATION_ID_4).use {
       startPlayingExploration()
       onView(
         RecyclerViewMatcher.atPositionOnView(
@@ -111,7 +111,7 @@ class StateFragmentAccessibilityTest {
   @InternalCoroutinesApi
   @ExperimentalCoroutinesApi
   fun testStateFragment_loadDragDropExp_moveUpWithAccessibility() {
-    launchForExploration(TEST_EXPLORATION_ID_8).use {
+    launchForExploration(TEST_EXPLORATION_ID_4).use {
       startPlayingExploration()
       onView(
         RecyclerViewMatcher.atPositionOnView(

--- a/domain/src/main/assets/test_exp_id_0.json
+++ b/domain/src/main/assets/test_exp_id_0.json
@@ -1,5 +1,5 @@
 {
-  "exploration_id": "0",
+  "exploration_id": "test_exp_id_0",
   "author_notes": "",
   "blurb": "",
   "category": "Welcome",

--- a/domain/src/main/assets/test_exp_id_1.json
+++ b/domain/src/main/assets/test_exp_id_1.json
@@ -1,5 +1,5 @@
 {
-  "exploration_id": "1",
+  "exploration_id": "test_exp_id_1",
   "author_notes": "",
   "blurb": "",
   "category": "Welcome",

--- a/domain/src/main/assets/test_exp_id_2.json
+++ b/domain/src/main/assets/test_exp_id_2.json
@@ -1,5 +1,5 @@
 {
-  "exploration_id": "2",
+  "exploration_id": "test_exp_id_2",
   "language_code": "en",
   "param_specs": {},
   "param_changes": [],

--- a/domain/src/main/assets/test_exp_id_3.json
+++ b/domain/src/main/assets/test_exp_id_3.json
@@ -1,5 +1,5 @@
 {
-  "exploration_id": "3",
+  "exploration_id": "test_exp_id_3",
   "author_notes": "",
   "blurb": "",
   "category": "Welcome",

--- a/domain/src/main/assets/test_exp_id_4.json
+++ b/domain/src/main/assets/test_exp_id_4.json
@@ -1,6 +1,6 @@
 {
   "correctness_feedback_enabled": false,
-  "exploration_id": "drag_and_drop_test_exploration",
+  "exploration_id": "test_exp_id_4",
   "states": {
     "End": {
       "param_changes": [],

--- a/domain/src/main/assets/test_story_id_0.json
+++ b/domain/src/main/assets/test_story_id_0.json
@@ -1,0 +1,26 @@
+{
+  "story_nodes": [
+    {
+      "description": "Learning about oppia app in First Story",
+      "exploration_id": "test_exp_id_2",
+      "destination_node_ids": [],
+      "thumbnail_filename": "",
+      "outline_is_finalized": false,
+      "id": "node_1",
+      "prerequisite_skill_ids": [],
+      "thumbnail_bg_color": "#D68F78",
+      "exp_summary_dict": {
+        "thumbnail_bg_color": "#d68453",
+        "title": "Prototype Exploration inner",
+        "language_code": "en",
+        "objective": "Learn about oppia app via testing.",
+        "id": "test_exp_id_2"
+      },
+      "outline": "",
+      "title": "Prototype Exploration",
+      "acquired_skill_ids": []
+    }
+  ],
+  "story_description": "",
+  "story_title": "First Story"
+}

--- a/domain/src/main/assets/test_story_id_1.json
+++ b/domain/src/main/assets/test_story_id_1.json
@@ -1,0 +1,70 @@
+{
+  "story_nodes": [
+    {
+      "description": "Learning about oppia app in Second Story.",
+      "exploration_id": "test_exp_id_1",
+      "destination_node_ids": [
+        "node_2"
+      ],
+      "thumbnail_filename": "",
+      "outline_is_finalized": false,
+      "id": "node_1",
+      "prerequisite_skill_ids": [],
+      "thumbnail_bg_color": "#D68F78",
+      "exp_summary_dict": {
+        "thumbnail_bg_color": "#d68453",
+        "title": "Second Exploration inner",
+        "language_code": "en",
+        "objective": "Learn about oppia app via testing in second exploration.",
+        "id": "test_exp_id_1"
+      },
+      "outline": "",
+      "title": "Second Exploration",
+      "acquired_skill_ids": []
+    },
+    {
+      "description": "Learning about oppia app in Second Story",
+      "exploration_id": "test_exp_id_0",
+      "destination_node_ids": [
+        "node_3"
+      ],
+      "thumbnail_filename": "",
+      "outline_is_finalized": false,
+      "id": "node_2",
+      "prerequisite_skill_ids": [],
+      "thumbnail_bg_color": "#D68F78",
+      "exp_summary_dict": {
+        "thumbnail_bg_color": "#d68453",
+        "title": "Third Exploration inner",
+        "language_code": "en",
+        "objective": "Learn about oppia app via testing in third exploration.",
+        "id": "test_exp_id_0"
+      },
+      "outline": "",
+      "title": "Third Exploration",
+      "acquired_skill_ids": []
+    },
+    {
+      "description": "Learning about oppia app in Second Story",
+      "exploration_id": "test_exp_id_3",
+      "destination_node_ids": [],
+      "thumbnail_filename": "",
+      "outline_is_finalized": false,
+      "id": "node_3",
+      "prerequisite_skill_ids": [],
+      "thumbnail_bg_color": "#D68F78",
+      "exp_summary_dict": {
+        "thumbnail_bg_color": "#d68453",
+        "title": "Fourth Exploration inner",
+        "language_code": "en",
+        "objective": "Learn about oppia app via testing in fourth exploration",
+        "id": "test_exp_id_3"
+      },
+      "outline": "",
+      "title": "Fourth Exploration",
+      "acquired_skill_ids": []
+    }
+  ],
+  "story_description": "",
+  "story_title": "Second Story"
+}

--- a/domain/src/main/assets/test_story_id_2.json
+++ b/domain/src/main/assets/test_story_id_2.json
@@ -1,0 +1,26 @@
+{
+  "story_nodes": [
+    {
+      "description": "Learning about oppia app in Other Interesting Story",
+      "exploration_id": "test_exp_id_4",
+      "destination_node_ids": [],
+      "thumbnail_filename": "",
+      "outline_is_finalized": false,
+      "id": "node_1",
+      "prerequisite_skill_ids": [],
+      "thumbnail_bg_color": "#D68F78",
+      "exp_summary_dict": {
+        "thumbnail_bg_color": "#d68453",
+        "title": "Fifth Exploration inner",
+        "language_code": "en",
+        "objective": "Learn about oppia app via testing in fifth exploration.",
+        "id": "test_exp_id_4"
+      },
+      "outline": "",
+      "title": "Fifth Exploration",
+      "acquired_skill_ids": []
+    }
+  ],
+  "story_description": "",
+  "story_title": "Other Interesting Story"
+}

--- a/domain/src/main/assets/test_topic_id_0.json
+++ b/domain/src/main/assets/test_topic_id_0.json
@@ -1,0 +1,41 @@
+{
+  "canonical_story_dicts": [
+    {
+      "thumbnail_bg_color": "#B378F1",
+      "description": "",
+      "title": "First Story",
+      "node_titles": [
+        "Prototype Exploration"
+      ],
+      "thumbnail_filename": "",
+      "published": true,
+      "id": "test_story_id_0"
+    },
+    {
+      "thumbnail_bg_color": "#78B3F1",
+      "description": "",
+      "title": "Second Story",
+      "node_titles": [
+        "Second Exploration",
+        "Third Exploration",
+        "Fourth Exploration"
+      ],
+      "thumbnail_filename": "",
+      "published": true,
+      "id": "test_story_id_1"
+    }
+  ],
+  "uncategorized_skill_ids": [],
+  "additional_story_dicts": [],
+  "topic_description": "A topic investigating the interesting aspects of the Oppia Android app.",
+  "topic_name": "First Test Topic",
+  "topic_id": "test_topic_id_0",
+  "version": 1,
+  "skill_descriptions": {
+    "test_skill_id_0": "An important skill",
+    "test_skill_id_1": "Another important skill",
+    "test_skill_id_2": "A different skill in a different topic Another important skill",
+    "test_skill_id_3": "Another important skill 4"
+  },
+  "subtopics": []
+}

--- a/domain/src/main/assets/test_topic_id_1.json
+++ b/domain/src/main/assets/test_topic_id_1.json
@@ -1,0 +1,26 @@
+{
+  "canonical_story_dicts": [
+    {
+      "thumbnail_bg_color": "#B378F1",
+      "description": "",
+      "title": "Other Interesting Story",
+      "node_titles": [
+        "Fifth Exploration"
+      ],
+      "thumbnail_filename": "",
+      "published": true,
+      "id": "test_story_id_2"
+    }
+  ],
+  "uncategorized_skill_ids": [],
+  "additional_story_dicts": [],
+  "topic_description": "A topic considering the various implications of having especially long topic descriptions. These descriptions almost certainly need to wrap, which should be interesting in the UI (especially on small screens). Consider also that there may even be multiple points pertaining to a topic, some of which may require expanding the description section in order to read the whole topic description.",
+  "topic_name": "Second Test Topic",
+  "topic_id": "test_topic_id_1",
+  "version": 3,
+  "skill_descriptions": {
+    "test_skill_id_0": "An important skill",
+    "test_skill_id_1": "Another important skill"
+  },
+  "subtopics": []
+}

--- a/domain/src/main/java/org/oppia/domain/exploration/ExplorationRetriever.kt
+++ b/domain/src/main/java/org/oppia/domain/exploration/ExplorationRetriever.kt
@@ -9,17 +9,16 @@ import org.oppia.domain.topic.RATIOS_EXPLORATION_ID_0
 import org.oppia.domain.topic.RATIOS_EXPLORATION_ID_1
 import org.oppia.domain.topic.RATIOS_EXPLORATION_ID_2
 import org.oppia.domain.topic.RATIOS_EXPLORATION_ID_3
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_0
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_1
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_2
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_3
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_4
 import org.oppia.domain.util.JsonAssetRetriever
 import org.oppia.domain.util.StateRetriever
 import org.oppia.util.logging.ExceptionLogger
 import java.io.IOException
 import javax.inject.Inject
-
-const val TEST_EXPLORATION_ID_5 = "0"
-const val TEST_EXPLORATION_ID_6 = "1"
-const val TEST_EXPLORATION_ID_30 = "2"
-const val TEST_EXPLORATION_ID_7 = "3"
-const val TEST_EXPLORATION_ID_8 = "4"
 
 // TODO(#59): Make this class inaccessible outside of the domain package except for tests. UI code should not be allowed
 //  to depend on this utility.
@@ -34,11 +33,11 @@ class ExplorationRetriever @Inject constructor(
   /** Loads and returns an exploration for the specified exploration ID, or fails. */
   internal fun loadExploration(explorationId: String): Exploration {
     return when (explorationId) {
-      TEST_EXPLORATION_ID_5 -> loadExplorationFromAsset("welcome.json")
-      TEST_EXPLORATION_ID_6 -> loadExplorationFromAsset("about_oppia.json")
-      TEST_EXPLORATION_ID_30 -> loadExplorationFromAsset("prototype_exploration.json")
-      TEST_EXPLORATION_ID_7 -> loadExplorationFromAsset("oppia_exploration.json")
-      TEST_EXPLORATION_ID_8 -> loadExplorationFromAsset("drag_and_drop_test_exploration.json")
+      TEST_EXPLORATION_ID_0 -> loadExplorationFromAsset("test_exp_id_0.json")
+      TEST_EXPLORATION_ID_1 -> loadExplorationFromAsset("test_exp_id_1.json")
+      TEST_EXPLORATION_ID_2 -> loadExplorationFromAsset("test_exp_id_2.json")
+      TEST_EXPLORATION_ID_3 -> loadExplorationFromAsset("test_exp_id_3.json")
+      TEST_EXPLORATION_ID_4 -> loadExplorationFromAsset("test_exp_id_4.json")
       FRACTIONS_EXPLORATION_ID_0 -> loadExplorationFromAsset("fractions_exploration0.json")
       FRACTIONS_EXPLORATION_ID_1 -> loadExplorationFromAsset("fractions_exploration1.json")
       RATIOS_EXPLORATION_ID_0 -> loadExplorationFromAsset("ratios_exploration0.json")

--- a/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
@@ -418,11 +418,11 @@ class TopicController @Inject constructor(
 
   // TODO(#21): Expose this as a data provider, or omit if it's not needed.
   internal fun retrieveTopic(topicId: String): Topic {
-    return createTopicFromJson("$topicId.json")
+    return createTopicFromJson(topicId)
   }
 
   internal fun retrieveStory(storyId: String): StorySummary {
-    return createStorySummaryFromJsonFile(storyId)
+    return createStorySummaryFromJson(storyId)
   }
 
   // TODO(#45): Expose this as a data provider, or omit if it's not needed.
@@ -615,15 +615,14 @@ class TopicController @Inject constructor(
    * Creates topic from its json representation. The json file is expected to have
    * a key called 'topic' that holds the topic data.
    */
-  private fun createTopicFromJson(topicFileName: String): Topic {
-    val topicData = jsonAssetRetriever.loadJsonFromAsset(topicFileName)!!
+  private fun createTopicFromJson(topicId: String): Topic {
+    val topicData = jsonAssetRetriever.loadJsonFromAsset("$topicId.json")!!
     val subtopicList: List<Subtopic> =
       createSubtopicListFromJsonArray(topicData.optJSONArray("subtopics"))
     val skillSummaryList: List<SkillSummary> =
       createSkillSummaryListFromJsonObject(topicData.optJSONObject("skill_descriptions"))
     val storySummaryList: List<StorySummary> =
       createStorySummaryListFromJsonArray(topicData.optJSONArray("canonical_story_dicts"))
-    val topicId = topicData.getString("topic_id")
     return Topic.newBuilder()
       .setTopicId(topicId)
       .setName(topicData.getString("topic_name"))
@@ -736,14 +735,14 @@ class TopicController @Inject constructor(
     for (i in 0 until storySummaryJsonArray!!.length()) {
       val currentStorySummaryJsonObject = storySummaryJsonArray.optJSONObject(i)
       val storySummary: StorySummary =
-        createStorySummaryFromJsonFile(currentStorySummaryJsonObject.optString("id"))
+        createStorySummaryFromJson(currentStorySummaryJsonObject.optString("id"))
       storySummaryList.add(storySummary)
     }
     return storySummaryList
   }
 
   /** Creates a list of [StorySummary]s for topic given its json representation and the index of the story in json. */
-  private fun createStorySummaryFromJsonFile(storyId: String): StorySummary {
+  private fun createStorySummaryFromJson(storyId: String): StorySummary {
     val storyDataJsonObject = jsonAssetRetriever.loadJsonFromAsset("$storyId.json")
     return StorySummary.newBuilder()
       .setStoryId(storyId)

--- a/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
@@ -27,7 +27,6 @@ import org.oppia.app.model.Translation
 import org.oppia.app.model.TranslationMapping
 import org.oppia.app.model.Voiceover
 import org.oppia.app.model.VoiceoverMapping
-import org.oppia.domain.exploration.TEST_EXPLORATION_ID_30
 import org.oppia.domain.util.JsonAssetRetriever
 import org.oppia.domain.util.StateRetriever
 import org.oppia.util.data.AsyncResult
@@ -69,6 +68,20 @@ const val FRACTIONS_QUESTION_ID_9 = "YQwbX2r6p3Xj"
 const val FRACTIONS_QUESTION_ID_10 = "NNuVGmbJpnj5"
 const val RATIOS_QUESTION_ID_0 = "QiKxvAXpvUbb"
 val TOPIC_FILE_ASSOCIATIONS = mapOf(
+  TEST_TOPIC_ID_0 to listOf(
+    "test_exp_id_0.json",
+    "test_exp_id_1.json",
+    "test_exp_id_2.json",
+    "test_exp_id_3.json",
+    "test_story_id_0.json",
+    "test_story_id_1.json",
+    "test_topic_id_0.json"
+  ),
+  TEST_TOPIC_ID_1 to listOf(
+    "test_exp_id_4.json",
+    "test_story_id_2.json",
+    "test_topic_id_1.json"
+  ),
   FRACTIONS_TOPIC_ID to listOf(
     "fractions_exploration0.json",
     "fractions_exploration1.json",
@@ -405,29 +418,11 @@ class TopicController @Inject constructor(
 
   // TODO(#21): Expose this as a data provider, or omit if it's not needed.
   internal fun retrieveTopic(topicId: String): Topic {
-    return when (topicId) {
-      TEST_TOPIC_ID_0 -> createTestTopic0()
-      TEST_TOPIC_ID_1 -> createTestTopic1()
-      FRACTIONS_TOPIC_ID -> createTopicFromJson(
-        "GJ2rLXRKD5hw.json"
-      )
-      RATIOS_TOPIC_ID -> createTopicFromJson(
-        "omzF4oqgeTXd.json"
-      )
-      else -> throw IllegalArgumentException("Invalid topic ID: $topicId")
-    }
+    return createTopicFromJson("$topicId.json")
   }
 
   internal fun retrieveStory(storyId: String): StorySummary {
-    return when (storyId) {
-      TEST_STORY_ID_0 -> createTestTopic0Story0()
-      TEST_STORY_ID_1 -> createTestTopic0Story1()
-      TEST_STORY_ID_2 -> createTestTopic1Story2()
-      FRACTIONS_STORY_ID_0 -> createStorySummaryFromJsonFile(storyId)
-      RATIOS_STORY_ID_0 -> createStorySummaryFromJsonFile(storyId)
-      RATIOS_STORY_ID_1 -> createStorySummaryFromJsonFile(storyId)
-      else -> throw IllegalArgumentException("Invalid story ID: $storyId")
-    }
+    return createStorySummaryFromJsonFile(storyId)
   }
 
   // TODO(#45): Expose this as a data provider, or omit if it's not needed.
@@ -616,39 +611,6 @@ class TopicController @Inject constructor(
       .build()
   }
 
-  private fun createTestTopic0(): Topic {
-    return Topic.newBuilder()
-      .setTopicId(TEST_TOPIC_ID_0)
-      .setName("First Test Topic")
-      .setDescription("A topic investigating the interesting aspects of the Oppia Android app.")
-      .addStory(createTestTopic0Story0())
-      .addSkill(createTestTopic0Skill0())
-      .addStory(createTestTopic0Story1())
-      .addSkill(createTestTopic0Skill1())
-      .addSkill(createTestTopic0Skill2())
-      .addSkill(createTestTopic0Skill3())
-      .setTopicThumbnail(createTopicThumbnail0())
-      .build()
-  }
-
-  private fun createTestTopic1(): Topic {
-    return Topic.newBuilder()
-      .setTopicId(TEST_TOPIC_ID_1)
-      .setName("Second Test Topic")
-      .setDescription(
-        "A topic considering the various implications of having especially long " +
-          "topic descriptions. These descriptions almost certainly need to wrap, which " +
-          "should be interesting in the UI (especially on small screens). " +
-          "Consider also that there may even be multiple points pertaining to a topic, " +
-          "some of which may require expanding the description section in order " +
-          "to read the whole topic description."
-      )
-      .addStory(createTestTopic1Story2())
-      .addSkill(createTestTopic1Skill0())
-      .setTopicThumbnail(createTopicThumbnail1())
-      .build()
-  }
-
   /**
    * Creates topic from its json representation. The json file is expected to have
    * a key called 'topic' that holds the topic data.
@@ -702,7 +664,6 @@ class TopicController @Inject constructor(
    */
   private fun createSubtopicListFromJsonArray(subtopicJsonArray: JSONArray?): List<Subtopic> {
     val subtopicList = mutableListOf<Subtopic>()
-
     for (i in 0 until subtopicJsonArray!!.length()) {
       val skillIdList = ArrayList<String>()
 
@@ -816,84 +777,6 @@ class TopicController @Inject constructor(
     return chapterList
   }
 
-  private fun createTestTopic0Story0(): StorySummary {
-    return StorySummary.newBuilder()
-      .setStoryId(TEST_STORY_ID_0)
-      .setStoryName("First Story")
-      .setStoryThumbnail(createStoryThumbnail0())
-      .addChapter(createTestTopic0Story0Chapter0())
-      .build()
-  }
-
-  private fun createTestTopic0Story0Chapter0(): ChapterSummary {
-    return ChapterSummary.newBuilder()
-      .setExplorationId(TEST_EXPLORATION_ID_30)
-      .setName("Prototype Exploration")
-      .setSummary("This is the prototype exploration to verify interaction functionality.")
-      .setChapterPlayState(ChapterPlayState.COMPLETION_STATUS_UNSPECIFIED)
-      .setChapterThumbnail(createChapterThumbnail0())
-      .build()
-  }
-
-  private fun createTestTopic0Story1(): StorySummary {
-    return StorySummary.newBuilder()
-      .setStoryId(TEST_STORY_ID_1)
-      .setStoryName("Second Story")
-      .setStoryThumbnail(createStoryThumbnail1())
-      .addChapter(createTestTopic0Story1Chapter0())
-      .addChapter(createTestTopic0Story1Chapter1())
-      .addChapter(createTestTopic0Story1Chapter2())
-      .build()
-  }
-
-  private fun createTestTopic0Story1Chapter0(): ChapterSummary {
-    return ChapterSummary.newBuilder()
-      .setExplorationId(TEST_EXPLORATION_ID_1)
-      .setName("Second Exploration")
-      .setSummary("This is the second exploration summary")
-      .setChapterPlayState(ChapterPlayState.COMPLETION_STATUS_UNSPECIFIED)
-      .setChapterThumbnail(createChapterThumbnail1())
-      .build()
-  }
-
-  private fun createTestTopic0Story1Chapter1(): ChapterSummary {
-    return ChapterSummary.newBuilder()
-      .setExplorationId(TEST_EXPLORATION_ID_2)
-      .setName("Third Exploration")
-      .setSummary("This is the third exploration summary")
-      .setChapterPlayState(ChapterPlayState.COMPLETION_STATUS_UNSPECIFIED)
-      .setChapterThumbnail(createChapterThumbnail2())
-      .build()
-  }
-
-  private fun createTestTopic0Story1Chapter2(): ChapterSummary {
-    return ChapterSummary.newBuilder()
-      .setExplorationId(TEST_EXPLORATION_ID_3)
-      .setName("Fourth Exploration")
-      .setSummary("This is the fourth exploration summary")
-      .setChapterPlayState(ChapterPlayState.COMPLETION_STATUS_UNSPECIFIED)
-      .setChapterThumbnail(createChapterThumbnail3())
-      .build()
-  }
-
-  private fun createTestTopic1Story2(): StorySummary {
-    return StorySummary.newBuilder()
-      .setStoryId(TEST_STORY_ID_2)
-      .setStoryName("Other Interesting Story")
-      .setStoryThumbnail(createStoryThumbnail1())
-      .addChapter(createTestTopic1Story2Chapter0())
-      .build()
-  }
-
-  private fun createTestTopic1Story2Chapter0(): ChapterSummary {
-    return ChapterSummary.newBuilder()
-      .setExplorationId(TEST_EXPLORATION_ID_4)
-      .setName("Fifth Exploration")
-      .setChapterPlayState(ChapterPlayState.COMPLETION_STATUS_UNSPECIFIED)
-      .setChapterThumbnail(createChapterThumbnail4())
-      .build()
-  }
-
   private fun createTestTopic0Skill0(): SkillSummary {
     return SkillSummary.newBuilder()
       .setSkillId(TEST_SKILL_ID_0)
@@ -903,22 +786,6 @@ class TopicController @Inject constructor(
   }
 
   private fun createTestTopic0Skill1(): SkillSummary {
-    return SkillSummary.newBuilder()
-      .setSkillId(TEST_SKILL_ID_1)
-      .setDescription("Another important skill")
-      .setSkillThumbnail(createSkillThumbnail(TEST_SKILL_ID_1))
-      .build()
-  }
-
-  private fun createTestTopic0Skill2(): SkillSummary {
-    return SkillSummary.newBuilder()
-      .setSkillId(TEST_SKILL_ID_1)
-      .setDescription("A different skill in a different topic Another important skill")
-      .setSkillThumbnail(createSkillThumbnail(TEST_SKILL_ID_1))
-      .build()
-  }
-
-  private fun createTestTopic0Skill3(): SkillSummary {
     return SkillSummary.newBuilder()
       .setSkillId(TEST_SKILL_ID_1)
       .setDescription("Another important skill")

--- a/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
@@ -44,7 +44,7 @@ import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.parser.DefaultGcsPrefix
 import org.oppia.util.parser.ImageDownloadUrlTemplate
 import org.oppia.util.threading.BackgroundDispatcher
-import java.util.*
+import java.util.Date
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
@@ -44,7 +44,7 @@ import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.parser.DefaultGcsPrefix
 import org.oppia.util.parser.ImageDownloadUrlTemplate
 import org.oppia.util.threading.BackgroundDispatcher
-import java.util.Date
+import java.util.*
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -60,12 +60,17 @@ const val SUBTOPIC_TOPIC_ID = "1"
 const val RATIOS_TOPIC_ID = "omzF4oqgeTXd"
 val TOPIC_THUMBNAILS = mapOf(
   FRACTIONS_TOPIC_ID to createTopicThumbnail0(),
-  RATIOS_TOPIC_ID to createTopicThumbnail1()
+  RATIOS_TOPIC_ID to createTopicThumbnail1(),
+  TEST_TOPIC_ID_0 to createTopicThumbnail2(),
+  TEST_TOPIC_ID_1 to createTopicThumbnail3()
 )
 val STORY_THUMBNAILS = mapOf(
   FRACTIONS_STORY_ID_0 to createStoryThumbnail0(),
   RATIOS_STORY_ID_0 to createStoryThumbnail1(),
-  RATIOS_STORY_ID_1 to createStoryThumbnail2()
+  RATIOS_STORY_ID_1 to createStoryThumbnail2(),
+  TEST_STORY_ID_0 to createStoryThumbnail3(),
+  TEST_STORY_ID_1 to createStoryThumbnail4(),
+  TEST_STORY_ID_2 to createStoryThumbnail5()
 )
 val EXPLORATION_THUMBNAILS = mapOf(
   FRACTIONS_EXPLORATION_ID_0 to createChapterThumbnail0(),
@@ -73,7 +78,12 @@ val EXPLORATION_THUMBNAILS = mapOf(
   RATIOS_EXPLORATION_ID_0 to createChapterThumbnail2(),
   RATIOS_EXPLORATION_ID_1 to createChapterThumbnail3(),
   RATIOS_EXPLORATION_ID_2 to createChapterThumbnail4(),
-  RATIOS_EXPLORATION_ID_3 to createChapterThumbnail5()
+  RATIOS_EXPLORATION_ID_3 to createChapterThumbnail5(),
+  TEST_EXPLORATION_ID_0 to createChapterThumbnail6(),
+  TEST_EXPLORATION_ID_1 to createChapterThumbnail7(),
+  TEST_EXPLORATION_ID_2 to createChapterThumbnail8(),
+  TEST_EXPLORATION_ID_3 to createChapterThumbnail9(),
+  TEST_EXPLORATION_ID_4 to createChapterThumbnail0()
 )
 
 private const val CUSTOM_IMG_TAG = "oppia-noninteractive-image"
@@ -181,23 +191,17 @@ class TopicListController @Inject constructor(
 
   private fun createTopicList(): TopicList {
     val topicListBuilder = TopicList.newBuilder()
-      .addTopicSummary(createTopicSummary0())
-      .addTopicSummary(createTopicSummary1())
-      .addTopicSummary(createFractionsTopicSummary())
-      .addTopicSummary(createRatiosTopicSummary())
+      .addTopicSummary(createTopicSummary(TEST_TOPIC_ID_0))
+      .addTopicSummary(createTopicSummary(TEST_TOPIC_ID_1))
+      .addTopicSummary(createTopicSummary(FRACTIONS_TOPIC_ID))
+      .addTopicSummary(createTopicSummary(RATIOS_TOPIC_ID))
     return topicListBuilder.build()
   }
 
-  private fun createFractionsTopicSummary(): TopicSummary {
+  private fun createTopicSummary(topicId: String): TopicSummary {
     val fractionsJson =
-      jsonAssetRetriever.loadJsonFromAsset("GJ2rLXRKD5hw.json")!!
-    return createTopicSummaryFromJson(FRACTIONS_TOPIC_ID, fractionsJson)
-  }
-
-  private fun createRatiosTopicSummary(): TopicSummary {
-    val ratiosJson =
-      jsonAssetRetriever.loadJsonFromAsset("omzF4oqgeTXd.json")!!
-    return createTopicSummaryFromJson(RATIOS_TOPIC_ID, ratiosJson)
+      jsonAssetRetriever.loadJsonFromAsset("$topicId.json")!!
+    return createTopicSummaryFromJson(topicId, fractionsJson)
   }
 
   private fun createTopicSummaryFromJson(topicId: String, jsonObject: JSONObject): TopicSummary {
@@ -229,36 +233,6 @@ class TopicListController @Inject constructor(
       .setTotalSkillCount(jsonObject.getJSONObject("skill_descriptions").length())
       .setTotalChapterCount(totalChapterCount)
       .setTopicThumbnail(TOPIC_THUMBNAILS.getValue(topicId))
-      .build()
-  }
-
-  private fun createTopicSummary0(): TopicSummary {
-    return TopicSummary.newBuilder()
-      .setTopicId(TEST_TOPIC_ID_0)
-      .setName("First Topic")
-      .setVersion(1)
-      .setSubtopicCount(0)
-      .setCanonicalStoryCount(2)
-      .setUncategorizedSkillCount(0)
-      .setAdditionalStoryCount(0)
-      .setTotalSkillCount(2)
-      .setTotalChapterCount(4)
-      .setTopicThumbnail(createTopicThumbnail0())
-      .build()
-  }
-
-  private fun createTopicSummary1(): TopicSummary {
-    return TopicSummary.newBuilder()
-      .setTopicId(TEST_TOPIC_ID_1)
-      .setName("Second Topic")
-      .setVersion(3)
-      .setSubtopicCount(0)
-      .setCanonicalStoryCount(1)
-      .setUncategorizedSkillCount(0)
-      .setAdditionalStoryCount(0)
-      .setTotalSkillCount(1)
-      .setTotalChapterCount(1)
-      .setTopicThumbnail(createTopicThumbnail1())
       .build()
   }
 
@@ -518,6 +492,20 @@ internal fun createTopicThumbnail1(): LessonThumbnail {
     .build()
 }
 
+internal fun createTopicThumbnail2(): LessonThumbnail {
+  return LessonThumbnail.newBuilder()
+    .setThumbnailGraphic(LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS)
+    .setBackgroundColorRgb(0xd5836f)
+    .build()
+}
+
+internal fun createTopicThumbnail3(): LessonThumbnail {
+  return LessonThumbnail.newBuilder()
+    .setThumbnailGraphic(LessonThumbnailGraphic.BAKER)
+    .setBackgroundColorRgb(0xd5A26f)
+    .build()
+}
+
 internal fun createStoryThumbnail0(): LessonThumbnail {
   return LessonThumbnail.newBuilder()
     .setThumbnailGraphic(LessonThumbnailGraphic.DUCK_AND_CHICKEN)
@@ -536,6 +524,27 @@ internal fun createStoryThumbnail2(): LessonThumbnail {
   return LessonThumbnail.newBuilder()
     .setThumbnailGraphic(LessonThumbnailGraphic.CHILD_WITH_CUPCAKES)
     .setBackgroundColorRgb(0xa5ecd3)
+    .build()
+}
+
+internal fun createStoryThumbnail3(): LessonThumbnail {
+  return LessonThumbnail.newBuilder()
+    .setThumbnailGraphic(LessonThumbnailGraphic.BAKER)
+    .setBackgroundColorRgb(0xa5a2d3)
+    .build()
+}
+
+internal fun createStoryThumbnail4(): LessonThumbnail {
+  return LessonThumbnail.newBuilder()
+    .setThumbnailGraphic(LessonThumbnailGraphic.COMPARING_FRACTIONS)
+    .setBackgroundColorRgb(0xf2ecd3)
+    .build()
+}
+
+internal fun createStoryThumbnail5(): LessonThumbnail {
+  return LessonThumbnail.newBuilder()
+    .setThumbnailGraphic(LessonThumbnailGraphic.DERIVE_A_RATIO)
+    .setBackgroundColorRgb(0xf2ec63)
     .build()
 }
 
@@ -578,5 +587,33 @@ internal fun createChapterThumbnail5(): LessonThumbnail {
   return LessonThumbnail.newBuilder()
     .setThumbnailGraphic(LessonThumbnailGraphic.DUCK_AND_CHICKEN)
     .setBackgroundColorRgb(0xd3a5ec)
+    .build()
+}
+
+internal fun createChapterThumbnail6(): LessonThumbnail {
+  return LessonThumbnail.newBuilder()
+    .setThumbnailGraphic(LessonThumbnailGraphic.BAKER)
+    .setBackgroundColorRgb(0xd325ec)
+    .build()
+}
+
+internal fun createChapterThumbnail7(): LessonThumbnail {
+  return LessonThumbnail.newBuilder()
+    .setThumbnailGraphic(LessonThumbnailGraphic.PERSON_WITH_PIE_CHART)
+    .setBackgroundColorRgb(0xd985ec)
+    .build()
+}
+
+internal fun createChapterThumbnail8(): LessonThumbnail {
+  return LessonThumbnail.newBuilder()
+    .setThumbnailGraphic(LessonThumbnailGraphic.DUCK_AND_CHICKEN)
+    .setBackgroundColorRgb(0xd3aa2c)
+    .build()
+}
+
+internal fun createChapterThumbnail9(): LessonThumbnail {
+  return LessonThumbnail.newBuilder()
+    .setThumbnailGraphic(LessonThumbnailGraphic.CHILD_WITH_FRACTIONS_HOMEWORK)
+    .setBackgroundColorRgb(0xd3a67ec)
     .build()
 }

--- a/domain/src/test/java/org/oppia/domain/exploration/ExplorationDataControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/exploration/ExplorationDataControllerTest.kt
@@ -49,7 +49,10 @@ import org.oppia.domain.topic.RATIOS_EXPLORATION_ID_0
 import org.oppia.domain.topic.RATIOS_EXPLORATION_ID_1
 import org.oppia.domain.topic.RATIOS_EXPLORATION_ID_2
 import org.oppia.domain.topic.RATIOS_EXPLORATION_ID_3
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_0
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_1
 import org.oppia.domain.topic.TEST_EXPLORATION_ID_3
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_4
 import org.oppia.testing.FakeExceptionLogger
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
@@ -129,7 +132,7 @@ class ExplorationDataControllerTest {
   fun testController_providesInitialLiveDataForTheWelcomeExploration() =
     runBlockingTest(coroutineContext) {
       val explorationLiveData =
-        explorationDataController.getExplorationById(TEST_EXPLORATION_ID_5)
+        explorationDataController.getExplorationById(TEST_EXPLORATION_ID_0)
       advanceUntilIdle()
       explorationLiveData.observeForever(mockExplorationObserver)
       val expectedExplorationStateSet = listOf(
@@ -152,7 +155,7 @@ class ExplorationDataControllerTest {
   fun testController_providesInitialLiveDataForTheAboutOppiaExploration() =
     runBlockingTest(coroutineContext) {
       val explorationLiveData =
-        explorationDataController.getExplorationById(TEST_EXPLORATION_ID_6)
+        explorationDataController.getExplorationById(TEST_EXPLORATION_ID_1)
       advanceUntilIdle()
       explorationLiveData.observeForever(mockExplorationObserver)
       val expectedExplorationStateSet = listOf(
@@ -321,7 +324,7 @@ class ExplorationDataControllerTest {
   fun testStartPlayingExploration_withoutStoppingSession_fails() =
     runBlockingTest(coroutineContext) {
       explorationDataController.startPlayingExploration(TEST_EXPLORATION_ID_3)
-      explorationDataController.startPlayingExploration(TEST_EXPLORATION_ID_7)
+      explorationDataController.startPlayingExploration(TEST_EXPLORATION_ID_4)
       advanceUntilIdle()
 
       val exception = fakeExceptionLogger.getMostRecentException()

--- a/domain/src/test/java/org/oppia/domain/exploration/ExplorationProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/exploration/ExplorationProgressControllerTest.kt
@@ -46,6 +46,8 @@ import org.oppia.domain.classify.rules.multiplechoiceinput.MultipleChoiceInputMo
 import org.oppia.domain.classify.rules.numberwithunits.NumberWithUnitsRuleModule
 import org.oppia.domain.classify.rules.numericinput.NumericInputRuleModule
 import org.oppia.domain.classify.rules.textinput.TextInputRuleModule
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_0
+import org.oppia.domain.topic.TEST_EXPLORATION_ID_1
 import org.oppia.domain.util.toAnswerString
 import org.oppia.testing.FakeExceptionLogger
 import org.oppia.testing.TestLogReportingModule
@@ -195,7 +197,7 @@ class ExplorationProgressControllerTest {
   @ExperimentalCoroutinesApi
   fun testPlayExploration_valid_returnsSuccess() = runBlockingTest(coroutineContext) {
     val resultLiveData =
-      explorationDataController.startPlayingExploration(TEST_EXPLORATION_ID_5)
+      explorationDataController.startPlayingExploration(TEST_EXPLORATION_ID_0)
     resultLiveData.observeForever(mockAsyncResultLiveDataObserver)
     advanceUntilIdle()
 
@@ -214,7 +216,7 @@ class ExplorationProgressControllerTest {
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
       advanceUntilIdle()
 
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
 
       // The second-to-latest result stays pending since the exploration was loading (the actual result is the fully
       // loaded exploration). This is only true if the observer begins before starting to load the exploration.
@@ -232,7 +234,7 @@ class ExplorationProgressControllerTest {
     coroutineContext
   ) {
     val exploration = getTestExploration5()
-    playExploration(TEST_EXPLORATION_ID_5)
+    playExploration(TEST_EXPLORATION_ID_0)
 
     val currentStateLiveData =
       explorationProgressController.getCurrentState()
@@ -265,7 +267,7 @@ class ExplorationProgressControllerTest {
       endExploration()
 
       // Then a valid one.
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       val currentStateLiveData =
         explorationProgressController.getCurrentState()
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
@@ -305,11 +307,11 @@ class ExplorationProgressControllerTest {
   fun testPlayExploration_withoutFinishingPrevious_failsWithError() =
     runBlockingTest(coroutineContext) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
 
       // Try playing another exploration without finishing the previous one.
       val resultLiveData =
-        explorationDataController.startPlayingExploration(TEST_EXPLORATION_ID_5)
+        explorationDataController.startPlayingExploration(TEST_EXPLORATION_ID_0)
       resultLiveData.observeForever(mockAsyncResultLiveDataObserver)
       advanceUntilIdle()
 
@@ -328,11 +330,11 @@ class ExplorationProgressControllerTest {
         explorationProgressController.getCurrentState()
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
       // Start with playing a valid exploration, then stop.
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       endExploration()
 
       // Then another valid one.
-      playExploration(TEST_EXPLORATION_ID_6)
+      playExploration(TEST_EXPLORATION_ID_1)
 
       // The latest result should correspond to the valid ID, and the progress controller should gracefully recover.
       verify(
@@ -373,7 +375,7 @@ class ExplorationProgressControllerTest {
   fun testSubmitAnswer_whileLoading_failsWithError() = runBlockingTest(coroutineContext) {
     // Start playing an exploration, but don't wait for it to complete.
     subscribeToCurrentStateToAllowExplorationToLoad()
-    explorationDataController.startPlayingExploration(TEST_EXPLORATION_ID_5)
+    explorationDataController.startPlayingExploration(TEST_EXPLORATION_ID_0)
 
     val result =
       explorationProgressController.submitAnswer(createMultipleChoiceAnswer(0))
@@ -396,7 +398,7 @@ class ExplorationProgressControllerTest {
   fun testSubmitAnswer_forMultipleChoice_correctAnswer_succeeds() =
     runBlockingTest(coroutineContext) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
 
       val result =
         explorationProgressController.submitAnswer(createMultipleChoiceAnswer(0))
@@ -418,7 +420,7 @@ class ExplorationProgressControllerTest {
       coroutineContext
     ) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
 
       val result =
         explorationProgressController.submitAnswer(createMultipleChoiceAnswer(0))
@@ -441,7 +443,7 @@ class ExplorationProgressControllerTest {
     coroutineContext
   ) {
     subscribeToCurrentStateToAllowExplorationToLoad()
-    playExploration(TEST_EXPLORATION_ID_5)
+    playExploration(TEST_EXPLORATION_ID_0)
 
     val result =
       explorationProgressController.submitAnswer(createMultipleChoiceAnswer(0))
@@ -463,7 +465,7 @@ class ExplorationProgressControllerTest {
       coroutineContext
     ) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
 
       val result =
         explorationProgressController.submitAnswer(createMultipleChoiceAnswer(1))
@@ -489,7 +491,7 @@ class ExplorationProgressControllerTest {
       val currentStateLiveData =
         explorationProgressController.getCurrentState()
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
 
       submitMultipleChoiceAnswer(0)
 
@@ -519,7 +521,7 @@ class ExplorationProgressControllerTest {
       val currentStateLiveData =
         explorationProgressController.getCurrentState()
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
 
       submitMultipleChoiceAnswer(2)
 
@@ -549,7 +551,7 @@ class ExplorationProgressControllerTest {
       coroutineContext
     ) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswer(2)
 
       submitMultipleChoiceAnswer(0)
@@ -593,7 +595,7 @@ class ExplorationProgressControllerTest {
   fun testMoveToNext_whileLoadingExploration_failsWithError() = runBlockingTest(coroutineContext) {
     // Start playing an exploration, but don't wait for it to complete.
     subscribeToCurrentStateToAllowExplorationToLoad()
-    explorationDataController.startPlayingExploration(TEST_EXPLORATION_ID_5)
+    explorationDataController.startPlayingExploration(TEST_EXPLORATION_ID_0)
 
     val moveToStateResult = explorationProgressController.moveToNextState()
     moveToStateResult.observeForever(mockAsyncResultLiveDataObserver)
@@ -609,7 +611,7 @@ class ExplorationProgressControllerTest {
   @ExperimentalCoroutinesApi
   fun testMoveToNext_forPendingInitialState_failsWithError() = runBlockingTest(coroutineContext) {
     subscribeToCurrentStateToAllowExplorationToLoad()
-    playExploration(TEST_EXPLORATION_ID_5)
+    playExploration(TEST_EXPLORATION_ID_0)
 
     val moveToStateResult = explorationProgressController.moveToNextState()
     moveToStateResult.observeForever(mockAsyncResultLiveDataObserver)
@@ -627,7 +629,7 @@ class ExplorationProgressControllerTest {
   @ExperimentalCoroutinesApi
   fun testMoveToNext_forCompletedState_succeeds() = runBlockingTest(coroutineContext) {
     subscribeToCurrentStateToAllowExplorationToLoad()
-    playExploration(TEST_EXPLORATION_ID_5)
+    playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswer(0)
 
     val moveToStateResult = explorationProgressController.moveToNextState()
@@ -644,7 +646,7 @@ class ExplorationProgressControllerTest {
     val currentStateLiveData =
       explorationProgressController.getCurrentState()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
-    playExploration(TEST_EXPLORATION_ID_5)
+    playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswer(0)
 
     moveToNextState()
@@ -664,7 +666,7 @@ class ExplorationProgressControllerTest {
   fun testMoveToNext_afterMovingFromCompletedState_failsWithError() =
     runBlockingTest(coroutineContext) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswer(0)
       moveToNextState()
 
@@ -703,7 +705,7 @@ class ExplorationProgressControllerTest {
     runBlockingTest(coroutineContext) {
       // Start playing an exploration, but don't wait for it to complete.
       subscribeToCurrentStateToAllowExplorationToLoad()
-      explorationDataController.startPlayingExploration(TEST_EXPLORATION_ID_5)
+      explorationDataController.startPlayingExploration(TEST_EXPLORATION_ID_0)
 
       val moveToStateResult =
         explorationProgressController.moveToPreviousState()
@@ -722,7 +724,7 @@ class ExplorationProgressControllerTest {
   fun testMoveToPrevious_onPendingInitialState_failsWithError() =
     runBlockingTest(coroutineContext) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
 
       val moveToStateResult =
         explorationProgressController.moveToPreviousState()
@@ -742,7 +744,7 @@ class ExplorationProgressControllerTest {
   fun testMoveToPrevious_onCompletedInitialState_failsWithError() =
     runBlockingTest(coroutineContext) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswer(0)
 
       val moveToStateResult =
@@ -763,7 +765,7 @@ class ExplorationProgressControllerTest {
   fun testMoveToPrevious_forStateWithCompletedPreviousState_succeeds() =
     runBlockingTest(coroutineContext) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
 
       val moveToStateResult =
@@ -783,7 +785,7 @@ class ExplorationProgressControllerTest {
       val currentStateLiveData =
         explorationProgressController.getCurrentState()
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
 
       moveToPreviousState()
@@ -805,7 +807,7 @@ class ExplorationProgressControllerTest {
   fun testMoveToPrevious_navigatedForwardThenBackToInitial_failsWithError() =
     runBlockingTest(coroutineContext) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
       moveToPreviousState()
 
@@ -828,7 +830,7 @@ class ExplorationProgressControllerTest {
   fun testSubmitAnswer_forTextInput_correctAnswer_returnsOutcomeWithTransition() =
     runBlockingTest(coroutineContext) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
 
       val result =
@@ -851,7 +853,7 @@ class ExplorationProgressControllerTest {
   fun testSubmitAnswer_forTextInput_wrongAnswer_returnsDefaultOutcome() =
     runBlockingTest(coroutineContext) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
 
       val result =
@@ -875,7 +877,7 @@ class ExplorationProgressControllerTest {
     coroutineContext
   ) {
     subscribeToCurrentStateToAllowExplorationToLoad()
-    playExploration(TEST_EXPLORATION_ID_5)
+    playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswerAndMoveToNextState(0)
 
     val result =
@@ -905,7 +907,7 @@ class ExplorationProgressControllerTest {
     coroutineContext
   ) {
     subscribeToCurrentStateToAllowExplorationToLoad()
-    playExploration(TEST_EXPLORATION_ID_5)
+    playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswerAndMoveToNextState(0)
 
     // Verify that the current state updates. It should stay pending, on submission of wrong answer.
@@ -946,7 +948,7 @@ class ExplorationProgressControllerTest {
     coroutineContext
   ) {
     subscribeToCurrentStateToAllowExplorationToLoad()
-    playExploration(TEST_EXPLORATION_ID_5)
+    playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswerAndMoveToNextState(0)
 
     // Verify that the current state updates. It should stay pending, on submission of wrong answer.
@@ -984,7 +986,7 @@ class ExplorationProgressControllerTest {
       coroutineContext
     ) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
 
       val result =
@@ -1026,7 +1028,7 @@ class ExplorationProgressControllerTest {
       coroutineContext
     ) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
 
       val result =
@@ -1053,7 +1055,7 @@ class ExplorationProgressControllerTest {
   fun testSubmitAnswer_forTextInput_withSpaces_updatesStateWithVerbatimAnswer() =
     runBlockingTest(coroutineContext) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
 
       val result =
@@ -1086,7 +1088,7 @@ class ExplorationProgressControllerTest {
     coroutineContext
   ) {
     subscribeToCurrentStateToAllowExplorationToLoad()
-    playExploration(TEST_EXPLORATION_ID_5)
+    playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswerAndMoveToNextState(0)
 
     val result =
@@ -1115,7 +1117,7 @@ class ExplorationProgressControllerTest {
       val currentStateLiveData =
         explorationProgressController.getCurrentState()
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
 
       moveToPreviousState()
@@ -1139,7 +1141,7 @@ class ExplorationProgressControllerTest {
       val currentStateLiveData =
         explorationProgressController.getCurrentState()
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
       submitTextInputAnswer("Finnish") // Submit the answer but do not proceed to the next state.
 
@@ -1164,7 +1166,7 @@ class ExplorationProgressControllerTest {
       coroutineContext
     ) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0) // First state -> second
       submitTextInputAnswerAndMoveToNextState("Finnish") // Second state -> third
 
@@ -1193,7 +1195,7 @@ class ExplorationProgressControllerTest {
       explorationProgressController.getCurrentState()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
 
-    playExploration(TEST_EXPLORATION_ID_5)
+    playExploration(TEST_EXPLORATION_ID_0)
 
     // The initial state should not have a next state.
     verify(
@@ -1213,7 +1215,7 @@ class ExplorationProgressControllerTest {
       val currentStateLiveData =
         explorationProgressController.getCurrentState()
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
 
       submitMultipleChoiceAnswer(0)
 
@@ -1234,7 +1236,7 @@ class ExplorationProgressControllerTest {
       val currentStateLiveData =
         explorationProgressController.getCurrentState()
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
 
       submitMultipleChoiceAnswerAndMoveToNextState(0)
 
@@ -1254,7 +1256,7 @@ class ExplorationProgressControllerTest {
       val currentStateLiveData =
         explorationProgressController.getCurrentState()
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
 
       moveToPreviousState()
@@ -1277,7 +1279,7 @@ class ExplorationProgressControllerTest {
       val currentStateLiveData =
         explorationProgressController.getCurrentState()
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
 
       moveToPreviousState()
@@ -1299,7 +1301,7 @@ class ExplorationProgressControllerTest {
       coroutineContext
     ) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
       submitTextInputAnswerAndMoveToNextState("Finnish")
 
@@ -1324,7 +1326,7 @@ class ExplorationProgressControllerTest {
   fun testSubmitAnswer_forNumericInput_wrongAnswer_returnsOutcomeWithTransition() =
     runBlockingTest(coroutineContext) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
       submitTextInputAnswerAndMoveToNextState("Finnish")
 
@@ -1349,7 +1351,7 @@ class ExplorationProgressControllerTest {
   fun testSubmitAnswer_forContinue_returnsOutcomeWithTransition() =
     runBlockingTest(coroutineContext) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
       submitTextInputAnswerAndMoveToNextState("Finnish")
       submitNumericInputAnswerAndMoveToNextState(121.0)
@@ -1376,7 +1378,7 @@ class ExplorationProgressControllerTest {
     val currentStateLiveData =
       explorationProgressController.getCurrentState()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
-    playExploration(TEST_EXPLORATION_ID_5)
+    playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswerAndMoveToNextState(0)
     submitTextInputAnswerAndMoveToNextState("Finnish")
     submitNumericInputAnswerAndMoveToNextState(121.0)
@@ -1402,7 +1404,7 @@ class ExplorationProgressControllerTest {
       val currentStateLiveData =
         explorationProgressController.getCurrentState()
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
       submitTextInputAnswerAndMoveToNextState("Finnish")
 
@@ -1428,7 +1430,7 @@ class ExplorationProgressControllerTest {
   @ExperimentalCoroutinesApi
   fun testMoveToNext_onFinalState_failsWithError() = runBlockingTest(coroutineContext) {
     subscribeToCurrentStateToAllowExplorationToLoad()
-    playExploration(TEST_EXPLORATION_ID_5)
+    playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswerAndMoveToNextState(0)
     submitTextInputAnswerAndMoveToNextState("Finnish")
     submitNumericInputAnswerAndMoveToNextState(121.0)
@@ -1454,7 +1456,7 @@ class ExplorationProgressControllerTest {
         explorationProgressController.getCurrentState()
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
 
-      playExploration(TEST_EXPLORATION_ID_6)
+      playExploration(TEST_EXPLORATION_ID_1)
       submitContinueButtonAnswerAndMoveToNextState()
       submitMultipleChoiceAnswerAndMoveToNextState(3) // Those were all the questions I had!
       submitContinueButtonAnswerAndMoveToNextState()
@@ -1479,7 +1481,7 @@ class ExplorationProgressControllerTest {
         explorationProgressController.getCurrentState()
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
 
-      playExploration(TEST_EXPLORATION_ID_6)
+      playExploration(TEST_EXPLORATION_ID_1)
       submitContinueButtonAnswerAndMoveToNextState()
       submitMultipleChoiceAnswerAndMoveToNextState(0) // How do your explorations work?
       submitTextInputAnswerAndMoveToNextState("Oppia Otter") // Can I ask your name?
@@ -1508,7 +1510,7 @@ class ExplorationProgressControllerTest {
       currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
       playThroughExploration5()
 
-      playExploration(TEST_EXPLORATION_ID_6)
+      playExploration(TEST_EXPLORATION_ID_1)
       submitContinueButtonAnswerAndMoveToNextState()
       // Those were all the questions I had!
       submitMultipleChoiceAnswerAndMoveToNextState(3)
@@ -1544,7 +1546,7 @@ class ExplorationProgressControllerTest {
   fun testMoveToPrevious_navigatedForwardThenBackToInitial_failsWithError_logsException() =
     runBlockingTest(coroutineContext) {
       subscribeToCurrentStateToAllowExplorationToLoad()
-      playExploration(TEST_EXPLORATION_ID_5)
+      playExploration(TEST_EXPLORATION_ID_0)
       submitMultipleChoiceAnswerAndMoveToNextState(0)
       moveToPreviousState()
 
@@ -1592,11 +1594,11 @@ class ExplorationProgressControllerTest {
     }
 
   private suspend fun getTestExploration5(): Exploration {
-    return explorationRetriever.loadExploration(TEST_EXPLORATION_ID_5)
+    return explorationRetriever.loadExploration(TEST_EXPLORATION_ID_0)
   }
 
   private suspend fun getTestExploration6(): Exploration {
-    return explorationRetriever.loadExploration(TEST_EXPLORATION_ID_6)
+    return explorationRetriever.loadExploration(TEST_EXPLORATION_ID_1)
   }
 
   private fun setUpTestApplicationComponent() {
@@ -1689,7 +1691,7 @@ class ExplorationProgressControllerTest {
 
   @ExperimentalCoroutinesApi
   private fun playThroughExploration5() {
-    playExploration(TEST_EXPLORATION_ID_5)
+    playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswerAndMoveToNextState(0)
     submitTextInputAnswerAndMoveToNextState("Finnish")
     submitNumericInputAnswerAndMoveToNextState(121.0)

--- a/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
@@ -54,7 +54,7 @@ import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import org.robolectric.annotation.Config
 import java.io.FileNotFoundException
-import java.util.Date
+import java.util.*
 import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -413,7 +413,8 @@ class TopicControllerTest {
       verifyGetStorySucceeded()
       val story = storySummaryResultCaptor.value!!.getOrThrow()
       val chapter = story.getChapter(0)
-      assertThat(chapter.chapterThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.CHILD_WITH_FRACTIONS_HOMEWORK)
+      assertThat(chapter.chapterThumbnail.thumbnailGraphic)
+        .isEqualTo(LessonThumbnailGraphic.CHILD_WITH_FRACTIONS_HOMEWORK)
     }
 
   @Test
@@ -1067,7 +1068,8 @@ class TopicControllerTest {
 
   @Test
   @ExperimentalCoroutinesApi
-  fun testOngoingTopicList_finishOneEntireTopicAndOneChapterInAnotherTopic_ongoingTopicListIsCorrect() = // ktlint-disable max-line-length
+  fun testOngoingTopicList_finishOneEntireTopicAndOneChapterInAnotherTopic_ongoingTopicListIsCorrect() =
+    // ktlint-disable max-line-length
     runBlockingTest(coroutineContext) {
       // Mark entire FRACTIONS topic as finished.
       markFractionsStory0Chapter0AsCompleted()
@@ -1161,7 +1163,8 @@ class TopicControllerTest {
 
   @Test
   @ExperimentalCoroutinesApi
-  fun testCompletedStoryList_finishOneEntireStoryAndOneChapterInAnotherStory_completedStoryListIsCorrect() = // ktlint-disable max-line-length
+  fun testCompletedStoryList_finishOneEntireStoryAndOneChapterInAnotherStory_completedStoryListIsCorrect() =
+    // ktlint-disable max-line-length
     runBlockingTest(coroutineContext) {
       markFractionsStory0Chapter0AsCompleted()
       advanceUntilIdle()

--- a/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
@@ -54,7 +54,7 @@ import org.oppia.util.threading.BackgroundDispatcher
 import org.oppia.util.threading.BlockingDispatcher
 import org.robolectric.annotation.Config
 import java.io.FileNotFoundException
-import java.util.*
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -1068,8 +1068,7 @@ class TopicControllerTest {
 
   @Test
   @ExperimentalCoroutinesApi
-  fun testOngoingTopicList_finishOneEntireTopicAndOneChapterInAnotherTopic_ongoingTopicListIsCorrect() =
-    // ktlint-disable max-line-length
+  fun testOngoingTopicList_finishOneEntireTopicAndOneChapterInAnotherTopic_ongoingTopicListIsCorrect() = // ktlint-disable max-line-length
     runBlockingTest(coroutineContext) {
       // Mark entire FRACTIONS topic as finished.
       markFractionsStory0Chapter0AsCompleted()
@@ -1163,8 +1162,7 @@ class TopicControllerTest {
 
   @Test
   @ExperimentalCoroutinesApi
-  fun testCompletedStoryList_finishOneEntireStoryAndOneChapterInAnotherStory_completedStoryListIsCorrect() =
-    // ktlint-disable max-line-length
+  fun testCompletedStoryList_finishOneEntireStoryAndOneChapterInAnotherStory_completedStoryListIsCorrect() = // ktlint-disable max-line-length
     runBlockingTest(coroutineContext) {
       markFractionsStory0Chapter0AsCompleted()
       advanceUntilIdle()

--- a/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
@@ -181,7 +181,7 @@ class TopicControllerTest {
       verifyGetTopicSucceeded()
       val topic = topicResultCaptor.value!!.getOrThrow()
       assertThat(topic.topicThumbnail.thumbnailGraphic)
-        .isEqualTo(LessonThumbnailGraphic.DUCK_AND_CHICKEN)
+        .isEqualTo(LessonThumbnailGraphic.BAKER)
     }
 
   @Test
@@ -413,7 +413,7 @@ class TopicControllerTest {
       verifyGetStorySucceeded()
       val story = storySummaryResultCaptor.value!!.getOrThrow()
       val chapter = story.getChapter(0)
-      assertThat(chapter.chapterThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.BAKER)
+      assertThat(chapter.chapterThumbnail.thumbnailGraphic).isEqualTo(LessonThumbnailGraphic.CHILD_WITH_FRACTIONS_HOMEWORK)
     }
 
   @Test
@@ -455,7 +455,7 @@ class TopicControllerTest {
       val story = storySummaryResultCaptor.value!!.getOrThrow()
       assertThat(getExplorationIds(story)).containsExactly(
         TEST_EXPLORATION_ID_1,
-        TEST_EXPLORATION_ID_2,
+        TEST_EXPLORATION_ID_0,
         TEST_EXPLORATION_ID_3
       ).inOrder()
     }

--- a/domain/src/test/java/org/oppia/domain/topic/TopicListControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicListControllerTest.kt
@@ -147,7 +147,7 @@ class TopicListControllerTest {
     val topicList = topicListLiveData.value!!.getOrThrow()
     val firstTopic = topicList.getTopicSummary(0)
     assertThat(firstTopic.topicId).isEqualTo(TEST_TOPIC_ID_0)
-    assertThat(firstTopic.name).isEqualTo("First Topic")
+    assertThat(firstTopic.name).isEqualTo("First Test Topic")
   }
 
   @Test
@@ -157,7 +157,7 @@ class TopicListControllerTest {
     val topicList = topicListLiveData.value!!.getOrThrow()
     val firstTopic = topicList.getTopicSummary(0)
     assertThat(firstTopic.topicThumbnail.thumbnailGraphic)
-      .isEqualTo(LessonThumbnailGraphic.CHILD_WITH_FRACTIONS_HOMEWORK)
+      .isEqualTo(LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS)
   }
 
   @Test
@@ -176,7 +176,7 @@ class TopicListControllerTest {
     val topicList = topicListLiveData.value!!.getOrThrow()
     val secondTopic = topicList.getTopicSummary(1)
     assertThat(secondTopic.topicId).isEqualTo(TEST_TOPIC_ID_1)
-    assertThat(secondTopic.name).isEqualTo("Second Topic")
+    assertThat(secondTopic.name).isEqualTo("Second Test Topic")
   }
 
   @Test
@@ -186,7 +186,7 @@ class TopicListControllerTest {
     val topicList = topicListLiveData.value!!.getOrThrow()
     val secondTopic = topicList.getTopicSummary(1)
     assertThat(secondTopic.topicThumbnail.thumbnailGraphic)
-      .isEqualTo(LessonThumbnailGraphic.DUCK_AND_CHICKEN)
+      .isEqualTo(LessonThumbnailGraphic.BAKER)
   }
 
   @Test

--- a/domain/src/test/java/org/oppia/domain/util/StateRetrieverTest.kt
+++ b/domain/src/test/java/org/oppia/domain/util/StateRetrieverTest.kt
@@ -33,7 +33,7 @@ import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Singleton
 
-const val DRAG_DROP_TEST_EXPLORATION_NAME = "drag_and_drop_test_exploration.json"
+const val DRAG_DROP_TEST_EXPLORATION_NAME = "test_exp_id_4.json"
 const val IMAGE_REGION_SELECTION_TEST_EXPLORATION_NAME =
   "image_region_selection_test_exploration.json"
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

This PR shifts the contents of `First Test Topic` and `Second Test Topic` to json files. During this transition, there have been lot of minor changes like `exploration-id` was fixed for consistency, `thumbnails` were changed to have variety of images, etc which has led to a lot of minor changes. For example, following ids have been changed as mentioned below:
1. `TEST_EXPLORATION_ID_5` -> `TEST_EXPLORATION_ID_0`
2. `TEST_EXPLORATION_ID_6` -> `TEST_EXPLORATION_ID_2`
3. `TEST_EXPLORATION_ID_30` -> `TEST_EXPLORATION_ID_3`
4. `TEST_EXPLORATION_ID_7` -> `TEST_EXPLORATION_ID_4`
5. `TEST_EXPLORATION_ID_8` -> `TEST_EXPLORATION_ID_5`
6. `First Topic` has been renamed to `First Test Topic` (This was an inconsistency which you can notice in current app, check the title of topic in home screen and then in toolbar to TopicActivity)
7. `Second Topic` has been renamed to `Second Test Topic`  (This was an inconsistency which you can notice in current app, check the title of topic in home screen and then in toolbar to TopicActivity)

Now, such changes have led to changes in multiple files across app and domain layer.

## How to test
1. First proof that this implementation is correct is the fact that all domain layer test cases are passing with a minor changes.
2. Before checking-in in this branch, check the entire app on develop, including concept-cards (described below), maybe take screenshots for better comparison later on.
3. Now run this app and check the entire app once again, like HomeScreen, Promoted Story Cards, Recently Played Stories (click on View All), 4 tabs in topic, exploration-player, question-player, revision-card in fractions (only 1st revision card will work), concept card (described below).
4. Checking concept card - for this, in manifest file, you will need to set ConceptCardFragmentTestActivity as launcher activity.

You will notice that most changes in this branch which appears in the app is change in images which is fine, along with that this PR has led to two bonus advantages:
1. Now even the test topics show `download size` in `Topic-Info`
2. In current develop, except `Prototype Exploration`, no other exploration works correctly and leads to blank screen, this has been fixed in this PR.


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
