### PR TITLE
Fix #1783: Partially revert back to the old LiTagHandler

### DIFF
--- a/utility/src/main/java/org/oppia/util/parser/BulletTagHandler.kt
+++ b/utility/src/main/java/org/oppia/util/parser/BulletTagHandler.kt
@@ -2,9 +2,8 @@ package org.oppia.util.parser
 
 import android.text.Editable
 import android.text.Spannable
-import android.text.SpannableStringBuilder
+import android.text.Spanned
 import android.text.style.BulletSpan
-import org.xml.sax.Attributes
 
 /** The custom tag corresponding to [BulletTagHandler]. */
 const val CUSTOM_BULLET_LIST_TAG = "oppia-li"
@@ -14,24 +13,21 @@ const val CUSTOM_BULLET_LIST_TAG = "oppia-li"
  * [CustomHtmlContentHandler].
  */
 class BulletTagHandler : CustomHtmlContentHandler.CustomTagHandler {
-  override fun handleTag(
-    attributes: Attributes,
-    openIndex: Int,
-    closeIndex: Int,
-    output: Editable
-  ) {
-    val spannableBuilder = SpannableStringBuilder(
-      output.subSequence(
-        openIndex,
-        closeIndex
-      )
-    )
-    spannableBuilder.append("\n")
-    if (openIndex != closeIndex) {
-      spannableBuilder.setSpan(
-        BulletSpan(), 0, spannableBuilder.length, Spannable.SPAN_INCLUSIVE_EXCLUSIVE
-      )
+  /** Helper marker class. */
+  private class Bullet
+
+  override fun handleOpeningTag(output: Editable) {
+    output.setSpan(Bullet(), output.length, output.length, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+  }
+
+  override fun handleClosingTag(output: Editable) {
+    output.append("\n")
+    output.getSpans(0, output.length, Bullet::class.java).lastOrNull()?.let {
+      val start = output.getSpanStart(it)
+      output.removeSpan(it)
+      if (start != output.length) {
+        output.setSpan(BulletSpan(), start, output.length, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
+      }
     }
-    output.replace(openIndex, closeIndex, spannableBuilder)
   }
 }

--- a/utility/src/main/java/org/oppia/util/parser/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/util/parser/CustomHtmlContentHandler.kt
@@ -94,6 +94,7 @@ class CustomHtmlContentHandler private constructor(
           currentTrackedCustomTags += TrackedCustomTag(
             localCurrentTrackedTag.tag, localCurrentTrackedTag.attributes, output.length
           )
+          customTagHandlers.getValue(tag).handleOpeningTag(output)
         }
       }
       tag in customTagHandlers -> {
@@ -105,6 +106,7 @@ class CustomHtmlContentHandler private constructor(
           "Expected tracked tag $currentTrackedTag to match custom tag: $tag"
         }
         val (_, attributes, openTagIndex) = currentTrackedCustomTag
+        customTagHandlers.getValue(tag).handleClosingTag(output)
         customTagHandlers.getValue(tag).handleTag(attributes, openTagIndex, output.length, output)
       }
     }
@@ -122,12 +124,32 @@ class CustomHtmlContentHandler private constructor(
     /**
      * Called when a custom tag is encountered. This is always called after the closing tag.
      *
-     * @param attributes The tag's attributes
-     * @param openIndex The index in the output [Editable] at which this tag begins
-     * @param closeIndex The index in the output [Editable] at which this tag ends
-     * @param output The destination [Editable] to which spans can be added
+     * @param attributes the tag's attributes
+     * @param openIndex the index in the output [Editable] at which this tag begins
+     * @param closeIndex the index in the output [Editable] at which this tag ends
+     * @param output the destination [Editable] to which spans can be added
      */
-    fun handleTag(attributes: Attributes, openIndex: Int, closeIndex: Int, output: Editable)
+    fun handleTag(attributes: Attributes, openIndex: Int, closeIndex: Int, output: Editable) {}
+
+    /**
+     * Called when the opening of a custom tag is encountered. This does not support processing
+     * attributes of the tag--[handleTag] should be used, instead.
+     *
+     * This function will always be called before [handleClosingTag].
+     *
+     * @param output the destination [Editable] to which spans can be added
+     */
+    fun handleOpeningTag(output: Editable) {}
+
+    /**
+     * Called when the closing of a custom tag is encountered. This does not support processing
+     * attributes of the tag--[handleTag] should be used, instead.
+     *
+     * This function will always be called before [handleClosingTag].
+     *
+     * @param output the destination [Editable] to which spans can be added
+     */
+    fun handleClosingTag(output: Editable) {}
   }
 
   companion object {

--- a/utility/src/test/java/org/oppia/util/parser/CustomHtmlContentHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/util/parser/CustomHtmlContentHandlerTest.kt
@@ -78,6 +78,26 @@ class CustomHtmlContentHandlerTest {
   }
 
   @Test
+  fun testParseHtml_withOneCustomTag_nonAttributeHandlersAreCalledBeforeAttributeAndInOrder() {
+    val fakeTagHandler = FakeTagHandler()
+
+    CustomHtmlContentHandler.fromHtml(
+      html = "<custom-tag custom-attribute=\"value\">content</custom-tag>",
+      imageGetter = mockImageGetter,
+      customTagHandlers = mapOf("custom-tag" to fakeTagHandler)
+    )
+
+    assertThat(fakeTagHandler.handleOpeningTagCalled).isTrue()
+    assertThat(fakeTagHandler.handleClosingTagCalled).isTrue()
+    assertThat(fakeTagHandler.handleTagCalled).isTrue()
+    // Call order: opening tag -> close tag -> handle tag.
+    assertThat(fakeTagHandler.handleOpeningTagCallIndex)
+      .isLessThan(fakeTagHandler.handleClosingTagCallIndex)
+    assertThat(fakeTagHandler.handleClosingTagCallIndex)
+      .isLessThan(fakeTagHandler.handleTagCallIndex)
+  }
+
+  @Test
   fun testParseHtml_withOneCustomTag_missingHandler_keepsContent() {
     val parsedHtml =
       CustomHtmlContentHandler.fromHtml(
@@ -146,7 +166,13 @@ class CustomHtmlContentHandlerTest {
 
   private class FakeTagHandler : CustomHtmlContentHandler.CustomTagHandler {
     var handleTagCalled = false
+    var handleTagCallIndex = -1
+    var handleOpeningTagCalled = false
+    var handleOpeningTagCallIndex = -1
+    var handleClosingTagCalled = false
+    var handleClosingTagCallIndex = -1
     lateinit var attributes: Attributes
+    private var methodCallCount = 0
 
     override fun handleTag(
       attributes: Attributes,
@@ -155,7 +181,18 @@ class CustomHtmlContentHandlerTest {
       output: Editable
     ) {
       handleTagCalled = true
+      handleTagCallIndex = methodCallCount++
       this.attributes = attributes
+    }
+
+    override fun handleOpeningTag(output: Editable) {
+      handleOpeningTagCalled = true
+      handleOpeningTagCallIndex = methodCallCount++
+    }
+
+    override fun handleClosingTag(output: Editable) {
+      handleClosingTagCalled = true
+      handleClosingTagCallIndex = methodCallCount++
     }
   }
 


### PR DESCRIPTION
Fixes #1783.

This reverts back to the old LiTagHandler but in a way that's interoperable with the new custom tag handler, and is a bit cleaner (since it still uses a custom <li> tag rather than relying on the real one). The subsequent implementation is a bit simpler, too.

There just seemed to be a bunch of subtle issues at managing paragraph spans that the previous solution doesn't handle correctly (I suspect it has something to do with the previous solution not making 'space' for the beginning of the span since it's only processing the list at the end rather than beginning + end). Thus, reverting back to the previous behavior should be safer and result in a more robust implementation than trying to continue making the new approach work.