### PR TITLE
Fix #1786: Improve offline asset support

### DIFF
--- a/domain/src/main/java/org/oppia/domain/question/QuestionRetriever.kt
+++ b/domain/src/main/java/org/oppia/domain/question/QuestionRetriever.kt
@@ -1,0 +1,57 @@
+package org.oppia.domain.question
+
+import org.json.JSONObject
+import org.oppia.app.model.Question
+import org.oppia.domain.util.JsonAssetRetriever
+import org.oppia.domain.util.StateRetriever
+import javax.inject.Inject
+
+// TODO(#1580): Restrict access using Bazel visibilities.
+/** Retriever for [Question] objects from the filesystem. */
+class QuestionRetriever @Inject constructor(
+  private val jsonAssetRetriever: JsonAssetRetriever,
+  private val stateRetriever: StateRetriever
+) {
+  /**
+   * Returns a list of [Question]s corresponding to the specified list of skills, loaded from the
+   * filesystem.
+   */
+  fun loadQuestions(skillIdsList: List<String>): List<Question> {
+    val questionsList = mutableListOf<Question>()
+    val questionJsonArray = jsonAssetRetriever.loadJsonFromAsset(
+      "questions.json"
+    )?.getJSONArray("question_dicts")!!
+
+    for (skillId in skillIdsList) {
+      for (i in 0 until questionJsonArray.length()) {
+        val questionJsonObject = questionJsonArray.getJSONObject(i)
+        val questionLinkedSkillsJsonArray =
+          questionJsonObject.optJSONArray("linked_skill_ids")
+        val linkedSkillIdList = mutableListOf<String>()
+        for (j in 0 until questionLinkedSkillsJsonArray.length()) {
+          linkedSkillIdList.add(questionLinkedSkillsJsonArray.getString(j))
+        }
+        if (linkedSkillIdList.contains(skillId)) {
+          questionsList.add(createQuestionFromJsonObject(questionJsonObject))
+        }
+      }
+    }
+    return questionsList
+  }
+
+  private fun createQuestionFromJsonObject(questionJson: JSONObject): Question {
+    return Question.newBuilder()
+      .setQuestionId(questionJson.getString("id"))
+      .setQuestionState(
+        stateRetriever.createStateFromJson(
+          "question", questionJson.getJSONObject("question_state_data")
+        )
+      )
+      .addAllLinkedSkillIds(
+        jsonAssetRetriever.getStringsFromJSONArray(
+          questionJson.getJSONArray("linked_skill_ids")
+        )
+      )
+      .build()
+  }
+}

