### PR TITLE
Fix #1589 : Naming consistency for DataProviderIds in doma…

### DIFF
--- a/domain/src/main/java/org/oppia/domain/exploration/ExplorationDataController.kt
+++ b/domain/src/main/java/org/oppia/domain/exploration/ExplorationDataController.kt
@@ -9,7 +9,7 @@ import org.oppia.util.data.DataProviders
 import org.oppia.util.system.OppiaClock
 import javax.inject.Inject
 
-private const val EXPLORATION_DATA_PROVIDER_ID = "ExplorationDataProvider"
+private const val EXPLORATION_DATA_PROVIDER_ID = "exploration_data_provider_id"
 
 /**
  * Controller for loading explorations by ID, or beginning to play an exploration.

--- a/domain/src/main/java/org/oppia/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/domain/exploration/ExplorationProgressController.kt
@@ -20,7 +20,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.concurrent.withLock
 
-private const val CURRENT_STATE_DATA_PROVIDER_ID = "CurrentStateDataProvider"
+private const val CURRENT_STATE_DATA_PROVIDER_ID = "current_state_data_provider_id"
 
 /**
  * Controller that tracks and reports the learner's ephemeral/non-persisted progress through an exploration. Note that

--- a/domain/src/main/java/org/oppia/domain/question/QuestionAssessmentProgressController.kt
+++ b/domain/src/main/java/org/oppia/domain/question/QuestionAssessmentProgressController.kt
@@ -23,8 +23,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.concurrent.withLock
 
-private const val CURRENT_QUESTION_DATA_PROVIDER_ID = "CurrentQuestionDataProvider"
-private const val EMPTY_QUESTIONS_LIST_DATA_PROVIDER_ID = "EmptyQuestionsListDataProvider"
+private const val CURRENT_QUESTION_DATA_PROVIDER_ID = "current_question_data_provider_id"
+private const val EMPTY_QUESTIONS_LIST_DATA_PROVIDER_ID = "empty_questions_list_data_provider_id"
 
 /**
  * Controller that tracks and reports the learner's ephemeral/non-persisted progress through a practice training

--- a/domain/src/main/java/org/oppia/domain/question/QuestionTrainingController.kt
+++ b/domain/src/main/java/org/oppia/domain/question/QuestionTrainingController.kt
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 import kotlin.random.Random
 
 private const val TRAINING_QUESTIONS_PROVIDER = "TrainingQuestionsProvider"
-private const val RETRIEVE_QUESTIONS_RESULT_DATA_PROVIDER = "RetrieveQuestionsResultsProvider"
+private const val RETRIEVE_QUESTIONS_RESULT_DATA_PROVIDER = "retrieve_questions_results_provider"
 
 /** Controller for retrieving a set of questions. */
 @Singleton

--- a/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
@@ -67,7 +67,7 @@ private const val FRACTIONS_SUBTOPIC_ID_3 = 3
 private const val FRACTIONS_SUBTOPIC_ID_4 = 4
 private const val SUBTOPIC_BG_COLOR = "#FFFFFF"
 
-private const val QUESTION_DATA_PROVIDER_ID = "QuestionDataProvider"
+private const val QUESTION_DATA_PROVIDER_ID = "question_data_provider_id"
 private const val TRANSFORMED_GET_COMPLETED_STORIES_PROVIDER_ID =
   "transformed_get_completed_stories_provider_id"
 private const val TRANSFORMED_GET_ONGOING_TOPICS_PROVIDER_ID =


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fix #1589 
Naming consistency for DataProviderIds in domain-layer
In domain layer all data provider ids should follow consistent pattern.
We should follow below mentioned style:

Name of constant & value should be the same (e.g. QUESTION_DATA_PROVIDER_ID and "question_data_provider_id")
Constant name should be UPPER_SNAKE_CASE and value should be lower_snake_case
Use ID format: <function_name>_<optional_context>_PROVIDER_ID where the function_name is the exact function the provider used (expected to be just 1) and optional_context is used to disambiguate either when the ID is used in different functions or if the same function is overloaded

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
