### PR TITLE
Fix #1485: Rich text image is cut-off 

### DIFF
--- a/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
@@ -92,9 +92,9 @@ class UrlImageParser private constructor(
           if (drawableHeight >= maximumImageSize || drawableWidth >= maximumImageSize) {
             // The multipleFactor value is used to make sure that the aspect ratio of the image remains the same.
             // Example: Height is 420, width is 440 and maximumImageSize is 200.
-            // Then multipleFactor will be (200/420).
-            // The new height will be 168 and new width will be 176.
-            val multipleFactor = if (drawableHeight <= drawableWidth) {
+            // Then multipleFactor will be (200/440).
+            // The new height will be 191 and new width will be 200.
+            val multipleFactor = if (drawableHeight >= drawableWidth) {
               // If height is less then the multipleFactor, value is determined by height.
               (maximumImageSize.toDouble() / drawableHeight.toDouble())
             } else {

--- a/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
@@ -88,6 +88,22 @@ class UrlImageParser private constructor(
             drawableHeight = (drawableHeight.toDouble() * multipleFactor).toInt()
             drawableWidth = (drawableWidth.toDouble() * multipleFactor).toInt()
           }
+          val maximumImageSize = context.resources.getDimensionPixelSize(R.dimen.maximum_image_size)
+          if (drawableHeight >= maximumImageSize || drawableWidth >= maximumImageSize) {
+            // The multipleFactor value is used to make sure that the aspect ratio of the image remains the same.
+            // Example: Height is 420, width is 440 and maximumImageSize is 200.
+            // Then multipleFactor will be (200/420).
+            // The new height will be 168 and new width will be 176.
+            val multipleFactor = if (drawableHeight <= drawableWidth) {
+              // If height is less then the multipleFactor, value is determined by height.
+              (maximumImageSize.toDouble() / drawableHeight.toDouble())
+            } else {
+              // If width is less then the multipleFactor, value is determined by width.
+              (maximumImageSize.toDouble() / drawableWidth.toDouble())
+            }
+            drawableHeight = (drawableHeight.toDouble() * multipleFactor).toInt()
+            drawableWidth = (drawableWidth.toDouble() * multipleFactor).toInt()
+          }
           val initialDrawableMargin = if (imageCenterAlign) {
             calculateInitialMargin(it, drawableWidth)
           } else {

--- a/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
@@ -79,10 +79,10 @@ class UrlImageParser private constructor(
             // Then multipleFactor will be 2 (120/60).
             // The new height will be 180 and new width will be 120.
             val multipleFactor = if (drawableHeight <= drawableWidth) {
-              // If height is less then the multipleFactor, value is determined by height.
+              // If height is less then the width, multipleFactor value is determined by height.
               (minimumImageSize.toDouble() / drawableHeight.toDouble())
             } else {
-              // If width is less then the multipleFactor, value is determined by width.
+              // If height is less then the width, multipleFactor value is determined by width.
               (minimumImageSize.toDouble() / drawableWidth.toDouble())
             }
             drawableHeight = (drawableHeight.toDouble() * multipleFactor).toInt()
@@ -95,10 +95,10 @@ class UrlImageParser private constructor(
             // Then multipleFactor will be (200/440).
             // The new height will be 191 and new width will be 200.
             val multipleFactor = if (drawableHeight >= drawableWidth) {
-              // If height is less then the multipleFactor, value is determined by height.
+              // If height is greater then the width, multipleFactor value is determined by height.
               (maximumImageSize.toDouble() / drawableHeight.toDouble())
             } else {
-              // If width is less then the multipleFactor, value is determined by width.
+              // If height is greater then the width, multipleFactor value is determined by width.
               (maximumImageSize.toDouble() / drawableWidth.toDouble())
             }
             drawableHeight = (drawableHeight.toDouble() * multipleFactor).toInt()

--- a/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
@@ -88,7 +88,7 @@ class UrlImageParser private constructor(
             drawableHeight = (drawableHeight.toDouble() * multipleFactor).toInt()
             drawableWidth = (drawableWidth.toDouble() * multipleFactor).toInt()
           }
-          val maximumImageSize = context.resources.getDimensionPixelSize(R.dimen.maximum_image_size)
+          val maximumImageSize = it
           if (drawableHeight >= maximumImageSize || drawableWidth >= maximumImageSize) {
             // The multipleFactor value is used to make sure that the aspect ratio of the image remains the same.
             // Example: Height is 420, width is 440 and maximumImageSize is 200.

--- a/utility/src/main/res/values/dimens.xml
+++ b/utility/src/main/res/values/dimens.xml
@@ -5,4 +5,5 @@
   <dimen name="bullet_y_offset">2dp</dimen>
   <dimen name="bullet_leading_margin">24dp</dimen>
   <dimen name="minimum_image_size">48dp</dimen>
+  <dimen name="maximum_image_size">200dp</dimen>
 </resources>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix #1485 
Added `maximum_image_size = 200dp`

Example: Height is 420, width is 440 and `maximumImageSize` is 200
Then `multipleFactor` will be (200/440) = 0.4.
The new height will be 191 and the new width will be 200.

### How to Test
1. Create Nexus-S 25API emulator (any available API level)
2. Run the app
3. Open Ratios Topic
4. Start Equivalent Ratios exploration
5. Try other Explorations also to check if all images are coming correctly on screen

### Screenshot
Nexus S - 28 API(portrait) and 7 WSVGA Tablet(Landscape)
<p>
<img src="https://user-images.githubusercontent.com/25057618/88267755-e8e7a780-ccee-11ea-9d16-12bb41c60ebe.png" width="200" height="400" />
<img src="https://user-images.githubusercontent.com/25057618/88267761-ec7b2e80-ccee-11ea-86b1-a8e236f6f050.png" width="200" height="400" />
<img src="https://user-images.githubusercontent.com/25057618/88267776-f2710f80-ccee-11ea-84e1-a36ae03fbd56.png" width="200" height="400" />
<img src="https://user-images.githubusercontent.com/25057618/88267744-e5542080-ccee-11ea-8b4f-537543bd03a2.png"/>
<img src="https://user-images.githubusercontent.com/25057618/88267769-eedd8880-ccee-11ea-85d7-6b38e9a6f183.png"/>
</p>

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