--- a/domain/src/main/java/org/oppia/domain/topic/ConceptCardRetriever.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/ConceptCardRetriever.kt
@@ -1,0 +1,154 @@
+package org.oppia.domain.topic
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.oppia.app.model.ConceptCard
+import org.oppia.app.model.SubtitledHtml
+import org.oppia.app.model.Translation
+import org.oppia.app.model.TranslationMapping
+import org.oppia.app.model.Voiceover
+import org.oppia.app.model.VoiceoverMapping
+import org.oppia.domain.util.JsonAssetRetriever
+import javax.inject.Inject
+
+// TODO(#1580): Restrict access using Bazel visibilities.
+/** Retriever for [ConceptCard] objects from the filesystem. */
+class ConceptCardRetriever @Inject constructor(
+  private val jsonAssetRetriever: JsonAssetRetriever
+) {
+  /**
+   * Returns a [ConceptCard] corresponding to the specified skill ID, loaded from the filesystem.
+   */
+  fun loadConceptCard(skillId: String): ConceptCard {
+    val skillData = getSkillJsonObject(skillId)
+    if (skillData.length() <= 0) {
+      return ConceptCard.getDefaultInstance()
+    }
+    val skillContents = skillData.getJSONObject("skill_contents")
+    val workedExamplesList = createWorkedExamplesFromJson(
+      skillContents.getJSONArray(
+        "worked_examples"
+      )
+    )
+
+    val recordedVoiceoverMapping = hashMapOf<String, VoiceoverMapping>()
+    recordedVoiceoverMapping["explanation"] = createRecordedVoiceoversFromJson(
+      skillContents
+        .optJSONObject("recorded_voiceovers")
+        .optJSONObject("voiceovers_mapping")
+        .optJSONObject(
+          skillContents.optJSONObject("explanation").optString("content_id")
+        )!!
+    )
+    for (workedExample in workedExamplesList) {
+      recordedVoiceoverMapping[workedExample.contentId] = createRecordedVoiceoversFromJson(
+        skillContents
+          .optJSONObject("recorded_voiceovers")
+          .optJSONObject("voiceovers_mapping")
+          .optJSONObject(workedExample.contentId)
+      )
+    }
+
+    val writtenTranslationMapping = hashMapOf<String, TranslationMapping>()
+    writtenTranslationMapping["explanation"] = createWrittenTranslationFromJson(
+      skillContents
+        .optJSONObject("written_translations")
+        .optJSONObject("translations_mapping")
+        .optJSONObject(
+          skillContents.optJSONObject("explanation").optString("content_id")
+        )!!
+    )
+    for (workedExample in workedExamplesList) {
+      writtenTranslationMapping[workedExample.contentId] = createWrittenTranslationFromJson(
+        skillContents
+          .optJSONObject("written_translations")
+          .optJSONObject("translations_mapping")
+          .optJSONObject(workedExample.contentId)
+      )
+    }
+
+    return ConceptCard.newBuilder()
+      .setSkillId(skillData.getString("id"))
+      .setSkillDescription(skillData.getString("description"))
+      .setExplanation(
+        SubtitledHtml.newBuilder()
+          .setHtml(skillContents.getJSONObject("explanation").getString("html"))
+          .setContentId(
+            skillContents.getJSONObject("explanation").getString(
+              "content_id"
+            )
+          ).build()
+      )
+      .addAllWorkedExample(workedExamplesList)
+      .putAllWrittenTranslation(writtenTranslationMapping)
+      .putAllRecordedVoiceover(recordedVoiceoverMapping)
+      .build()
+  }
+
+  private fun getSkillJsonObject(skillId: String): JSONObject {
+    val skillJsonArray = jsonAssetRetriever
+      .loadJsonFromAsset("skills.json")?.optJSONArray("skills")
+      ?: return JSONObject("")
+    for (i in 0 until skillJsonArray.length()) {
+      val currentSkillJsonObject = skillJsonArray.optJSONObject(i)
+      if (skillId == currentSkillJsonObject.optString("id")) {
+        return currentSkillJsonObject
+      }
+    }
+    return JSONObject("")
+  }
+
+  private fun createWorkedExamplesFromJson(workedExampleData: JSONArray): List<SubtitledHtml> {
+    val workedExampleList = mutableListOf<SubtitledHtml>()
+    for (i in 0 until workedExampleData.length()) {
+      workedExampleList.add(
+        SubtitledHtml.newBuilder()
+          .setContentId(workedExampleData.getJSONObject(i).getString("content_id"))
+          .setHtml(workedExampleData.getJSONObject(i).getString("html"))
+          .build()
+      )
+    }
+    return workedExampleList
+  }
+
+  private fun createWrittenTranslationFromJson(
+    translationMappingJsonObject: JSONObject?
+  ): TranslationMapping {
+    if (translationMappingJsonObject == null) {
+      return TranslationMapping.getDefaultInstance()
+    }
+    val translationMappingBuilder = TranslationMapping.newBuilder()
+    val languages = translationMappingJsonObject.keys()
+    while (languages.hasNext()) {
+      val language = languages.next()
+      val translationJson = translationMappingJsonObject.optJSONObject(language)
+      val translation = Translation.newBuilder()
+        .setHtml(translationJson.optString("html"))
+        .setNeedsUpdate(translationJson.optBoolean("needs_update"))
+        .build()
+      translationMappingBuilder.putTranslationMapping(language, translation)
+    }
+    return translationMappingBuilder.build()
+  }
+
+  private fun createRecordedVoiceoversFromJson(
+    voiceoverMappingJsonObject: JSONObject?
+  ): VoiceoverMapping {
+    if (voiceoverMappingJsonObject == null) {
+      return VoiceoverMapping.getDefaultInstance()
+    }
+    val voiceoverMappingBuilder = VoiceoverMapping.newBuilder()
+    val languages = voiceoverMappingJsonObject.keys()
+    while (languages.hasNext()) {
+      val language = languages.next()
+      val voiceoverJson = voiceoverMappingJsonObject.optJSONObject(language)
+      val voiceover = Voiceover.newBuilder()
+        .setFileName(voiceoverJson.optString("filename"))
+        .setNeedsUpdate(voiceoverJson.optBoolean("needs_update"))
+        .setFileSizeBytes(voiceoverJson.optLong("file_size_bytes"))
+        .build()
+      voiceoverMappingBuilder.putVoiceoverMapping(language, voiceover)
+    }
+    return voiceoverMappingBuilder.build()
+  }
+}

