### PR TITLE
Fix #1805: My Downloads is now hidden

### DIFF
--- a/app/src/main/res/menu/navigation_drawer_menu.xml
+++ b/app/src/main/res/menu/navigation_drawer_menu.xml
@@ -18,7 +18,8 @@
     <item
       android:id="@+id/nav_my_downloads"
       android:icon="@drawable/ic_folder_open_24dp"
-      android:title="@string/menu_my_downloads" />
+      android:title="@string/menu_my_downloads"
+      android:visible="false" />
     <item
       android:id="@+id/nav_switch_profile"
       android:icon="@drawable/ic_profile_exit"

--- a/app/src/sharedTest/java/org/oppia/app/testing/NavigationDrawerTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/testing/NavigationDrawerTestActivityTest.kt
@@ -49,6 +49,7 @@ import org.hamcrest.Matchers.instanceOf
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.app.R
@@ -326,7 +327,9 @@ class NavigationDrawerTestActivityTest {
     }
   }
 
+  // TODO(#1806): Enable this once lowfi implementation is done.
   @Test
+  @Ignore("My Downloads is removed until we have full download support.")
   fun testNavigationDrawerTestActivity_openNavigationDrawer_selectMyDownloadsMenuInNavigationDrawer_showsMyDownloadsFragmentSuccessfully() { // ktlint-disable max-line-length
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withId(R.id.home_activity_drawer_layout)).perform(open())


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

Fixes #1805 

This PR hides `My Downloads` from Navigation Drawer.

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
