### PR TITLE
Fix #1534: Each submitted answer shows correct-tick, once correct answer is submitted in question player

### DIFF
--- a/app/src/main/java/org/oppia/app/player/state/StatePlayerRecyclerViewAssembler.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StatePlayerRecyclerViewAssembler.kt
@@ -487,7 +487,7 @@ class StatePlayerRecyclerViewAssembler private constructor(
   ): SubmittedAnswerViewModel {
     val submittedAnswerViewModel =
       SubmittedAnswerViewModel(userAnswer, gcsEntityId, hasConversationView, isSplitView.get()!!)
-    submittedAnswerViewModel.isCorrectAnswer.set(isCorrectAnswer.get())
+    submittedAnswerViewModel.isCorrectAnswer.set(isAnswerCorrect)
     submittedAnswerViewModel.isExtraInteractionAnswerCorrect.set(isAnswerCorrect)
     return submittedAnswerViewModel
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix #1534 

### How to Test

1. Go to Fractions
2. Click on Practice
3. Select few subtopics - Start
4. Now once you get a question, mark few incorrect marks.
5. Mark a correct answer.
6. Click on Previous Responses
7. Notice that only the correct item shows tickmark.

<img src="https://user-images.githubusercontent.com/25057618/89268623-6ba92480-d656-11ea-9af9-279fbdc6cd3b.png" wdith="250" height="450" />

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
