### PR TITLE
Fixes part of #40 & #42: Generalisation Highfi Mobile Portrait + Landscape

### DIFF
--- a/app/src/main/res/layout-land/state_fragment.xml
+++ b/app/src/main/res/layout-land/state_fragment.xml
@@ -6,6 +6,7 @@
   <data>
 
     <import type="android.view.View" />
+
     <variable
       name="presenter"
       type="org.oppia.app.player.state.StateFragmentPresenter" />
@@ -39,10 +40,10 @@
         android:scrollbars="none"
         app:data="@{viewModel.itemList}"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/center_guideline"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
       <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/extra_interaction_recycler_view"
@@ -55,18 +56,18 @@
         android:visibility="@{viewModel.isSplitView ? View.VISIBLE : View.GONE}"
         app:data="@{viewModel.rightItemList}"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintStart_toEndOf="@id/center_guideline"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintStart_toEndOf="@id/center_guideline"
+        app:layout_constraintTop_toTopOf="parent" />
 
       <androidx.constraintlayout.widget.Guideline
         android:id="@+id/center_guideline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        tools:layout_constraintGuide_percent="0.5f"
-        app:layout_constraintGuide_percent="@{viewModel.centerGuidelinePercentage.floatValue()}" />
+        app:layout_constraintGuide_percent="@{viewModel.centerGuidelinePercentage.floatValue()}"
+        tools:layout_constraintGuide_percent="0.5f" />
 
       <FrameLayout
         android:id="@+id/audio_fragment_container"
@@ -90,33 +91,31 @@
     <FrameLayout
       android:id="@+id/hints_and_solution_fragment_placeholder"
       android:layout_width="match_parent"
-      android:layout_height="match_parent">
-    </FrameLayout>
+      android:layout_height="match_parent"></FrameLayout>
 
     <FrameLayout
       android:id="@+id/hints_and_solution_fragment_container"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:layout_gravity="bottom|start"
       android:background="@drawable/hints_background"
-      android:visibility="@{viewModel.isHintBulbVisible() ? View.VISIBLE : View.GONE}"
-      android:layout_gravity="bottom|start">
+      android:visibility="@{viewModel.isHintBulbVisible() ? View.VISIBLE : View.GONE}">
 
       <ImageView
         android:id="@+id/dot_hint"
         android:layout_width="8dp"
         android:layout_height="6dp"
-        android:layout_margin="8dp"
         android:layout_gravity="top|end"
-        android:visibility="@{viewModel.isHintOpenedAndUnRevealed() ? View.VISIBLE : View.GONE}"
+        android:layout_margin="8dp"
         android:src="@drawable/ic_dot_yellow_24dp"
-        />
+        android:visibility="@{viewModel.isHintOpenedAndUnRevealed() ? View.VISIBLE : View.GONE}" />
+
       <ImageView
         android:id="@+id/hint_bulb"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="12dp"
-        android:src="@drawable/ic_hintbulb_whilte_24dp"
-        />
+        android:src="@drawable/ic_hintbulb_whilte_24dp" />
     </FrameLayout>
 
     <FrameLayout

--- a/app/src/main/res/layout-land/state_fragment.xml
+++ b/app/src/main/res/layout-land/state_fragment.xml
@@ -67,21 +67,25 @@
         android:orientation="vertical"
         tools:layout_constraintGuide_percent="0.5f"
         app:layout_constraintGuide_percent="@{viewModel.centerGuidelinePercentage.floatValue()}" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <FrameLayout
-      android:id="@+id/audio_fragment_container"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_gravity="top"
-      android:layout_marginStart="24dp">
 
       <FrameLayout
-        android:id="@+id/audio_fragment_placeholder"
-        android:layout_width="match_parent"
+        android:id="@+id/audio_fragment_container"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:visibility="@{viewModel.isAudioBarVisible ? View.VISIBLE : View.GONE}" />
-    </FrameLayout>
+        android:layout_gravity="top"
+        app:layoutMarginEnd="@{viewModel.isSplitView() ? @dimen/margin_64 : @dimen/margin_120}"
+        app:layoutMarginStart="@{viewModel.isSplitView() ? @dimen/margin_64 : @dimen/margin_120}"
+        app:layout_constraintEnd_toStartOf="@id/center_guideline"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <FrameLayout
+          android:id="@+id/audio_fragment_placeholder"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:visibility="@{viewModel.isAudioBarVisible ? View.VISIBLE : View.GONE}" />
+      </FrameLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <FrameLayout
       android:id="@+id/hints_and_solution_fragment_placeholder"

