### PR TITLE
Fix #1703: Add click functionality to CompletedStoryList item

### DIFF
--- a/app/src/main/java/org/oppia/app/completedstorylist/CompletedStoryItemViewModel.kt
+++ b/app/src/main/java/org/oppia/app/completedstorylist/CompletedStoryItemViewModel.kt
@@ -1,10 +1,30 @@
 package org.oppia.app.completedstorylist
 
+import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModel
+import org.oppia.app.home.RouteToTopicPlayStoryListener
 import org.oppia.app.model.CompletedStory
+import org.oppia.app.shim.IntentFactoryShim
 
 /** Completed story view model for the recycler view in [CompletedStoryListFragment]. */
 class CompletedStoryItemViewModel(
+  val activity: AppCompatActivity,
+  val internalProfileId: Int,
   val completedStory: CompletedStory,
-  val entityType: String
-) : ViewModel()
+  val entityType: String,
+  private val intentFactoryShim: IntentFactoryShim
+) : ViewModel(), RouteToTopicPlayStoryListener {
+  fun onCompletedStoryItemClicked() {
+    routeToTopicPlayStory(internalProfileId, completedStory.topicId, completedStory.storyId)
+  }
+
+  override fun routeToTopicPlayStory(internalProfileId: Int, topicId: String, storyId: String) {
+    val intent = intentFactoryShim.createTopicPlayStoryActivityIntent(
+      activity.applicationContext,
+      internalProfileId,
+      topicId,
+      storyId
+    )
+    activity.startActivity(intent)
+  }
+}

--- a/app/src/main/java/org/oppia/app/completedstorylist/CompletedStoryListViewModel.kt
+++ b/app/src/main/java/org/oppia/app/completedstorylist/CompletedStoryListViewModel.kt
@@ -1,11 +1,13 @@
 package org.oppia.app.completedstorylist
 
+import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import org.oppia.app.fragment.FragmentScope
 import org.oppia.app.model.CompletedStoryList
 import org.oppia.app.model.ProfileId
