### PR TITLE
Fixes #1201 & #1199: Options - Tablet (Portrait) (Landscape) (Highfi) 

### DIFF
--- a/app/src/main/java/org/oppia/app/administratorcontrols/AdministratorControlsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/administratorcontrols/AdministratorControlsFragmentPresenter.kt
@@ -161,7 +161,7 @@ class AdministratorControlsFragmentPresenter @Inject constructor(
     return when (selectedFragment) {
       PROFILE_LIST_FRAGMENT -> 1
       APP_VERSION_FRAGMENT -> 3
-      else -> throw InvalidParameterException()
+      else -> throw InvalidParameterException("Not a valid fragment in getSelectedFragmentIndex.")
     }
   }
 

--- a/app/src/main/java/org/oppia/app/options/OptionControlsViewModel.kt
+++ b/app/src/main/java/org/oppia/app/options/OptionControlsViewModel.kt
@@ -1,6 +1,7 @@
 package org.oppia.app.options
 
 import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.ObservableField
 import androidx.databinding.ObservableList
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -35,6 +36,7 @@ class OptionControlsViewModel @Inject constructor(
   private val loadAppLanguageListListener = activity as LoadAppLanguageListListener
   private var isFirstOpen = true
   val uiLiveData = MutableLiveData<Boolean>()
+  val selectedFragmentIndex = ObservableField<Int>()
 
   /**
    * Should be called with `false` when the UI starts to load, then with `true` after the UI

--- a/app/src/main/java/org/oppia/app/options/OptionsActivity.kt
+++ b/app/src/main/java/org/oppia/app/options/OptionsActivity.kt
@@ -10,6 +10,10 @@ import org.oppia.app.drawer.KEY_NAVIGATION_PROFILE_ID
 import javax.inject.Inject
 
 private const val SELECTED_OPTIONS_TITLE_KEY = "SELECTED_OPTIONS_TITLE_KEY"
+private const val SELECTED_FRAGMENT_KEY = "SELECTED_FRAGMENT_KEY"
+const val READING_TEXT_SIZE_FRAGMENT = "READING_TEXT_SIZE_FRAGMENT"
+const val APP_LANGUAGE_FRAGMENT = "APP_LANGUAGE_FRAGMENT"
+const val DEFAULT_AUDIO_FRAGMENT = "DEFAULT_AUDIO_FRAGMENT"
 
 /** The activity for setting user preferences. */
 class OptionsActivity :
@@ -24,6 +28,7 @@ class OptionsActivity :
   lateinit var optionActivityPresenter: OptionsActivityPresenter
   // used to initially load the suitable fragment in the case of multipane.
   private var isFirstOpen = true
+  private lateinit var selectedFragment: String
 
   companion object {
     // TODO(#1655): Re-restrict access to fields in tests post-Gradle.
@@ -52,8 +57,18 @@ class OptionsActivity :
     if (savedInstanceState != null) {
       isFirstOpen = false
     }
+    selectedFragment = if (savedInstanceState == null) {
+      READING_TEXT_SIZE_FRAGMENT
+    } else {
+      savedInstanceState.get(SELECTED_FRAGMENT_KEY) as String
+    }
     val extraOptionsTitle = savedInstanceState?.getString(SELECTED_OPTIONS_TITLE_KEY)
-    optionActivityPresenter.handleOnCreate(isFromNavigationDrawer, extraOptionsTitle, isFirstOpen)
+    optionActivityPresenter.handleOnCreate(
+      isFromNavigationDrawer,
+      extraOptionsTitle,
+      isFirstOpen,
+      selectedFragment
+    )
     title = getString(R.string.menu_options)
   }
 
@@ -109,16 +124,19 @@ class OptionsActivity :
   }
 
   override fun loadReadingTextSizeFragment(textSize: String) {
+    selectedFragment = READING_TEXT_SIZE_FRAGMENT
     optionActivityPresenter.setExtraOptionTitle(getString(R.string.reading_text_size))
-    optionActivityPresenter.loadStoryTextSizeFragment(textSize)
+    optionActivityPresenter.loadReadingTextSizeFragment(textSize)
   }
 
   override fun loadAppLanguageFragment(appLanguage: String) {
+    selectedFragment = APP_LANGUAGE_FRAGMENT
     optionActivityPresenter.setExtraOptionTitle(getString(R.string.app_language))
     optionActivityPresenter.loadAppLanguageFragment(appLanguage)
   }
 
   override fun loadAudioLanguageFragment(audioLanguage: String) {
+    selectedFragment = DEFAULT_AUDIO_FRAGMENT
     optionActivityPresenter.setExtraOptionTitle(getString(R.string.audio_language))
     optionActivityPresenter.loadAudioLanguageFragment(audioLanguage)
   }
