### PR TITLE
Fix duplication of hints & solutions manager fragment

### DIFF
--- a/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivityPresenter.kt
@@ -100,18 +100,13 @@ class ExplorationActivityPresenter @Inject constructor(
       ).commitNow()
     }
 
-    if (getHintsAndSolutionExplorationManagerFragment() == null) {
+    if (getHintsAndSolutionManagerFragment() == null) {
       activity.supportFragmentManager.beginTransaction().add(
         R.id.exploration_fragment_placeholder,
-        HintsAndSolutionExplorationManagerFragment()
+        HintsAndSolutionExplorationManagerFragment(),
+        TAG_HINTS_AND_SOLUTION_EXPLORATION_MANAGER
       ).commitNow()
     }
-  }
-
-  private fun getHintsAndSolutionExplorationManagerFragment(): HintsAndSolutionExplorationManagerFragment? { // ktlint-disable max-line-length
-    return activity.supportFragmentManager.findFragmentByTag(
-      TAG_HINTS_AND_SOLUTION_EXPLORATION_MANAGER
-    ) as HintsAndSolutionExplorationManagerFragment?
   }
 
   fun showAudioButton() = exploreViewModel.showAudioButton.set(true)
@@ -131,6 +126,12 @@ class ExplorationActivityPresenter @Inject constructor(
     return activity.supportFragmentManager.findFragmentByTag(
       TAG_EXPLORATION_FRAGMENT
     ) as ExplorationFragment?
+  }
+
+  private fun getHintsAndSolutionManagerFragment(): HintsAndSolutionExplorationManagerFragment? {
+    return activity.supportFragmentManager.findFragmentByTag(
+      TAG_HINTS_AND_SOLUTION_EXPLORATION_MANAGER
+    ) as HintsAndSolutionExplorationManagerFragment?
   }
 
   fun stopExploration() {


### PR DESCRIPTION
The hints & solutions manager de-duplication check isn't quite correct: it checks whether the manager fragment is present by tag, but never associates the added fragment with that tag. Thus, each time onCreate() is called it will add another copy of the manager fragment.