### PR TITLE
Fixes #1649 Add Proto Models for RatioExpression Interaction

### DIFF
--- a/domain/src/main/java/org/oppia/domain/util/InteractionObjectExtensions.kt
+++ b/domain/src/main/java/org/oppia/domain/util/InteractionObjectExtensions.kt
@@ -20,7 +20,6 @@ import org.oppia.app.model.InteractionObject.ObjectTypeCase.SIGNED_INT
 import org.oppia.app.model.ListOfSetsOfHtmlStrings
 import org.oppia.app.model.NumberUnit
 import org.oppia.app.model.NumberWithUnits
-import org.oppia.app.model.RatioExpression
 import org.oppia.app.model.StringList
 
 /** Returns a parsable string representation of a user-submitted answer version of this [InteractionObject]. */

--- a/domain/src/main/java/org/oppia/domain/util/InteractionObjectExtensions.kt
+++ b/domain/src/main/java/org/oppia/domain/util/InteractionObjectExtensions.kt
@@ -20,6 +20,7 @@ import org.oppia.app.model.InteractionObject.ObjectTypeCase.SIGNED_INT
 import org.oppia.app.model.ListOfSetsOfHtmlStrings
 import org.oppia.app.model.NumberUnit
 import org.oppia.app.model.NumberWithUnits
+import org.oppia.app.model.RatioExpression
 import org.oppia.app.model.StringList
 
 /** Returns a parsable string representation of a user-submitted answer version of this [InteractionObject]. */
@@ -36,7 +37,7 @@ fun InteractionObject.toAnswerString(): String {
     LIST_OF_SETS_OF_HTML_STRING -> listOfSetsOfHtmlString.toAnswerString()
     IMAGE_WITH_REGIONS -> imageWithRegions.toAnswerString()
     CLICK_ON_IMAGE -> clickOnImage.toAnswerString()
-    RATIO_EXPRESSION -> ratioExpression.html
+    RATIO_EXPRESSION -> ratioExpression.toAnswerString()
     OBJECTTYPE_NOT_SET -> "" // The default InteractionObject should be an empty string.
   }
 }
@@ -74,6 +75,10 @@ private fun StringList.toAnswerString(): String {
 
 private fun ListOfSetsOfHtmlStrings.toAnswerString(): String {
   return setOfHtmlStringsList.joinToString { "[${it.toAnswerString()}]" }
+}
+
+private fun RatioExpression.toAnswerString(): String {
+  return ratioComponentList.joinToString(separator = ":")
 }
 
 private fun ImageWithRegions.toAnswerString(): String =

--- a/domain/src/main/java/org/oppia/domain/util/InteractionObjectExtensions.kt
+++ b/domain/src/main/java/org/oppia/domain/util/InteractionObjectExtensions.kt
@@ -13,12 +13,14 @@ import org.oppia.app.model.InteractionObject.ObjectTypeCase.NON_NEGATIVE_INT
 import org.oppia.app.model.InteractionObject.ObjectTypeCase.NORMALIZED_STRING
 import org.oppia.app.model.InteractionObject.ObjectTypeCase.NUMBER_WITH_UNITS
 import org.oppia.app.model.InteractionObject.ObjectTypeCase.OBJECTTYPE_NOT_SET
+import org.oppia.app.model.InteractionObject.ObjectTypeCase.RATIO_EXPRESSION
 import org.oppia.app.model.InteractionObject.ObjectTypeCase.REAL
 import org.oppia.app.model.InteractionObject.ObjectTypeCase.SET_OF_HTML_STRING
 import org.oppia.app.model.InteractionObject.ObjectTypeCase.SIGNED_INT
 import org.oppia.app.model.ListOfSetsOfHtmlStrings
 import org.oppia.app.model.NumberUnit
 import org.oppia.app.model.NumberWithUnits
+import org.oppia.app.model.RatioExpression
 import org.oppia.app.model.StringList
 
 /** Returns a parsable string representation of a user-submitted answer version of this [InteractionObject]. */
@@ -35,6 +37,7 @@ fun InteractionObject.toAnswerString(): String {
     LIST_OF_SETS_OF_HTML_STRING -> listOfSetsOfHtmlString.toAnswerString()
     IMAGE_WITH_REGIONS -> imageWithRegions.toAnswerString()
     CLICK_ON_IMAGE -> clickOnImage.toAnswerString()
+    RATIO_EXPRESSION -> ratioExpression.html
     OBJECTTYPE_NOT_SET -> "" // The default InteractionObject should be an empty string.
   }
 }