--- a/app/src/main/res/layout-sw600dp-land/state_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-land/state_fragment.xml
@@ -6,6 +6,7 @@
   <data>
 
     <import type="android.view.View" />
+
     <variable
       name="presenter"
       type="org.oppia.app.player.state.StateFragmentPresenter" />
@@ -36,14 +37,14 @@
         android:divider="@android:color/transparent"
         android:overScrollMode="never"
         android:paddingTop="@{viewModel.isAudioBarVisible ? @dimen/padding_48 : @dimen/padding_0}"
-        android:scrollbars="none"
         android:paddingBottom="112dp"
+        android:scrollbars="none"
         app:data="@{viewModel.itemList}"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/center_guideline"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
       <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/extra_interaction_recycler_view"
@@ -52,34 +53,34 @@
         android:clipToPadding="false"
         android:divider="@android:color/transparent"
         android:overScrollMode="never"
-        android:scrollbars="none"
         android:paddingBottom="112dp"
+        android:scrollbars="none"
         android:visibility="@{viewModel.isSplitView ? View.VISIBLE : View.GONE}"
         app:data="@{viewModel.rightItemList}"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintStart_toEndOf="@id/center_guideline"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintStart_toEndOf="@id/center_guideline"
+        app:layout_constraintTop_toTopOf="parent" />
 
       <androidx.constraintlayout.widget.Guideline
         android:id="@+id/center_guideline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        tools:layout_constraintGuide_percent="0.5f"
-        app:layout_constraintGuide_percent="@{viewModel.centerGuidelinePercentage.floatValue()}" />
+        app:layout_constraintGuide_percent="@{viewModel.centerGuidelinePercentage.floatValue()}"
+        tools:layout_constraintGuide_percent="0.5f" />
 
       <FrameLayout
         android:id="@+id/audio_fragment_container"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_gravity="top"
-        app:layoutMarginStart="@{viewModel.isSplitView() ? @dimen/margin_64 : @dimen/margin_192}"
         app:layoutMarginEnd="@{viewModel.isSplitView() ? @dimen/margin_64 : @dimen/margin_192}"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layoutMarginStart="@{viewModel.isSplitView() ? @dimen/margin_64 : @dimen/margin_192}"
+        app:layout_constraintEnd_toStartOf="@id/center_guideline"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/center_guideline">
+        app:layout_constraintTop_toTopOf="parent">
 
         <FrameLayout
           android:id="@+id/audio_fragment_placeholder"
@@ -92,33 +93,31 @@
     <FrameLayout
       android:id="@+id/hints_and_solution_fragment_placeholder"
       android:layout_width="match_parent"
-      android:layout_height="match_parent">
-    </FrameLayout>
+      android:layout_height="match_parent"></FrameLayout>
 
     <FrameLayout
       android:id="@+id/hints_and_solution_fragment_container"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:layout_gravity="bottom|start"
       android:background="@drawable/hints_background"
-      android:visibility="@{viewModel.isHintBulbVisible() ? View.VISIBLE : View.GONE}"
-      android:layout_gravity="bottom|start">
+      android:visibility="@{viewModel.isHintBulbVisible() ? View.VISIBLE : View.GONE}">
 
       <ImageView
         android:id="@+id/dot_hint"
         android:layout_width="8dp"
         android:layout_height="6dp"
-        android:layout_margin="8dp"
         android:layout_gravity="top|end"
-        android:visibility="@{viewModel.isHintOpenedAndUnRevealed() ? View.VISIBLE : View.GONE}"
+        android:layout_margin="8dp"
         android:src="@drawable/ic_dot_yellow_24dp"
-        />
+        android:visibility="@{viewModel.isHintOpenedAndUnRevealed() ? View.VISIBLE : View.GONE}" />
+
       <ImageView
         android:id="@+id/hint_bulb"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="12dp"
