### PR TITLE
Fix #1782 and part of #1781: Fix text view image loading issues

### DIFF
--- a/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
@@ -8,12 +8,15 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.PictureDrawable
 import android.text.Html
+import android.view.View
+import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.widget.TextView
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 import org.oppia.util.R
 import javax.inject.Inject
+import kotlin.math.max
 
 // TODO(#169): Replace this with exploration asset downloader.
 // TODO(#277): Add test cases for loading image.
@@ -67,8 +70,21 @@ class UrlImageParser private constructor(
 
     override fun onResourceReady(resource: T, transition: Transition<in T>?) {
       val drawable = drawableFactory(resource)
+      val viewMaxWidth = htmlContentTextView.maxWidth.takeIf { it != -1 && it != Int.MAX_VALUE} ?: 0
       htmlContentTextView.post {
-        htmlContentTextView.width {
+        htmlContentTextView.width { viewWidth ->
+          val layoutParams = htmlContentTextView.layoutParams
+          val maxAvailableWidth = if (layoutParams.width == ViewGroup.LayoutParams.WRAP_CONTENT) {
+            // Assume that wrap_content cases means that the view cannot exceed its parent's width
+            // minus margins.
+            val parent = htmlContentTextView.parent
+            if (parent is View && layoutParams is ViewGroup.MarginLayoutParams) {
+              // Only pick the computed space if it allows the view to expand to accommodate larger
+              // images.
+              max(viewWidth, parent.width - (layoutParams.leftMargin + layoutParams.rightMargin))
+            } else viewWidth
+          } else viewWidth
+
           var drawableHeight = drawable.intrinsicHeight
           var drawableWidth = drawable.intrinsicWidth
           val minimumImageSize = context.resources.getDimensionPixelSize(R.dimen.minimum_image_size)
@@ -87,8 +103,9 @@ class UrlImageParser private constructor(
             drawableHeight = (drawableHeight.toDouble() * multipleFactor).toInt()
             drawableWidth = (drawableWidth.toDouble() * multipleFactor).toInt()
           }
-          val maximumImageSize =
-            it - context.resources.getDimensionPixelSize(R.dimen.maximum_content_item_padding)
+          val maxContentItemPadding =
+            context.resources.getDimensionPixelSize(R.dimen.maximum_content_item_padding)
+          val maximumImageSize = maxAvailableWidth - maxContentItemPadding
           if (drawableWidth >= maximumImageSize) {
             // The multipleFactor value is used to make sure that the aspect ratio of the image remains the same.
             // Example: Height is 420, width is 440 and maximumImageSize is 200.
@@ -105,7 +122,7 @@ class UrlImageParser private constructor(
             drawableWidth = (drawableWidth.toDouble() * multipleFactor).toInt()
           }
           val initialDrawableMargin = if (imageCenterAlign) {
-            calculateInitialMargin(it, drawableWidth)
+            calculateInitialMargin(maxAvailableWidth, drawableWidth)
           } else {
             0
           }

--- a/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/util/parser/UrlImageParser.kt
@@ -70,7 +70,6 @@ class UrlImageParser private constructor(
 
     override fun onResourceReady(resource: T, transition: Transition<in T>?) {
       val drawable = drawableFactory(resource)
-      val viewMaxWidth = htmlContentTextView.maxWidth.takeIf { it != -1 && it != Int.MAX_VALUE} ?: 0
       htmlContentTextView.post {
         htmlContentTextView.width { viewWidth ->
           val layoutParams = htmlContentTextView.layoutParams


### PR DESCRIPTION
Fixes #1782
Partly fixes #1781 (for online cases)

There seems to be a not well-documented or seen bug in AOSP wherein TextViews with HTML that only contains an ImageSpan and no other visible text can result in the TextView seemingly being ignored for layout & measurement. This results in our image computation for ImageSpan failing. The hack involves adding spaces around the image (technically just 1 is needed, but 2 are added to keep the image horizontally centered) which triggers Android to properly lay out the view & allow our image computation to kick-in. I filed #1796 to track finding a better long-term solution.

Note that this also includes another semi-hacky workaround: getting Android to layout the view is only part of the solution. In cases when TextView is using wrap_content, we don't have a true maximum to use when ensuring the image doesn't exceed its container's bounds. For the purpose of keeping things simple for now, we're assuming that in such cases we can limit the TextView's dimensions to that of its parent's minus established right/left margins. This should be correct in all cases (unless a maxWidth is set smaller than the parent--we don't account for this right now).

No new tests were added for the UrlImageParser work. #277 is tracking adding test cases for the parser (there's a bit too much to do there for me to do it quickly, so I deferred to that issue, instead).

Thanks to @rt4914 for the early investigation with the wrap_content part.