@@ -129,5 +147,6 @@ class OptionsActivity :
     if (titleTextView != null) {
       outState.putString(SELECTED_OPTIONS_TITLE_KEY, titleTextView.text.toString())
     }
+    outState.putString(SELECTED_FRAGMENT_KEY, selectedFragment)
   }
 }

--- a/app/src/main/java/org/oppia/app/options/OptionsActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/options/OptionsActivityPresenter.kt
@@ -22,7 +22,8 @@ class OptionsActivityPresenter @Inject constructor(
   fun handleOnCreate(
     isFromNavigationDrawer: Boolean,
     extraOptionsTitle: String?,
-    isFirstOpen: Boolean
+    isFirstOpen: Boolean,
+    selectedFragment: String
   ) {
     activity.setContentView(R.layout.option_activity)
     val titleTextView =
@@ -46,7 +47,7 @@ class OptionsActivityPresenter @Inject constructor(
     }
     activity.supportFragmentManager.beginTransaction().add(
       R.id.options_fragment_placeholder,
-      OptionsFragment.newInstance(isMultipane, isFirstOpen)
+      OptionsFragment.newInstance(isMultipane, isFirstOpen, selectedFragment)
     ).commitNow()
   }
 
@@ -88,12 +89,13 @@ class OptionsActivityPresenter @Inject constructor(
     getOptionFragment()?.updateAudioLanguage(audioLanguage)
   }
 
-  fun loadStoryTextSizeFragment(textSize: String) {
-    val storyTextSizeFragment = ReadingTextSizeFragment.newInstance(textSize)
+  fun loadReadingTextSizeFragment(textSize: String) {
+    val readingTextSizeFragment = ReadingTextSizeFragment.newInstance(textSize)
     activity.supportFragmentManager
       .beginTransaction()
-      .add(R.id.multipane_options_container, storyTextSizeFragment)
+      .add(R.id.multipane_options_container, readingTextSizeFragment)
       .commitNow()
+    getOptionFragment()?.setSelectedFragment(READING_TEXT_SIZE_FRAGMENT)
   }
 
   fun loadAppLanguageFragment(appLanguage: String) {
@@ -103,6 +105,7 @@ class OptionsActivityPresenter @Inject constructor(
       .beginTransaction()
       .add(R.id.multipane_options_container, appLanguageFragment)
       .commitNow()
+    getOptionFragment()?.setSelectedFragment(APP_LANGUAGE_FRAGMENT)
   }
 
   fun loadAudioLanguageFragment(audioLanguage: String) {
@@ -112,6 +115,7 @@ class OptionsActivityPresenter @Inject constructor(
       .beginTransaction()
       .add(R.id.multipane_options_container, defaultAudioFragment)
       .commitNow()
+    getOptionFragment()?.setSelectedFragment(DEFAULT_AUDIO_FRAGMENT)
   }
 
   fun setExtraOptionTitle(title: String) {

--- a/app/src/main/java/org/oppia/app/options/OptionsFragment.kt
+++ b/app/src/main/java/org/oppia/app/options/OptionsFragment.kt
@@ -15,8 +15,9 @@ const val REQUEST_CODE_TEXT_SIZE = 1
 const val REQUEST_CODE_APP_LANGUAGE = 2
 const val REQUEST_CODE_AUDIO_LANGUAGE = 3
 
-private const val IS_MULTIPANE_EXTRA = "IS_MULTIPANE"
+private const val IS_MULTIPANE_EXTRA = "IS_MULTIPANE_EXTRA"
 private const val IS_FIRST_OPEN_EXTRA = "IS_FIRST_OPEN_EXTRA"
+private const val SELECTED_FRAGMENT_EXTRA = "SELECTED_FRAGMENT_EXTRA"
 
 /** Fragment that contains an introduction to the app. */
 class OptionsFragment : InjectableFragment() {
@@ -24,10 +25,15 @@ class OptionsFragment : InjectableFragment() {
   lateinit var optionsFragmentPresenter: OptionsFragmentPresenter
 
   companion object {
-    fun newInstance(isMultipane: Boolean, isFirstOpen: Boolean): OptionsFragment {
+    fun newInstance(
+      isMultipane: Boolean,
+      isFirstOpen: Boolean,
+      selectedFragment: String
+    ): OptionsFragment {
       val args = Bundle()
       args.putBoolean(IS_MULTIPANE_EXTRA, isMultipane)
       args.putBoolean(IS_FIRST_OPEN_EXTRA, isFirstOpen)
+      args.putString(SELECTED_FRAGMENT_EXTRA, selectedFragment)
       val fragment = OptionsFragment()
       fragment.arguments = args
       return fragment
@@ -48,7 +54,14 @@ class OptionsFragment : InjectableFragment() {
       checkNotNull(arguments) { "Expected arguments to be passed to OptionsFragment" }
     val isMultipane = args.getBoolean(IS_MULTIPANE_EXTRA)
     val isFirstOpen = args.getBoolean(IS_FIRST_OPEN_EXTRA)
-    return optionsFragmentPresenter.handleCreateView(inflater, container, isMultipane, isFirstOpen)
+    val selectedFragment = args.getString(SELECTED_FRAGMENT_EXTRA)
+    return optionsFragmentPresenter.handleCreateView(
+      inflater,
+      container,
+      isMultipane,
+      isFirstOpen,
+      selectedFragment
+    )
   }
 
   fun updateReadingTextSize(textSize: String) {
@@ -66,6 +79,12 @@ class OptionsFragment : InjectableFragment() {
   fun updateAudioLanguage(audioLanguage: String) {
     optionsFragmentPresenter.runAfterUIInitialization {
       optionsFragmentPresenter.updateAudioLanguage(audioLanguage)
+    }
+  }
+
+  fun setSelectedFragment(selectedLanguage: String) {
+    optionsFragmentPresenter.runAfterUIInitialization {
+      optionsFragmentPresenter.setSelectedFragment(selectedLanguage)
     }
   }
 }

--- a/app/src/main/java/org/oppia/app/options/OptionsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/options/OptionsFragmentPresenter.kt
@@ -167,7 +167,7 @@ class OptionsFragmentPresenter @Inject constructor(
       READING_TEXT_SIZE_FRAGMENT -> 0
       APP_LANGUAGE_FRAGMENT -> 1
       DEFAULT_AUDIO_FRAGMENT -> 2
-      else -> throw InvalidParameterException()
+      else -> throw InvalidParameterException("Not a valid fragment in getSelectedFragmentIndex.")
     }
   }
 

--- a/app/src/main/java/org/oppia/app/options/OptionsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/options/OptionsFragmentPresenter.kt
@@ -21,6 +21,7 @@ import org.oppia.app.recyclerview.BindableAdapter
 import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.util.logging.ConsoleLogger
+import java.security.InvalidParameterException
 import javax.inject.Inject
 
 const val READING_TEXT_SIZE = "READING_TEXT_SIZE"
@@ -58,7 +59,8 @@ class OptionsFragmentPresenter @Inject constructor(
     inflater: LayoutInflater,
     container: ViewGroup?,
     isMultipane: Boolean,
-    isFirstOpen: Boolean
+    isFirstOpen: Boolean,
+    selectedFragment: String
   ): View? {
     viewModel.isUIInitialized(false)
     viewModel.isFirstOpen(isFirstOpen)
@@ -82,6 +84,7 @@ class OptionsFragmentPresenter @Inject constructor(
       it.lifecycleOwner = fragment
       it.viewModel = viewModel
     }
+    setSelectedFragment(selectedFragment)
     viewModel.isUIInitialized(true)
     return binding.root
   }
@@ -91,9 +94,18 @@ class OptionsFragmentPresenter @Inject constructor(
       .newBuilder<OptionsItemViewModel, ViewType> { viewModel ->
         viewModel.isMultipane.set(isMultipane)
         when (viewModel) {
-          is OptionsReadingTextSizeViewModel -> ViewType.VIEW_TYPE_READING_TEXT_SIZE
-          is OptionsAppLanguageViewModel -> ViewType.VIEW_TYPE_APP_LANGUAGE
-          is OptionsAudioLanguageViewModel -> ViewType.VIEW_TYPE_AUDIO_LANGUAGE
+          is OptionsReadingTextSizeViewModel -> {
+            viewModel.itemIndex.set(0)
+            ViewType.VIEW_TYPE_READING_TEXT_SIZE
+          }
+          is OptionsAppLanguageViewModel -> {
+            viewModel.itemIndex.set(1)
+            ViewType.VIEW_TYPE_APP_LANGUAGE
+          }
+          is OptionsAudioLanguageViewModel -> {
+            viewModel.itemIndex.set(2)
+            ViewType.VIEW_TYPE_AUDIO_LANGUAGE
+          }
           else -> throw IllegalArgumentException("Encountered unexpected view model: $viewModel")
         }
       }
@@ -122,6 +134,7 @@ class OptionsFragmentPresenter @Inject constructor(
     binding: OptionStoryTextSizeBinding,
     model: OptionsReadingTextSizeViewModel
   ) {
+    binding.commonViewModel = viewModel
     binding.viewModel = model
   }
 
@@ -129,6 +142,7 @@ class OptionsFragmentPresenter @Inject constructor(
     binding: OptionAppLanguageBinding,
     model: OptionsAppLanguageViewModel
   ) {
+    binding.commonViewModel = viewModel
     binding.viewModel = model
   }
 
@@ -136,7 +150,25 @@ class OptionsFragmentPresenter @Inject constructor(
     binding: OptionAudioLanguageBinding,
     model: OptionsAudioLanguageViewModel
   ) {
+    binding.commonViewModel = viewModel
     binding.viewModel = model
+  }
+
+  fun setSelectedFragment(selectedFragment: String) {
+    viewModel.selectedFragmentIndex.set(
+      getSelectedFragmentIndex(
+        selectedFragment
+      )
+    )
+  }
+
+  private fun getSelectedFragmentIndex(selectedFragment: String): Int {
+    return when (selectedFragment) {
+      READING_TEXT_SIZE_FRAGMENT -> 0
+      APP_LANGUAGE_FRAGMENT -> 1
+      DEFAULT_AUDIO_FRAGMENT -> 2
+      else -> throw InvalidParameterException()
+    }
   }
 
   private fun getOptionControlsItemViewModel(): OptionControlsViewModel {

--- a/app/src/main/java/org/oppia/app/options/OptionsItemViewModel.kt
+++ b/app/src/main/java/org/oppia/app/options/OptionsItemViewModel.kt
@@ -6,4 +6,5 @@ import org.oppia.app.viewmodel.ObservableViewModel
 /** Option items view model for the recyclerView in [OptionsFragment] */
 abstract class OptionsItemViewModel : ObservableViewModel() {
   val isMultipane = ObservableField<Boolean>(false)
+  val itemIndex = ObservableField<Int>()
 }

--- a/app/src/main/res/drawable/general_item_background_border_cyan.xml
+++ b/app/src/main/res/drawable/general_item_background_border_cyan.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+  android:shape="rectangle">
+  <solid android:color="@color/adminHighlighted" />
+  <stroke
+    android:width="1dp"
+    android:color="@color/black_12" />
+</shape>

--- a/app/src/main/res/layout-sw600dp/option_activity.xml
+++ b/app/src/main/res/layout-sw600dp/option_activity.xml
@@ -16,14 +16,15 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="match_parent">
+      android:layout_height="match_parent"
+      android:background="@color/oppiaGreyBackground">
 
       <FrameLayout
         android:id="@+id/options_fragment_placeholder"
         android:layout_width="0dp"
         android:layout_height="match_parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/multipane_guideline"
+        app:layout_constraintEnd_toStartOf="@+id/options_separator"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>
 
@@ -31,6 +32,12 @@
         android:id="@+id/options_activity_selected_options_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="24dp"
+        android:fontFamily="sans-serif-medium"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="18sp"
+        android:background="@color/transparent"
         app:layout_constraintStart_toEndOf="@id/multipane_guideline"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>
@@ -39,6 +46,7 @@
         android:id="@+id/multipane_options_container"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:layout_marginTop="24dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/multipane_guideline"
@@ -50,6 +58,15 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.38" />
+
+      <View
+        android:id="@+id/options_separator"
+        android:layout_width="1dp"
+        android:layout_height="0dp"
+        android:background="@color/oppiaOnboardingDivider"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/multipane_guideline"
+        app:layout_constraintTop_toTopOf="parent" />
 
       <View
         android:layout_width="match_parent"

--- a/app/src/main/res/layout-sw600dp/option_app_language.xml
+++ b/app/src/main/res/layout-sw600dp/option_app_language.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <data>
+
+    <variable
+      name="commonViewModel"
+      type="org.oppia.app.options.OptionControlsViewModel" />
+
+    <variable
+      name="viewModel"
+      type="org.oppia.app.options.OptionsAppLanguageViewModel" />
+  </data>
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/app_language_item_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="48dp"
+    android:background="@{commonViewModel.selectedFragmentIndex == viewModel.itemIndex ? @drawable/general_item_background_border_cyan : @drawable/general_item_background_border}"
+    android:onClick="@{(v) -> viewModel.onAppLanguageClicked()}"
+    android:paddingStart="16dp"
+    android:paddingTop="20dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="20dp">
+
+    <TextView
+      android:id="@+id/app_language_label_text_view"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fontFamily="sans-serif"
+      android:text="@string/app_language"
+      android:textColor="@color/oppiaPrimaryTextDark"
+      android:textSize="16sp"
+      app:layout_constraintBottom_toTopOf="@id/app_language_text_view"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+      android:id="@+id/app_language_text_view"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fontFamily="sans-serif"
+      android:text="@{viewModel.appLanguage}"
+      android:textColor="@color/black_54"
+      android:textSize="14sp"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/app_language_label_text_view" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout-sw600dp/option_audio_language.xml
+++ b/app/src/main/res/layout-sw600dp/option_audio_language.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <data>
+
+    <variable
+      name="commonViewModel"
+      type="org.oppia.app.options.OptionControlsViewModel" />
+
+    <variable
+      name="viewModel"
+      type="org.oppia.app.options.OptionsAudioLanguageViewModel" />
+  </data>
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/audio_laguage_item_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@{commonViewModel.selectedFragmentIndex == viewModel.itemIndex ? @drawable/general_item_background_border_cyan : @drawable/general_item_background_border}"
+    android:minHeight="48dp"
+    android:onClick="@{(v) -> viewModel.onAudioLanguageClicked()}"
+    android:paddingStart="16dp"
+    android:paddingTop="20dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="20dp">
+
+    <TextView
+      android:id="@+id/audio_language_label_text_view"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fontFamily="sans-serif"
+      android:text="@string/audio_language"
+      android:textColor="@color/oppiaPrimaryTextDark"
+      android:textSize="16sp"
+      app:layout_constraintBottom_toTopOf="@id/audio_language_text_view"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+      android:id="@+id/audio_language_text_view"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fontFamily="sans-serif"
+      android:text="@{viewModel.audioLanguage}"
+      android:textColor="@color/black_54"
+      android:textSize="14sp"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/audio_language_label_text_view" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout-sw600dp/option_story_text_size.xml
+++ b/app/src/main/res/layout-sw600dp/option_story_text_size.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <data>
+
+    <variable
+      name="commonViewModel"
+      type="org.oppia.app.options.OptionControlsViewModel" />
+
+    <variable
+      name="viewModel"
+      type="org.oppia.app.options.OptionsReadingTextSizeViewModel" />
+  </data>
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/reading_text_size_item_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@{commonViewModel.selectedFragmentIndex == viewModel.itemIndex ? @drawable/general_item_background_border_cyan : @drawable/general_item_background_border}"
+    android:minHeight="48dp"
+    android:onClick="@{(v) -> viewModel.onReadingTextSizeClicked()}"
+    android:paddingStart="16dp"
+    android:paddingTop="20dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="20dp">
+
+    <TextView
+      android:id="@+id/reading_text_size_label_text_view"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fontFamily="sans-serif"
+      android:text="@string/reading_text_size"
+      android:textColor="@color/oppiaPrimaryTextDark"
+      android:textSize="16sp"
+      app:layout_constraintBottom_toTopOf="@id/reading_text_size_text_view"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+      android:id="@+id/reading_text_size_text_view"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fontFamily="sans-serif"
+      android:text="@{viewModel.readingTextSize}"
+      android:textColor="@color/black_54"
+      android:textSize="14sp"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/reading_text_size_label_text_view" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout-sw600dp/reading_text_size_fragment.xml
+++ b/app/src/main/res/layout-sw600dp/reading_text_size_fragment.xml
@@ -18,7 +18,6 @@
       <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="28dp"
         android:background="@color/white"
         android:orientation="vertical">
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
- Fixes #1199 
- Fixes #1201 
- Implemented high-fi UI for **OptionsActivity** for tablet
- Mocks: [land](https://xd.adobe.com/view/d405de00-a871-4f0f-73a0-f8acef30349b-a234/screen/421aa1ca-594a-452e-8367-c990916a5fe6/) - [port](https://xd.adobe.com/view/d405de00-a871-4f0f-73a0-f8acef30349b-a234/screen/20631bfd-3756-47a1-9353-ac0a8e9615cd/)
## Screenshots
![screenshot-٢٠٢٠-٠٨-٣٠_٢١ ٣٩ ٥٠ ٠٠٧](https://user-images.githubusercontent.com/8533363/91665902-2d8a0e00-eaf9-11ea-99c7-46add78e9ea4.png)
![screenshot-٢٠٢٠-٠٨-٣٠_٢١ ٣٩ ٤٨ ٢٣٢](https://user-images.githubusercontent.com/8533363/91665904-2ebb3b00-eaf9-11ea-88f4-558da3deb4ab.png)
![screenshot-٢٠٢٠-٠٨-٣٠_٢١ ٣٩ ٤٦ ٢٦٢](https://user-images.githubusercontent.com/8533363/91665906-2fec6800-eaf9-11ea-9923-103e940746e2.png)
![screenshot-٢٠٢٠-٠٨-٣٠_٢١ ٣٩ ٣٩ ٥٩٦](https://user-images.githubusercontent.com/8533363/91665907-3084fe80-eaf9-11ea-9d39-83f7ba062f70.png)
![screenshot-٢٠٢٠-٠٨-٣٠_٢١ ٣٩ ٣٧ ٠٣٦](https://user-images.githubusercontent.com/8533363/91665908-311d9500-eaf9-11ea-954a-636b98449393.png)
![screenshot-٢٠٢٠-٠٨-٣٠_٢١ ٣٩ ٣٢ ٨٠٢](https://user-images.githubusercontent.com/8533363/91665910-31b62b80-eaf9-11ea-8af8-e9f2ec19454f.png)

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
