### PR TITLE
Fix #1536: Showing Previous Response Header gives crash

### DIFF
--- a/app/src/main/res/layout-land/previous_responses_header_item.xml
+++ b/app/src/main/res/layout-land/previous_responses_header_item.xml
@@ -23,7 +23,7 @@
 
     <FrameLayout
       android:layout_width="0dp"
-      android:layout_height="1dp"
+      android:layout_height="@{viewModel.isSplitView? @dimen/thickness_2 : @dimen/thickness_1, default=@dimen/thickness_1}"
       android:background="@color/mid_grey"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toStartOf="@+id/previous_responses_header_text"
@@ -48,7 +48,7 @@
 
     <FrameLayout
       android:layout_width="0dp"
-      android:layout_height="1dp"
+      android:layout_height="@{viewModel.isSplitView? @dimen/thickness_2 : @dimen/thickness_1, default=@dimen/thickness_1}"
       android:background="@color/mid_grey"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout-sw600dp-land/previous_responses_header_item.xml
+++ b/app/src/main/res/layout-sw600dp-land/previous_responses_header_item.xml
@@ -59,7 +59,7 @@
 
     <FrameLayout
       android:layout_width="0dp"
-      android:layout_height="2dp"
+      android:layout_height="@{viewModel.isSplitView? @dimen/thickness_2 : @dimen/thickness_1, default=@dimen/thickness_1}"
       android:background="@color/mid_grey"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toStartOf="@+id/previous_responses_header_text"
@@ -84,7 +84,7 @@
 
     <FrameLayout
       android:layout_width="0dp"
-      android:layout_height="2dp"
+      android:layout_height="@{viewModel.isSplitView? @dimen/thickness_2 : @dimen/thickness_1, default=@dimen/thickness_1}"
       android:background="@color/mid_grey"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout-sw600dp-port/previous_responses_header_item.xml
+++ b/app/src/main/res/layout-sw600dp-port/previous_responses_header_item.xml
@@ -59,7 +59,7 @@
 
     <FrameLayout
       android:layout_width="0dp"
-      android:layout_height="2dp"
+      android:layout_height="@{viewModel.isSplitView? @dimen/thickness_2 : @dimen/thickness_1, default=@dimen/thickness_1}"
       android:background="@color/mid_grey"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toStartOf="@+id/previous_responses_header_text"
@@ -84,7 +84,7 @@
 
     <FrameLayout
       android:layout_width="0dp"
-      android:layout_height="2dp"
+      android:layout_height="@{viewModel.isSplitView? @dimen/thickness_2 : @dimen/thickness_1, default=@dimen/thickness_1}"
       android:background="@color/mid_grey"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/previous_responses_header_item.xml
+++ b/app/src/main/res/layout/previous_responses_header_item.xml
@@ -59,7 +59,7 @@
 
     <FrameLayout
       android:layout_width="0dp"
-      android:layout_height="@{viewModel.isSplitView? @dimen/thickness_2 : @dimen/thickness_1}"
+      android:layout_height="@{viewModel.isSplitView? @dimen/thickness_2 : @dimen/thickness_1, default=@dimen/thickness_1}"
       android:background="@color/mid_grey"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toStartOf="@+id/previous_responses_header_text"
@@ -84,7 +84,7 @@
 
     <FrameLayout
       android:layout_width="0dp"
-      android:layout_height="@{viewModel.isSplitView? @dimen/thickness_2 : @dimen/thickness_1}"
+      android:layout_height="@{viewModel.isSplitView? @dimen/thickness_2 : @dimen/thickness_1, default=@dimen/thickness_1}"
       android:background="@color/mid_grey"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #1536 
Added default height to Data Binding in XML

**For Reviewer**
Do we need to do the same for `*land/previous_response_header_item.xml` file also?

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