-        android:src="@drawable/ic_hintbulb_whilte_24dp"
-        />
+        android:src="@drawable/ic_hintbulb_whilte_24dp" />
     </FrameLayout>
 
     <FrameLayout

--- a/app/src/main/res/layout-sw600dp-port/state_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-port/state_fragment.xml
@@ -6,6 +6,7 @@
   <data>
 
     <import type="android.view.View" />
+
     <variable
       name="presenter"
       type="org.oppia.app.player.state.StateFragmentPresenter" />
@@ -36,14 +37,14 @@
         android:divider="@android:color/transparent"
         android:overScrollMode="never"
         android:paddingTop="@{viewModel.isAudioBarVisible ? @dimen/padding_48 : @dimen/padding_0}"
-        android:scrollbars="none"
         android:paddingBottom="112dp"
+        android:scrollbars="none"
         app:data="@{viewModel.itemList}"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/center_guideline"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
       <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/extra_interaction_recycler_view"
@@ -52,34 +53,34 @@
         android:clipToPadding="false"
         android:divider="@android:color/transparent"
         android:overScrollMode="never"
-        android:scrollbars="none"
         android:paddingBottom="112dp"
+        android:scrollbars="none"
         android:visibility="@{viewModel.isSplitView ? View.VISIBLE : View.GONE}"
         app:data="@{viewModel.rightItemList}"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintStart_toEndOf="@id/center_guideline"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintStart_toEndOf="@id/center_guideline"
+        app:layout_constraintTop_toTopOf="parent" />
 
       <androidx.constraintlayout.widget.Guideline
         android:id="@+id/center_guideline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        tools:layout_constraintGuide_percent="0.5f"
-        app:layout_constraintGuide_percent="@{viewModel.centerGuidelinePercentage.floatValue()}" />
+        app:layout_constraintGuide_percent="@{viewModel.centerGuidelinePercentage.floatValue()}"
+        tools:layout_constraintGuide_percent="0.5f" />
 
       <FrameLayout
         android:id="@+id/audio_fragment_container"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_gravity="top"
-        app:layoutMarginStart="@{viewModel.isSplitView() ? @dimen/margin_32 : @dimen/margin_128}"
         app:layoutMarginEnd="@{viewModel.isSplitView() ? @dimen/margin_32 : @dimen/margin_128}"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layoutMarginStart="@{viewModel.isSplitView() ? @dimen/margin_32 : @dimen/margin_128}"
+        app:layout_constraintEnd_toStartOf="@id/center_guideline"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/center_guideline">
+        app:layout_constraintTop_toTopOf="parent">
 
         <FrameLayout
           android:id="@+id/audio_fragment_placeholder"
@@ -92,33 +93,31 @@
     <FrameLayout
       android:id="@+id/hints_and_solution_fragment_placeholder"
       android:layout_width="match_parent"
-      android:layout_height="match_parent">
-    </FrameLayout>
+      android:layout_height="match_parent"></FrameLayout>
 
     <FrameLayout
       android:id="@+id/hints_and_solution_fragment_container"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:layout_gravity="bottom|start"
       android:background="@drawable/hints_background"
-      android:visibility="@{viewModel.isHintBulbVisible() ? View.VISIBLE : View.GONE}"
-      android:layout_gravity="bottom|start">
+      android:visibility="@{viewModel.isHintBulbVisible() ? View.VISIBLE : View.GONE}">
 
       <ImageView
         android:id="@+id/dot_hint"
         android:layout_width="8dp"
         android:layout_height="6dp"
-        android:layout_margin="8dp"
         android:layout_gravity="top|end"
-        android:visibility="@{viewModel.isHintOpenedAndUnRevealed() ? View.VISIBLE : View.GONE}"
+        android:layout_margin="8dp"
         android:src="@drawable/ic_dot_yellow_24dp"
-        />
+        android:visibility="@{viewModel.isHintOpenedAndUnRevealed() ? View.VISIBLE : View.GONE}" />
+
       <ImageView
         android:id="@+id/hint_bulb"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="12dp"
-        android:src="@drawable/ic_hintbulb_whilte_24dp"
-        />
+        android:src="@drawable/ic_hintbulb_whilte_24dp" />
     </FrameLayout>
 
     <FrameLayout