--- a/domain/src/main/java/org/oppia/domain/topic/PrimeTopicAssetsControllerImpl.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/PrimeTopicAssetsControllerImpl.kt
@@ -149,11 +149,11 @@ class PrimeTopicAssetsControllerImpl @Inject constructor(
       val conceptCardImageUrls = conceptCards.flatMap(::collectImageUrls)
       val revisionCardImageUrls = revisionCards.flatMap(::collectImageUrls)
       val imageUrls = (
-        thumbnailUrls
-          + explorationImageUrls
-          + questionImageUrls
-          + conceptCardImageUrls
-          + revisionCardImageUrls
+        thumbnailUrls +
+          explorationImageUrls +
+          questionImageUrls +
+          conceptCardImageUrls +
+          revisionCardImageUrls
         ).toSet()
       logger.d("AssetRepo", "Downloading up to ${imageUrls.size} images")
       val startTime = SystemClock.elapsedRealtime()
@@ -352,7 +352,7 @@ class PrimeTopicAssetsControllerImpl @Inject constructor(
   }
 
   private fun collectImageUrls(exploration: Exploration): Collection<String> {
-    return collectImageUrls(exploration, exploration.id, explorationEntityType,::getUriForImage) {
+    return collectImageUrls(exploration, exploration.id, explorationEntityType, ::getUriForImage) {
       collectSubtitledHtmls(it.statesMap.values)
     }
   }
@@ -456,7 +456,9 @@ class PrimeTopicAssetsControllerImpl @Inject constructor(
   }
 
   private fun getUriForQuestionImage(
-    entityId: String, entityType: String, imageFileName: String
+    entityId: String,
+    entityType: String,
+    imageFileName: String
   ): String {
     return computeUrlForImageDownloads(
       imageDownloadUrlTemplate, questionGcsResource, entityType, entityId, imageFileName
@@ -464,7 +466,9 @@ class PrimeTopicAssetsControllerImpl @Inject constructor(
   }
 
   private fun getUriForThumbnail(
-    entityId: String, entityType: String, imageFileName: String
+    entityId: String,
+    entityType: String,
+    imageFileName: String
   ): String {
     return computeUrlForImageDownloads(
       thumbnailDownloadUrlTemplate, gcsResource, entityType, entityId, imageFileName

--- a/domain/src/main/java/org/oppia/domain/topic/PrimeTopicAssetsControllerImpl.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/PrimeTopicAssetsControllerImpl.kt
@@ -339,6 +339,15 @@ class PrimeTopicAssetsControllerImpl @Inject constructor(
       }
     }
 
+    for (subtopic in topic.subtopicList) {
+      val subtopicThumbnail = subtopic.subtopicThumbnail
+      if (subtopicThumbnail.thumbnailFilename.isNotBlank()) {
+        thumbnailUrls += getUriForThumbnail(
+          topic.topicId, topicEntityType, subtopicThumbnail.thumbnailFilename
+        )
+      }
+    }
+
     return thumbnailUrls
   }
 

--- a/domain/src/main/java/org/oppia/domain/topic/PrimeTopicAssetsControllerImpl.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/PrimeTopicAssetsControllerImpl.kt
@@ -23,23 +23,35 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import org.oppia.app.model.AnswerGroup
+import org.oppia.app.model.ChapterSummary
+import org.oppia.app.model.ConceptCard
 import org.oppia.app.model.Exploration
 import org.oppia.app.model.Hint
 import org.oppia.app.model.Interaction
 import org.oppia.app.model.Outcome
+import org.oppia.app.model.Question
+import org.oppia.app.model.RevisionCard
 import org.oppia.app.model.Solution
 import org.oppia.app.model.State
+import org.oppia.app.model.StorySummary
 import org.oppia.app.model.SubtitledHtml
-import org.oppia.app.model.Voiceover
-import org.oppia.app.model.VoiceoverMapping
+import org.oppia.app.model.Subtopic
+import org.oppia.app.model.Topic
 import org.oppia.domain.exploration.ExplorationRetriever
+import org.oppia.domain.question.QuestionRetriever
 import org.oppia.domain.util.JsonAssetRetriever
 import org.oppia.util.caching.AssetRepository
 import org.oppia.util.caching.TopicListToCache
 import org.oppia.util.gcsresource.DefaultResourceBucketName
+import org.oppia.util.gcsresource.QuestionResourceBucketName
 import org.oppia.util.logging.ConsoleLogger
+import org.oppia.util.parser.ConceptCardHtmlParserEntityType
 import org.oppia.util.parser.DefaultGcsPrefix
+import org.oppia.util.parser.ExplorationHtmlParserEntityType
 import org.oppia.util.parser.ImageDownloadUrlTemplate
+import org.oppia.util.parser.StoryHtmlParserEntityType
+import org.oppia.util.parser.ThumbnailDownloadUrlTemplate
+import org.oppia.util.parser.TopicHtmlParserEntityType
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -63,10 +75,19 @@ class PrimeTopicAssetsControllerImpl @Inject constructor(
   private val topicController: TopicController,
   private val jsonAssetRetriever: JsonAssetRetriever,
   private val explorationRetriever: ExplorationRetriever,
+  private val questionRetriever: QuestionRetriever,
+  private val conceptCardRetriever: ConceptCardRetriever,
+  private val revisionCardRetriever: RevisionCardRetriever,
   @DefaultGcsPrefix private val gcsPrefix: String,
   @DefaultResourceBucketName private val gcsResource: String,
+  @QuestionResourceBucketName private val questionGcsResource: String,
   @ImageDownloadUrlTemplate private val imageDownloadUrlTemplate: String,
-  @TopicListToCache private val topicListToCache: List<String>
+  @ThumbnailDownloadUrlTemplate private val thumbnailDownloadUrlTemplate: String,
+  @TopicListToCache private val topicListToCache: List<String>,
+  @ExplorationHtmlParserEntityType private val explorationEntityType: String,
+  @ConceptCardHtmlParserEntityType private val conceptCardEntityType: String,
+  @TopicHtmlParserEntityType private val topicEntityType: String,
+  @StoryHtmlParserEntityType private val storyEntityType: String
 ) : PrimeTopicAssetsController {
 
   // NOTE TO DEVELOPERS: Don't ever do this. The application should use shared dispatchers to
@@ -112,18 +133,31 @@ class PrimeTopicAssetsControllerImpl @Inject constructor(
     extraDispatcherScope.launch {
       primeAssetJobs.forEach { it.await() }
 
-      // Only download binary assets for one fractions lesson. The others can still be streamed.
-      val explorations = loadExplorations(topicListToCache)
-      val voiceoverUrls = listOf<String>()
-      val imageUrls = collectAllImageUrls(explorations).toSet()
-      logger.d(
-        "AssetRepo",
-        "Downloading up to ${voiceoverUrls.size} voiceovers and ${imageUrls.size} images"
-      )
+      // Only download binary assets for configured topics. The others can still be streamed.
+      val topics = loadTopics(topicListToCache)
+      val explorationIds = topics.flatMap(::extractExplorationIds).toSet()
+      val skillIds = topics.flatMap(::extractSkillIds).toSet()
+
+      val explorations = loadExplorations(explorationIds)
+      val questions = loadQuestions(skillIds)
+      val conceptCards = loadConceptCards(skillIds)
+      val revisionCards = loadRevisionCards(topics)
+
+      val thumbnailUrls = topics.flatMap(::collectThumbnailUrls)
+      val explorationImageUrls = explorations.flatMap(::collectImageUrls)
+      val questionImageUrls = questions.flatMap(::collectImageUrls)
+      val conceptCardImageUrls = conceptCards.flatMap(::collectImageUrls)
+      val revisionCardImageUrls = revisionCards.flatMap(::collectImageUrls)
+      val imageUrls = (
+        thumbnailUrls
+          + explorationImageUrls
+          + questionImageUrls
+          + conceptCardImageUrls
+          + revisionCardImageUrls
+        ).toSet()
+      logger.d("AssetRepo", "Downloading up to ${imageUrls.size} images")
       val startTime = SystemClock.elapsedRealtime()
-      val downloadUrls = (voiceoverUrls + imageUrls).filterNot(
-        assetRepository::isRemoteBinarAssetDownloaded
-      )
+      val downloadUrls = imageUrls.filterNot(assetRepository::isRemoteBinarAssetDownloaded)
       val assetDownloadCount = downloadUrls.size
       primeDownloadStatus.postValue(
         PrimeAssetsStatus(currentDownloadCount.get(), assetDownloadCount)
@@ -171,12 +205,10 @@ class PrimeTopicAssetsControllerImpl @Inject constructor(
             val appCompatActivity = it as AppCompatActivity
             primeDownloadStatus.observe(
               appCompatActivity,
-              object : Observer<PrimeAssetsStatus> {
-                override fun onChanged(primeAssetsStatus: PrimeAssetsStatus?) {
-                  primeAssetsStatus?.let { status ->
-                    if (status.totalDownloadCount > 0 && !dialogShown.get()) {
-                      showProgressDialog(appCompatActivity, dialogStyleResId)
-                    }
+              Observer<PrimeAssetsStatus> { primeAssetsStatus ->
+                primeAssetsStatus?.let { status ->
+                  if (status.totalDownloadCount > 0 && !dialogShown.get()) {
+                    showProgressDialog(appCompatActivity, dialogStyleResId)
                   }
                 }
               }
@@ -240,78 +272,152 @@ class PrimeTopicAssetsControllerImpl @Inject constructor(
     })
   }
 
+  private fun loadTopics(topicIds: Collection<String>): Collection<Topic> {
+    return topicIds.map(topicController::retrieveTopic)
+  }
+
   private fun loadExplorations(explorationIds: Collection<String>): Collection<Exploration> {
     return explorationIds.map(explorationRetriever::loadExploration)
   }
 
-  @Suppress("unused") // Voiceovers can't be played while offline, so don't cache them for now.
-  private fun collectAllDesiredVoiceoverUrls(
-    explorations: Collection<Exploration>
-  ): Collection<String> {
-    return explorations.flatMap(::collectDesiredVoiceoverUrls)
+  private fun loadQuestions(skillIds: Collection<String>): Collection<Question> {
+    return questionRetriever.loadQuestions(skillIds.toList())
   }
 
-  private fun collectDesiredVoiceoverUrls(exploration: Exploration): Collection<String> {
-    return extractDesiredVoiceovers(exploration).map { voiceover ->
-      getUriForVoiceover(
-        exploration.id,
-        voiceover
-      )
+  private fun loadConceptCards(skillIds: Collection<String>): Collection<ConceptCard> {
+    return skillIds.map(conceptCardRetriever::loadConceptCard)
+  }
+
+  private fun loadRevisionCards(topics: Collection<Topic>): List<Pair<String, RevisionCard>> {
+    return topics.flatMap {
+      loadRevisionCards(it.topicId to it.subtopicList.map(Subtopic::getSubtopicId))
     }
   }
 
-  private fun extractDesiredVoiceovers(exploration: Exploration): Collection<Voiceover> {
-    val states = exploration.statesMap.values
-    val mappings = states.flatMap(::getDesiredVoiceoverMapping)
-    return mappings.flatMap { it.voiceoverMappingMap.values }
+  private fun loadRevisionCards(
+    topicIdToSubtopicIds: Pair<String, Iterable<Int>>
+  ): Collection<Pair<String, RevisionCard>> {
+    val topicId = topicIdToSubtopicIds.first
+    return topicIdToSubtopicIds.second.map {
+      topicId to revisionCardRetriever.loadRevisionCard(topicId, it)
+    }
   }
 
-  private fun getDesiredVoiceoverMapping(state: State): Collection<VoiceoverMapping> {
-    val voiceoverMappings = state.recordedVoiceoversMap
-    val contentIds = extractDesiredContentIds(state).filter(String::isNotEmpty)
-    return voiceoverMappings.filterKeys(contentIds::contains).values
+  private fun extractExplorationIds(topic: Topic): List<String> {
+    val chapters = topic.storyList.flatMap(StorySummary::getChapterList)
+    return chapters.map(ChapterSummary::getExplorationId)
   }
 
-  /** Returns all collection IDs from the specified [State] that can actually be played by a user. */
-  private fun extractDesiredContentIds(state: State): Collection<String> {
-    val stateContentSubtitledHtml = state.content
-    val defaultFeedbackSubtitledHtml = state.interaction.defaultOutcome.feedback
-    val answerGroupOutcomes = state.interaction.answerGroupsList
-      .map(AnswerGroup::getOutcome)
-    val answerGroupsSubtitledHtml = answerGroupOutcomes.map(Outcome::getFeedback)
-    val targetedSubtitledHtmls =
-      answerGroupsSubtitledHtml + stateContentSubtitledHtml + defaultFeedbackSubtitledHtml
-    return targetedSubtitledHtmls.map(SubtitledHtml::getContentId)
+  private fun extractSkillIds(topic: Topic): List<String> {
+    return topic.subtopicList.flatMap(Subtopic::getSkillIdsList)
   }
 
-  private fun collectAllImageUrls(explorations: Collection<Exploration>): Collection<String> {
-    return explorations.flatMap(::collectImageUrls)
+  private fun collectThumbnailUrls(topic: Topic): Collection<String> {
+    val thumbnailUrls = mutableListOf<String>()
+    val topicThumbnail = topic.topicThumbnail
+    if (topicThumbnail.thumbnailFilename.isNotBlank()) {
+      thumbnailUrls += getUriForThumbnail(
+        topic.topicId, topicEntityType, topicThumbnail.thumbnailFilename
+      )
+    }
+
+    for (storySummary in topic.storyList) {
+      val storyThumbnail = storySummary.storyThumbnail
+      if (storyThumbnail.thumbnailFilename.isNotBlank()) {
+        thumbnailUrls += getUriForThumbnail(
+          storySummary.storyId, storyEntityType, storyThumbnail.thumbnailFilename
+        )
+      }
+
+      for (chapterSummary in storySummary.chapterList) {
+        val chapterThumbnail = chapterSummary.chapterThumbnail
+        if (chapterThumbnail.thumbnailFilename.isNotBlank()) {
+          thumbnailUrls += getUriForThumbnail(
+            storySummary.storyId, storyEntityType, chapterThumbnail.thumbnailFilename
+          )
+        }
+      }
+    }
+
+    return thumbnailUrls
   }
 
   private fun collectImageUrls(exploration: Exploration): Collection<String> {
-    val subtitledHtmls = collectSubtitledHtmls(exploration)
-    val imageSources = subtitledHtmls.flatMap(::getImageSourcesFromHtml)
-    return imageSources.toSet().map { imageSource ->
-      getUriForImage(exploration.id, imageSource)
+    return collectImageUrls(exploration, exploration.id, explorationEntityType,::getUriForImage) {
+      collectSubtitledHtmls(it.statesMap.values)
     }
   }
 
-  private fun collectSubtitledHtmls(exploration: Exploration): Collection<SubtitledHtml> {
-    val states = exploration.statesMap.values
+  private fun collectImageUrls(question: Question): Collection<String> {
+    // TODO(#497): Update this to properly link to question assets.
+    val skillId = question.linkedSkillIdsList.firstOrNull() ?: ""
+    return collectImageUrls(question, skillId, "skill", ::getUriForQuestionImage) {
+      collectSubtitledHtmls(listOf(question.questionState))
+    }
+  }
+
+  private fun collectImageUrls(conceptCard: ConceptCard): Collection<String> {
+    return collectImageUrls(
+      conceptCard,
+      conceptCard.skillId,
+      conceptCardEntityType,
+      ::getUriForImage,
+      ::collectSubtitledHtmls
+    )
+  }
+
+  private fun collectImageUrls(
+    topicIdToRevisionCard: Pair<String, RevisionCard>
+  ): Collection<String> {
+    return collectImageUrls(
+      topicIdToRevisionCard.second,
+      topicIdToRevisionCard.first,
+      topicEntityType,
+      ::getUriForImage,
+      ::collectSubtitledHtmls
+    )
+  }
+
+  private fun <T> collectImageUrls(
+    entity: T,
+    entityId: String,
+    entityType: String,
+    computeUriForImage: (String, String, String) -> String,
+    collectSubtitledHtmls: (T) -> Collection<SubtitledHtml>
+  ): Collection<String> {
+    val subtitledHtmls = collectSubtitledHtmls(entity)
+    val imageSources = subtitledHtmls.flatMap(::getImageSourcesFromHtml)
+    return imageSources.toSet().map { imageSource ->
+      computeUriForImage(entityId, entityType, imageSource)
+    }
+  }
+
+  private fun collectSubtitledHtmls(states: Iterable<State>): Collection<SubtitledHtml> {
     val stateContents = states.map(State::getContent)
     val stateInteractions = states.map(State::getInteraction)
+
     val stateSolutions =
       stateInteractions.map(Interaction::getSolution).map(Solution::getExplanation)
     val stateHints = stateInteractions.flatMap(
       Interaction::getHintList
     ).map(Hint::getHintContent)
+
     val answerGroupOutcomes =
       stateInteractions.flatMap(Interaction::getAnswerGroupsList).map(AnswerGroup::getOutcome)
     val defaultOutcomes = stateInteractions.map(Interaction::getDefaultOutcome)
     val outcomeFeedbacks = (answerGroupOutcomes + defaultOutcomes)
       .map(Outcome::getFeedback)
+
     val allSubtitledHtmls = stateContents + stateSolutions + stateHints + outcomeFeedbacks
     return allSubtitledHtmls.filter { it != SubtitledHtml.getDefaultInstance() }
+  }
+
+  private fun collectSubtitledHtmls(conceptCard: ConceptCard): Collection<SubtitledHtml> {
+    return conceptCard.workedExampleList + conceptCard.explanation
+  }
+
+  private fun collectSubtitledHtmls(revisionCard: RevisionCard): Collection<SubtitledHtml> {
+    return listOf(revisionCard.pageContents)
   }
 
   private fun getImageSourcesFromHtml(subtitledHtml: SubtitledHtml): Collection<String> {
@@ -334,16 +440,37 @@ class PrimeTopicAssetsControllerImpl @Inject constructor(
       .replace("&amp;quot;", "")
   }
 
-  private fun getUriForVoiceover(explorationId: String, voiceover: Voiceover): String {
-    return "https://storage.googleapis.com/$gcsResource/exploration" +
-      "/$explorationId/assets/audio/${voiceover.fileName}"
+  private fun getUriForImage(entityId: String, entityType: String, imageFileName: String): String {
+    return computeUrlForImageDownloads(
+      imageDownloadUrlTemplate, gcsResource, entityType, entityId, imageFileName
+    )
   }
 
-  private fun getUriForImage(explorationId: String, imageFileName: String): String {
-    val downloadUrlFile = String.format(
-      imageDownloadUrlTemplate, "exploration", explorationId, imageFileName
+  private fun getUriForQuestionImage(
+    entityId: String, entityType: String, imageFileName: String
+  ): String {
+    return computeUrlForImageDownloads(
+      imageDownloadUrlTemplate, questionGcsResource, entityType, entityId, imageFileName
     )
-    return "$gcsPrefix/$gcsResource/$downloadUrlFile"
+  }
+
+  private fun getUriForThumbnail(
+    entityId: String, entityType: String, imageFileName: String
+  ): String {
+    return computeUrlForImageDownloads(
+      thumbnailDownloadUrlTemplate, gcsResource, entityType, entityId, imageFileName
+    )
+  }
+
+  private fun computeUrlForImageDownloads(
+    template: String,
+    gcsBucket: String,
+    entityType: String,
+    entityId: String,
+    imageFileName: String
+  ): String {
+    val downloadUrlFile = String.format(template, entityType, entityId, imageFileName)
+    return "$gcsPrefix/$gcsBucket/$downloadUrlFile"
   }
 
   private data class PrimeAssetsStatus(

--- a/domain/src/main/java/org/oppia/domain/topic/RevisionCardRetriever.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/RevisionCardRetriever.kt
@@ -1,0 +1,36 @@
+package org.oppia.domain.topic
+
+import org.oppia.app.model.RevisionCard
+import org.oppia.app.model.SubtitledHtml
+import org.oppia.domain.util.JsonAssetRetriever
+import javax.inject.Inject
+
+// TODO(#1580): Restrict access using Bazel visibilities.
+/** Retriever for [RevisionCard] objects from the filesystem. */
+class RevisionCardRetriever @Inject constructor(
+  private val jsonAssetRetriever: JsonAssetRetriever
+) {
+  /**
+   * Returns a [RevisionCard] given a subtopic ID in the specific topic, loaded from the filesystem.
+   */
+  fun loadRevisionCard(topicId: String, subtopicId: Int): RevisionCard {
+    val subtopicJsonObject =
+      jsonAssetRetriever.loadJsonFromAsset(topicId + "_" + subtopicId + ".json")
+        ?: return RevisionCard.getDefaultInstance()
+    val subtopicData = subtopicJsonObject.getJSONObject("page_contents")!!
+    val subtopicTitle = subtopicJsonObject.getString("subtopic_title")!!
+    return RevisionCard.newBuilder()
+      .setSubtopicTitle(subtopicTitle)
+      .setPageContents(
+        SubtitledHtml.newBuilder()
+          .setHtml(subtopicData.getJSONObject("subtitled_html").getString("html"))
+          .setContentId(
+            subtopicData.getJSONObject("subtitled_html").getString(
+              "content_id"
+            )
+          )
+          .build()
+      )
+      .build()
+  }
+}

--- a/utility/src/main/java/org/oppia/util/caching/AssetRepository.kt
+++ b/utility/src/main/java/org/oppia/util/caching/AssetRepository.kt
@@ -55,6 +55,7 @@ class AssetRepository @Inject constructor(
    */
   fun loadRemoteBinaryAsset(url: String): () -> ByteArray {
     return {
+      logger.d("AssetRepo", "Loading binary asset: $url")
       val stream = openLocalCacheFileForRead(url) ?: openCachingStreamToRemoteFile(url)
       stream.use { it.readBytes() }
     }

--- a/utility/src/main/java/org/oppia/util/caching/CachingModule.kt
+++ b/utility/src/main/java/org/oppia/util/caching/CachingModule.kt
@@ -11,7 +11,7 @@ private const val RATIOS_TOPIC = "omzF4oqgeTXd"
 class CachingModule {
   @Provides
   @CacheAssetsLocally
-  fun provideCacheAssetsLocally(): Boolean = true
+  fun provideCacheAssetsLocally(): Boolean = false
 
   @Provides
   @TopicListToCache

--- a/utility/src/main/java/org/oppia/util/caching/CachingModule.kt
+++ b/utility/src/main/java/org/oppia/util/caching/CachingModule.kt
@@ -3,24 +3,17 @@ package org.oppia.util.caching
 import dagger.Module
 import dagger.Provides
 
-private const val FRACTIONS_EXPLORATION_ID_0 = "umPkwp0L1M0-"
-private const val FRACTIONS_EXPLORATION_ID_1 = "MjZzEVOG47_1"
-private const val RATIOS_EXPLORATION_ID_0 = "2mzzFVDLuAj8"
-private const val RATIOS_EXPLORATION_ID_1 = "5NWuolNcwH6e"
-private const val RATIOS_EXPLORATION_ID_2 = "k2bQ7z5XHNbK"
-private const val RATIOS_EXPLORATION_ID_3 = "tIoSb3HZFN6e"
+private const val FRACTIONS_TOPIC = "GJ2rLXRKD5hw"
+private const val RATIOS_TOPIC = "omzF4oqgeTXd"
 
 /** Provides dependencies corresponding to the app's caching policies. */
 @Module
 class CachingModule {
   @Provides
   @CacheAssetsLocally
-  fun provideCacheAssetsLocally(): Boolean = false
+  fun provideCacheAssetsLocally(): Boolean = true
 
   @Provides
   @TopicListToCache
-  fun provideTopicListToCache() = listOf(
-    FRACTIONS_EXPLORATION_ID_0, FRACTIONS_EXPLORATION_ID_1, RATIOS_EXPLORATION_ID_0,
-    RATIOS_EXPLORATION_ID_1, RATIOS_EXPLORATION_ID_2, RATIOS_EXPLORATION_ID_3
-  )
+  fun provideTopicListToCache() = listOf(FRACTIONS_TOPIC, RATIOS_TOPIC)
 }


### PR DESCRIPTION
Fixes #1786

Add support for additional offline image caching, including:
- Topic thumbnails
- Story thumbnails
- Chapter thumbnails
- Revision card thumbnails
- Question assets
- Revision card assets
- Concept card assets