### PR TITLE
Fix #1802 : Reading text size not scrollable or flexible

### DIFF
--- a/app/src/main/java/org/oppia/app/options/ReadingTextSizeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/options/ReadingTextSizeFragmentPresenter.kt
@@ -1,6 +1,7 @@
 package org.oppia.app.options
 
 import android.content.Intent
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -44,23 +45,31 @@ class ReadingTextSizeFragmentPresenter @Inject constructor(private val fragment:
     when (readingTextSize) {
       getReadingTextSize(ReadingTextSize.SMALL_TEXT_SIZE) -> {
         binding.readingTextSizeSeekBar.progress = 0
-        binding.previewTextview.textSize =
+        binding.previewTextview.setTextSize(
+          TypedValue.COMPLEX_UNIT_PX,
           getReadingTextSizeInFloat(ReadingTextSize.SMALL_TEXT_SIZE)
+        )
       }
       getReadingTextSize(ReadingTextSize.MEDIUM_TEXT_SIZE) -> {
         binding.readingTextSizeSeekBar.progress = 5
-        binding.previewTextview.textSize =
-          getReadingTextSizeInFloat(ReadingTextSize.MEDIUM_TEXT_SIZE)
+        binding.previewTextview.setTextSize(
+          TypedValue.COMPLEX_UNIT_PX,
+          getReadingTextSizeInFloat(ReadingTextSize.SMALL_TEXT_SIZE)
+        )
       }
-      getReadingTextSize(ReadingTextSize.LARGE_TEXT_SIZE) -> {
+      getReadingTextSize(ReadingTextSize.MEDIUM_TEXT_SIZE) -> {
         binding.readingTextSizeSeekBar.progress = 10
-        binding.previewTextview.textSize =
+        binding.previewTextview.setTextSize(
+          TypedValue.COMPLEX_UNIT_PX,
           getReadingTextSizeInFloat(ReadingTextSize.LARGE_TEXT_SIZE)
+        )
       }
       getReadingTextSize(ReadingTextSize.EXTRA_LARGE_TEXT_SIZE) -> {
         binding.readingTextSizeSeekBar.progress = 15
-        binding.previewTextview.textSize =
+        binding.previewTextview.setTextSize(
+          TypedValue.COMPLEX_UNIT_PX,
           getReadingTextSizeInFloat(ReadingTextSize.EXTRA_LARGE_TEXT_SIZE)
+        )
       }
     }
 
@@ -77,23 +86,31 @@ class ReadingTextSizeFragmentPresenter @Inject constructor(private val fragment:
           when (progressValue) {
             0 -> {
               fontSize = getReadingTextSize(ReadingTextSize.SMALL_TEXT_SIZE)
-              binding.previewTextview.textSize =
+              binding.previewTextview.setTextSize(
+                TypedValue.COMPLEX_UNIT_PX,
                 getReadingTextSizeInFloat(ReadingTextSize.SMALL_TEXT_SIZE)
+              )
             }
             5 -> {
               fontSize = getReadingTextSize(ReadingTextSize.MEDIUM_TEXT_SIZE)
-              binding.previewTextview.textSize =
+              binding.previewTextview.setTextSize(
+                TypedValue.COMPLEX_UNIT_PX,
                 getReadingTextSizeInFloat(ReadingTextSize.MEDIUM_TEXT_SIZE)
+              )
             }
             10 -> {
               fontSize = getReadingTextSize(ReadingTextSize.LARGE_TEXT_SIZE)
-              binding.previewTextview.textSize =
+              binding.previewTextview.setTextSize(
+                TypedValue.COMPLEX_UNIT_PX,
                 getReadingTextSizeInFloat(ReadingTextSize.LARGE_TEXT_SIZE)
+              )
             }
             else -> {
               fontSize = getReadingTextSize(ReadingTextSize.EXTRA_LARGE_TEXT_SIZE)
-              binding.previewTextview.textSize =
+              binding.previewTextview.setTextSize(
+                TypedValue.COMPLEX_UNIT_PX,
                 getReadingTextSizeInFloat(ReadingTextSize.EXTRA_LARGE_TEXT_SIZE)
+              )
             }
           }
           seekBar.progress = progressValue

--- a/app/src/main/java/org/oppia/app/options/ReadingTextSizeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/options/ReadingTextSizeFragmentPresenter.kt
@@ -57,7 +57,7 @@ class ReadingTextSizeFragmentPresenter @Inject constructor(private val fragment:
           getReadingTextSizeInFloat(ReadingTextSize.MEDIUM_TEXT_SIZE)
         )
       }
-      getReadingTextSize(ReadingTextSize.MEDIUM_TEXT_SIZE) -> {
+      getReadingTextSize(ReadingTextSize.LARGE_TEXT_SIZE) -> {
         binding.readingTextSizeSeekBar.progress = 10
         binding.previewTextview.setTextSize(
           TypedValue.COMPLEX_UNIT_PX,

--- a/app/src/main/java/org/oppia/app/options/ReadingTextSizeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/options/ReadingTextSizeFragmentPresenter.kt
@@ -54,7 +54,7 @@ class ReadingTextSizeFragmentPresenter @Inject constructor(private val fragment:
         binding.readingTextSizeSeekBar.progress = 5
         binding.previewTextview.setTextSize(
           TypedValue.COMPLEX_UNIT_PX,
-          getReadingTextSizeInFloat(ReadingTextSize.SMALL_TEXT_SIZE)
+          getReadingTextSizeInFloat(ReadingTextSize.MEDIUM_TEXT_SIZE)
         )
       }
       getReadingTextSize(ReadingTextSize.MEDIUM_TEXT_SIZE) -> {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #1802 
Preview Text now displays the correct and real size of the text in stories.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.

Screenshots for the same - 

<img src="https://user-images.githubusercontent.com/54636525/92412313-19818480-f169-11ea-9b03-14dcd19fc261.jpg" width="280">    <img src="https://user-images.githubusercontent.com/54636525/92412315-1a1a1b00-f169-11ea-8431-0aee1907ce4e.jpg" width="280">
<img src="https://user-images.githubusercontent.com/54636525/92412316-1b4b4800-f169-11ea-9328-8aab64d00db0.jpg" width="280">    <img src="https://user-images.githubusercontent.com/54636525/92412318-1be3de80-f169-11ea-8bfe-fb7e20cd3a91.jpg" width="280">