--- a/app/src/main/res/layout-sw600dp-port/state_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-port/state_fragment.xml
@@ -75,8 +75,8 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_gravity="top"
-        app:layoutMarginStart="@{viewModel.isSplitView() ? @dimen/margin_64 : @dimen/margin_128}"
-        app:layoutMarginEnd="@{viewModel.isSplitView() ? @dimen/margin_64 : @dimen/margin_128}"
+        app:layoutMarginStart="@{viewModel.isSplitView() ? @dimen/margin_32 : @dimen/margin_128}"
+        app:layoutMarginEnd="@{viewModel.isSplitView() ? @dimen/margin_32 : @dimen/margin_128}"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/center_guideline">

--- a/app/src/main/res/layout/audio_fragment.xml
+++ b/app/src/main/res/layout/audio_fragment.xml
@@ -17,8 +17,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="center_horizontal"
-    android:layout_marginStart="@dimen/audio_fragment_margin"
-    android:layout_marginEnd="@dimen/audio_fragment_margin"
     android:layout_marginBottom="12dp"
     android:background="@drawable/audio_background"
     android:elevation="8dp"

--- a/app/src/main/res/layout/state_fragment.xml
+++ b/app/src/main/res/layout/state_fragment.xml
@@ -74,8 +74,8 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_gravity="top"
-        app:layoutMarginEnd="@{viewModel.isSplitView() ? @dimen/margin_64 : @dimen/margin_24}"
-        app:layoutMarginStart="@{viewModel.isSplitView() ? @dimen/margin_64 : @dimen/margin_24}"
+        app:layoutMarginEnd="@{viewModel.isSplitView() ? @dimen/margin_32 : @dimen/margin_28}"
+        app:layoutMarginStart="@{viewModel.isSplitView() ? @dimen/margin_32 : @dimen/margin_28}"
         app:layout_constraintEnd_toStartOf="@id/center_guideline"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

This PR fixes the margin around the audio-bar.
Checkout `Fractions` -> `What is a Fraction?`exploration for audio player. 
For now, we cannot test this UI for `Split` screen view because that screen does not contain a voiceover. But still it not hard to check this because in the layout-editor of android-studio you can easily see the margins/padding.

## Margin Values Start/End

Mobile View Portrait: `28dp`
Mobile View Landscape: `120dp`
Tablet View Portrait: `128dp`
Tablet View Landscape: `192dp`
Split View Portrait: `32dp`
Split View Landscape: `64dp`

## References/Screenshot
https://xd.adobe.com/view/d405de00-a871-4f0f-73a0-f8acef30349b-a234/screen/997dbb42-330e-4144-b39d-38ee0163c693/
https://xd.adobe.com/view/d405de00-a871-4f0f-73a0-f8acef30349b-a234/screen/093aeee5-4da0-4dad-ae13-c7e7e933347a/specs/
https://xd.adobe.com/view/ee9e607b-dbd6-4372-48dc-b687d32af3da-98af/screen/650cd7d5-6e30-420c-acf3-f0f5f79823d0/specs/
https://xd.adobe.com/view/e8aa4198-3940-47f9-514a-f41cc54457f6-9e9b/screen/d74f0571-471f-4ea6-a3a5-32e135253c56/specs/
https://xd.adobe.com/view/d405de00-a871-4f0f-73a0-f8acef30349b-a234/screen/7bcb9dd0-0d24-4e93-ba12-3a9f28c4e7d7/specs/
https://xd.adobe.com/view/d405de00-a871-4f0f-73a0-f8acef30349b-a234/screen/72484161-8707-438a-bf20-50f964216d76/specs/

## Screenshot
![Screenshot_1597362173](https://user-images.githubusercontent.com/9396084/90197822-7a799f00-dded-11ea-876b-ba72dc90355a.png)
![Screenshot_1597362177](https://user-images.githubusercontent.com/9396084/90197829-7ea5bc80-dded-11ea-98d1-c30c7491e987.png)
![Screenshot_1597362189](https://user-images.githubusercontent.com/9396084/90197830-806f8000-dded-11ea-9509-230377f32104.png)
![Screenshot_1597362200](https://user-images.githubusercontent.com/9396084/90197835-836a7080-dded-11ea-9644-21e76c7aaeae.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