+import org.oppia.app.shim.IntentFactoryShim
 import org.oppia.domain.topic.TopicController
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.logging.ConsoleLogger
@@ -15,6 +17,8 @@ import javax.inject.Inject
 /** The ViewModel for [CompletedStoryListFragment]. */
 @FragmentScope
 class CompletedStoryListViewModel @Inject constructor(
+  private val activity: AppCompatActivity,
+  private val intentFactoryShim: IntentFactoryShim,
   private val topicController: TopicController,
   private val logger: ConsoleLogger,
   @StoryHtmlParserEntityType private val entityType: String
@@ -59,7 +63,7 @@ class CompletedStoryListViewModel @Inject constructor(
     val itemViewModelList: MutableList<CompletedStoryItemViewModel> = mutableListOf()
     itemViewModelList.addAll(
       completedStoryList.completedStoryList.map { completedStory ->
-        CompletedStoryItemViewModel(completedStory, entityType)
+        CompletedStoryItemViewModel(activity, internalProfileId, completedStory, entityType, intentFactoryShim)
       }
     )
     return itemViewModelList

--- a/app/src/main/java/org/oppia/app/completedstorylist/CompletedStoryListViewModel.kt
+++ b/app/src/main/java/org/oppia/app/completedstorylist/CompletedStoryListViewModel.kt
@@ -63,7 +63,13 @@ class CompletedStoryListViewModel @Inject constructor(
     val itemViewModelList: MutableList<CompletedStoryItemViewModel> = mutableListOf()
     itemViewModelList.addAll(
       completedStoryList.completedStoryList.map { completedStory ->
-        CompletedStoryItemViewModel(activity, internalProfileId, completedStory, entityType, intentFactoryShim)
+        CompletedStoryItemViewModel(
+          activity,
+          internalProfileId,
+          completedStory,
+          entityType,
+          intentFactoryShim
+        )
       }
     )
     return itemViewModelList

--- a/app/src/main/res/layout-land/completed_story_item.xml
+++ b/app/src/main/res/layout-land/completed_story_item.xml
@@ -19,14 +19,15 @@
     android:layout_marginTop="12dp"
     android:layout_marginEnd="16dp"
     android:layout_marginBottom="12dp"
+    android:clickable="true"
+    android:focusable="true"
+    android:onClick="@{(v) -> viewModel.onCompletedStoryItemClicked()}"
     app:cardCornerRadius="4dp"
     app:cardElevation="4dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:clickable="true"
-      android:focusable="true">
+      android:layout_height="match_parent">
 
       <org.oppia.app.customview.LessonThumbnailImageView
         android:id="@+id/completed_story_lesson_thumbnail"

--- a/app/src/main/res/layout-sw600dp-land/completed_story_item.xml
+++ b/app/src/main/res/layout-sw600dp-land/completed_story_item.xml
@@ -18,14 +18,15 @@
     android:layout_marginStart="32dp"
     android:layout_marginTop="24dp"
     android:layout_marginEnd="32dp"
-    app:cardElevation="4dp"
-    app:cardCornerRadius="4dp">
+    android:clickable="true"
+    android:focusable="true"
+    android:onClick="@{(v) -> viewModel.onCompletedStoryItemClicked()}"
+    app:cardCornerRadius="4dp"
+    app:cardElevation="4dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:clickable="true"
-      android:focusable="true">
+      android:layout_height="match_parent">
 
       <org.oppia.app.customview.LessonThumbnailImageView
         android:id="@+id/completed_story_lesson_thumbnail"
@@ -79,12 +80,12 @@
           android:layout_marginEnd="8dp"
           android:ellipsize="end"
           android:fontFamily="sans-serif-light"
+          android:lines="1"
           android:paddingBottom="12dp"
           android:text="@{viewModel.completedStory.topicName}"
           android:textAllCaps="true"
           android:textColor="@color/oppiaStrokeBlack"
           android:textSize="14sp"
-          android:lines="1"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@+id/completed_story_name_text_view" />
       </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-sw600dp-port/completed_story_item.xml
+++ b/app/src/main/res/layout-sw600dp-port/completed_story_item.xml
@@ -18,14 +18,15 @@
     android:layout_marginStart="24dp"
     android:layout_marginTop="36dp"
     android:layout_marginEnd="24dp"
-    app:cardElevation="4dp"
-    app:cardCornerRadius="4dp">
+    android:clickable="true"
+    android:focusable="true"
+    android:onClick="@{(v) -> viewModel.onCompletedStoryItemClicked()}"
+    app:cardCornerRadius="4dp"
+    app:cardElevation="4dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:clickable="true"
-      android:focusable="true">
+      android:layout_height="match_parent">
 
       <org.oppia.app.customview.LessonThumbnailImageView
         android:id="@+id/completed_story_lesson_thumbnail"
@@ -79,12 +80,12 @@
           android:layout_marginEnd="8dp"
           android:ellipsize="end"
           android:fontFamily="sans-serif-light"
+          android:lines="1"
           android:paddingBottom="12dp"
           android:text="@{viewModel.completedStory.topicName}"
           android:textAllCaps="true"
           android:textColor="@color/oppiaStrokeBlack"
           android:textSize="14sp"
-          android:lines="1"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@+id/completed_story_name_text_view" />
       </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/completed_story_item.xml
+++ b/app/src/main/res/layout/completed_story_item.xml
@@ -19,13 +19,15 @@
     android:layout_marginTop="12dp"
     android:layout_marginEnd="8dp"
     android:layout_marginBottom="12dp"
-    app:cardCornerRadius="4dp">
+    android:clickable="true"
+    android:focusable="true"
+    android:onClick="@{(v) -> viewModel.onCompletedStoryItemClicked()}"
+    app:cardCornerRadius="4dp"
+    app:cardElevation="4dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:clickable="true"
-      android:focusable="true">
+      android:layout_height="match_parent">
 
       <org.oppia.app.customview.LessonThumbnailImageView
         android:id="@+id/completed_story_lesson_thumbnail"

--- a/app/src/main/res/layout/ongoing_topic_item.xml
+++ b/app/src/main/res/layout/ongoing_topic_item.xml
@@ -21,7 +21,8 @@
     android:layout_marginTop="12dp"
     android:layout_marginEnd="8dp"
     android:layout_marginBottom="12dp"
-    app:cardCornerRadius="4dp">
+    app:cardCornerRadius="4dp"
+    app:cardElevation="4dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"

--- a/app/src/sharedTest/java/org/oppia/app/completedstorylist/CompletedStoryListActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/completedstorylist/CompletedStoryListActivityTest.kt
@@ -187,6 +187,34 @@ class CompletedStoryListActivityTest {
   }
 
   @Test
+  fun testCompletedStoryList_configurationChange_clickOnItem0_intentIsCorrect() {
+    launch<CompletedStoryListActivity>(
+      createCompletedStoryListActivityIntent(
+        internalProfileId
+      )
+    ).use {
+      onView(isRoot()).perform(orientationLandscape())
+      waitForTheView(withText(containsString("Matthew Goes to the Bakery")))
+      onView(withId(R.id.completed_story_list)).perform(
+        scrollToPosition<RecyclerView.ViewHolder>(
+          0
+        )
+      )
+      onView(
+        atPositionOnView(
+          R.id.completed_story_list,
+          0,
+          R.id.completed_story_name_text_view
+        )
+      ).perform(click())
+      intended(hasComponent(TopicActivity::class.java.name))
+      intended(hasExtra(TopicActivity.getProfileIdKey(), internalProfileId))
+      intended(hasExtra(TopicActivity.getTopicIdKey(), FRACTIONS_TOPIC_ID))
+      intended(hasExtra(TopicActivity.getStoryIdKey(), FRACTIONS_STORY_ID_0))
+    }
+  }
+
+  @Test
   fun testCompletedStoryList_checkItem0_titleIsCorrect() {
     launch<CompletedStoryListActivity>(
       createCompletedStoryListActivityIntent(

--- a/app/src/sharedTest/java/org/oppia/app/completedstorylist/CompletedStoryListActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/completedstorylist/CompletedStoryListActivityTest.kt
@@ -15,10 +15,14 @@ import androidx.test.espresso.PerformException
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.ViewInteraction
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 import androidx.test.espresso.idling.CountingIdlingResource
 import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -40,7 +44,10 @@ import org.junit.runner.RunWith
 import org.oppia.app.R
 import org.oppia.app.model.ProfileId
 import org.oppia.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
+import org.oppia.app.topic.TopicActivity
 import org.oppia.app.utility.OrientationChangeAction.Companion.orientationLandscape
+import org.oppia.domain.topic.FRACTIONS_STORY_ID_0
+import org.oppia.domain.topic.FRACTIONS_TOPIC_ID
 import org.oppia.domain.topic.StoryProgressTestHelper
 import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
@@ -149,6 +156,33 @@ class CompletedStoryListActivityTest {
           withText(containsString("Matthew Goes to the Bakery"))
         )
       )
+    }
+  }
+
+  @Test
+  fun testCompletedStoryList_clickOnItem0_intentIsCorrect() {
+    launch<CompletedStoryListActivity>(
+      createCompletedStoryListActivityIntent(
+        internalProfileId
+      )
+    ).use {
+      waitForTheView(withText(containsString("Matthew Goes to the Bakery")))
+      onView(withId(R.id.completed_story_list)).perform(
+        scrollToPosition<RecyclerView.ViewHolder>(
+          0
+        )
+      )
+      onView(
+        atPositionOnView(
+          R.id.completed_story_list,
+          0,
+          R.id.completed_story_name_text_view
+        )
+      ).perform(click())
+      intended(hasComponent(TopicActivity::class.java.name))
+      intended(hasExtra(TopicActivity.getProfileIdKey(), internalProfileId))
+      intended(hasExtra(TopicActivity.getTopicIdKey(), FRACTIONS_TOPIC_ID))
+      intended(hasExtra(TopicActivity.getStoryIdKey(), FRACTIONS_STORY_ID_0))
     }
   }
 

--- a/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
@@ -291,6 +291,7 @@ class TopicController @Inject constructor(
         val completedStoryBuilder = CompletedStory.newBuilder()
           .setStoryId(storySummary.storyId)
           .setStoryName(storySummary.storyName)
+          .setTopicId(topic.topicId)
           .setTopicName(topic.name)
           .setLessonThumbnail(storySummary.storyThumbnail)
         completedStoryList.add(completedStoryBuilder.build())

--- a/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
@@ -1025,6 +1025,7 @@ class TopicControllerTest {
     val completedStoryList = completedStoryListResultCaptor.value.getOrThrow()
     assertThat(completedStoryList.completedStoryCount).isEqualTo(1)
     assertThat(completedStoryList.completedStoryList[0].storyId).isEqualTo(FRACTIONS_STORY_ID_0)
+    assertThat(completedStoryList.completedStoryList[0].topicId).isEqualTo(FRACTIONS_TOPIC_ID)
   }
 
   @Test
@@ -1065,6 +1066,7 @@ class TopicControllerTest {
     val completedStoryList = completedStoryListResultCaptor.value.getOrThrow()
     assertThat(completedStoryList.completedStoryCount).isEqualTo(1)
     assertThat(completedStoryList.completedStoryList[0].storyId).isEqualTo(RATIOS_STORY_ID_0)
+    assertThat(completedStoryList.completedStoryList[0].topicId).isEqualTo(RATIOS_TOPIC_ID)
   }
 
   @Test

--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -135,11 +135,14 @@ message CompletedStory {
   // The name of the story being completed.
   string story_name = 2;
 
+  // The ID of the topic which contains this story.
+  string topic_id = 3;
+
   // The name of the topic this story is part of.
-  string topic_name = 3;
+  string topic_name = 4;
 
   // The thumbnail that should be displayed for this completed story.
-  LessonThumbnail lesson_thumbnail = 4;
+  LessonThumbnail lesson_thumbnail = 5;
 }
 
 // Corresponds to the list of stories the player is currently playing across all topics.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fix #1702
As per this comment #1659 (comment)

The completed-story-item item should be clickable and should route to Topic-Lessons page.

Also, the `CompletedStory` item does not contain a topic-id and therefore I added that in proto and updated the domain code accordingly.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
