### PR TITLE
Enable GitHub actions to be run manually

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,8 @@ name: CI Lint and Tests
 
 # Controls when the action will run. Triggers the workflow on pull request
 # events or push events in the develop branch.
-on: 
+on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:    


### PR DESCRIPTION
Enable GitHub actions to be run manually with a workflow dispatch (see https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/). This will be useful for manually triggering the test flows on release branches.
