### PR TITLE
Remove PhotoView Dependancy

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,8 +96,7 @@ dependencies {
       "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version",
       'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1',
       'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1',
-      'org.mockito:mockito-core:2.7.22',
-      'com.github.chrisbanes:PhotoView:2.3.0'
+      'org.mockito:mockito-core:2.7.22'
   )
   testImplementation(
       'androidx.test:core:1.2.0',
@@ -159,9 +158,6 @@ dependencies {
   androidTestImplementation project(":model")
   implementation project(":domain")
   implementation project(":utility")
-}
-repositories {
-  maven { url "https://jitpack.io" }
 }
 // The GeneratedMessageLite implementations of protobufs are depending on protobuf-java
 // instead of protobuf-lite after Android Studio 3.5,

--- a/app/src/main/java/org/oppia/app/utility/ClickableAreasImage.kt
+++ b/app/src/main/java/org/oppia/app/utility/ClickableAreasImage.kt
@@ -1,14 +1,12 @@
 package org.oppia.app.utility
 
+import android.graphics.Rect
 import android.graphics.RectF
 import android.view.MotionEvent
 import android.view.View
 import android.widget.FrameLayout
-import android.widget.ImageView
 import androidx.core.view.forEachIndexed
 import androidx.core.view.isVisible
-import com.github.chrisbanes.photoview.OnPhotoTapListener
-import com.github.chrisbanes.photoview.PhotoViewAttacher
 import org.oppia.app.R
 import org.oppia.app.model.ImageWithRegions
 import org.oppia.app.player.state.ImageRegionSelectionInteractionView
@@ -21,13 +19,16 @@ class ClickableAreasImage(
   private val imageView: ImageRegionSelectionInteractionView,
   private val parentView: FrameLayout,
   private val listener: OnClickableAreaClickedListener
-) : OnPhotoTapListener {
-  private val attacher: PhotoViewAttacher = PhotoViewAttacher(imageView)
+) {
 
   init {
-    attacher.setOnPhotoTapListener(this)
+    imageView.setOnTouchListener { view, motionEvent ->
+      if (motionEvent.action == MotionEvent.ACTION_DOWN) {
+        onPhotoTap(motionEvent.x, motionEvent.y)
+      }
+      return@setOnTouchListener false
+    }
   }
-
   /**
    * Called when an image is clicked.
    *
@@ -35,15 +36,15 @@ class ClickableAreasImage(
    * @param x the relative x coordinate according to image
    * @param y the relative y coordinate according to image
    */
-  override fun onPhotoTap(view: ImageView, x: Float, y: Float) {
+  private fun onPhotoTap(x: Float, y: Float) {
     // Show default region for non-accessibility cases and this will be only called when user taps on unspecified region.
     if (!imageView.isAccessibilityEnabled()) {
       resetRegionSelectionViews()
       val defaultRegion = parentView.findViewById<View>(R.id.default_selected_region)
       defaultRegion.setBackgroundResource(R.drawable.selected_region_background)
-      defaultRegion.x = getXCoordinate(x)
-      defaultRegion.y = getYCoordinate(y)
-      listener.onClickableAreaTouched(DefaultRegionClickedEvent())
+      defaultRegion.x = x
+      defaultRegion.y = y
+      listener.onClickableAreaTouched(DefaultRegionClickedEvent)
     }
   }
 
@@ -59,13 +60,15 @@ class ClickableAreasImage(
 
   /** Get X co-ordinate scaled according to image.*/
   private fun getXCoordinate(x: Float): Float {
-    val rect = attacher.displayRect
+    val rect = Rect()
+    imageView.getLocalVisibleRect(rect)
     return (x * rect.width()) + rect.left
   }
 
   /** Get Y co-ordinate scaled according to image.*/
   private fun getYCoordinate(y: Float): Float {
-    val rect = attacher.displayRect
+    val rect = Rect()
+    imageView.getLocalVisibleRect(rect)
     return (y * rect.height()) + rect.top
   }
 

--- a/app/src/main/java/org/oppia/app/utility/ClickableAreasImage.kt
+++ b/app/src/main/java/org/oppia/app/utility/ClickableAreasImage.kt
@@ -20,7 +20,7 @@ class ClickableAreasImage(
   private val parentView: FrameLayout,
   private val listener: OnClickableAreaClickedListener
 ) {
-
+  private var rect = Rect()
   init {
     imageView.setOnTouchListener { view, motionEvent ->
       if (motionEvent.action == MotionEvent.ACTION_DOWN) {
@@ -60,20 +60,25 @@ class ClickableAreasImage(
 
   /** Get X co-ordinate scaled according to image.*/
   private fun getXCoordinate(x: Float): Float {
-    val rect = Rect()
-    imageView.getLocalVisibleRect(rect)
     return (x * rect.width()) + rect.left
   }
 
   /** Get Y co-ordinate scaled according to image.*/
   private fun getYCoordinate(y: Float): Float {
-    val rect = Rect()
-    imageView.getLocalVisibleRect(rect)
     return (y * rect.height()) + rect.top
+  }
+
+  private fun getImageViewWidth(): Int {
+    return imageView.width - imageView.paddingLeft - imageView.paddingRight
+  }
+
+  private fun getImageViewHeight(): Int {
+    return imageView.height - imageView.paddingTop - imageView.paddingBottom
   }
 
   /** Add selectable regions to [FrameLayout].*/
   fun addRegionViews() {
+    rect = Rect(0, 0, getImageViewWidth(), getImageViewHeight())
     parentView.let {
       if (it.childCount > 2) {
         it.removeViews(2, it.childCount - 1) // remove all other views

--- a/app/src/main/java/org/oppia/app/utility/ClickableAreasImage.kt
+++ b/app/src/main/java/org/oppia/app/utility/ClickableAreasImage.kt
@@ -60,25 +60,25 @@ class ClickableAreasImage(
 
   /** Get X co-ordinate scaled according to image.*/
   private fun getXCoordinate(x: Float): Float {
-    return (x * rect.width()) + rect.left
+    return x * getImageViewContentWidth()
   }
 
   /** Get Y co-ordinate scaled according to image.*/
   private fun getYCoordinate(y: Float): Float {
-    return (y * rect.height()) + rect.top
+    return y * getImageViewContentHeight()
   }
 
-  private fun getImageViewWidth(): Int {
+  private fun getImageViewContentWidth(): Int {
     return imageView.width - imageView.paddingLeft - imageView.paddingRight
   }
 
-  private fun getImageViewHeight(): Int {
+  private fun getImageViewContentHeight(): Int {
     return imageView.height - imageView.paddingTop - imageView.paddingBottom
   }
 
   /** Add selectable regions to [FrameLayout].*/
   fun addRegionViews() {
-    rect = Rect(0, 0, getImageViewWidth(), getImageViewHeight())
+    rect = Rect(0, 0, getImageViewContentWidth(), getImageViewContentHeight())
     parentView.let {
       if (it.childCount > 2) {
         it.removeViews(2, it.childCount - 1) // remove all other views

--- a/app/src/main/java/org/oppia/app/utility/RegionClickEvent.kt
+++ b/app/src/main/java/org/oppia/app/utility/RegionClickEvent.kt
@@ -10,5 +10,5 @@ sealed class RegionClickedEvent
  */
 data class NamedRegionClickedEvent(val regionLabel: String) : RegionClickedEvent()
 
-/** Class to be used in case when [OnClickableAreaClickedListener] is called with an unspecified region. */
-class DefaultRegionClickedEvent() : RegionClickedEvent()
+/** object to be used in case when [OnClickableAreaClickedListener] is called with an unspecified region. */
+object DefaultRegionClickedEvent : RegionClickedEvent()

--- a/app/src/sharedTest/java/org/oppia/app/testing/ImageRegionSelectionInteractionViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/testing/ImageRegionSelectionInteractionViewTest.kt
@@ -84,17 +84,16 @@ class ImageRegionSelectionInteractionViewTest {
     launch(ImageRegionSelectionTestActivity::class.java).use {
       it.onActivity {
         it.clickable_image_view.setListener(onClickableAreaClickedListener)
-
-        onView(withId(R.id.clickable_image_view)).perform(
-          clickPoint(0.3f, 0.3f)
-        )
-
-        verify(onClickableAreaClickedListener)
-          .onClickableAreaTouched(
-            capture(regionClickedEvent)
-          )
-        assertThat(regionClickedEvent.value).isEqualTo(NamedRegionClickedEvent("Region 3"))
       }
+      onView(withId(R.id.clickable_image_view)).perform(
+        clickPoint(0.3f, 0.3f)
+      )
+
+      verify(onClickableAreaClickedListener)
+        .onClickableAreaTouched(
+          capture(regionClickedEvent)
+        )
+      assertThat(regionClickedEvent.value).isEqualTo(NamedRegionClickedEvent("Region 3"))
     }
   }
 
@@ -103,32 +102,32 @@ class ImageRegionSelectionInteractionViewTest {
     launch(ImageRegionSelectionTestActivity::class.java).use {
       it.onActivity {
         it.clickable_image_view.setListener(onClickableAreaClickedListener)
-        onView(withId(R.id.clickable_image_view)).perform(
-          clickPoint(0.3f, 0.3f)
-        )
-        onView(allOf(withTagValue(`is`("Region 3"))))
-          .check(
-            matches(isDisplayed())
-          )
-
-        onView(withId(R.id.clickable_image_view)).perform(
-          clickPoint(0.7f, 0.3f)
-        )
-        onView(allOf(withTagValue(`is`("Region 2"))))
-          .check(
-            matches(isDisplayed())
-          )
-
-        verify(
-          onClickableAreaClickedListener,
-          times(2)
-        ).onClickableAreaTouched(
-          capture(
-            regionClickedEvent
-          )
-        )
-        assertThat(regionClickedEvent.value).isEqualTo(NamedRegionClickedEvent("Region 2"))
       }
+      onView(withId(R.id.clickable_image_view)).perform(
+        clickPoint(0.3f, 0.3f)
+      )
+      onView(allOf(withTagValue(`is`("Region 3"))))
+        .check(
+          matches(isDisplayed())
+        )
+
+      onView(withId(R.id.clickable_image_view)).perform(
+        clickPoint(0.7f, 0.3f)
+      )
+      onView(allOf(withTagValue(`is`("Region 2"))))
+        .check(
+          matches(isDisplayed())
+        )
+
+      verify(
+        onClickableAreaClickedListener,
+        times(2)
+      ).onClickableAreaTouched(
+        capture(
+          regionClickedEvent
+        )
+      )
+      assertThat(regionClickedEvent.value).isEqualTo(NamedRegionClickedEvent("Region 2"))
     }
   }
 
@@ -137,18 +136,18 @@ class ImageRegionSelectionInteractionViewTest {
     launch(ImageRegionSelectionTestActivity::class.java).use {
       it.onActivity {
         it.clickable_image_view.setListener(onClickableAreaClickedListener)
-        onView(withId(R.id.clickable_image_view)).perform(
-          clickPoint(0.0f, 0.0f)
-        )
-        onView(withId(R.id.default_selected_region)).check(
-          matches(isDisplayed())
-        )
-        verify(onClickableAreaClickedListener)
-          .onClickableAreaTouched(
-            capture(regionClickedEvent)
-          )
-        assertThat(regionClickedEvent.value).isEqualTo(DefaultRegionClickedEvent())
       }
+      onView(withId(R.id.clickable_image_view)).perform(
+        clickPoint(0.0f, 0.0f)
+      )
+      onView(withId(R.id.default_selected_region)).check(
+        matches(isDisplayed())
+      )
+      verify(onClickableAreaClickedListener)
+        .onClickableAreaTouched(
+          capture(regionClickedEvent)
+        )
+      assertThat(regionClickedEvent.value).isEqualTo(DefaultRegionClickedEvent)
     }
   }
 
@@ -223,7 +222,7 @@ class ImageRegionSelectionInteractionViewTest {
           matches(not(isDisplayed()))
         )
 
-        assertThat(regionClickedEvent.value).isEqualTo(DefaultRegionClickedEvent())
+        assertThat(regionClickedEvent.value).isEqualTo(DefaultRegionClickedEvent)
       }
     }
   }

--- a/app/src/sharedTest/java/org/oppia/app/testing/ImageRegionSelectionInteractionViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/testing/ImageRegionSelectionInteractionViewTest.kt
@@ -157,32 +157,32 @@ class ImageRegionSelectionInteractionViewTest {
     launch(ImageRegionSelectionTestActivity::class.java).use {
       it.onActivity {
         it.clickable_image_view.setListener(onClickableAreaClickedListener)
-        onView(withId(R.id.clickable_image_view)).perform(
-          clickPoint(0.3f, 0.3f)
-        )
-        onView(allOf(withTagValue(`is`("Region 3"))))
-          .check(
-            matches(isDisplayed())
-          )
-
-        onView(withId(R.id.clickable_image_view)).perform(
-          clickPoint(0.7f, 0.3f)
-        )
-        onView(allOf(withTagValue(`is`("Region 2"))))
-          .check(
-            matches(isDisplayed())
-          )
-
-        verify(
-          onClickableAreaClickedListener,
-          times(2)
-        ).onClickableAreaTouched(
-          capture(
-            regionClickedEvent
-          )
-        )
-        assertThat(regionClickedEvent.value).isEqualTo(NamedRegionClickedEvent("Region 2"))
       }
+      onView(withId(R.id.clickable_image_view)).perform(
+        clickPoint(0.3f, 0.3f)
+      )
+      onView(allOf(withTagValue(`is`("Region 3"))))
+        .check(
+          matches(isDisplayed())
+        )
+
+      onView(withId(R.id.clickable_image_view)).perform(
+        clickPoint(0.7f, 0.3f)
+      )
+      onView(allOf(withTagValue(`is`("Region 2"))))
+        .check(
+          matches(isDisplayed())
+        )
+
+      verify(
+        onClickableAreaClickedListener,
+        times(2)
+      ).onClickableAreaTouched(
+        capture(
+          regionClickedEvent
+        )
+      )
+      assertThat(regionClickedEvent.value).isEqualTo(NamedRegionClickedEvent("Region 2"))
     }
   }
 
@@ -192,20 +192,20 @@ class ImageRegionSelectionInteractionViewTest {
     launch(ImageRegionSelectionTestActivity::class.java).use {
       it.onActivity {
         it.clickable_image_view.setListener(onClickableAreaClickedListener)
-        onView(withId(R.id.clickable_image_view)).perform(
-          clickPoint(0.3f, 0.3f)
-        )
-        onView(allOf(withTagValue(`is`("Region 3"))))
-          .check(
-            matches(isDisplayed())
-          )
-
-        verify(onClickableAreaClickedListener)
-          .onClickableAreaTouched(
-            capture(regionClickedEvent)
-          )
-        assertThat(regionClickedEvent.value).isEqualTo(NamedRegionClickedEvent("Region 3"))
       }
+      onView(withId(R.id.clickable_image_view)).perform(
+        clickPoint(0.3f, 0.3f)
+      )
+      onView(allOf(withTagValue(`is`("Region 3"))))
+        .check(
+          matches(isDisplayed())
+        )
+
+      verify(onClickableAreaClickedListener)
+        .onClickableAreaTouched(
+          capture(regionClickedEvent)
+        )
+      assertThat(regionClickedEvent.value).isEqualTo(NamedRegionClickedEvent("Region 3"))
     }
   }
 
@@ -215,15 +215,15 @@ class ImageRegionSelectionInteractionViewTest {
     launch(ImageRegionSelectionTestActivity::class.java).use { scenario ->
       scenario.onActivity {
         it.clickable_image_view.setListener(onClickableAreaClickedListener)
-        onView(withId(R.id.clickable_image_view)).perform(
-          clickPoint(0.0f, 0.0f)
-        )
-        onView(withId(R.id.default_selected_region)).check(
-          matches(not(isDisplayed()))
-        )
-
-        assertThat(regionClickedEvent.value).isEqualTo(DefaultRegionClickedEvent)
       }
+      onView(withId(R.id.clickable_image_view)).perform(
+        clickPoint(0.0f, 0.0f)
+      )
+      onView(withId(R.id.default_selected_region)).check(
+        matches(not(isDisplayed()))
+      )
+
+      assertThat(regionClickedEvent.value).isEqualTo(DefaultRegionClickedEvent)
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
This PR removes the dependency of PhotoView Library that were introduced in #1457. 

**Need for this**
In #1457 we introduced a library to get calculate image rect for laying out other views and it was working fine as well but there was delay in function execution/invocation for a particular case.
We could've had anticipated this but i. couldn't verify the test because there was some issue with my machine and i couldn't run the test and that's why this issue was never encountered but today i fixed my machine and tried to run the test and found out that the test was incorrect and there was multiple issues listed below:-
1) Using object instead of class for DefaultRegionClickedEvent - https://github.com/oppia/oppia-android/blob/ffb7e94b2de5eb8797a3aac6702965fad2079a13/app/src/main/java/org/oppia/app/utility/RegionClickEvent.kt#L14
so if we try to verify the value of class object using mockito it would fail as we were checking the class objects in this case and in case of NamedRegionClickedEvent we were region checking string value. To fix this i had to change this class to a object 

2)Test introduced in 1457 inside `ImageRegionSelectionInteractionViewTest ` had a slight mistake because of that they were not executing properly
https://github.com/oppia/oppia-android/blob/ffb7e94b2de5eb8797a3aac6702965fad2079a13/app/src/sharedTest/java/org/oppia/app/testing/ImageRegionSelectionInteractionViewTest.kt#L88

If you can see above everything is written inside onActivity callback and because of that weren't checking the code at all so i had to move the test out of the onActivity callback

3)PhotoView `onPhotoTap()`  had a delay in function execution which were causing  the below condition to fail 
https://github.com/oppia/oppia-android/blob/ffb7e94b2de5eb8797a3aac6702965fad2079a13/app/src/sharedTest/java/org/oppia/app/testing/ImageRegionSelectionInteractionViewTest.kt#L150
We were getting an error that `mockito had no interaction with the above listener` and that was happening because onPhotoTap was executing the function after some milliseconds because of some computation and tests were getting checked before that and in order to fix that i removed the dependency of PhotoView Library and added my own implementation.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
