### PR TITLE
Fix #1562: Bug fix promoted story list

### DIFF
--- a/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
@@ -27,7 +27,6 @@ import org.oppia.app.model.TopicList
 import org.oppia.app.model.TopicSummary
 import org.oppia.domain.oppialogger.OppiaLogger
 import org.oppia.domain.profile.ProfileManagementController
-import org.oppia.domain.topic.StoryProgressTestHelper
 import org.oppia.domain.topic.TopicListController
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.datetime.DateTimeUtil
@@ -42,7 +41,6 @@ class HomeFragmentPresenter @Inject constructor(
   private val fragment: Fragment,
   private val profileManagementController: ProfileManagementController,
   private val topicListController: TopicListController,
-  private val storyProgressTestHelper: StoryProgressTestHelper,
   private val oppiaClock: OppiaClock,
   private val logger: ConsoleLogger,
   private val oppiaLogger: OppiaLogger
@@ -67,9 +65,6 @@ class HomeFragmentPresenter @Inject constructor(
     internalProfileId = activity.intent.getIntExtra(KEY_NAVIGATION_PROFILE_ID, -1)
     profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
     logHomeActivityEvent()
-
-    storyProgressTestHelper.markPartialStoryProgressForFractions(profileId, true)
-    storyProgressTestHelper.markTwoPartialStoryProgressForRatios(profileId, true)
 
     welcomeViewModel = WelcomeViewModel()
     promotedStoryListViewModel = PromotedStoryListViewModel(activity, internalProfileId)

--- a/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
@@ -27,6 +27,7 @@ import org.oppia.app.model.TopicList
 import org.oppia.app.model.TopicSummary
 import org.oppia.domain.oppialogger.OppiaLogger
 import org.oppia.domain.profile.ProfileManagementController
+import org.oppia.domain.topic.StoryProgressTestHelper
 import org.oppia.domain.topic.TopicListController
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.datetime.DateTimeUtil
@@ -41,6 +42,7 @@ class HomeFragmentPresenter @Inject constructor(
   private val fragment: Fragment,
   private val profileManagementController: ProfileManagementController,
   private val topicListController: TopicListController,
+  private val storyProgressTestHelper: StoryProgressTestHelper,
   private val oppiaClock: OppiaClock,
   private val logger: ConsoleLogger,
   private val oppiaLogger: OppiaLogger
@@ -65,6 +67,9 @@ class HomeFragmentPresenter @Inject constructor(
     internalProfileId = activity.intent.getIntExtra(KEY_NAVIGATION_PROFILE_ID, -1)
     profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
     logHomeActivityEvent()
+
+    storyProgressTestHelper.markPartialStoryProgressForFractions(profileId, true)
+    storyProgressTestHelper.markTwoPartialStoryProgressForRatios(profileId, true)
 
     welcomeViewModel = WelcomeViewModel()
     promotedStoryListViewModel = PromotedStoryListViewModel(activity, internalProfileId)
@@ -180,10 +185,20 @@ class HomeFragmentPresenter @Inject constructor(
     getAssumedSuccessfulOngoingStoryList().observe(
       fragment,
       Observer<OngoingStoryList> {
-        it.recentStoryList.take(limit).forEach { promotedStory ->
-          val recentStory = PromotedStoryViewModel(activity, internalProfileId)
-          recentStory.setPromotedStory(promotedStory)
-          promotedStoryList.add(recentStory)
+        promotedStoryList.clear()
+        if (it.recentStoryCount != 0) {
+          it.recentStoryList.take(limit).forEach { promotedStory ->
+            val recentStory = PromotedStoryViewModel(activity, internalProfileId)
+            recentStory.setPromotedStory(promotedStory)
+            promotedStoryList.add(recentStory)
+          }
+        } else {
+          // TODO(#936): Optimise this as part of recommended stories.
+          it.olderStoryList.take(limit).forEach { promotedStory ->
+            val oldStory = PromotedStoryViewModel(activity, internalProfileId)
+            oldStory.setPromotedStory(promotedStory)
+            promotedStoryList.add(oldStory)
+          }
         }
         topicListAdapter.notifyItemChanged(1)
       }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #1562 

In #1554 we noticed one issue, if user have progress in old stories but not in recent stories, the home screen promoted stories looks empty but the `RecentlyPlayedActivity` looks correct. So to fix this I have optimised the logic a bit.
1. If there are recent stories, only recent stories will be show in `HomeActivity` and not the old-stories.
2. If there are no recent stories, then old stories will be show in `HomeActivity` as recent stories, because that's the most recent stories from user perspective. 

This will further be improvised once we have `Recommended Stories` in place as part of #936 

## How to test
Using `StoryProgressTestHelper` make partial progress but as old story using following code.

```
   storyProgressTestHelper.markPartialStoryProgressForFractions(profileId, true)
   storyProgressTestHelper.markTwoPartialStoryProgressForRatios(profileId, true)
```

## Screenshot
![Screenshot_1596712534](https://user-images.githubusercontent.com/9396084/89526540-8968bc00-d805-11ea-92f8-f7f43fa13abc.png)
![Screenshot_1596712540](https://user-images.githubusercontent.com/9396084/89526548-8cfc4300-d805-11ea-9972-09f5a045f83c.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