--- a/domain/src/test/java/org/oppia/domain/util/InteractionObjectExtensionsTest.kt
+++ b/domain/src/test/java/org/oppia/domain/util/InteractionObjectExtensionsTest.kt
@@ -75,7 +75,7 @@ class InteractionObjectExtensionsTest {
   @Test
   fun testToAnswerStr_ratioExpression_correctlyFormatsElements() {
     val ratioExpression = RatioExpression.newBuilder()
-      .setHtml("1:2:3")
+      .addAllRatioComponent(listOf(1, 2, 3))
       .build()
 
     val interactionObject =

--- a/domain/src/test/java/org/oppia/domain/util/InteractionObjectExtensionsTest.kt
+++ b/domain/src/test/java/org/oppia/domain/util/InteractionObjectExtensionsTest.kt
@@ -13,6 +13,7 @@ import org.oppia.app.model.ImageWithRegions.LabeledRegion.Region.RegionType.RECT
 import org.oppia.app.model.InteractionObject
 import org.oppia.app.model.ListOfSetsOfHtmlStrings
 import org.oppia.app.model.Point2d
+import org.oppia.app.model.RatioExpression
 import org.oppia.app.model.StringList
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -69,6 +70,19 @@ class InteractionObjectExtensionsTest {
 
     assertThat(interactionObject.toAnswerString())
       .isEqualTo("[(a, b, c), (0.3, 1.0)]")
+  }
+
+  @Test
+  fun testToAnswerStr_ratioExpression_correctlyFormatsElements() {
+    val ratioExpression = RatioExpression.newBuilder()
+      .setHtml("1:2:3")
+      .build()
+
+    val interactionObject =
+      InteractionObject.newBuilder().setRatioExpression(ratioExpression).build()
+
+    assertThat(interactionObject.toAnswerString())
+      .isEqualTo("1:2:3")
   }
 
   private fun createPoint2d(x: Float, y: Float): Point2d {

--- a/model/src/main/proto/interaction_object.proto
+++ b/model/src/main/proto/interaction_object.proto
@@ -31,8 +31,9 @@ message StringList {
   repeated string html = 1;
 }
 
-// Structure containing a ratio object for eg - [1,2,3].
+// Structure containing a ratio object for eg - [1,2,3] for 1:2:3.
 message RatioExpression {
+  // List of components in a ratio.
   // It's also expected that list should have more than 1 elements with
   // 0 and 1 elements are invalid states.
   repeated uint32 ratio_component = 1;

--- a/model/src/main/proto/interaction_object.proto
+++ b/model/src/main/proto/interaction_object.proto
@@ -31,9 +31,11 @@ message StringList {
   repeated string html = 1;
 }
 
-// Structure containing a ratio object.
+// Structure containing a ratio object for eg - [1,2,3].
 message RatioExpression {
-  repeated uint32 ratio_component = 1;
+  // It's also expected that list should have more than 1 elements with
+  // 0 and 1 elements are invalid states.
+  repeated uint32 ratio_component s= 1;
 }
 
 // Structure for a number with units object.

--- a/model/src/main/proto/interaction_object.proto
+++ b/model/src/main/proto/interaction_object.proto
@@ -35,7 +35,7 @@ message StringList {
 message RatioExpression {
   // It's also expected that list should have more than 1 elements with
   // 0 and 1 elements are invalid states.
-  repeated uint32 ratio_component s= 1;
+  repeated uint32 ratio_component = 1;
 }
 
 // Structure for a number with units object.

--- a/model/src/main/proto/interaction_object.proto
+++ b/model/src/main/proto/interaction_object.proto
@@ -33,7 +33,7 @@ message StringList {
 
 // Structure containing a ratio object.
 message RatioExpression {
-  string html = 1;
+  repeated uint32 ratio_component = 1;
 }
 
 // Structure for a number with units object.

--- a/model/src/main/proto/interaction_object.proto
+++ b/model/src/main/proto/interaction_object.proto
@@ -22,12 +22,18 @@ message InteractionObject {
     ListOfSetsOfHtmlStrings list_of_sets_of_html_string = 9;
     ImageWithRegions image_with_regions = 10;
     ClickOnImage click_on_image = 11;
+    RatioExpression ratio_expression = 12;
   }
 }
 
 // Structure containing a string list.
 message StringList {
   repeated string html = 1;
+}
+
+// Structure containing a ratio object.
+message RatioExpression {
+  string html = 1;
 }
 
 // Structure for a number with units object.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #1649 
Adds a new proto-model for the ratio interaction which works on the basis of Unicode with string validation for ratio(eg 1:2:3). For any clarification - [design doc](https://docs.google.com/document/d/1DfGt5VnfD1ueMfbLMq1J52tLYuYvRD6CemFop5_HtIA/edit#).


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
