### PR TITLE
Introduce data provider extension functions

### DIFF
--- a/app/src/main/java/org/oppia/app/administratorcontrols/AdministratorControlsViewModel.kt
+++ b/app/src/main/java/org/oppia/app/administratorcontrols/AdministratorControlsViewModel.kt
@@ -18,6 +18,7 @@ import org.oppia.app.model.ProfileId
 import org.oppia.app.shim.IntentFactoryShim
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -37,7 +38,7 @@ class AdministratorControlsViewModel @Inject constructor(
 
   private val deviceSettingsLiveData: LiveData<DeviceSettings> by lazy {
     Transformations.map(
-      profileManagementController.getDeviceSettings(),
+      profileManagementController.getDeviceSettings().toLiveData(),
       ::processGetDeviceSettingsResult
     )
   }

--- a/app/src/main/java/org/oppia/app/administratorcontrols/administratorcontrolsitemviewmodel/AdministratorControlsDownloadPermissionsViewModel.kt
+++ b/app/src/main/java/org/oppia/app/administratorcontrols/administratorcontrolsitemviewmodel/AdministratorControlsDownloadPermissionsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.Observer
 import org.oppia.app.model.DeviceSettings
 import org.oppia.app.model.ProfileId
 import org.oppia.domain.profile.ProfileManagementController
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 
 /** [ViewModel] for the recycler view in [AdministratorControlsFragment]. */
@@ -23,25 +24,27 @@ class AdministratorControlsDownloadPermissionsViewModel(
     ObservableField<Boolean>(deviceSettings.automaticallyUpdateTopics)
 
   fun onTopicWifiUpdatePermissionChanged(checked: Boolean) {
-    profileManagementController.updateWifiPermissionDeviceSettings(userProfileId, checked).observe(
-      fragment,
-      Observer {
-        if (it.isFailure()) {
-          logger.e(
-            "AdministratorControlsFragment",
-            "Failed to update topic update on wifi permission",
-            it.getErrorOrNull()!!
-          )
+    profileManagementController.updateWifiPermissionDeviceSettings(userProfileId, checked)
+      .toLiveData()
+      .observe(
+        fragment,
+        Observer {
+          if (it.isFailure()) {
+            logger.e(
+              "AdministratorControlsFragment",
+              "Failed to update topic update on wifi permission",
+              it.getErrorOrNull()!!
+            )
+          }
         }
-      }
-    )
+      )
   }
 
   fun onTopicAutoUpdatePermissionChanged(checked: Boolean) {
     profileManagementController.updateTopicAutomaticallyPermissionDeviceSettings(
       userProfileId,
       checked
-    ).observe(
+    ).toLiveData().observe(
       fragment,
       Observer {
         if (it.isFailure()) {

--- a/app/src/main/java/org/oppia/app/application/ApplicationInjector.kt
+++ b/app/src/main/java/org/oppia/app/application/ApplicationInjector.kt
@@ -1,9 +1,10 @@
 package org.oppia.app.application
 
 import org.oppia.app.profile.ProfileInputView
+import org.oppia.util.data.DataProvidersInjector
 
 /** Injector for application-level dependencies that can't be directly injected where needed. */
-interface ApplicationInjector {
+interface ApplicationInjector : DataProvidersInjector {
 
   // TODO(#1619): Remove post-modularization.
   fun inject(profileInputView: ProfileInputView)

--- a/app/src/main/java/org/oppia/app/application/ApplicationInjectorProvider.kt
+++ b/app/src/main/java/org/oppia/app/application/ApplicationInjectorProvider.kt
@@ -1,6 +1,11 @@
 package org.oppia.app.application
 
+import org.oppia.util.data.DataProvidersInjector
+import org.oppia.util.data.DataProvidersInjectorProvider
+
 /** Provider for [ApplicationInjector]. The application context will implement this interface. */
-interface ApplicationInjectorProvider {
+interface ApplicationInjectorProvider : DataProvidersInjectorProvider {
   fun getApplicationInjector(): ApplicationInjector
+
+  override fun getDataProvidersInjector(): DataProvidersInjector = getApplicationInjector()
 }

--- a/app/src/main/java/org/oppia/app/completedstorylist/CompletedStoryListViewModel.kt
+++ b/app/src/main/java/org/oppia/app/completedstorylist/CompletedStoryListViewModel.kt
@@ -10,6 +10,7 @@ import org.oppia.app.shim.IntentFactoryShim
 import org.oppia.app.viewmodel.ObservableViewModel
 import org.oppia.domain.topic.TopicController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.parser.StoryHtmlParserEntityType
 import javax.inject.Inject
@@ -29,7 +30,7 @@ class CompletedStoryListViewModel @Inject constructor(
   private val completedStoryListResultLiveData: LiveData<AsyncResult<CompletedStoryList>> by lazy {
     topicController.getCompletedStoryList(
       ProfileId.newBuilder().setInternalId(internalProfileId).build()
-    )
+    ).toLiveData()
   }
 
   private val completedStoryLiveData: LiveData<CompletedStoryList> by lazy {

--- a/app/src/main/java/org/oppia/app/drawer/NavigationDrawerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/drawer/NavigationDrawerFragmentPresenter.kt
@@ -33,6 +33,7 @@ import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.domain.topic.TopicController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.statusbar.StatusBarColor
 import javax.inject.Inject
@@ -87,7 +88,7 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
 
   private fun getProfileData(): LiveData<Profile> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId),
+      profileManagementController.getProfile(profileId).toLiveData(),
       ::processGetProfileResult
     )
   }
@@ -136,7 +137,7 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
 
   private fun getCompletedStoryListCount(): LiveData<CompletedStoryList> {
     return Transformations.map(
-      topicController.getCompletedStoryList(profileId),
+      topicController.getCompletedStoryList(profileId).toLiveData(),
       ::processGetCompletedStoryListResult
     )
   }
@@ -165,7 +166,7 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
 
   private fun getOngoingTopicListCount(): LiveData<OngoingTopicList> {
     return Transformations.map(
-      topicController.getOngoingTopicList(profileId),
+      topicController.getOngoingTopicList(profileId).toLiveData(),
       ::processGetOngoingTopicListResult
     )
   }

--- a/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/HomeFragmentPresenter.kt
@@ -30,6 +30,7 @@ import org.oppia.domain.oppialogger.OppiaLogger
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.domain.topic.TopicListController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.datetime.DateTimeUtil
 import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.parser.StoryHtmlParserEntityType
@@ -119,7 +120,7 @@ class HomeFragmentPresenter @Inject constructor(
 
   private fun getProfileData(): LiveData<Profile> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId),
+      profileManagementController.getProfile(profileId).toLiveData(),
       ::processGetProfileResult
     )
   }
@@ -185,7 +186,7 @@ class HomeFragmentPresenter @Inject constructor(
   private val ongoingStoryListSummaryResultLiveData:
     LiveData<AsyncResult<OngoingStoryList>>
     by lazy {
-      topicListController.getOngoingStoryList(profileId)
+      topicListController.getOngoingStoryList(profileId).toLiveData()
     }
 
   private fun subscribeToOngoingStoryList() {

--- a/app/src/main/java/org/oppia/app/home/recentlyplayed/RecentlyPlayedFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/home/recentlyplayed/RecentlyPlayedFragmentPresenter.kt
@@ -21,6 +21,7 @@ import org.oppia.app.model.PromotedStory
 import org.oppia.domain.exploration.ExplorationDataController
 import org.oppia.domain.topic.TopicListController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.parser.StoryHtmlParserEntityType
 import javax.inject.Inject
@@ -70,7 +71,7 @@ class RecentlyPlayedFragmentPresenter @Inject constructor(
     by lazy {
       topicListController.getOngoingStoryList(
         ProfileId.newBuilder().setInternalId(internalProfileId).build()
-      )
+      ).toLiveData()
     }
 
   private fun subscribeToOngoingStoryList() {

--- a/app/src/main/java/org/oppia/app/ongoingtopiclist/OngoingTopicListViewModel.kt
+++ b/app/src/main/java/org/oppia/app/ongoingtopiclist/OngoingTopicListViewModel.kt
@@ -10,6 +10,7 @@ import org.oppia.app.shim.IntentFactoryShim
 import org.oppia.app.viewmodel.ObservableViewModel
 import org.oppia.domain.topic.TopicController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.parser.TopicHtmlParserEntityType
 import javax.inject.Inject
@@ -29,7 +30,7 @@ class OngoingTopicListViewModel @Inject constructor(
   private val ongoingTopicListResultLiveData: LiveData<AsyncResult<OngoingTopicList>> by lazy {
     topicController.getOngoingTopicList(
       ProfileId.newBuilder().setInternalId(internalProfileId).build()
-    )
+    ).toLiveData()
   }
 
   private val ongoingTopicListLiveData: LiveData<OngoingTopicList> by lazy {

--- a/app/src/main/java/org/oppia/app/options/OptionControlsViewModel.kt
+++ b/app/src/main/java/org/oppia/app/options/OptionControlsViewModel.kt
@@ -16,6 +16,7 @@ import org.oppia.app.model.ReadingTextSize
 import org.oppia.app.viewmodel.ObservableArrayList
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -47,7 +48,7 @@ class OptionControlsViewModel @Inject constructor(
   }
 
   private val profileResultLiveData: LiveData<AsyncResult<Profile>> by lazy {
-    profileManagementController.getProfile(profileId)
+    profileManagementController.getProfile(profileId).toLiveData()
   }
 
   private val profileLiveData: LiveData<Profile> by lazy { getProfileData() }

--- a/app/src/main/java/org/oppia/app/options/OptionsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/options/OptionsFragmentPresenter.kt
@@ -20,6 +20,7 @@ import org.oppia.app.model.ReadingTextSize
 import org.oppia.app.recyclerview.BindableAdapter
 import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.profile.ProfileManagementController
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import java.security.InvalidParameterException
 import javax.inject.Inject
@@ -187,7 +188,7 @@ class OptionsFragmentPresenter @Inject constructor(
         profileManagementController.updateReadingTextSize(
           profileId,
           ReadingTextSize.SMALL_TEXT_SIZE
-        ).observe(
+        ).toLiveData().observe(
           fragment,
           Observer {
             if (it.isSuccess()) {
@@ -206,7 +207,7 @@ class OptionsFragmentPresenter @Inject constructor(
         profileManagementController.updateReadingTextSize(
           profileId,
           ReadingTextSize.MEDIUM_TEXT_SIZE
-        ).observe(
+        ).toLiveData().observe(
           fragment,
           Observer {
             if (it.isSuccess()) {
@@ -225,7 +226,7 @@ class OptionsFragmentPresenter @Inject constructor(
         profileManagementController.updateReadingTextSize(
           profileId,
           ReadingTextSize.LARGE_TEXT_SIZE
-        ).observe(
+        ).toLiveData().observe(
           fragment,
           Observer {
             if (it.isSuccess()) {
@@ -245,7 +246,7 @@ class OptionsFragmentPresenter @Inject constructor(
         profileManagementController.updateReadingTextSize(
           profileId,
           ReadingTextSize.EXTRA_LARGE_TEXT_SIZE
-        ).observe(
+        ).toLiveData().observe(
           fragment,
           Observer {
             if (it.isSuccess()) {
@@ -270,7 +271,7 @@ class OptionsFragmentPresenter @Inject constructor(
         profileManagementController.updateAppLanguage(
           profileId,
           AppLanguage.ENGLISH_APP_LANGUAGE
-        ).observe(
+        ).toLiveData().observe(
           fragment,
           Observer {
             if (it.isSuccess()) {
@@ -289,7 +290,7 @@ class OptionsFragmentPresenter @Inject constructor(
         profileManagementController.updateAppLanguage(
           profileId,
           AppLanguage.HINDI_APP_LANGUAGE
-        ).observe(
+        ).toLiveData().observe(
           fragment,
           Observer {
             if (it.isSuccess()) {
@@ -308,7 +309,7 @@ class OptionsFragmentPresenter @Inject constructor(
         profileManagementController.updateAppLanguage(
           profileId,
           AppLanguage.CHINESE_APP_LANGUAGE
-        ).observe(
+        ).toLiveData().observe(
           fragment,
           Observer {
             if (it.isSuccess()) {
@@ -327,7 +328,7 @@ class OptionsFragmentPresenter @Inject constructor(
         profileManagementController.updateAppLanguage(
           profileId,
           AppLanguage.FRENCH_APP_LANGUAGE
-        ).observe(
+        ).toLiveData().observe(
           fragment,
           Observer {
             if (it.isSuccess()) {
@@ -353,7 +354,7 @@ class OptionsFragmentPresenter @Inject constructor(
         profileManagementController.updateAudioLanguage(
           profileId,
           AudioLanguage.NO_AUDIO
-        ).observe(
+        ).toLiveData().observe(
           fragment,
           Observer {
             if (it.isSuccess()) {
@@ -372,7 +373,7 @@ class OptionsFragmentPresenter @Inject constructor(
         profileManagementController.updateAudioLanguage(
           profileId,
           AudioLanguage.ENGLISH_AUDIO_LANGUAGE
-        ).observe(
+        ).toLiveData().observe(
           fragment,
           Observer {
             if (it.isSuccess()) {
@@ -391,7 +392,7 @@ class OptionsFragmentPresenter @Inject constructor(
         profileManagementController.updateAudioLanguage(
           profileId,
           AudioLanguage.HINDI_AUDIO_LANGUAGE
-        ).observe(
+        ).toLiveData().observe(
           fragment,
           Observer {
             if (it.isSuccess()) {
@@ -410,7 +411,7 @@ class OptionsFragmentPresenter @Inject constructor(
         profileManagementController.updateAudioLanguage(
           profileId,
           AudioLanguage.CHINESE_AUDIO_LANGUAGE
-        ).observe(
+        ).toLiveData().observe(
           fragment,
           Observer {
             if (it.isSuccess()) {
@@ -429,7 +430,7 @@ class OptionsFragmentPresenter @Inject constructor(
         profileManagementController.updateAudioLanguage(
           profileId,
           AudioLanguage.FRENCH_AUDIO_LANGUAGE
-        ).observe(
+        ).toLiveData().observe(
           fragment,
           Observer {
             if (it.isSuccess()) {

--- a/app/src/main/java/org/oppia/app/player/audio/AudioFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/audio/AudioFragmentPresenter.kt
@@ -26,6 +26,7 @@ import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.audio.CellularAudioDialogController
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.networking.NetworkConnectionUtil
 import javax.inject.Inject
@@ -64,7 +65,7 @@ class AudioFragmentPresenter @Inject constructor(
     internalProfileId: Int
   ): View? {
     profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
-    cellularAudioDialogController.getCellularDataPreference()
+    cellularAudioDialogController.getCellularDataPreference().toLiveData()
       .observe(
         fragment,
         Observer<AsyncResult<CellularDataPreference>> {
@@ -112,7 +113,7 @@ class AudioFragmentPresenter @Inject constructor(
 
   private fun getProfileData(): LiveData<String> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId),
+      profileManagementController.getProfile(profileId).toLiveData(),
       ::processGetProfileResult
     )
   }

--- a/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/ExplorationActivityPresenter.kt
@@ -23,6 +23,7 @@ import org.oppia.app.utility.FontScaleConfigurationUtil
 import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.exploration.ExplorationDataController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -229,7 +230,7 @@ class ExplorationActivityPresenter @Inject constructor(
   }
 
   private fun updateToolbarTitle(explorationId: String) {
-    subscribeToExploration(explorationDataController.getExplorationById(explorationId))
+    subscribeToExploration(explorationDataController.getExplorationById(explorationId).toLiveData())
   }
 
   private fun subscribeToExploration(

--- a/app/src/main/java/org/oppia/app/player/exploration/ExplorationManagerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/ExplorationManagerFragmentPresenter.kt
@@ -11,6 +11,7 @@ import org.oppia.app.model.ProfileId
 import org.oppia.app.model.ReadingTextSize
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -36,7 +37,7 @@ class ExplorationManagerFragmentPresenter @Inject constructor(
 
   private fun retrieveReadingTextSize(): LiveData<ReadingTextSize> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId),
+      profileManagementController.getProfile(profileId).toLiveData(),
       ::processReadingTextSizeResult
     )
   }

--- a/app/src/main/java/org/oppia/app/player/exploration/HintsAndSolutionExplorationManagerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/exploration/HintsAndSolutionExplorationManagerFragmentPresenter.kt
@@ -8,6 +8,7 @@ import org.oppia.app.fragment.FragmentScope
 import org.oppia.app.model.EphemeralState
 import org.oppia.domain.exploration.ExplorationProgressController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -20,7 +21,7 @@ class HintsAndSolutionExplorationManagerFragmentPresenter @Inject constructor(
 ) {
 
   private val ephemeralStateLiveData: LiveData<AsyncResult<EphemeralState>> by lazy {
-    explorationProgressController.getCurrentState()
+    explorationProgressController.getCurrentState().toLiveData()
   }
 
   fun handleCreateView(): View? {

--- a/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/player/state/StateFragmentPresenter.kt
@@ -34,6 +34,7 @@ import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.exploration.ExplorationProgressController
 import org.oppia.domain.topic.StoryProgressController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.gcsresource.DefaultResourceBucketName
 import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.parser.ExplorationHtmlParserEntityType
@@ -78,7 +79,7 @@ class StateFragmentPresenter @Inject constructor(
   }
   private lateinit var recyclerViewAssembler: StatePlayerRecyclerViewAssembler
   private val ephemeralStateLiveData: LiveData<AsyncResult<EphemeralState>> by lazy {
-    explorationProgressController.getCurrentState()
+    explorationProgressController.getCurrentState().toLiveData()
   }
 
   fun handleCreateView(

--- a/app/src/main/java/org/oppia/app/profile/AddProfileActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/profile/AddProfileActivityPresenter.kt
@@ -30,6 +30,7 @@ import org.oppia.app.databinding.AddProfileActivityBinding
 import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import javax.inject.Inject
 
 const val GALLERY_INTENT_RESULT_CODE = 1
@@ -214,7 +215,7 @@ class AddProfileActivityPresenter @Inject constructor(
           allowDownloadAccess = allowDownloadAccess,
           colorRgb = activity.intent.getIntExtra(KEY_ADD_PROFILE_COLOR_RGB, -10710042),
           isAdmin = false
-        )
+        ).toLiveData()
         .observe(
           activity,
           Observer {

--- a/app/src/main/java/org/oppia/app/profile/AdminPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/profile/AdminPinActivityPresenter.kt
@@ -15,6 +15,7 @@ import org.oppia.app.databinding.AdminPinActivityBinding
 import org.oppia.app.model.ProfileId
 import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.profile.ProfileManagementController
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import javax.inject.Inject
 
 /** The presenter for [AdminPinActivity]. */
@@ -109,7 +110,7 @@ class AdminPinActivityPresenter @Inject constructor(
           .setInternalId(activity.intent.getIntExtra(KEY_ADMIN_PIN_PROFILE_ID, -1))
           .build()
 
-      profileManagementController.updatePin(profileId, inputPin).observe(
+      profileManagementController.updatePin(profileId, inputPin).toLiveData().observe(
         activity,
         Observer {
           if (it.isSuccess()) {

--- a/app/src/main/java/org/oppia/app/profile/PinPasswordActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/profile/PinPasswordActivityPresenter.kt
@@ -18,6 +18,7 @@ import org.oppia.app.model.ProfileId
 import org.oppia.app.utility.LifecycleSafeTimerFactory
 import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.profile.ProfileManagementController
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.statusbar.StatusBarColor
 import javax.inject.Inject
 
@@ -67,7 +68,9 @@ class PinPasswordActivityPresenter @Inject constructor(
           ) {
             if (inputtedPin.toString() == pinViewModel.correctPin.get()) {
               profileManagementController
-                .loginToProfile(ProfileId.newBuilder().setInternalId(profileId).build())
+                .loginToProfile(
+                  ProfileId.newBuilder().setInternalId(profileId).build()
+                ).toLiveData()
                 .observe(
                   activity,
                   Observer {

--- a/app/src/main/java/org/oppia/app/profile/PinPasswordViewModel.kt
+++ b/app/src/main/java/org/oppia/app/profile/PinPasswordViewModel.kt
@@ -9,6 +9,7 @@ import org.oppia.app.model.ProfileId
 import org.oppia.app.viewmodel.ObservableViewModel
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -28,7 +29,7 @@ class PinPasswordViewModel @Inject constructor(
 
   val profile: LiveData<Profile> by lazy {
     Transformations.map(
-      profileManagementController.getProfile(profileId),
+      profileManagementController.getProfile(profileId).toLiveData(),
       ::processGetProfileResult
     )
   }

--- a/app/src/main/java/org/oppia/app/profile/ProfileChooserFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/profile/ProfileChooserFragmentPresenter.kt
@@ -26,6 +26,7 @@ import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.oppialogger.OppiaLogger
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.statusbar.StatusBarColor
 import org.oppia.util.system.OppiaClock
@@ -119,7 +120,7 @@ class ProfileChooserFragmentPresenter @Inject constructor(
 
   private val wasProfileEverBeenAdded: LiveData<Boolean> by lazy {
     Transformations.map(
-      profileManagementController.getWasProfileEverAdded(),
+      profileManagementController.getWasProfileEverAdded().toLiveData(),
       ::processWasProfileEverBeenAddedResult
     )
   }
@@ -174,7 +175,7 @@ class ProfileChooserFragmentPresenter @Inject constructor(
     binding.hasProfileEverBeenAddedValue = hasProfileEverBeenAddedValue
     binding.profileChooserItem.setOnClickListener {
       if (model.profile.pin.isEmpty()) {
-        profileManagementController.loginToProfile(model.profile.id).observe(
+        profileManagementController.loginToProfile(model.profile.id).toLiveData().observe(
           fragment,
           Observer {
             if (it.isSuccess()) {

--- a/app/src/main/java/org/oppia/app/profile/ProfileChooserViewModel.kt
+++ b/app/src/main/java/org/oppia/app/profile/ProfileChooserViewModel.kt
@@ -11,6 +11,7 @@ import org.oppia.app.model.ProfileId
 import org.oppia.app.viewmodel.ObservableViewModel
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import java.util.Locale
 import javax.inject.Inject
@@ -26,7 +27,9 @@ class ProfileChooserViewModel @Inject constructor(
   private val routeToAdminPinListener = fragment as RouteToAdminPinListener
 
   val profiles: LiveData<List<ProfileChooserUiModel>> by lazy {
-    Transformations.map(profileManagementController.getProfiles(), ::processGetProfilesResult)
+    Transformations.map(
+      profileManagementController.getProfiles().toLiveData(), ::processGetProfilesResult
+    )
   }
 
   lateinit var adminPin: String

--- a/app/src/main/java/org/oppia/app/profile/ResetPinDialogFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/profile/ResetPinDialogFragmentPresenter.kt
@@ -14,6 +14,7 @@ import org.oppia.app.fragment.FragmentScope
 import org.oppia.app.model.ProfileId
 import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.profile.ProfileManagementController
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import javax.inject.Inject
 
 /** The presenter for [ResetPinDialogFragment]. */
@@ -77,7 +78,7 @@ class ResetPinDialogFragmentPresenter @Inject constructor(
         }
         if (input.length == 3) {
           profileManagementController
-            .updatePin(ProfileId.newBuilder().setInternalId(profileId).build(), input)
+            .updatePin(ProfileId.newBuilder().setInternalId(profileId).build(), input).toLiveData()
             .observe(
               fragment,
               Observer {

--- a/app/src/main/java/org/oppia/app/profileprogress/ProfilePictureActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/profileprogress/ProfilePictureActivityPresenter.kt
@@ -13,6 +13,7 @@ import org.oppia.app.model.ProfileAvatar
 import org.oppia.app.model.ProfileId
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.statusbar.StatusBarColor
 import javax.inject.Inject
@@ -51,7 +52,7 @@ class ProfilePictureActivityPresenter @Inject constructor(
 
   private fun getProfileData(): LiveData<Profile> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId),
+      profileManagementController.getProfile(profileId).toLiveData(),
       ::processGetProfileResult
     )
   }

--- a/app/src/main/java/org/oppia/app/profileprogress/ProfileProgressViewModel.kt
+++ b/app/src/main/java/org/oppia/app/profileprogress/ProfileProgressViewModel.kt
@@ -19,6 +19,7 @@ import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.domain.topic.TopicController
 import org.oppia.domain.topic.TopicListController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.parser.StoryHtmlParserEntityType
 import javax.inject.Inject
@@ -57,7 +58,7 @@ class ProfileProgressViewModel @Inject constructor(
 
   private fun getProfileData(): LiveData<Profile> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId), ::processGetProfileResult
+      profileManagementController.getProfile(profileId).toLiveData(), ::processGetProfileResult
     )
   }
 
@@ -82,7 +83,7 @@ class ProfileProgressViewModel @Inject constructor(
   }
 
   private val ongoingStoryListResultLiveData: LiveData<AsyncResult<OngoingStoryList>> by lazy {
-    topicListController.getOngoingStoryList(profileId)
+    topicListController.getOngoingStoryList(profileId).toLiveData()
   }
 
   private val ongoingStoryListLiveData: LiveData<OngoingStoryList> by lazy {
@@ -147,7 +148,7 @@ class ProfileProgressViewModel @Inject constructor(
 
   private fun getCompletedStoryListCount(): LiveData<CompletedStoryList> {
     return Transformations.map(
-      topicController.getCompletedStoryList(profileId),
+      topicController.getCompletedStoryList(profileId).toLiveData(),
       ::processGetCompletedStoryListResult
     )
   }
@@ -176,7 +177,7 @@ class ProfileProgressViewModel @Inject constructor(
 
   private fun getOngoingTopicListCount(): LiveData<OngoingTopicList> {
     return Transformations.map(
-      topicController.getOngoingTopicList(profileId),
+      topicController.getOngoingTopicList(profileId).toLiveData(),
       ::processGetOngoingTopicListResult
     )
   }

--- a/app/src/main/java/org/oppia/app/settings/profile/ProfileEditActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/settings/profile/ProfileEditActivityPresenter.kt
@@ -12,6 +12,7 @@ import org.oppia.app.databinding.ProfileEditActivityBinding
 import org.oppia.app.model.ProfileId
 import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.profile.ProfileManagementController
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -68,7 +69,7 @@ class ProfileEditActivityPresenter @Inject constructor(
         profileManagementController.updateAllowDownloadAccess(
           ProfileId.newBuilder().setInternalId(profileId).build(),
           checked
-        ).observe(
+        ).toLiveData().observe(
           activity,
           Observer {
             if (it.isFailure()) {
@@ -97,7 +98,7 @@ class ProfileEditActivityPresenter @Inject constructor(
       }
       .setPositiveButton(R.string.profile_edit_delete_dialog_positive) { dialog, _ ->
         profileManagementController
-          .deleteProfile(ProfileId.newBuilder().setInternalId(profileId).build())
+          .deleteProfile(ProfileId.newBuilder().setInternalId(profileId).build()).toLiveData()
           .observe(
             activity,
             Observer {

--- a/app/src/main/java/org/oppia/app/settings/profile/ProfileEditViewModel.kt
+++ b/app/src/main/java/org/oppia/app/settings/profile/ProfileEditViewModel.kt
@@ -10,6 +10,7 @@ import org.oppia.app.model.ProfileId
 import org.oppia.app.viewmodel.ObservableViewModel
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -28,7 +29,7 @@ class ProfileEditViewModel @Inject constructor(
 
   val profile: LiveData<Profile> by lazy {
     Transformations.map(
-      profileManagementController.getProfile(profileId),
+      profileManagementController.getProfile(profileId).toLiveData(),
       ::processGetProfileResult
     )
   }

--- a/app/src/main/java/org/oppia/app/settings/profile/ProfileListViewModel.kt
+++ b/app/src/main/java/org/oppia/app/settings/profile/ProfileListViewModel.kt
@@ -7,6 +7,7 @@ import org.oppia.app.model.Profile
 import org.oppia.app.viewmodel.ObservableViewModel
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import java.util.Locale
 import javax.inject.Inject
@@ -18,7 +19,9 @@ class ProfileListViewModel @Inject constructor(
   private val profileManagementController: ProfileManagementController
 ) : ObservableViewModel() {
   val profiles: LiveData<List<Profile>> by lazy {
-    Transformations.map(profileManagementController.getProfiles(), ::processGetProfilesResult)
+    Transformations.map(
+      profileManagementController.getProfiles().toLiveData(), ::processGetProfilesResult
+    )
   }
 
   private fun processGetProfilesResult(profilesResult: AsyncResult<List<Profile>>): List<Profile> {

--- a/app/src/main/java/org/oppia/app/settings/profile/ProfileRenameActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/settings/profile/ProfileRenameActivityPresenter.kt
@@ -16,6 +16,7 @@ import org.oppia.app.profile.ProfileInputView
 import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import javax.inject.Inject
 
 /** The presenter for [ProfileRenameActivity]. */
@@ -66,7 +67,7 @@ class ProfileRenameActivityPresenter @Inject constructor(
         return@setOnClickListener
       }
       profileManagementController
-        .updateName(ProfileId.newBuilder().setInternalId(profileId).build(), name)
+        .updateName(ProfileId.newBuilder().setInternalId(profileId).build(), name).toLiveData()
         .observe(
           activity,
           Observer {

--- a/app/src/main/java/org/oppia/app/settings/profile/ProfileResetPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/settings/profile/ProfileResetPinActivityPresenter.kt
@@ -13,6 +13,7 @@ import org.oppia.app.model.ProfileId
 import org.oppia.app.profile.ProfileInputView
 import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.profile.ProfileManagementController
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import javax.inject.Inject
 
 /** The presenter for [ProfileResetPinActivity]. */
@@ -115,7 +116,7 @@ class ProfileResetPinActivityPresenter @Inject constructor(
         return@setOnClickListener
       }
       profileManagementController
-        .updatePin(ProfileId.newBuilder().setInternalId(profileId).build(), pin)
+        .updatePin(ProfileId.newBuilder().setInternalId(profileId).build(), pin).toLiveData()
         .observe(
           activity,
           Observer {

--- a/app/src/main/java/org/oppia/app/splash/SplashActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/app/splash/SplashActivityPresenter.kt
@@ -15,6 +15,7 @@ import org.oppia.app.profile.ProfileChooserActivity
 import org.oppia.domain.onboarding.AppStartupStateController
 import org.oppia.domain.topic.PrimeTopicAssetsController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -77,7 +78,7 @@ class SplashActivityPresenter @Inject constructor(
 
   private fun getOnboardingFlow(): LiveData<StartupMode> {
     return Transformations.map(
-      appStartupStateController.getAppStartupState(),
+      appStartupStateController.getAppStartupState().toLiveData(),
       ::processStartupState
     )
   }

--- a/app/src/main/java/org/oppia/app/story/StoryViewModel.kt
+++ b/app/src/main/java/org/oppia/app/story/StoryViewModel.kt
@@ -14,6 +14,7 @@ import org.oppia.app.story.storyitemviewmodel.StoryItemViewModel
 import org.oppia.domain.exploration.ExplorationDataController
 import org.oppia.domain.topic.TopicController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.parser.StoryHtmlParserEntityType
 import javax.inject.Inject
@@ -39,7 +40,7 @@ class StoryViewModel @Inject constructor(
       ProfileId.newBuilder().setInternalId(internalProfileId).build(),
       topicId,
       storyId
-    )
+    ).toLiveData()
   }
 
   private val storyLiveData: LiveData<StorySummary> by lazy {

--- a/app/src/main/java/org/oppia/app/topic/TopicViewModel.kt
+++ b/app/src/main/java/org/oppia/app/topic/TopicViewModel.kt
@@ -8,6 +8,7 @@ import org.oppia.app.model.Topic
 import org.oppia.app.viewmodel.ObservableViewModel
 import org.oppia.domain.topic.TopicController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -24,7 +25,7 @@ class TopicViewModel @Inject constructor(
     topicController.getTopic(
       ProfileId.newBuilder().setInternalId(internalProfileId).build(),
       topicId
-    )
+    ).toLiveData()
   }
 
   private val topicLiveData: LiveData<Topic> by lazy {

--- a/app/src/main/java/org/oppia/app/topic/info/TopicInfoFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/topic/info/TopicInfoFragmentPresenter.kt
@@ -15,6 +15,7 @@ import org.oppia.app.model.Topic
 import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.topic.TopicController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.gcsresource.DefaultResourceBucketName
 import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.parser.HtmlParser
@@ -87,7 +88,7 @@ class TopicInfoFragmentPresenter @Inject constructor(
     topicController.getTopic(
       ProfileId.newBuilder().setInternalId(internalProfileId).build(),
       topicId
-    )
+    ).toLiveData()
   }
 
   private fun getTopicList(): LiveData<Topic> {

--- a/app/src/main/java/org/oppia/app/topic/lessons/TopicLessonsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/topic/lessons/TopicLessonsFragmentPresenter.kt
@@ -19,6 +19,7 @@ import org.oppia.app.topic.RouteToStoryListener
 import org.oppia.domain.exploration.ExplorationDataController
 import org.oppia.domain.topic.TopicController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -77,7 +78,7 @@ class TopicLessonsFragmentPresenter @Inject constructor(
     topicController.getTopic(
       ProfileId.newBuilder().setInternalId(internalProfileId).build(),
       topicId
-    )
+    ).toLiveData()
   }
 
   private fun subscribeToTopicLiveData() {

--- a/app/src/main/java/org/oppia/app/topic/practice/TopicPracticeViewModel.kt
+++ b/app/src/main/java/org/oppia/app/topic/practice/TopicPracticeViewModel.kt
@@ -12,6 +12,7 @@ import org.oppia.app.topic.practice.practiceitemviewmodel.TopicPracticeSubtopicV
 import org.oppia.app.viewmodel.ObservableViewModel
 import org.oppia.domain.topic.TopicController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -29,7 +30,7 @@ class TopicPracticeViewModel @Inject constructor(
     topicController.getTopic(
       ProfileId.newBuilder().setInternalId(internalProfileId).build(),
       topicId
-    )
+    ).toLiveData()
   }
 
   private val topicLiveData: LiveData<Topic> by lazy { getTopicList() }

--- a/app/src/main/java/org/oppia/app/topic/questionplayer/HintsAndSolutionQuestionManagerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/topic/questionplayer/HintsAndSolutionQuestionManagerFragmentPresenter.kt
@@ -8,6 +8,7 @@ import org.oppia.app.fragment.FragmentScope
 import org.oppia.app.model.EphemeralQuestion
 import org.oppia.domain.question.QuestionAssessmentProgressController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -20,7 +21,7 @@ class HintsAndSolutionQuestionManagerFragmentPresenter @Inject constructor(
 ) {
 
   private val ephemeralStateLiveData: LiveData<AsyncResult<EphemeralQuestion>> by lazy {
-    questionProgressController.getCurrentQuestion()
+    questionProgressController.getCurrentQuestion().toLiveData()
   }
 
   fun handleCreateView(): View? {

--- a/app/src/main/java/org/oppia/app/topic/questionplayer/QuestionPlayerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/topic/questionplayer/QuestionPlayerFragmentPresenter.kt
@@ -32,6 +32,7 @@ import org.oppia.app.viewmodel.ViewModelProvider
 import org.oppia.domain.oppialogger.OppiaLogger
 import org.oppia.domain.question.QuestionAssessmentProgressController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.gcsresource.QuestionResourceBucketName
 import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.system.OppiaClock
@@ -58,7 +59,7 @@ class QuestionPlayerFragmentPresenter @Inject constructor(
 
   private val questionViewModel by lazy { getQuestionPlayerViewModel() }
   private val ephemeralQuestionLiveData: LiveData<AsyncResult<EphemeralQuestion>> by lazy {
-    questionAssessmentProgressController.getCurrentQuestion()
+    questionAssessmentProgressController.getCurrentQuestion().toLiveData()
   }
   private lateinit var binding: QuestionPlayerFragmentBinding
   private lateinit var recyclerViewAssembler: StatePlayerRecyclerViewAssembler

--- a/app/src/main/java/org/oppia/app/topic/revision/TopicRevisionViewModel.kt
+++ b/app/src/main/java/org/oppia/app/topic/revision/TopicRevisionViewModel.kt
@@ -10,6 +10,7 @@ import org.oppia.app.topic.revision.revisionitemviewmodel.TopicRevisionItemViewM
 import org.oppia.app.viewmodel.ObservableViewModel
 import org.oppia.domain.topic.TopicController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import org.oppia.util.parser.TopicHtmlParserEntityType
 import javax.inject.Inject
@@ -29,7 +30,7 @@ class TopicRevisionViewModel @Inject constructor(
     fragment as RevisionSubtopicSelector
 
   private val topicResultLiveData: LiveData<AsyncResult<Topic>> by lazy {
-    topicController.getTopic(profileId, topicId)
+    topicController.getTopic(profileId, topicId).toLiveData()
   }
 
   private val topicLiveData: LiveData<Topic> by lazy { getTopicList() }

--- a/app/src/main/java/org/oppia/app/walkthrough/end/WalkthroughFinalFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/walkthrough/end/WalkthroughFinalFragmentPresenter.kt
@@ -16,6 +16,7 @@ import org.oppia.app.model.Topic
 import org.oppia.app.walkthrough.WalkthroughActivity
 import org.oppia.domain.topic.TopicController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -82,7 +83,7 @@ class WalkthroughFinalFragmentPresenter @Inject constructor(
   }
 
   private val topicResultLiveData: LiveData<AsyncResult<Topic>> by lazy {
-    topicController.getTopic(profileId, topicId = topicId)
+    topicController.getTopic(profileId, topicId = topicId).toLiveData()
   }
 
   private fun getTopic(): LiveData<Topic> {

--- a/app/src/main/java/org/oppia/app/walkthrough/welcome/WalkthroughWelcomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/app/walkthrough/welcome/WalkthroughWelcomeFragmentPresenter.kt
@@ -19,6 +19,7 @@ import org.oppia.app.walkthrough.WalkthroughPageChanger
 import org.oppia.app.walkthrough.WalkthroughPages
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -68,7 +69,7 @@ class WalkthroughWelcomeFragmentPresenter @Inject constructor(
 
   private fun getProfileData(): LiveData<Profile> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId),
+      profileManagementController.getProfile(profileId).toLiveData(),
       ::processGetProfileResult
     )
   }

--- a/app/src/sharedTest/java/org/oppia/app/administratorcontrols/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/administratorcontrols/AppVersionActivityTest.kt
@@ -230,7 +230,7 @@ class AppVersionActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/completedstorylist/CompletedStoryListActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/completedstorylist/CompletedStoryListActivityTest.kt
@@ -452,7 +452,7 @@ class CompletedStoryListActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/faq/FAQListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/faq/FAQListFragmentTest.kt
@@ -177,7 +177,7 @@ class FAQListFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/faq/FAQSingleActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/faq/FAQSingleActivityTest.kt
@@ -176,7 +176,7 @@ class FAQSingleActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/help/HelpFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/help/HelpFragmentTest.kt
@@ -206,7 +206,7 @@ class HelpFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/home/HomeActivityTest.kt
@@ -652,7 +652,7 @@ class HomeActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/home/RecentlyPlayedFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/home/RecentlyPlayedFragmentTest.kt
@@ -835,7 +835,7 @@ class RecentlyPlayedFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/mydownloads/MyDownloadsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/mydownloads/MyDownloadsFragmentTest.kt
@@ -206,7 +206,7 @@ class MyDownloadsFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/onboarding/OnboardingFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/onboarding/OnboardingFragmentTest.kt
@@ -566,7 +566,7 @@ class OnboardingFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/ongoingtopiclist/OngoingTopicListActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/ongoingtopiclist/OngoingTopicListActivityTest.kt
@@ -460,7 +460,7 @@ class OngoingTopicListActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/options/OptionsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/options/OptionsFragmentTest.kt
@@ -333,7 +333,7 @@ class OptionsFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/parser/HtmlParserTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/parser/HtmlParserTest.kt
@@ -284,7 +284,7 @@ class HtmlParserTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/player/audio/AudioFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/audio/AudioFragmentTest.kt
@@ -408,7 +408,7 @@ class AudioFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/exploration/ExplorationActivityTest.kt
@@ -793,7 +793,7 @@ class ExplorationActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/player/state/StateFragmentTest.kt
@@ -62,6 +62,8 @@ import org.oppia.app.R
 import org.oppia.app.activity.ActivityComponent
 import org.oppia.app.application.ActivityComponentFactory
 import org.oppia.app.application.ApplicationComponent
+import org.oppia.app.application.ApplicationInjector
+import org.oppia.app.application.ApplicationInjectorProvider
 import org.oppia.app.application.ApplicationModule
 import org.oppia.app.application.ApplicationStartupListenerModule
 import org.oppia.app.player.state.hintsandsolution.HintsAndSolutionConfigFastShowTestModule
@@ -1454,7 +1456,7 @@ class StateFragmentTest {
     fun isOnRobolectric(): Boolean
   }
 
-  class TestApplication : Application(), ActivityComponentFactory {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerStateFragmentTest_TestApplicationComponent.builder()
         .setApplication(this)
@@ -1468,5 +1470,7 @@ class StateFragmentTest {
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
+
+    override fun getApplicationInjector(): ApplicationInjector = component
   }
 }

--- a/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
@@ -1625,7 +1625,7 @@ class AddProfileActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profile/AddProfileActivityTest.kt
@@ -515,8 +515,10 @@ class AddProfileActivityTest {
       ).perform(
         typeText("123"), closeSoftKeyboard()
       )
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
       onView(withId(R.id.add_profile_activity_create_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
       onView(
         allOf(
           withId(R.id.error_text),
@@ -530,6 +532,7 @@ class AddProfileActivityTest {
   fun testAddProfileActivity_changeConfiguration_inputNameWithNumbers_clickCreate_checkNameOnlyLettersError() { // ktlint-disable max-line-length
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
       onView(
         allOf(
@@ -539,8 +542,10 @@ class AddProfileActivityTest {
       ).perform(
         typeText("123"), closeSoftKeyboard()
       )
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
       onView(withId(R.id.add_profile_activity_create_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
       onView(
         allOf(
           withId(R.id.error_text),
@@ -565,6 +570,7 @@ class AddProfileActivityTest {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
       onView(withId(R.id.add_profile_activity_create_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
       onView(
         allOf(
           withId(R.id.input),
@@ -599,6 +605,7 @@ class AddProfileActivityTest {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
       onView(withId(R.id.add_profile_activity_create_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
       onView(
         allOf(
           withId(R.id.input),

--- a/app/src/sharedTest/java/org/oppia/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profile/AdminAuthActivityTest.kt
@@ -534,7 +534,7 @@ class AdminAuthActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/profile/AdminPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profile/AdminPinActivityTest.kt
@@ -783,7 +783,7 @@ class AdminPinActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/profile/PinPasswordActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profile/PinPasswordActivityTest.kt
@@ -729,7 +729,7 @@ class PinPasswordActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/profile/ProfileChooserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profile/ProfileChooserFragmentTest.kt
@@ -83,6 +83,7 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.testing.profile.ProfileTestHelper
 import org.oppia.util.caching.testing.CachingTestModule
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.gcsresource.GcsResourceModule
 import org.oppia.util.logging.LoggerModule
 import org.oppia.util.logging.firebase.FirebaseLogUploaderModule
@@ -532,7 +533,7 @@ class ProfileChooserFragmentTest {
       true,
       -10710042,
       true
-    )
+    ).toLiveData()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       onView(
         atPositionOnView(
@@ -557,7 +558,7 @@ class ProfileChooserFragmentTest {
       true,
       -10710042,
       true
-    )
+    ).toLiveData()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       onView(withId(R.id.administrator_controls_linear_layout)).perform(click())
       intended(hasComponent(AdminPinActivity::class.java.name))

--- a/app/src/sharedTest/java/org/oppia/app/profile/ProfileChooserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profile/ProfileChooserFragmentTest.kt
@@ -717,7 +717,7 @@ class ProfileChooserFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/profileprogress/ProfilePictureActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profileprogress/ProfilePictureActivityTest.kt
@@ -129,7 +129,7 @@ class ProfilePictureActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/profileprogress/ProfileProgressFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/profileprogress/ProfileProgressFragmentTest.kt
@@ -813,7 +813,7 @@ class ProfileProgressFragmentTest {
       HintsAndSolutionConfigModule::class, FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/recyclerview/BindableAdapterTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/recyclerview/BindableAdapterTest.kt
@@ -418,7 +418,7 @@ class BindableAdapterTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/settings/profile/ProfileEditActivityTest.kt
@@ -61,6 +61,7 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.testing.profile.ProfileTestHelper
 import org.oppia.util.caching.testing.CachingTestModule
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.gcsresource.GcsResourceModule
 import org.oppia.util.logging.LoggerModule
 import org.oppia.util.logging.firebase.FirebaseLogUploaderModule
@@ -326,7 +327,7 @@ class ProfileEditActivityTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = false
-    )
+    ).toLiveData()
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -348,7 +349,7 @@ class ProfileEditActivityTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = false
-    )
+    ).toLiveData()
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,

--- a/app/src/sharedTest/java/org/oppia/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/settings/profile/ProfileEditActivityTest.kt
@@ -381,7 +381,7 @@ class ProfileEditActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/settings/profile/ProfileListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/settings/profile/ProfileListFragmentTest.kt
@@ -292,7 +292,7 @@ class ProfileListFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/settings/profile/ProfileRenameActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/settings/profile/ProfileRenameActivityTest.kt
@@ -58,6 +58,7 @@ import org.oppia.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.domain.question.QuestionModule
 import org.oppia.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.testing.TestAccessibilityModule
+import org.oppia.testing.TestCoroutineDispatchers
 import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.testing.profile.ProfileTestHelper
@@ -86,6 +87,9 @@ class ProfileRenameActivityTest {
 
   @Inject
   lateinit var profileTestHelper: ProfileTestHelper
+
+  @Inject
+  lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
 
   @Before
   fun setUp() {
@@ -140,7 +144,9 @@ class ProfileRenameActivityTest {
           isDescendantOfA(withId(R.id.input_name))
         )
       ).perform(typeText("James"))
+      testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_save_button)).check(matches(isEnabled()))
     }
   }
@@ -159,7 +165,9 @@ class ProfileRenameActivityTest {
           isDescendantOfA(withId(R.id.input_name))
         )
       ).perform(typeText("James"))
+      testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
+      testCoroutineDispatchers.runCurrent()
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).check(
         matches(
           withText("James")
@@ -240,7 +248,9 @@ class ProfileRenameActivityTest {
           isDescendantOfA(withId(R.id.input_name))
         )
       ).perform(typeText("123"))
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_save_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
       onView(
         allOf(
           withId(R.id.error_text),
@@ -266,13 +276,16 @@ class ProfileRenameActivityTest {
           isDescendantOfA(withId(R.id.input_name))
         )
       ).perform(typeText("123"))
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_save_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
       onView(
         allOf(
           withId(R.id.input),
           isDescendantOfA(withId(R.id.input_name))
         )
       ).perform(typeText(" "))
+      testCoroutineDispatchers.runCurrent()
       onView(
         allOf(
           withId(R.id.error_text),
@@ -294,7 +307,9 @@ class ProfileRenameActivityTest {
         typeText("test"),
         closeSoftKeyboard()
       )
+      testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
+      testCoroutineDispatchers.runCurrent()
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_name)))).check(
         matches(
           withText("test")
@@ -317,8 +332,11 @@ class ProfileRenameActivityTest {
         typeText("Admin"),
         closeSoftKeyboard()
       )
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_save_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
+      testCoroutineDispatchers.runCurrent()
       onView(
         allOf(
           withId(R.id.error_text),
@@ -338,6 +356,7 @@ class ProfileRenameActivityTest {
     ).use {
       onView(withId(R.id.profile_rename_save_button)).check(matches(not(isClickable())))
       onView(isRoot()).perform(orientationLandscape())
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_save_button)).check(matches(not(isClickable())))
     }
   }

--- a/app/src/sharedTest/java/org/oppia/app/settings/profile/ProfileRenameActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/settings/profile/ProfileRenameActivityTest.kt
@@ -362,7 +362,7 @@ class ProfileRenameActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/settings/profile/ProfileResetPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/settings/profile/ProfileResetPinActivityTest.kt
@@ -739,7 +739,7 @@ class ProfileResetPinActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/splash/SplashActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/splash/SplashActivityTest.kt
@@ -289,7 +289,7 @@ class SplashActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/app/src/sharedTest/java/org/oppia/app/story/StoryActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/story/StoryActivityTest.kt
@@ -168,7 +168,7 @@ class StoryActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/story/StoryFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/story/StoryFragmentTest.kt
@@ -388,7 +388,7 @@ class StoryFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/testing/DragDropTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/testing/DragDropTestActivityTest.kt
@@ -175,7 +175,7 @@ class DragDropTestActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/testing/ImageRegionSelectionInteractionViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/testing/ImageRegionSelectionInteractionViewTest.kt
@@ -286,7 +286,7 @@ class ImageRegionSelectionInteractionViewTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/testing/InputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/testing/InputInteractionViewTestActivityTest.kt
@@ -985,7 +985,7 @@ class InputInteractionViewTestActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/testing/NavigationDrawerTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/testing/NavigationDrawerTestActivityTest.kt
@@ -646,7 +646,7 @@ class NavigationDrawerTestActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/testing/TestFontScaleConfigurationUtilActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/testing/TestFontScaleConfigurationUtilActivityTest.kt
@@ -167,7 +167,7 @@ class TestFontScaleConfigurationUtilActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/testing/TopicTestActivityForStoryTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/testing/TopicTestActivityForStoryTest.kt
@@ -159,7 +159,7 @@ class TopicTestActivityForStoryTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/topic/TopicFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/TopicFragmentTest.kt
@@ -508,7 +508,7 @@ class TopicFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/topic/conceptcard/ConceptCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/conceptcard/ConceptCardFragmentTest.kt
@@ -229,7 +229,7 @@ class ConceptCardFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/topic/info/TopicInfoFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/info/TopicInfoFragmentTest.kt
@@ -343,7 +343,7 @@ class TopicInfoFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/topic/lessons/TopicLessonsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/lessons/TopicLessonsFragmentTest.kt
@@ -655,7 +655,7 @@ class TopicLessonsFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/topic/practice/TopicPracticeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/practice/TopicPracticeFragmentTest.kt
@@ -447,7 +447,7 @@ class TopicPracticeFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -354,7 +354,7 @@ class QuestionPlayerActivityTest {
       LogUploadWorkerModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/topic/revision/TopicRevisionFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/revision/TopicRevisionFragmentTest.kt
@@ -319,7 +319,7 @@ class TopicRevisionFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/topic/revisioncard/RevisionCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/topic/revisioncard/RevisionCardFragmentTest.kt
@@ -316,7 +316,7 @@ class RevisionCardFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/utility/RatioExtensionsTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/utility/RatioExtensionsTest.kt
@@ -114,7 +114,7 @@ class RatioExtensionsTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/walkthrough/WalkthroughActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/walkthrough/WalkthroughActivityTest.kt
@@ -158,7 +158,7 @@ class WalkthroughActivityTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/walkthrough/WalkthroughFinalFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/walkthrough/WalkthroughFinalFragmentTest.kt
@@ -233,7 +233,7 @@ class WalkthroughFinalFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/walkthrough/WalkthroughTopicListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/walkthrough/WalkthroughTopicListFragmentTest.kt
@@ -181,7 +181,7 @@ class WalkthroughTopicListFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/sharedTest/java/org/oppia/app/walkthrough/WalkthroughWelcomeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/app/walkthrough/WalkthroughWelcomeFragmentTest.kt
@@ -177,7 +177,7 @@ class WalkthroughWelcomeFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/test/java/org/oppia/app/home/HomeActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/app/home/HomeActivityLocalTest.kt
@@ -16,6 +16,8 @@ import org.junit.runner.RunWith
 import org.oppia.app.activity.ActivityComponent
 import org.oppia.app.application.ActivityComponentFactory
 import org.oppia.app.application.ApplicationComponent
+import org.oppia.app.application.ApplicationInjector
+import org.oppia.app.application.ApplicationInjectorProvider
 import org.oppia.app.application.ApplicationModule
 import org.oppia.app.application.ApplicationStartupListenerModule
 import org.oppia.app.model.EventLog
@@ -126,7 +128,7 @@ class HomeActivityLocalTest {
     fun inject(homeActivityLocalTest: HomeActivityLocalTest)
   }
 
-  class TestApplication : Application(), ActivityComponentFactory {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerHomeActivityLocalTest_TestApplicationComponent.builder()
         .setApplication(this)
@@ -140,5 +142,7 @@ class HomeActivityLocalTest {
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
+
+    override fun getApplicationInjector(): ApplicationInjector = component
   }
 }

--- a/app/src/test/java/org/oppia/app/parser/StringToRatioParserTest.kt
+++ b/app/src/test/java/org/oppia/app/parser/StringToRatioParserTest.kt
@@ -216,7 +216,7 @@ class StringToRatioParserTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/test/java/org/oppia/app/player/exploration/ExplorationActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/app/player/exploration/ExplorationActivityLocalTest.kt
@@ -15,6 +15,8 @@ import org.junit.runner.RunWith
 import org.oppia.app.activity.ActivityComponent
 import org.oppia.app.application.ActivityComponentFactory
 import org.oppia.app.application.ApplicationComponent
+import org.oppia.app.application.ApplicationInjector
+import org.oppia.app.application.ApplicationInjectorProvider
 import org.oppia.app.application.ApplicationModule
 import org.oppia.app.application.ApplicationStartupListenerModule
 import org.oppia.app.model.EventLog
@@ -166,7 +168,7 @@ class ExplorationActivityLocalTest {
     fun inject(explorationActivityLocalTest: ExplorationActivityLocalTest)
   }
 
-  class TestApplication : Application(), ActivityComponentFactory {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerExplorationActivityLocalTest_TestApplicationComponent.builder()
         .setApplication(this)
@@ -180,5 +182,7 @@ class ExplorationActivityLocalTest {
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
+
+    override fun getApplicationInjector(): ApplicationInjector = component
   }
 }

--- a/app/src/test/java/org/oppia/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/app/player/state/StateFragmentLocalTest.kt
@@ -1294,7 +1294,7 @@ class StateFragmentLocalTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/test/java/org/oppia/app/profile/ProfileChooserFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/app/profile/ProfileChooserFragmentLocalTest.kt
@@ -120,7 +120,7 @@ class ProfileChooserFragmentLocalTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/test/java/org/oppia/app/story/StoryActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/app/story/StoryActivityLocalTest.kt
@@ -136,7 +136,7 @@ class StoryActivityLocalTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/test/java/org/oppia/app/testing/CompletedStoryListSpanTest.kt
+++ b/app/src/test/java/org/oppia/app/testing/CompletedStoryListSpanTest.kt
@@ -19,6 +19,8 @@ import org.oppia.app.R
 import org.oppia.app.activity.ActivityComponent
 import org.oppia.app.application.ActivityComponentFactory
 import org.oppia.app.application.ApplicationComponent
+import org.oppia.app.application.ApplicationInjector
+import org.oppia.app.application.ApplicationInjectorProvider
 import org.oppia.app.application.ApplicationModule
 import org.oppia.app.application.ApplicationStartupListenerModule
 import org.oppia.app.completedstorylist.CompletedStoryListActivity
@@ -151,7 +153,7 @@ class CompletedStoryListSpanTest {
     fun inject(completedStoryListSpanTest: CompletedStoryListSpanTest)
   }
 
-  class TestApplication : Application(), ActivityComponentFactory {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerCompletedStoryListSpanTest_TestApplicationComponent.builder()
         .setApplication(this)
@@ -165,5 +167,7 @@ class CompletedStoryListSpanTest {
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
+
+    override fun getApplicationInjector(): ApplicationInjector = component
   }
 }

--- a/app/src/test/java/org/oppia/app/testing/OngoingTopicListSpanTest.kt
+++ b/app/src/test/java/org/oppia/app/testing/OngoingTopicListSpanTest.kt
@@ -20,6 +20,8 @@ import org.oppia.app.R
 import org.oppia.app.activity.ActivityComponent
 import org.oppia.app.application.ActivityComponentFactory
 import org.oppia.app.application.ApplicationComponent
+import org.oppia.app.application.ApplicationInjector
+import org.oppia.app.application.ApplicationInjectorProvider
 import org.oppia.app.application.ApplicationModule
 import org.oppia.app.application.ApplicationStartupListenerModule
 import org.oppia.app.ongoingtopiclist.OngoingTopicListActivity
@@ -162,7 +164,7 @@ class OngoingTopicListSpanTest {
     fun inject(ongoingTopicListSpanTest: OngoingTopicListSpanTest)
   }
 
-  class TestApplication : Application(), ActivityComponentFactory {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerOngoingTopicListSpanTest_TestApplicationComponent.builder()
         .setApplication(this)
@@ -176,5 +178,7 @@ class OngoingTopicListSpanTest {
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
+
+    override fun getApplicationInjector(): ApplicationInjector = component
   }
 }

--- a/app/src/test/java/org/oppia/app/testing/ProfileChooserSpanTest.kt
+++ b/app/src/test/java/org/oppia/app/testing/ProfileChooserSpanTest.kt
@@ -20,6 +20,8 @@ import org.junit.runner.RunWith
 import org.oppia.app.activity.ActivityComponent
 import org.oppia.app.application.ActivityComponentFactory
 import org.oppia.app.application.ApplicationComponent
+import org.oppia.app.application.ApplicationInjector
+import org.oppia.app.application.ApplicationInjectorProvider
 import org.oppia.app.application.ApplicationModule
 import org.oppia.app.application.ApplicationStartupListenerModule
 import org.oppia.app.player.state.hintsandsolution.HintsAndSolutionConfigModule
@@ -296,7 +298,7 @@ class ProfileChooserSpanTest {
     fun inject(profileChooserSpanTest: ProfileChooserSpanTest)
   }
 
-  class TestApplication : Application(), ActivityComponentFactory {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerProfileChooserSpanTest_TestApplicationComponent.builder()
         .setApplication(this)
@@ -310,5 +312,7 @@ class ProfileChooserSpanTest {
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
+
+    override fun getApplicationInjector(): ApplicationInjector = component
   }
 }

--- a/app/src/test/java/org/oppia/app/testing/ProfileProgressSpanCount.kt
+++ b/app/src/test/java/org/oppia/app/testing/ProfileProgressSpanCount.kt
@@ -19,6 +19,8 @@ import org.oppia.app.R
 import org.oppia.app.activity.ActivityComponent
 import org.oppia.app.application.ActivityComponentFactory
 import org.oppia.app.application.ApplicationComponent
+import org.oppia.app.application.ApplicationInjector
+import org.oppia.app.application.ApplicationInjectorProvider
 import org.oppia.app.application.ApplicationModule
 import org.oppia.app.application.ApplicationStartupListenerModule
 import org.oppia.app.player.state.hintsandsolution.HintsAndSolutionConfigModule
@@ -147,7 +149,7 @@ class ProfileProgressSpanCount {
     fun inject(profileProgressSpanCount: ProfileProgressSpanCount)
   }
 
-  class TestApplication : Application(), ActivityComponentFactory {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerProfileProgressSpanCount_TestApplicationComponent.builder()
         .setApplication(this)
@@ -161,5 +163,7 @@ class ProfileProgressSpanCount {
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
+
+    override fun getApplicationInjector(): ApplicationInjector = component
   }
 }

--- a/app/src/test/java/org/oppia/app/testing/TopicRevisionSpanTest.kt
+++ b/app/src/test/java/org/oppia/app/testing/TopicRevisionSpanTest.kt
@@ -19,6 +19,8 @@ import org.oppia.app.R
 import org.oppia.app.activity.ActivityComponent
 import org.oppia.app.application.ActivityComponentFactory
 import org.oppia.app.application.ApplicationComponent
+import org.oppia.app.application.ApplicationInjector
+import org.oppia.app.application.ApplicationInjectorProvider
 import org.oppia.app.application.ApplicationModule
 import org.oppia.app.application.ApplicationStartupListenerModule
 import org.oppia.app.player.state.hintsandsolution.HintsAndSolutionConfigModule
@@ -148,7 +150,7 @@ class TopicRevisionSpanTest {
     fun inject(topicRevisionSpanTest: TopicRevisionSpanTest)
   }
 
-  class TestApplication : Application(), ActivityComponentFactory {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerTopicRevisionSpanTest_TestApplicationComponent.builder()
         .setApplication(this)
@@ -162,5 +164,7 @@ class TopicRevisionSpanTest {
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
+
+    override fun getApplicationInjector(): ApplicationInjector = component
   }
 }

--- a/app/src/test/java/org/oppia/app/testing/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/test/java/org/oppia/app/testing/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -192,7 +192,7 @@ class AdministratorControlsFragmentTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/test/java/org/oppia/app/testing/options/AppLanguageFragmentTest.kt
+++ b/app/src/test/java/org/oppia/app/testing/options/AppLanguageFragmentTest.kt
@@ -26,6 +26,8 @@ import org.oppia.app.R
 import org.oppia.app.activity.ActivityComponent
 import org.oppia.app.application.ActivityComponentFactory
 import org.oppia.app.application.ApplicationComponent
+import org.oppia.app.application.ApplicationInjector
+import org.oppia.app.application.ApplicationInjectorProvider
 import org.oppia.app.application.ApplicationModule
 import org.oppia.app.application.ApplicationStartupListenerModule
 import org.oppia.app.options.APP_LANGUAGE
@@ -233,7 +235,7 @@ class AppLanguageFragmentTest {
     fun inject(appLanguageFragmentTest: AppLanguageFragmentTest)
   }
 
-  class TestApplication : Application(), ActivityComponentFactory {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerAppLanguageFragmentTest_TestApplicationComponent.builder()
         .setApplication(this)
@@ -247,5 +249,7 @@ class AppLanguageFragmentTest {
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
+
+    override fun getApplicationInjector(): ApplicationInjector = component
   }
 }

--- a/app/src/test/java/org/oppia/app/testing/options/DefaultAudioFragmentTest.kt
+++ b/app/src/test/java/org/oppia/app/testing/options/DefaultAudioFragmentTest.kt
@@ -26,6 +26,8 @@ import org.oppia.app.R
 import org.oppia.app.activity.ActivityComponent
 import org.oppia.app.application.ActivityComponentFactory
 import org.oppia.app.application.ApplicationComponent
+import org.oppia.app.application.ApplicationInjector
+import org.oppia.app.application.ApplicationInjectorProvider
 import org.oppia.app.application.ApplicationModule
 import org.oppia.app.application.ApplicationStartupListenerModule
 import org.oppia.app.options.AUDIO_LANGUAGE
@@ -234,7 +236,7 @@ class DefaultAudioFragmentTest {
     fun inject(defaultAudioFragmentTest: DefaultAudioFragmentTest)
   }
 
-  class TestApplication : Application(), ActivityComponentFactory {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerDefaultAudioFragmentTest_TestApplicationComponent.builder()
         .setApplication(this)
@@ -248,5 +250,7 @@ class DefaultAudioFragmentTest {
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
+
+    override fun getApplicationInjector(): ApplicationInjector = component
   }
 }

--- a/app/src/test/java/org/oppia/app/testing/options/OptionsFragmentTest.kt
+++ b/app/src/test/java/org/oppia/app/testing/options/OptionsFragmentTest.kt
@@ -24,6 +24,8 @@ import org.oppia.app.R
 import org.oppia.app.activity.ActivityComponent
 import org.oppia.app.application.ActivityComponentFactory
 import org.oppia.app.application.ApplicationComponent
+import org.oppia.app.application.ApplicationInjector
+import org.oppia.app.application.ApplicationInjectorProvider
 import org.oppia.app.application.ApplicationModule
 import org.oppia.app.application.ApplicationStartupListenerModule
 import org.oppia.app.options.APP_LANGUAGE
@@ -281,7 +283,7 @@ class OptionsFragmentTest {
     fun inject(optionsFragmentTest: OptionsFragmentTest)
   }
 
-  class TestApplication : Application(), ActivityComponentFactory {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerOptionsFragmentTest_TestApplicationComponent.builder()
         .setApplication(this)
@@ -295,5 +297,7 @@ class OptionsFragmentTest {
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
+
+    override fun getApplicationInjector(): ApplicationInjector = component
   }
 }

--- a/app/src/test/java/org/oppia/app/testing/options/ReadingTextSizeFragmentTest.kt
+++ b/app/src/test/java/org/oppia/app/testing/options/ReadingTextSizeFragmentTest.kt
@@ -34,6 +34,8 @@ import org.oppia.app.R
 import org.oppia.app.activity.ActivityComponent
 import org.oppia.app.application.ActivityComponentFactory
 import org.oppia.app.application.ApplicationComponent
+import org.oppia.app.application.ApplicationInjector
+import org.oppia.app.application.ApplicationInjectorProvider
 import org.oppia.app.application.ApplicationModule
 import org.oppia.app.application.ApplicationStartupListenerModule
 import org.oppia.app.options.OptionsActivity
@@ -247,7 +249,7 @@ class ReadingTextSizeFragmentTest {
     fun inject(readingTextSizeFragmentTest: ReadingTextSizeFragmentTest)
   }
 
-  class TestApplication : Application(), ActivityComponentFactory {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerReadingTextSizeFragmentTest_TestApplicationComponent.builder()
         .setApplication(this)
@@ -261,5 +263,7 @@ class ReadingTextSizeFragmentTest {
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
+
+    override fun getApplicationInjector(): ApplicationInjector = component
   }
 }

--- a/app/src/test/java/org/oppia/app/testing/player/split/PlayerSplitScreenTesting.kt
+++ b/app/src/test/java/org/oppia/app/testing/player/split/PlayerSplitScreenTesting.kt
@@ -16,6 +16,8 @@ import org.junit.runner.RunWith
 import org.oppia.app.activity.ActivityComponent
 import org.oppia.app.application.ActivityComponentFactory
 import org.oppia.app.application.ApplicationComponent
+import org.oppia.app.application.ApplicationInjector
+import org.oppia.app.application.ApplicationInjectorProvider
 import org.oppia.app.application.ApplicationModule
 import org.oppia.app.application.ApplicationStartupListenerModule
 import org.oppia.app.player.state.hintsandsolution.HintsAndSolutionConfigModule
@@ -176,7 +178,7 @@ class PlayerSplitScreenTesting {
     fun inject(playerSplitScreenTesting: PlayerSplitScreenTesting)
   }
 
-  class TestApplication : Application(), ActivityComponentFactory {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerPlayerSplitScreenTesting_TestApplicationComponent.builder()
         .setApplication(this)
@@ -190,5 +192,7 @@ class PlayerSplitScreenTesting {
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
+
+    override fun getApplicationInjector(): ApplicationInjector = component
   }
 }

--- a/app/src/test/java/org/oppia/app/testing/player/state/StateFragmentAccessibilityTest.kt
+++ b/app/src/test/java/org/oppia/app/testing/player/state/StateFragmentAccessibilityTest.kt
@@ -21,6 +21,8 @@ import org.oppia.app.activity.ActivityComponent
 import org.oppia.app.application.ActivityComponentFactory
 import org.oppia.app.application.ApplicationComponent
 import org.oppia.app.application.ApplicationContext
+import org.oppia.app.application.ApplicationInjector
+import org.oppia.app.application.ApplicationInjectorProvider
 import org.oppia.app.application.ApplicationModule
 import org.oppia.app.application.ApplicationStartupListenerModule
 import org.oppia.app.player.state.StateFragment
@@ -185,7 +187,7 @@ class StateFragmentAccessibilityTest {
     fun inject(stateFragmentAccessibilityTest: StateFragmentAccessibilityTest)
   }
 
-  class TestApplication : Application(), ActivityComponentFactory {
+  class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerStateFragmentAccessibilityTest_TestApplicationComponent.builder()
         .setApplication(this)
@@ -199,5 +201,7 @@ class StateFragmentAccessibilityTest {
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
+
+    override fun getApplicationInjector(): ApplicationInjector = component
   }
 }

--- a/app/src/test/java/org/oppia/app/topic/info/TopicInfoFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/app/topic/info/TopicInfoFragmentLocalTest.kt
@@ -124,7 +124,7 @@ class TopicInfoFragmentLocalTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/test/java/org/oppia/app/topic/lessons/TopicLessonsFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/app/topic/lessons/TopicLessonsFragmentLocalTest.kt
@@ -126,7 +126,7 @@ class TopicLessonsFragmentLocalTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/test/java/org/oppia/app/topic/questionplayer/QuestionPlayerActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/app/topic/questionplayer/QuestionPlayerActivityLocalTest.kt
@@ -279,7 +279,7 @@ class QuestionPlayerActivityLocalTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/app/src/test/java/org/oppia/app/topic/revisioncard/RevisionCardActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/app/topic/revisioncard/RevisionCardActivityLocalTest.kt
@@ -116,7 +116,7 @@ class RevisionCardActivityLocalTest {
       FirebaseLogUploaderModule::class
     ]
   )
-  interface TestApplicationComponent : ApplicationComponent, ApplicationInjector {
+  interface TestApplicationComponent : ApplicationComponent {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 

--- a/data/src/test/java/org/oppia/data/persistence/PersistentCacheStoreTest.kt
+++ b/data/src/test/java/org/oppia/data/persistence/PersistentCacheStoreTest.kt
@@ -33,6 +33,7 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.threading.BackgroundDispatcher
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -582,7 +583,7 @@ class PersistentCacheStoreTest {
     cacheStore: PersistentCacheStore<T>,
     observer: Observer<AsyncResult<T>>
   ) {
-    dataProviders.convertToLiveData(cacheStore).observeForever(observer)
+    cacheStore.toLiveData().observeForever(observer)
     testCoroutineDispatchers.advanceUntilIdle()
   }
 

--- a/data/src/test/java/org/oppia/data/persistence/PersistentCacheStoreTest.kt
+++ b/data/src/test/java/org/oppia/data/persistence/PersistentCacheStoreTest.kt
@@ -626,7 +626,7 @@ class PersistentCacheStoreTest {
       TestLogReportingModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/domain/src/main/java/org/oppia/domain/audio/CellularAudioDialogController.kt
+++ b/domain/src/main/java/org/oppia/domain/audio/CellularAudioDialogController.kt
@@ -1,10 +1,8 @@
 package org.oppia.domain.audio
 
-import androidx.lifecycle.LiveData
 import org.oppia.app.model.CellularDataPreference
 import org.oppia.data.persistence.PersistentCacheStore
-import org.oppia.util.data.AsyncResult
-import org.oppia.util.data.DataProviders
+import org.oppia.util.data.DataProvider
 import org.oppia.util.logging.ConsoleLogger
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -13,7 +11,6 @@ import javax.inject.Singleton
 @Singleton
 class CellularAudioDialogController @Inject constructor(
   cacheStoreFactory: PersistentCacheStore.Factory,
-  private val dataProviders: DataProviders,
   private val logger: ConsoleLogger
 ) {
   private val cellularDataStore = cacheStoreFactory.create(
@@ -61,8 +58,6 @@ class CellularAudioDialogController @Inject constructor(
     }
   }
 
-  /** Returns a [LiveData] result indicating the user's cellular data preferences. */
-  fun getCellularDataPreference(): LiveData<AsyncResult<CellularDataPreference>> {
-    return dataProviders.convertToLiveData(cellularDataStore)
-  }
+  /** Returns a [DataProvider] indicating the user's cellular data preferences. */
+  fun getCellularDataPreference(): DataProvider<CellularDataPreference> = cellularDataStore
 }

--- a/domain/src/main/java/org/oppia/domain/exploration/ExplorationDataController.kt
+++ b/domain/src/main/java/org/oppia/domain/exploration/ExplorationDataController.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import org.oppia.app.model.Exploration
 import org.oppia.domain.oppialogger.exceptions.ExceptionsController
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProvider
 import org.oppia.util.data.DataProviders
 import org.oppia.util.system.OppiaClock
 import javax.inject.Inject
@@ -25,13 +26,12 @@ class ExplorationDataController @Inject constructor(
   private val oppiaClock: OppiaClock
 ) {
   /** Returns an [Exploration] given an ID. */
-  fun getExplorationById(id: String): LiveData<AsyncResult<Exploration>> {
-    val dataProvider = dataProviders.createInMemoryDataProviderAsync(
+  fun getExplorationById(id: String): DataProvider<Exploration> {
+    return dataProviders.createInMemoryDataProviderAsync(
       EXPLORATION_DATA_PROVIDER_ID
     ) {
       retrieveExplorationById(id)
     }
-    return dataProviders.convertToLiveData(dataProvider)
   }
 
   /**

--- a/domain/src/main/java/org/oppia/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/domain/exploration/ExplorationProgressController.kt
@@ -13,6 +13,7 @@ import org.oppia.domain.classify.AnswerClassificationController
 import org.oppia.domain.oppialogger.exceptions.ExceptionsController
 import org.oppia.util.data.AsyncDataSubscriptionManager
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProvider
 import org.oppia.util.data.DataProviders
 import org.oppia.util.system.OppiaClock
 import java.util.concurrent.locks.ReentrantLock
@@ -23,33 +24,32 @@ import kotlin.concurrent.withLock
 private const val CURRENT_STATE_DATA_PROVIDER_ID = "CurrentStateDataProvider"
 
 /**
- * Controller that tracks and reports the learner's ephemeral/non-persisted progress through an exploration. Note that
- * this controller only supports one active exploration at a time.
+ * Controller that tracks and reports the learner's ephemeral/non-persisted progress through an
+ * exploration. Note that this controller only supports one active exploration at a time.
  *
  * The current exploration session is started via the exploration data controller.
  *
- * This class is thread-safe, but the order of applied operations is arbitrary. Calling code should take care to ensure
- * that uses of this class do not specifically depend on ordering.
+ * This class is thread-safe, but the order of applied operations is arbitrary. Calling code should
+ * take care to ensure that uses of this class do not specifically depend on ordering.
  */
 @Singleton
 class ExplorationProgressController @Inject constructor(
-  private val dataProviders: DataProviders,
+  dataProviders: DataProviders,
   private val asyncDataSubscriptionManager: AsyncDataSubscriptionManager,
   private val explorationRetriever: ExplorationRetriever,
   private val answerClassificationController: AnswerClassificationController,
   private val exceptionsController: ExceptionsController,
   private val oppiaClock: OppiaClock
 ) {
-  // TODO(#180): Add support for hints.
   // TODO(#179): Add support for parameters.
-  // TODO(#181): Add support for solutions.
   // TODO(#182): Add support for refresher explorations.
-  // TODO(#90): Update the internal locking of this controller to use something like an in-memory blocking cache to
-  // simplify state locking. However, doing this correctly requires a fix in MediatorLiveData to avoid unexpected
-  // cancellations in chained cross-scope coroutines. Note that this is also essential to ensure post-load operations
-  // can be queued before load completes to avoid cases in tests where the exploration load operation needs to be fully
-  // finished before performing a post-load operation. The current state of the controller is leaking this
-  // implementation detail to tests.
+  // TODO(#90): Update the internal locking of this controller to use something like an in-memory
+  //  blocking cache to simplify state locking. However, doing this correctly requires a fix in
+  //  MediatorLiveData to avoid unexpected cancellations in chained cross-scope coroutines. Note
+  //  that this is also essential to ensure post-load operations can be queued before load completes
+  //  to avoid cases in tests where the exploration load operation needs to be fully finished before
+  //  performing a post-load operation. The current state of the controller is leaking this
+  //  implementation detail to tests.
 
   private val currentStateDataProvider =
     dataProviders.createInMemoryDataProviderAsync(
@@ -83,30 +83,34 @@ class ExplorationProgressController @Inject constructor(
   }
 
   /**
-   * Submits an answer to the current state and returns how the UI should respond to this answer. The returned
-   * [LiveData] will only have at most two results posted: a pending result, and then a completed success/failure
-   * result. Failures in this case represent a failure of the app (possibly due to networking conditions). The app
-   * should report this error in a consumable way to the user so that they may take action on it. No additional values
-   * will be reported to the [LiveData]. Each call to this method returns a new, distinct, [LiveData] object that must
-   * be observed. Note also that the returned [LiveData] is not guaranteed to begin with a pending state.
+   * Submits an answer to the current state and returns how the UI should respond to this answer.
+   * The returned [LiveData] will only have at most two results posted: a pending result, and then a
+   * completed success/failure result. Failures in this case represent a failure of the app
+   * (possibly due to networking conditions). The app should report this error in a consumable way
+   * to the user so that they may take action on it. No additional values will be reported to the
+   * [LiveData]. Each call to this method returns a new, distinct, [LiveData] object that must be
+   * observed. Note also that the returned [LiveData] is not guaranteed to begin with a pending
+   * state.
    *
-   * If the app undergoes a configuration change, calling code should rely on the [LiveData] from [getCurrentState] to
-   * know whether a current answer is pending. That [LiveData] will have its state changed to pending during answer
-   * submission and until answer resolution.
+   * If the app undergoes a configuration change, calling code should rely on the [LiveData] from
+   * [getCurrentState] to know whether a current answer is pending. That [LiveData] will have its
+   * state changed to pending during answer submission and until answer resolution.
    *
-   * Submitting an answer should result in the learner staying in the current state, moving to a new state in the
-   * exploration, being shown a concept card, or being navigated to another exploration altogether. Note that once a
-   * correct answer is processed, the current state reported to [getCurrentState] will change from a pending state to a
-   * completed state since the learner completed that card. The learner can then proceed from the current completed
-   * state to the next pending state using [moveToNextState].
+   * Submitting an answer should result in the learner staying in the current state, moving to a new
+   * state in the exploration, being shown a concept card, or being navigated to another exploration
+   * altogether. Note that once a correct answer is processed, the current state reported to
+   * [getCurrentState] will change from a pending state to a completed state since the learner
+   * completed that card. The learner can then proceed from the current completed state to the next
+   * pending state using [moveToNextState].
    *
-   * This method cannot be called until an exploration has started and [getCurrentState] returns a non-pending result
-   * or the result will fail. Calling code must also take care not to allow users to submit an answer while a previous
-   * answer is pending. That scenario will also result in a failed answer submission.
+   * This method cannot be called until an exploration has started and [getCurrentState] returns a
+   * non-pending result or the result will fail. Calling code must also take care not to allow users
+   * to submit an answer while a previous answer is pending. That scenario will also result in a
+   * failed answer submission.
    *
-   * No assumptions should be made about the completion order of the returned [LiveData] vs. the [LiveData] from
-   * [getCurrentState]. Also note that the returned [LiveData] will only have a single value and not be reused after
-   * that point.
+   * No assumptions should be made about the completion order of the returned [LiveData] vs. the
+   * [LiveData] from  [getCurrentState]. Also note that the returned [LiveData] will only have a
+   * single value and not be reused after that point.
    */
   fun submitAnswer(userAnswer: UserAnswer): LiveData<AsyncResult<AnswerOutcome>> {
     try {
@@ -150,8 +154,9 @@ class ExplorationProgressController @Inject constructor(
             )
           }
         } finally {
-          // Ensure that the user always returns to the VIEWING_STATE stage to avoid getting stuck in an 'always
-          // submitting answer' situation. This can specifically happen if answer classification throws an exception.
+          // Ensure that the user always returns to the VIEWING_STATE stage to avoid getting stuck
+          // in an 'always submitting answer' situation. This can specifically happen if answer
+          // classification throws an exception.
           explorationProgress.advancePlayStageTo(ExplorationProgress.PlayStage.VIEWING_STATE)
         }
 
@@ -200,8 +205,9 @@ class ExplorationProgressController @Inject constructor(
           )
           explorationProgress.stateDeck.pushStateForHint(state, hintIndex)
         } finally {
-          // Ensure that the user always returns to the VIEWING_STATE stage to avoid getting stuck in an 'always
-          // showing hint' situation. This can specifically happen if hint throws an exception.
+          // Ensure that the user always returns to the VIEWING_STATE stage to avoid getting stuck
+          // in an 'always showing hint' situation. This can specifically happen if hint throws an
+          // exception.
           explorationProgress.advancePlayStageTo(ExplorationProgress.PlayStage.VIEWING_STATE)
         }
         asyncDataSubscriptionManager.notifyChangeAsync(CURRENT_STATE_DATA_PROVIDER_ID)
@@ -243,8 +249,9 @@ class ExplorationProgressController @Inject constructor(
           solution = explorationProgress.stateGraph.computeSolutionForResult(state)
           explorationProgress.stateDeck.pushStateForSolution(state)
         } finally {
-          // Ensure that the user always returns to the VIEWING_STATE stage to avoid getting stuck in an 'always
-          // showing solution' situation. This can specifically happen if solution throws an exception.
+          // Ensure that the user always returns to the VIEWING_STATE stage to avoid getting stuck
+          // in an 'always showing solution' situation. This can specifically happen if solution
+          // throws an exception.
           explorationProgress.advancePlayStageTo(ExplorationProgress.PlayStage.VIEWING_STATE)
         }
 
@@ -258,14 +265,15 @@ class ExplorationProgressController @Inject constructor(
   }
 
   /**
-   * Navigates to the previous state in the graph. If the learner is currently on the initial state, this method will
-   * throw an exception. Calling code is responsible for ensuring this method is only called when it's possible to
-   * navigate backward.
+   * Navigates to the previous state in the graph. If the learner is currently on the initial state,
+   * this method will throw an exception. Calling code is responsible for ensuring this method is
+   * only called when it's possible to navigate backward.
    *
-   * @return a one-time [LiveData] indicating whether the movement to the previous state was successful, or a failure if
-   *     state navigation was attempted at an invalid time in the state graph (e.g. if currently viewing the initial
-   *     state of the exploration). It's recommended that calling code only listen to this result for failures, and
-   *     instead rely on [getCurrentState] for observing a successful transition to another state.
+   * @return a one-time [LiveData] indicating whether the movement to the previous state was
+   *     successful, or a failure if state navigation was attempted at an invalid time in the state
+   *     graph (e.g. if currently viewing the initial state of the exploration). It's recommended
+   *     that calling code only listen to this result for failures, and instead rely on
+   *     [getCurrentState] for observing a successful transition to another state.
    */
   fun moveToPreviousState(): LiveData<AsyncResult<Any?>> {
     try {
@@ -299,18 +307,19 @@ class ExplorationProgressController @Inject constructor(
   }
 
   /**
-   * Navigates to the next state in the graph. This method is only valid if the current [EphemeralState] reported by
-   * [getCurrentState] is a completed state. Calling code is responsible for ensuring this method is only called when
-   * it's possible to navigate forward.
+   * Navigates to the next state in the graph. This method is only valid if the current
+   * [EphemeralState] reported by [getCurrentState] is a completed state. Calling code is
+   * responsible for ensuring this method is only called when it's possible to navigate forward.
    *
-   * Note that if the current state is a pending state, the user needs to submit a correct answer that routes to a later
-   * state via [submitAnswer] in order for the current state to change to a completed state before forward navigation
-   * can occur.
+   * Note that if the current state is a pending state, the user needs to submit a correct answer
+   * that routes to a later state via [submitAnswer] in order for the current state to change to a
+   * completed state before forward navigation can occur.
    *
-   * @return a one-time [LiveData] indicating whether the movement to the next state was successful, or a failure if
-   *     state navigation was attempted at an invalid time in the state graph (e.g. if the current state is pending or
-   *     terminal). It's recommended that calling code only listen to this result for failures, and instead rely on
-   *     [getCurrentState] for observing a successful transition to another state.
+   * @return a one-time [LiveData] indicating whether the movement to the next state was successful,
+   *     or a failure if state navigation was attempted at an invalid time in the state graph (e.g.
+   *     if the current state is pending or terminal). It's recommended that calling code only
+   *     listen to this result for failures, and instead rely on [getCurrentState] for observing a
+   *     successful transition to another state.
    */
   fun moveToNextState(): LiveData<AsyncResult<Any?>> {
     try {
@@ -344,27 +353,27 @@ class ExplorationProgressController @Inject constructor(
   }
 
   /**
-   * Returns a [LiveData] monitoring the current [EphemeralState] the learner is currently viewing. If this state
-   * corresponds to a a terminal state, then the learner has completed the exploration. Note that [moveToPreviousState]
-   * and [moveToNextState] will automatically update observers of this live data when the next state is navigated to.
+   * Returns a [DataProvider] monitoring the current [EphemeralState] the learner is currently
+   * viewing. If this state corresponds to a a terminal state, then the learner has completed the
+   * exploration. Note that [moveToPreviousState] and [moveToNextState] will automatically update
+   * observers of this data provider when the next state is navigated to.
    *
-   * This [LiveData] may initially be pending while the exploration object is loaded. It may also switch from a
-   * completed to a pending result during transient operations like submitting an answer via [submitAnswer]. Calling
-   * code should be made resilient to this by caching the current state object to display since it may disappear
-   * temporarily during answer submission. Calling code should persist this state object across configuration changes if
-   * needed since it cannot rely on this [LiveData] for immediate state reconstitution after configuration changes.
+   * This [DataProvider] may initially be pending while the exploration object is loaded. It may
+   * also switch from a completed to a pending result during transient operations like submitting an
+   * answer via [submitAnswer]. Calling code should be made resilient to this by caching the current
+   * state object to display since it may disappear temporarily during answer submission. Calling
+   * code should persist this state object across configuration changes if needed since it cannot
+   * rely on this [DataProvider] for immediate state reconstitution after configuration changes.
    *
-   * The underlying state returned by this function can only be changed by calls to [moveToNextState] and
-   * [moveToPreviousState], or the exploration data controller if another exploration is loaded. UI code can be
-   * confident only calls from the UI layer will trigger state changes here to ensure atomicity between receiving and
-   * making state changes.
+   * The underlying state returned by this function can only be changed by calls to
+   * [moveToNextState] and [moveToPreviousState], or the exploration data controller if another
+   * exploration is loaded. UI code can be confident only calls from the UI layer will trigger state
+   * changes here to ensure atomicity between receiving and making state changes.
    *
-   * This method is safe to be called before an exploration has started. If there is no ongoing exploration, it should
-   * return a pending state.
+   * This method is safe to be called before an exploration has started. If there is no ongoing
+   * exploration, it should return a pending state.
    */
-  fun getCurrentState(): LiveData<AsyncResult<EphemeralState>> {
-    return dataProviders.convertToLiveData(currentStateDataProvider)
-  }
+  fun getCurrentState(): DataProvider<EphemeralState> = currentStateDataProvider
 
   private suspend fun retrieveCurrentStateAsync(): AsyncResult<EphemeralState> {
     return try {
@@ -385,10 +394,11 @@ class ExplorationProgressController @Inject constructor(
     val exploration = explorationId?.let(explorationRetriever::loadExploration)
 
     explorationProgressLock.withLock {
-      // It's possible for the exploration ID or stage to change between critical sections. However, this is the only
-      // way to ensure the exploration is loaded since suspended functions cannot be called within a mutex. Note that
-      // it's also possible for the stage to change between critical sections, sometimes due to this suspend function
-      // being called multiple times and a former call finishing the exploration load.
+      // It's possible for the exploration ID or stage to change between critical sections. However,
+      // this is the only way to ensure the exploration is loaded since suspended functions cannot
+      // be called within a mutex. Note that it's also possible for the stage to change between
+      // critical sections, sometimes due to this suspend function being called multiple times and a
+      // former call finishing the exploration load.
       check(
         exploration == null ||
           explorationProgress.currentExplorationId == explorationId
@@ -423,7 +433,8 @@ class ExplorationProgressController @Inject constructor(
     progress.stateGraph.reset(exploration.statesMap)
     progress.stateDeck.resetDeck(progress.stateGraph.getState(exploration.initStateName))
 
-    // Advance the stage, but do not notify observers since the current state can be reported immediately to the UI.
+    // Advance the stage, but do not notify observers since the current state can be reported
+    // immediately to the UI.
     progress.advancePlayStageTo(ExplorationProgress.PlayStage.VIEWING_STATE)
   }
 }

--- a/domain/src/main/java/org/oppia/domain/onboarding/AppStartupStateController.kt
+++ b/domain/src/main/java/org/oppia/domain/onboarding/AppStartupStateController.kt
@@ -1,12 +1,11 @@
 package org.oppia.domain.onboarding
 
-import androidx.lifecycle.LiveData
 import org.oppia.app.model.AppStartupState
 import org.oppia.app.model.AppStartupState.StartupMode
 import org.oppia.app.model.OnboardingState
 import org.oppia.data.persistence.PersistentCacheStore
-import org.oppia.util.data.AsyncResult
-import org.oppia.util.data.DataProviders
+import org.oppia.util.data.DataProvider
+import org.oppia.util.data.DataProviders.Companion.transform
 import org.oppia.util.logging.ConsoleLogger
 import java.text.ParseException
 import java.text.SimpleDateFormat
@@ -21,7 +20,6 @@ private const val APP_STARTUP_STATE_DATA_PROVIDER_ID = "app_startup_state_data_p
 @Singleton
 class AppStartupStateController @Inject constructor(
   cacheStoreFactory: PersistentCacheStore.Factory,
-  private val dataProviders: DataProviders,
   private val consoleLogger: ConsoleLogger,
   private val expirationMetaDataRetriever: ExpirationMetaDataRetriever
 ) {
@@ -31,7 +29,7 @@ class AppStartupStateController @Inject constructor(
     cacheStoreFactory.create("on_boarding_flow", OnboardingState.getDefaultInstance())
 
   private val appStartupStateDataProvider by lazy {
-    dataProviders.transform(APP_STARTUP_STATE_DATA_PROVIDER_ID, onboardingFlowStore) {
+    onboardingFlowStore.transform(APP_STARTUP_STATE_DATA_PROVIDER_ID) {
       AppStartupState.newBuilder().setStartupMode(computeAppStartupMode(it)).build()
     }
   }
@@ -68,12 +66,10 @@ class AppStartupStateController @Inject constructor(
   }
 
   /**
-   * Returns a [LiveData] containing the user's startup state, which in turn affect what initial app
-   * flow the user is directed to.
+   * Returns a [DataProvider] containing the user's startup state, which in turn affect what initial
+   * app flow the user is directed to.
    */
-  fun getAppStartupState(): LiveData<AsyncResult<AppStartupState>> {
-    return dataProviders.convertToLiveData(appStartupStateDataProvider)
-  }
+  fun getAppStartupState(): DataProvider<AppStartupState> = appStartupStateDataProvider
 
   private fun computeAppStartupMode(onboardingState: OnboardingState): StartupMode {
     return when {

--- a/domain/src/main/java/org/oppia/domain/question/QuestionAssessmentProgressController.kt
+++ b/domain/src/main/java/org/oppia/domain/question/QuestionAssessmentProgressController.kt
@@ -16,6 +16,7 @@ import org.oppia.util.data.AsyncDataSubscriptionManager
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProvider
 import org.oppia.util.data.DataProviders
+import org.oppia.util.data.DataProviders.Companion.transformNested
 import org.oppia.util.data.DataProviders.NestedTransformedDataProvider
 import org.oppia.util.system.OppiaClock
 import java.util.concurrent.locks.ReentrantLock
@@ -27,13 +28,14 @@ private const val CURRENT_QUESTION_DATA_PROVIDER_ID = "CurrentQuestionDataProvid
 private const val EMPTY_QUESTIONS_LIST_DATA_PROVIDER_ID = "EmptyQuestionsListDataProvider"
 
 /**
- * Controller that tracks and reports the learner's ephemeral/non-persisted progress through a practice training
- * session. Note that this controller only supports one active training session at a time.
+ * Controller that tracks and reports the learner's ephemeral/non-persisted progress through a
+ * practice training session. Note that this controller only supports one active training session at
+ * a time.
  *
  * The current training session is started via the question training controller.
  *
- * This class is thread-safe, but the order of applied operations is arbitrary. Calling code should take care to ensure
- * that uses of this class do not specifically depend on ordering.
+ * This class is thread-safe, but the order of applied operations is arbitrary. Calling code should
+ * take care to ensure that uses of this class do not specifically depend on ordering.
  */
 @Singleton
 class QuestionAssessmentProgressController @Inject constructor(
@@ -43,8 +45,10 @@ class QuestionAssessmentProgressController @Inject constructor(
   private val exceptionsController: ExceptionsController,
   private val oppiaClock: OppiaClock
 ) {
-  // TODO(#247): Add support for populating the list of skill IDs to review at the end of the training session.
-  // TODO(#248): Add support for the assessment ending prematurely due to learner demonstrating sufficient proficiency.
+  // TODO(#247): Add support for populating the list of skill IDs to review at the end of the
+  //  training session.
+  // TODO(#248): Add support for the assessment ending prematurely due to learner demonstrating
+  //  sufficient proficiency.
 
   private val progress = QuestionAssessmentProgress()
   private val progressLock = ReentrantLock()
@@ -81,30 +85,33 @@ class QuestionAssessmentProgressController @Inject constructor(
   }
 
   /**
-   * Submits an answer to the current question and returns how the UI should respond to this answer. The returned
-   * [LiveData] will only have at most two results posted: a pending result, and then a completed success/failure
-   * result. Failures in this case represent a failure of the app (possibly due to networking conditions). The app
-   * should report this error in a consumable way to the user so that they may take action on it. No additional values
-   * will be reported to the [LiveData]. Each call to this method returns a new, distinct, [LiveData] object that must
-   * be observed. Note also that the returned [LiveData] is not guaranteed to begin with a pending state.
+   * Submits an answer to the current question and returns how the UI should respond to this answer.
+   * The returned [LiveData] will only have at most two results posted: a pending result, and then a
+   * completed success/failure result. Failures in this case represent a failure of the app
+   * (possibly due to networking conditions). The app should report this error in a consumable way
+   * to the user so that they may take action on it. No additional values will be reported to the
+   * [LiveData]. Each call to this method returns a new, distinct, [LiveData] object that must be
+   * observed. Note also that the returned [LiveData] is not guaranteed to begin with a pending
+   * state.
    *
-   * If the app undergoes a configuration change, calling code should rely on the [LiveData] from [getCurrentQuestion]
-   * to know whether a current answer is pending. That [LiveData] will have its state changed to pending during answer
-   * submission and until answer resolution.
+   * If the app undergoes a configuration change, calling code should rely on the [LiveData] from
+   * [getCurrentQuestion] to know whether a current answer is pending. That [LiveData] will have its
+   * state changed to pending during answer submission and until answer resolution.
    *
-   * Submitting an answer should result in the learner staying in the current question or moving to a new question in
-   * the training session. Note that once a correct answer is processed, the current state reported to
-   * [getCurrentQuestion] will change from a pending question to a completed question since the learner completed that
-   * question card. The learner can then proceed from the current completed question to the next pending question using
-   * [moveToNextQuestion].
+   * Submitting an answer should result in the learner staying in the current question or moving to
+   * a new question in the training session. Note that once a correct answer is processed, the
+   * current state reported to [getCurrentQuestion] will change from a pending question to a
+   * completed question since the learner completed that question card. The learner can then proceed
+   * from the current completed question to the next pending question using [moveToNextQuestion].
    *
-   * This method cannot be called until a training session has started and [getCurrentQuestion] returns a non-pending
-   * result or the result will fail. Calling code must also take care not to allow users to submit an answer while a
-   * previous answer is pending. That scenario will also result in a failed answer submission.
+   * This method cannot be called until a training session has started and [getCurrentQuestion]
+   * returns a non-pending result or the result will fail. Calling code must also take care not to
+   * allow users to submit an answer while a previous answer is pending. That scenario will also
+   * result in a failed answer submission.
    *
-   * No assumptions should be made about the completion order of the returned [LiveData] vs. the [LiveData] from
-   * [getCurrentQuestion]. Also note that the returned [LiveData] will only have a single value and not be reused after
-   * that point.
+   * No assumptions should be made about the completion order of the returned [LiveData] vs. the
+   * [LiveData] from [getCurrentQuestion]. Also note that the returned [LiveData] will only have a
+   * single value and not be reused after that point.
    */
   fun submitAnswer(answer: UserAnswer): LiveData<AsyncResult<AnsweredQuestionOutcome>> {
     try {
@@ -145,8 +152,9 @@ class QuestionAssessmentProgressController @Inject constructor(
             }
           }
         } finally {
-          // Ensure that the user always returns to the VIEWING_STATE stage to avoid getting stuck in an 'always
-          // submitting answer' situation. This can specifically happen if answer classification throws an exception.
+          // Ensure that the user always returns to the VIEWING_STATE stage to avoid getting stuck
+          // in an 'always submitting answer' situation. This can specifically happen if answer
+          // classification throws an exception.
           progress.advancePlayStageTo(TrainStage.VIEWING_STATE)
         }
 
@@ -160,7 +168,11 @@ class QuestionAssessmentProgressController @Inject constructor(
     }
   }
 
-  fun submitHintIsRevealed(state: State, hintIsRevealed: Boolean, hintIndex: Int): LiveData<AsyncResult<Hint>> { // ktlint-disable max-line-length
+  fun submitHintIsRevealed(
+    state: State,
+    hintIsRevealed: Boolean,
+    hintIndex: Int
+  ): LiveData<AsyncResult<Hint>> {
     try {
       progressLock.withLock {
         check(progress.trainStage != TrainStage.NOT_IN_TRAINING_SESSION) {
@@ -182,8 +194,9 @@ class QuestionAssessmentProgressController @Inject constructor(
           )
           progress.stateDeck.pushStateForHint(state, hintIndex)
         } finally {
-          // Ensure that the user always returns to the VIEWING_STATE stage to avoid getting stuck in an 'always
-          // showing hint' situation. This can specifically happen if hint throws an exception.
+          // Ensure that the user always returns to the VIEWING_STATE stage to avoid getting stuck
+          // in an 'always showing hint' situation. This can specifically happen if hint throws an
+          // exception.
           progress.advancePlayStageTo(TrainStage.VIEWING_STATE)
         }
         asyncDataSubscriptionManager.notifyChangeAsync(CURRENT_QUESTION_DATA_PROVIDER_ID)
@@ -195,7 +208,6 @@ class QuestionAssessmentProgressController @Inject constructor(
     }
   }
 
-  /* ktlint-disable max-line-length */
   fun submitSolutionIsRevealed(state: State): LiveData<AsyncResult<Solution>> {
     try {
       progressLock.withLock {
@@ -215,8 +227,9 @@ class QuestionAssessmentProgressController @Inject constructor(
           solution = progress.stateList.computeSolutionForResult(state)
           progress.stateDeck.pushStateForSolution(state)
         } finally {
-          // Ensure that the user always returns to the VIEWING_STATE stage to avoid getting stuck in an 'always
-          // showing solution' situation. This can specifically happen if solution throws an exception.
+          // Ensure that the user always returns to the VIEWING_STATE stage to avoid getting stuck
+          // in an 'always showing solution' situation. This can specifically happen if solution
+          // throws an exception.
           progress.advancePlayStageTo(TrainStage.VIEWING_STATE)
         }
 
@@ -228,20 +241,20 @@ class QuestionAssessmentProgressController @Inject constructor(
       return MutableLiveData(AsyncResult.failed(e))
     }
   }
-  /* ktlint-enable max-line-length */
 
   /**
-   * Navigates to the next question in the assessment. This method is only valid if the current [EphemeralQuestion]
-   * reported by [getCurrentQuestion] is a completed question. Calling code is responsible for ensuring this method is
-   * only called when it's possible to navigate forward.
+   * Navigates to the next question in the assessment. This method is only valid if the current
+   * [EphemeralQuestion] reported by [getCurrentQuestion] is a completed question. Calling code is
+   * responsible for ensuring this method is only called when it's possible to navigate forward.
    *
-   * Note that if the current question is pending, the user needs to submit a correct answer via [submitAnswer] before
-   * forward navigation can occur.
+   * Note that if the current question is pending, the user needs to submit a correct answer via
+   * [submitAnswer] before forward navigation can occur.
    *
-   * @return a one-time [LiveData] indicating whether the movement to the next question was successful, or a failure if
-   *     question navigation was attempted at an invalid time (such as if the current question is pending or terminal).
-   *     It's recommended that calling code only listen to this result for failures, and instead rely on
-   *     [getCurrentQuestion] for observing a successful transition to another question.
+   * @return a one-time [LiveData] indicating whether the movement to the next question was
+   *     successful, or a failure if question navigation was attempted at an invalid time (such as
+   *     if the current question is pending or terminal). It's recommended that calling code only
+   *     listen to this result for failures, and instead rely on [getCurrentQuestion] for observing
+   *     a successful transition to another question.
    */
   fun moveToNextQuestion(): LiveData<AsyncResult<Any?>> {
     try {
@@ -267,35 +280,36 @@ class QuestionAssessmentProgressController @Inject constructor(
   }
 
   /**
-   * Returns a [LiveData] monitoring the current [EphemeralQuestion] the learner is currently viewing. If this state
-   * corresponds to a a terminal state, then the learner has completed the training session. Note that
-   * [moveToNextQuestion] will automatically update observers of this live data when the next question is navigated to.
+   * Returns a [DataProvider] monitoring the current [EphemeralQuestion] the learner is currently
+   * viewing. If this state corresponds to a a terminal state, then the learner has completed the
+   * training session. Note that [moveToNextQuestion] will automatically update observers of this
+   * data provider when the next question is navigated to.
    *
-   * This [LiveData] may switch from a completed to a pending result during transient operations like submitting an
-   * answer via [submitAnswer]. Calling code should be made resilient to this by caching the current question object to
-   * display since it may disappear temporarily during answer submission. Calling code should persist this state object
-   * across configuration changes if needed since it cannot rely on this [LiveData] for immediate UI reconstitution
-   * after configuration changes.
+   * This [DataProvider] may switch from a completed to a pending result during transient operations
+   * like submitting an answer via [submitAnswer]. Calling code should be made resilient to this by
+   * caching the current question object to display since it may disappear temporarily during answer
+   * submission. Calling code should persist this state object across configuration changes if
+   * needed since it cannot rely on this [DataProvider] for immediate UI reconstitution after
+   * configuration changes.
    *
-   * The underlying question returned by this function can only be changed by calls to [moveToNextQuestion], or the
-   * question training controller if another question session begins. UI code can be confident only calls from the UI
-   * layer will trigger changes here to ensure atomicity between receiving and making question state changes.
+   * The underlying question returned by this function can only be changed by calls to
+   * [moveToNextQuestion], or the question training controller if another question session begins.
+   * UI code can be confident only calls from the UI layer will trigger changes here to ensure
+   * atomicity between receiving and making question state changes.
    *
-   * This method is safe to be called before a training session has started. If there is no ongoing session, it should
-   * return a pending state, which means the returned value can switch from a success or failure state back to pending.
+   * This method is safe to be called before a training session has started. If there is no ongoing
+   * session, it should return a pending state, which means the returned value can switch from a
+   * success or failure state back to pending.
    */
-  fun getCurrentQuestion(): LiveData<AsyncResult<EphemeralQuestion>> {
-    return progressLock.withLock {
-      dataProviders.convertToLiveData(currentQuestionDataProvider)
-    }
+  fun getCurrentQuestion(): DataProvider<EphemeralQuestion> = progressLock.withLock {
+    currentQuestionDataProvider
   }
 
   private fun createCurrentQuestionDataProvider(
     questionsListDataProvider: DataProvider<List<Question>>
   ): NestedTransformedDataProvider<EphemeralQuestion> {
-    return dataProviders.createNestedTransformedDataProvider(
+    return questionsListDataProvider.transformNested(
       CURRENT_QUESTION_DATA_PROVIDER_ID,
-      questionsListDataProvider,
       this::retrieveCurrentQuestionAsync
     )
   }

--- a/domain/src/main/java/org/oppia/domain/question/QuestionTrainingController.kt
+++ b/domain/src/main/java/org/oppia/domain/question/QuestionTrainingController.kt
@@ -7,7 +7,8 @@ import org.oppia.domain.oppialogger.exceptions.ExceptionsController
 import org.oppia.domain.topic.TopicController
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProvider
-import org.oppia.util.data.DataProviders
+import org.oppia.util.data.DataProviders.Companion.toLiveData
+import org.oppia.util.data.DataProviders.Companion.transform
 import org.oppia.util.system.OppiaClock
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -21,7 +22,6 @@ private const val RETRIEVE_QUESTIONS_RESULT_DATA_PROVIDER = "RetrieveQuestionsRe
 class QuestionTrainingController @Inject constructor(
   private val questionAssessmentProgressController: QuestionAssessmentProgressController,
   private val topicController: TopicController,
-  private val dataProviders: DataProviders,
   private val exceptionsController: ExceptionsController,
   private val oppiaClock: OppiaClock,
   @QuestionCountPerTrainingSession private val questionCountPerSession: Int,
@@ -33,13 +33,14 @@ class QuestionTrainingController @Inject constructor(
   /**
    * Begins a question training session given a list of skill Ids and a total number of questions.
    *
-   * This method is not expected to fail. [QuestionAssessmentProgressController] should be used to manage the
-   * play state, and monitor the load success/failure of the training session.
+   * This method is not expected to fail. [QuestionAssessmentProgressController] should be used to
+   * manage the play state, and monitor the load success/failure of the training session.
    *
    * Questions will be shuffled and then the training session will begin.
    *
-   * @return a one-time [LiveData] to observe whether initiating the play request succeeded.
-   * The training session may still fail to load, but this provides early-failure detection.
+   * @return a one-time [DataProvider] to observe whether initiating the play request succeeded.
+   *     Note that the training session may still fail to load, but this provides early-failure
+   *     detection.
    */
   fun startQuestionTrainingSession(skillIdsList: List<String>): LiveData<AsyncResult<Any>> {
     return try {
@@ -49,10 +50,9 @@ class QuestionTrainingController @Inject constructor(
         retrieveQuestionsDataProvider
       )
       // Convert the data provider type to 'Any' via a transformation.
-      val erasedDataProvider: DataProvider<Any> = dataProviders.transform(
-        RETRIEVE_QUESTIONS_RESULT_DATA_PROVIDER, retrieveQuestionsDataProvider
-      ) { it }
-      dataProviders.convertToLiveData(erasedDataProvider)
+      val erasedDataProvider: DataProvider<Any> = retrieveQuestionsDataProvider
+        .transform(RETRIEVE_QUESTIONS_RESULT_DATA_PROVIDER) { it }
+      erasedDataProvider.toLiveData()
     } catch (e: Exception) {
       exceptionsController.logNonFatalException(e, oppiaClock.getCurrentCalendar().timeInMillis)
       MutableLiveData(AsyncResult.failed(e))
@@ -64,11 +64,11 @@ class QuestionTrainingController @Inject constructor(
   ): DataProvider<List<Question>> {
     val questionsDataProvider =
       topicController.retrieveQuestionsForSkillIds(skillIdsList)
-    // Cache the seed so that re-notifying that the underlying structure has changed won't regenerate the session
-    // (unless the questions themselves change). This is necessary since the underlying structure may be notified
-    // multiple times during a single submit answer operation.
+    // Cache the seed so that re-notifying that the underlying structure has changed won't
+    // regenerate the session (unless the questions themselves change). This is necessary since the
+    // underlying structure may be notified multiple times during a single submit answer operation.
     val seed = seedRandom.nextLong()
-    return dataProviders.transform(TRAINING_QUESTIONS_PROVIDER, questionsDataProvider) {
+    return questionsDataProvider.transform(TRAINING_QUESTIONS_PROVIDER) {
       val questionsList = if (skillIdsList.isEmpty()) {
         listOf()
       } else {
@@ -84,8 +84,8 @@ class QuestionTrainingController @Inject constructor(
     }
   }
 
-  // Attempts to fetch equal number of questions per skill. Removes any duplicates and limits the questions to be
-  // equal to TOTAL_QUESTIONS_PER_TOPIC questions.
+  // Attempts to fetch equal number of questions per skill. Removes any duplicates and limits the
+  // questions to be equal to TOTAL_QUESTIONS_PER_TOPIC questions.
   private fun getFilteredQuestionsForTraining(
     skillIdsList: List<String>,
     questionsList: List<Question>,
@@ -104,9 +104,9 @@ class QuestionTrainingController @Inject constructor(
   }
 
   /**
-   * Finishes the most recent training session started by [startQuestionTrainingSession].
-   * This method should only be called if there is a training session is being played,
-   * otherwise an exception will be thrown.
+   * Finishes the most recent training session started by [startQuestionTrainingSession]. This
+   * method should only be called if there is a training session is being played, otherwise an
+   * exception will be thrown.
    */
   fun stopQuestionTrainingSession(): LiveData<AsyncResult<Any?>> {
     return try {

--- a/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicController.kt
@@ -28,6 +28,8 @@ import org.oppia.domain.util.JsonAssetRetriever
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProvider
 import org.oppia.util.data.DataProviders
+import org.oppia.util.data.DataProviders.Companion.combineWith
+import org.oppia.util.data.DataProviders.Companion.transformAsync
 import org.oppia.util.system.OppiaClock
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -90,9 +92,9 @@ class TopicController @Inject constructor(
    *
    * @param profileId the ID corresponding to the profile for which progress needs fetched.
    * @param topicId the ID corresponding to the topic which needs to be returned.
-   * @return a [LiveData] for [Topic] combined with [TopicProgress].
+   * @return a [DataProvider] for [Topic] combined with [TopicProgress].
    */
-  fun getTopic(profileId: ProfileId, topicId: String): LiveData<AsyncResult<Topic>> {
+  fun getTopic(profileId: ProfileId, topicId: String): DataProvider<Topic> {
     val topicDataProvider =
       dataProviders.createInMemoryDataProviderAsync(TRANSFORMED_GET_TOPIC_PROVIDER_ID) {
         return@createInMemoryDataProviderAsync AsyncResult.success(retrieveTopic(topicId))
@@ -100,13 +102,10 @@ class TopicController @Inject constructor(
     val topicProgressDataProvider =
       storyProgressController.retrieveTopicProgressDataProvider(profileId, topicId)
 
-    return dataProviders.convertToLiveData(
-      dataProviders.combine(
-        COMBINED_TOPIC_PROVIDER_ID,
-        topicDataProvider,
-        topicProgressDataProvider,
-        ::combineTopicAndTopicProgress
-      )
+    return topicDataProvider.combineWith(
+      topicProgressDataProvider,
+      COMBINED_TOPIC_PROVIDER_ID,
+      ::combineTopicAndTopicProgress
     )
   }
 
@@ -116,13 +115,13 @@ class TopicController @Inject constructor(
    * @param profileId the ID corresponding to the profile for which progress needs fetched.
    * @param topicId the ID corresponding to the topic which contains this story.
    * @param storyId the ID corresponding to the story which needs to be returned.
-   * @return a [LiveData] for [StorySummary] combined with [StoryProgress].
+   * @return a [DataProvider] for [StorySummary] combined with [StoryProgress].
    */
   fun getStory(
     profileId: ProfileId,
     topicId: String,
     storyId: String
-  ): LiveData<AsyncResult<StorySummary>> {
+  ): DataProvider<StorySummary> {
     val storyDataProvider =
       dataProviders.createInMemoryDataProviderAsync(TRANSFORMED_GET_STORY_PROVIDER_ID) {
         return@createInMemoryDataProviderAsync AsyncResult.success(retrieveStory(topicId, storyId))
@@ -130,17 +129,17 @@ class TopicController @Inject constructor(
     val storyProgressDataProvider =
       storyProgressController.retrieveStoryProgressDataProvider(profileId, topicId, storyId)
 
-    return dataProviders.convertToLiveData(
-      dataProviders.combine(
-        COMBINED_STORY_PROVIDER_ID,
-        storyDataProvider,
-        storyProgressDataProvider,
-        ::combineStorySummaryAndStoryProgress
-      )
+    return storyDataProvider.combineWith(
+      storyProgressDataProvider,
+      COMBINED_STORY_PROVIDER_ID,
+      ::combineStorySummaryAndStoryProgress
     )
   }
 
-  /** Returns the [ConceptCard] corresponding to the specified skill ID, or a failed result if there is none. */
+  /**
+   * Returns the [ConceptCard] corresponding to the specified skill ID, or a failed result if there
+   * is none.
+   */
   fun getConceptCard(skillId: String): LiveData<AsyncResult<ConceptCard>> {
     return MutableLiveData(
       try {
@@ -152,7 +151,10 @@ class TopicController @Inject constructor(
     )
   }
 
-  /** Returns the [RevisionCard] corresponding to the specified topic Id and subtopic ID, or a failed result if there is none. */
+  /**
+   * Returns the [RevisionCard] corresponding to the specified topic Id and subtopic ID, or a failed
+   * result if there is none.
+   */
   fun getRevisionCard(topicId: String, subtopicId: Int): LiveData<AsyncResult<RevisionCard>> {
     return MutableLiveData(
       try {
@@ -164,44 +166,43 @@ class TopicController @Inject constructor(
     )
   }
 
-  /** Returns the list of all completed stories in the form of [CompletedStoryList] for a specific profile. */
-  fun getCompletedStoryList(profileId: ProfileId): LiveData<AsyncResult<CompletedStoryList>> {
-    return dataProviders.convertToLiveData(
-      dataProviders.transformAsync(
-        TRANSFORMED_GET_COMPLETED_STORIES_PROVIDER_ID,
-        storyProgressController.retrieveTopicProgressListDataProvider(profileId)
-      ) {
-        val completedStoryListBuilder = CompletedStoryList.newBuilder()
-        it.forEach { topicProgress ->
-          val topic = retrieveTopic(topicProgress.topicId)
-          val storyProgressList = mutableListOf<StoryProgress>()
-          val transformedStoryProgressList = topicProgress
-            .storyProgressMap.values.toList()
-          storyProgressList.addAll(transformedStoryProgressList)
+  /**
+   * Returns the list of all completed stories in the form of [CompletedStoryList] for a specific
+   * profile.
+   */
+  fun getCompletedStoryList(profileId: ProfileId): DataProvider<CompletedStoryList> {
+    return storyProgressController.retrieveTopicProgressListDataProvider(
+      profileId
+    ).transformAsync(TRANSFORMED_GET_COMPLETED_STORIES_PROVIDER_ID) {
+      val completedStoryListBuilder = CompletedStoryList.newBuilder()
+      it.forEach { topicProgress ->
+        val topic = retrieveTopic(topicProgress.topicId)
+        val storyProgressList = mutableListOf<StoryProgress>()
+        val transformedStoryProgressList = topicProgress
+          .storyProgressMap.values.toList()
+        storyProgressList.addAll(transformedStoryProgressList)
 
-          completedStoryListBuilder.addAllCompletedStory(
-            createCompletedStoryListFromProgress(
-              topic,
-              storyProgressList
-            )
+        completedStoryListBuilder.addAllCompletedStory(
+          createCompletedStoryListFromProgress(
+            topic,
+            storyProgressList
           )
-        }
-        AsyncResult.success(completedStoryListBuilder.build())
+        )
       }
-    )
+      AsyncResult.success(completedStoryListBuilder.build())
+    }
   }
 
-  /** Returns the list of ongoing topics in the form on [OngoingTopicList] for a specific profile. */
-  fun getOngoingTopicList(profileId: ProfileId): LiveData<AsyncResult<OngoingTopicList>> {
-    val ongoingTopicListDataProvider = dataProviders.transformAsync(
-      TRANSFORMED_GET_ONGOING_TOPICS_PROVIDER_ID,
-      storyProgressController.retrieveTopicProgressListDataProvider(profileId)
-    ) {
+  /**
+   * Returns the list of ongoing topics in the form on [OngoingTopicList] for a specific profile.
+   */
+  fun getOngoingTopicList(profileId: ProfileId): DataProvider<OngoingTopicList> {
+    return storyProgressController.retrieveTopicProgressListDataProvider(
+      profileId
+    ).transformAsync(TRANSFORMED_GET_ONGOING_TOPICS_PROVIDER_ID) {
       val ongoingTopicList = createOngoingTopicListFromProgress(it)
       AsyncResult.success(ongoingTopicList)
     }
-
-    return dataProviders.convertToLiveData(ongoingTopicListDataProvider)
   }
 
   fun retrieveQuestionsForSkillIds(skillIdsList: List<String>): DataProvider<List<Question>> {
@@ -250,7 +251,8 @@ class TopicController @Inject constructor(
       return false
     }
 
-    // If there is atleast 1 completed chapter and 1 not-completed chapter, it is definitely an ongoing-topic.
+    // If there is at least 1 completed chapter and 1 not-completed chapter, it is definitely an
+    // ongoing-topic.
     if (startedChapterProgressList.isNotEmpty()) {
       return true
     }
@@ -374,7 +376,10 @@ class TopicController @Inject constructor(
     return questionRetriever.loadQuestions(skillIdsList)
   }
 
-  /** Helper function for [combineTopicAndTopicProgress] to set first chapter as NOT_STARTED in [StorySummary]. */
+  /**
+   * Helper function for [combineTopicAndTopicProgress] to set first chapter as NOT_STARTED in
+   * [StorySummary].
+   */
   private fun setFirstChapterAsNotStarted(storySummary: StorySummary): StorySummary {
     return if (storySummary.chapterList.isNotEmpty()) {
       val storyBuilder = storySummary.toBuilder()
@@ -415,8 +420,8 @@ class TopicController @Inject constructor(
   }
 
   /**
-   * Creates the subtopic list of a topic from its json representation. The json file is expected to have
-   * a key called 'subtopic' that contains an array of skill Ids,subtopic_id and title.
+   * Creates the subtopic list of a topic from its json representation. The json file is expected to
+   * have a key called 'subtopic' that contains an array of skill Ids,subtopic_id and title.
    */
   private fun createSubtopicListFromJsonArray(subtopicJsonArray: JSONArray?): List<Subtopic> {
     val subtopicList = mutableListOf<Subtopic>()
@@ -482,8 +487,8 @@ class TopicController @Inject constructor(
   }
 
   /**
-   * Creates a list of [StorySummary]s for topic from its json representation. The json file is expected to have
-   * a key called 'canonical_story_dicts' that contains an array of story objects.
+   * Creates a list of [StorySummary]s for topic from its json representation. The json file is
+   * expected to have a key called 'canonical_story_dicts' that contains an array of story objects.
    */
   private fun createStorySummaryListFromJsonArray(
     topicId: String,
@@ -499,7 +504,10 @@ class TopicController @Inject constructor(
     return storySummaryList
   }
 
-  /** Creates a list of [StorySummary]s for topic given its json representation and the index of the story in json. */
+  /**
+   * Creates a list of [StorySummary]s for topic given its json representation and the index of the
+   * story in json.
+   */
   private fun createStorySummaryFromJson(topicId: String, storyId: String): StorySummary {
     val storyDataJsonObject = jsonAssetRetriever.loadJsonFromAsset("$storyId.json")
     return StorySummary.newBuilder()

--- a/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/domain/topic/TopicListController.kt
@@ -18,7 +18,8 @@ import org.oppia.app.model.TopicProgress
 import org.oppia.app.model.TopicSummary
 import org.oppia.domain.util.JsonAssetRetriever
 import org.oppia.util.data.AsyncResult
-import org.oppia.util.data.DataProviders
+import org.oppia.util.data.DataProvider
+import org.oppia.util.data.DataProviders.Companion.transformAsync
 import java.util.Date
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -74,7 +75,6 @@ private val EVICTION_TIME_MILLIS = TimeUnit.DAYS.toMillis(1)
 /** Controller for retrieving the list of topics available to the learner to play. */
 @Singleton
 class TopicListController @Inject constructor(
-  private val dataProviders: DataProviders,
   private val jsonAssetRetriever: JsonAssetRetriever,
   private val topicController: TopicController,
   private val storyProgressController: StoryProgressController
@@ -88,23 +88,20 @@ class TopicListController @Inject constructor(
   }
 
   /**
-   * Returns the list of ongoing [PromotedStory]s that can be viewed via a link on the homescreen. The total number of
-   * promoted stories should correspond to the ongoing story count within the [TopicList] returned by [getTopicList].
+   * Returns the list of ongoing [PromotedStory]s that can be viewed via a link on the homescreen.
+   * The total number of promoted stories should correspond to the ongoing story count within the
+   * [TopicList] returned by [getTopicList].
    *
-   * @param profileId the ID corresponding to the profile for which [PromotedStory] needs to be fetched.
-   * @return a [LiveData] for a [OngoingStoryList].
+   * @param profileId the ID corresponding to the profile for which [PromotedStory] needs to be
+   *    fetched.
+   * @return a [DataProvider] for an [OngoingStoryList].
    */
-
-  fun getOngoingStoryList(profileId: ProfileId): LiveData<AsyncResult<OngoingStoryList>> {
-    val ongoingStoryListDataProvider = dataProviders.transformAsync(
-      TRANSFORMED_GET_ONGOING_STORY_LIST_PROVIDER_ID,
-      storyProgressController.retrieveTopicProgressListDataProvider(profileId)
-    ) {
-      val ongoingStoryList = createOngoingStoryListFromProgress(it)
-      AsyncResult.success(ongoingStoryList)
-    }
-
-    return dataProviders.convertToLiveData(ongoingStoryListDataProvider)
+  fun getOngoingStoryList(profileId: ProfileId): DataProvider<OngoingStoryList> {
+    return storyProgressController.retrieveTopicProgressListDataProvider(profileId)
+      .transformAsync(TRANSFORMED_GET_ONGOING_STORY_LIST_PROVIDER_ID) {
+        val ongoingStoryList = createOngoingStoryListFromProgress(it)
+        AsyncResult.success(ongoingStoryList)
+      }
   }
 
   private fun createTopicList(): TopicList {

--- a/domain/src/test/java/org/oppia/domain/audio/CellularAudioDialogControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/audio/CellularAudioDialogControllerTest.kt
@@ -177,7 +177,7 @@ class CellularAudioDialogControllerTest {
       TestLogReportingModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/domain/src/test/java/org/oppia/domain/audio/CellularAudioDialogControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/audio/CellularAudioDialogControllerTest.kt
@@ -27,6 +27,8 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders.Companion.toLiveData
+import org.oppia.util.data.DataProvidersInjector
+import org.oppia.util.data.DataProvidersInjectorProvider
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -38,7 +40,7 @@ import javax.inject.Singleton
 
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
-@Config(manifest = Config.NONE)
+@Config(application = CellularAudioDialogControllerTest.TestApplication::class)
 class CellularAudioDialogControllerTest {
   @Rule
   @JvmField
@@ -62,10 +64,7 @@ class CellularAudioDialogControllerTest {
   }
 
   private fun setUpTestApplicationComponent() {
-    DaggerCellularAudioDialogControllerTest_TestApplicationComponent.builder()
-      .setApplication(ApplicationProvider.getApplicationContext())
-      .build()
-      .inject(this)
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
   @Test
@@ -178,7 +177,7 @@ class CellularAudioDialogControllerTest {
       TestLogReportingModule::class
     ]
   )
-  interface TestApplicationComponent {
+  interface TestApplicationComponent: DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance
@@ -187,5 +186,19 @@ class CellularAudioDialogControllerTest {
     }
 
     fun inject(cellularDataControllerTest: CellularAudioDialogControllerTest)
+  }
+
+  class TestApplication : Application(), DataProvidersInjectorProvider {
+    private val component: TestApplicationComponent by lazy {
+      DaggerCellularAudioDialogControllerTest_TestApplicationComponent.builder()
+        .setApplication(this)
+        .build()
+    }
+
+    fun inject(cellularDataControllerTest: CellularAudioDialogControllerTest) {
+      component.inject(cellularDataControllerTest)
+    }
+
+    override fun getDataProvidersInjector(): DataProvidersInjector = component
   }
 }

--- a/domain/src/test/java/org/oppia/domain/audio/CellularAudioDialogControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/audio/CellularAudioDialogControllerTest.kt
@@ -26,6 +26,7 @@ import org.oppia.testing.TestCoroutineDispatchers
 import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -70,7 +71,7 @@ class CellularAudioDialogControllerTest {
   @Test
   fun testController_providesInitialLiveData_indicatesToNotHideDialogAndNotUseCellularData() {
     val cellularDataPreference =
-      cellularAudioDialogController.getCellularDataPreference()
+      cellularAudioDialogController.getCellularDataPreference().toLiveData()
     cellularDataPreference.observeForever(mockCellularDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -83,7 +84,7 @@ class CellularAudioDialogControllerTest {
   @Test
   fun testController_setNeverUseCellularDataPref_providesLiveData_indicatesToHideDialogAndNotUseCellularData() { // ktlint-disable max-line-length
     val appHistory =
-      cellularAudioDialogController.getCellularDataPreference()
+      cellularAudioDialogController.getCellularDataPreference().toLiveData()
 
     appHistory.observeForever(mockCellularDataObserver)
     cellularAudioDialogController.setNeverUseCellularDataPreference()
@@ -98,7 +99,7 @@ class CellularAudioDialogControllerTest {
   @Test
   fun testController_setAlwaysUseCellularDataPref_providesLiveData_indicatesToHideDialogAndUseCellularData() { // ktlint-disable max-line-length
     val appHistory =
-      cellularAudioDialogController.getCellularDataPreference()
+      cellularAudioDialogController.getCellularDataPreference().toLiveData()
 
     appHistory.observeForever(mockCellularDataObserver)
     cellularAudioDialogController.setAlwaysUseCellularDataPreference()
@@ -117,7 +118,7 @@ class CellularAudioDialogControllerTest {
 
     setUpTestApplicationComponent()
     val appHistory =
-      cellularAudioDialogController.getCellularDataPreference()
+      cellularAudioDialogController.getCellularDataPreference().toLiveData()
     appHistory.observeForever(mockCellularDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -134,7 +135,7 @@ class CellularAudioDialogControllerTest {
 
     setUpTestApplicationComponent()
     val appHistory =
-      cellularAudioDialogController.getCellularDataPreference()
+      cellularAudioDialogController.getCellularDataPreference().toLiveData()
     appHistory.observeForever(mockCellularDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 

--- a/domain/src/test/java/org/oppia/domain/exploration/ExplorationDataControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/exploration/ExplorationDataControllerTest.kt
@@ -318,7 +318,7 @@ class ExplorationDataControllerTest {
       RatioInputModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/domain/src/test/java/org/oppia/domain/exploration/ExplorationDataControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/exploration/ExplorationDataControllerTest.kt
@@ -49,6 +49,7 @@ import org.oppia.testing.TestCoroutineDispatchers
 import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -98,7 +99,7 @@ class ExplorationDataControllerTest {
   @Test
   fun testController_providesInitialLiveDataForTheWelcomeExploration() {
     val explorationLiveData =
-      explorationDataController.getExplorationById(TEST_EXPLORATION_ID_0)
+      explorationDataController.getExplorationById(TEST_EXPLORATION_ID_0).toLiveData()
     explorationLiveData.observeForever(mockExplorationObserver)
     testCoroutineDispatchers.runCurrent()
     val expectedExplorationStateSet = listOf(
@@ -119,7 +120,7 @@ class ExplorationDataControllerTest {
   @Test
   fun testController_providesInitialLiveDataForTheAboutOppiaExploration() {
     val explorationLiveData =
-      explorationDataController.getExplorationById(TEST_EXPLORATION_ID_1)
+      explorationDataController.getExplorationById(TEST_EXPLORATION_ID_1).toLiveData()
     explorationLiveData.observeForever(mockExplorationObserver)
     testCoroutineDispatchers.runCurrent()
     val expectedExplorationStateSet = listOf(
@@ -140,7 +141,7 @@ class ExplorationDataControllerTest {
   @Test
   fun testController_providesInitialLiveDataForFractions0Exploration() {
     val explorationLiveData =
-      explorationDataController.getExplorationById(FRACTIONS_EXPLORATION_ID_0)
+      explorationDataController.getExplorationById(FRACTIONS_EXPLORATION_ID_0).toLiveData()
     explorationLiveData.observeForever(mockExplorationObserver)
     testCoroutineDispatchers.runCurrent()
     verify(mockExplorationObserver, atLeastOnce()).onChanged(explorationResultCaptor.capture())
@@ -156,7 +157,7 @@ class ExplorationDataControllerTest {
   @Test
   fun testController_providesInitialLiveDataForFractions1Exploration() {
     val explorationLiveData =
-      explorationDataController.getExplorationById(FRACTIONS_EXPLORATION_ID_1)
+      explorationDataController.getExplorationById(FRACTIONS_EXPLORATION_ID_1).toLiveData()
     explorationLiveData.observeForever(mockExplorationObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -172,7 +173,7 @@ class ExplorationDataControllerTest {
   @Test
   fun testController_providesInitialLiveDataForRatios0Exploration() {
     val explorationLiveData =
-      explorationDataController.getExplorationById(RATIOS_EXPLORATION_ID_0)
+      explorationDataController.getExplorationById(RATIOS_EXPLORATION_ID_0).toLiveData()
     explorationLiveData.observeForever(mockExplorationObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -188,7 +189,7 @@ class ExplorationDataControllerTest {
   @Test
   fun testController_providesInitialLiveDataForRatios1Exploration() {
     val explorationLiveData =
-      explorationDataController.getExplorationById(RATIOS_EXPLORATION_ID_1)
+      explorationDataController.getExplorationById(RATIOS_EXPLORATION_ID_1).toLiveData()
     explorationLiveData.observeForever(mockExplorationObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -204,7 +205,7 @@ class ExplorationDataControllerTest {
   @Test
   fun testController_providesInitialLiveDataForRatios2Exploration() {
     val explorationLiveData =
-      explorationDataController.getExplorationById(RATIOS_EXPLORATION_ID_2)
+      explorationDataController.getExplorationById(RATIOS_EXPLORATION_ID_2).toLiveData()
     explorationLiveData.observeForever(mockExplorationObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -220,7 +221,7 @@ class ExplorationDataControllerTest {
   @Test
   fun testController_providesInitialLiveDataForRatios3Exploration() {
     val explorationLiveData =
-      explorationDataController.getExplorationById(RATIOS_EXPLORATION_ID_3)
+      explorationDataController.getExplorationById(RATIOS_EXPLORATION_ID_3).toLiveData()
     explorationLiveData.observeForever(mockExplorationObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -236,7 +237,7 @@ class ExplorationDataControllerTest {
   @Test
   fun testController_returnsNullForNonExistentExploration() {
     val explorationLiveData =
-      explorationDataController.getExplorationById("NON_EXISTENT_TEST")
+      explorationDataController.getExplorationById("NON_EXISTENT_TEST").toLiveData()
     explorationLiveData.observeForever(mockExplorationObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -248,7 +249,7 @@ class ExplorationDataControllerTest {
   @Test
   fun testController_returnsNull_logsException() {
     val explorationLiveData =
-      explorationDataController.getExplorationById("NON_EXISTENT_TEST")
+      explorationDataController.getExplorationById("NON_EXISTENT_TEST").toLiveData()
     explorationLiveData.observeForever(mockExplorationObserver)
     testCoroutineDispatchers.runCurrent()
 

--- a/domain/src/test/java/org/oppia/domain/exploration/ExplorationDataControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/exploration/ExplorationDataControllerTest.kt
@@ -50,6 +50,8 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders.Companion.toLiveData
+import org.oppia.util.data.DataProvidersInjector
+import org.oppia.util.data.DataProvidersInjectorProvider
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -63,7 +65,7 @@ import javax.inject.Singleton
 /** Tests for [ExplorationDataController]. */
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
-@Config(manifest = Config.NONE)
+@Config(application = ExplorationDataControllerTest.TestApplication::class)
 class ExplorationDataControllerTest {
   @Rule
   @JvmField
@@ -90,10 +92,7 @@ class ExplorationDataControllerTest {
   }
 
   private fun setUpTestApplicationComponent() {
-    DaggerExplorationDataControllerTest_TestApplicationComponent.builder()
-      .setApplication(ApplicationProvider.getApplicationContext())
-      .build()
-      .inject(this)
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
   @Test
@@ -319,7 +318,7 @@ class ExplorationDataControllerTest {
       RatioInputModule::class
     ]
   )
-  interface TestApplicationComponent {
+  interface TestApplicationComponent: DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance
@@ -329,5 +328,19 @@ class ExplorationDataControllerTest {
     }
 
     fun inject(explorationDataControllerTest: ExplorationDataControllerTest)
+  }
+
+  class TestApplication : Application(), DataProvidersInjectorProvider {
+    private val component: TestApplicationComponent by lazy {
+      DaggerExplorationDataControllerTest_TestApplicationComponent.builder()
+        .setApplication(this)
+        .build()
+    }
+
+    fun inject(explorationDataControllerTest: ExplorationDataControllerTest) {
+      component.inject(explorationDataControllerTest)
+    }
+
+    override fun getDataProvidersInjector(): DataProvidersInjector = component
   }
 }

--- a/domain/src/test/java/org/oppia/domain/exploration/ExplorationProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/exploration/ExplorationProgressControllerTest.kt
@@ -53,6 +53,8 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders.Companion.toLiveData
+import org.oppia.util.data.DataProvidersInjector
+import org.oppia.util.data.DataProvidersInjectorProvider
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -70,7 +72,7 @@ private const val DEFAULT_CONTINUE_INTERACTION_TEXT_ANSWER = "Please continue."
 /** Tests for [ExplorationProgressController]. */
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
-@Config(manifest = Config.NONE)
+@Config(application = ExplorationProgressControllerTest.TestApplication::class)
 class ExplorationProgressControllerTest {
   // TODO(#114): Add much more thorough tests for the integration pathway.
 
@@ -1439,10 +1441,7 @@ class ExplorationProgressControllerTest {
   }
 
   private fun setUpTestApplicationComponent() {
-    DaggerExplorationProgressControllerTest_TestApplicationComponent.builder()
-      .setApplication(ApplicationProvider.getApplicationContext())
-      .build()
-      .inject(this)
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
   /**
@@ -1582,7 +1581,7 @@ class ExplorationProgressControllerTest {
       RatioInputModule::class
     ]
   )
-  interface TestApplicationComponent {
+  interface TestApplicationComponent: DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance
@@ -1592,5 +1591,19 @@ class ExplorationProgressControllerTest {
     }
 
     fun inject(explorationProgressControllerTest: ExplorationProgressControllerTest)
+  }
+
+  class TestApplication : Application(), DataProvidersInjectorProvider {
+    private val component: TestApplicationComponent by lazy {
+      DaggerExplorationProgressControllerTest_TestApplicationComponent.builder()
+        .setApplication(this)
+        .build()
+    }
+
+    fun inject(explorationProgressControllerTest: ExplorationProgressControllerTest) {
+      component.inject(explorationProgressControllerTest)
+    }
+
+    override fun getDataProvidersInjector(): DataProvidersInjector = component
   }
 }

--- a/domain/src/test/java/org/oppia/domain/exploration/ExplorationProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/exploration/ExplorationProgressControllerTest.kt
@@ -1581,7 +1581,7 @@ class ExplorationProgressControllerTest {
       RatioInputModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/domain/src/test/java/org/oppia/domain/exploration/ExplorationProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/exploration/ExplorationProgressControllerTest.kt
@@ -52,6 +52,7 @@ import org.oppia.testing.TestCoroutineDispatchers
 import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -134,7 +135,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_noExploration_isPending() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
 
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     testCoroutineDispatchers.runCurrent()
@@ -161,7 +162,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_playInvalidExploration_returnsFailure() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
 
     playExploration("invalid_exp_id")
@@ -190,7 +191,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_playExploration_returnsPendingResultFromLoadingExploration() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -212,7 +213,7 @@ class ExplorationProgressControllerTest {
     playExploration(TEST_EXPLORATION_ID_0)
 
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -240,7 +241,7 @@ class ExplorationProgressControllerTest {
     // Then a valid one.
     playExploration(TEST_EXPLORATION_ID_0)
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -293,7 +294,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_playSecondExploration_afterFinishingPrev_loaded_returnsInitialState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     // Start with playing a valid exploration, then stop.
     playExploration(TEST_EXPLORATION_ID_0)
@@ -436,7 +437,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_afterSubmittingCorrectMultiChoiceAnswer_becomesCompletedState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     playExploration(TEST_EXPLORATION_ID_0)
 
@@ -462,7 +463,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_afterSubmittingWrongMultiChoiceAnswer_updatesPendingState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     playExploration(TEST_EXPLORATION_ID_0)
 
@@ -578,7 +579,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testMoveToNext_forCompletedState_movesToNextState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswer(0)
@@ -704,7 +705,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testMoveToPrevious_forCompletedState_movesToPreviousState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswerAndMoveToNextState(0)
@@ -1003,7 +1004,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_afterMovePreviousAndNext_returnsCurrentState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswerAndMoveToNextState(0)
@@ -1025,7 +1026,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_afterMoveNextAndPrevious_returnsCurrentState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswerAndMoveToNextState(0)
@@ -1055,7 +1056,7 @@ class ExplorationProgressControllerTest {
     // Move to the previous state and register a new observer.
     moveToPreviousState() // Third state -> second
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver2)
     testCoroutineDispatchers.runCurrent()
 
@@ -1073,7 +1074,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_forFirstState_doesNotHaveNextState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
 
     playExploration(TEST_EXPLORATION_ID_0)
@@ -1090,7 +1091,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_forFirstState_afterAnswerSubmission_doesNotHaveNextState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     playExploration(TEST_EXPLORATION_ID_0)
 
@@ -1109,7 +1110,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_forSecondState_doesNotHaveNextState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     playExploration(TEST_EXPLORATION_ID_0)
 
@@ -1127,7 +1128,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_forSecondState_navigateBackward_hasNextState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswerAndMoveToNextState(0)
@@ -1146,7 +1147,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_forSecondState_navigateBackwardThenForward_doesNotHaveNextState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswerAndMoveToNextState(0)
@@ -1236,7 +1237,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_fifthState_isTerminalState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswerAndMoveToNextState(0)
@@ -1258,7 +1259,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_afterMoveToPrevious_onThirdState_updatesToCompletedSecondState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     playExploration(TEST_EXPLORATION_ID_0)
     submitMultipleChoiceAnswerAndMoveToNextState(0)
@@ -1306,7 +1307,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_afterPlayingFullSecondExploration_returnsTerminalState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
 
     playExploration(TEST_EXPLORATION_ID_1)
@@ -1327,7 +1328,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_afterPlayingFullSecondExploration_diffPath_returnsTerminalState() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
 
     playExploration(TEST_EXPLORATION_ID_1)
@@ -1351,7 +1352,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_afterPlayingThroughPreviousExplorations_returnsStateFromSecondExp() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
     playThroughExploration5()
 
@@ -1419,7 +1420,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testGetCurrentState_playInvalidExploration_returnsFailure_logsException() {
     val currentStateLiveData =
-      explorationProgressController.getCurrentState()
+      explorationProgressController.getCurrentState().toLiveData()
     currentStateLiveData.observeForever(mockCurrentStateLiveDataObserver)
 
     playExploration("invalid_exp_id")
@@ -1450,7 +1451,9 @@ class ExplorationProgressControllerTest {
    * implementation will only lazily load data based on whether there's an active subscription.
    */
   private fun subscribeToCurrentStateToAllowExplorationToLoad() {
-    explorationProgressController.getCurrentState().observeForever(mockCurrentStateLiveDataObserver)
+    explorationProgressController.getCurrentState()
+      .toLiveData()
+      .observeForever(mockCurrentStateLiveDataObserver)
   }
 
   private fun playExploration(explorationId: String) {

--- a/domain/src/test/java/org/oppia/domain/onboarding/AppStartupStateControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/onboarding/AppStartupStateControllerTest.kt
@@ -36,6 +36,7 @@ import org.oppia.testing.TestCoroutineDispatchers
 import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -103,7 +104,7 @@ class AppStartupStateControllerTest {
 
   @Test
   fun testController_providesInitialLiveData_indicatesUserHasNotOnboardedTheApp() {
-    val appStartupState = appStartupStateController.getAppStartupState()
+    val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -114,7 +115,7 @@ class AppStartupStateControllerTest {
 
   @Test
   fun testControllerObserver_observedAfterSettingAppOnboarded_providesLiveData_userDidNotOnboardApp() { // ktlint-disable max-line-length
-    val appStartupState = appStartupStateController.getAppStartupState()
+    val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
 
     appStartupState.observeForever(mockOnboardingObserver)
     appStartupStateController.markOnboardingFlowCompleted()
@@ -135,7 +136,7 @@ class AppStartupStateControllerTest {
     // Create the controller by creating another singleton graph and injecting it (simulating the
     // app being recreated).
     simulateAppRestart()
-    val appStartupState = appStartupStateController.getAppStartupState()
+    val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -160,7 +161,7 @@ class AppStartupStateControllerTest {
     testCoroutineDispatchers.runCurrent()
     simulateAppRestart()
 
-    val appStartupState = appStartupStateController.getAppStartupState()
+    val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -174,7 +175,7 @@ class AppStartupStateControllerTest {
   fun testInitialAppOpen_appDeprecationEnabled_beforeDeprecationDate_appNotDeprecated() {
     setUpOppiaApplication(expirationEnabled = true, expDate = dateStringAfterToday())
 
-    val appStartupState = appStartupStateController.getAppStartupState()
+    val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -187,7 +188,7 @@ class AppStartupStateControllerTest {
   fun testInitialAppOpen_appDeprecationEnabled_onDeprecationDate_appIsDeprecated() {
     setUpOppiaApplication(expirationEnabled = true, expDate = dateStringForToday())
 
-    val appStartupState = appStartupStateController.getAppStartupState()
+    val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -200,7 +201,7 @@ class AppStartupStateControllerTest {
   fun testInitialAppOpen_appDeprecationEnabled_afterDeprecationDate_appIsDeprecated() {
     setUpOppiaApplication(expirationEnabled = true, expDate = dateStringBeforeToday())
 
-    val appStartupState = appStartupStateController.getAppStartupState()
+    val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -213,7 +214,7 @@ class AppStartupStateControllerTest {
   fun testInitialAppOpen_appDeprecationDisabled_afterDeprecationDate_appIsNotDeprecated() {
     setUpOppiaApplication(expirationEnabled = false, expDate = dateStringBeforeToday())
 
-    val appStartupState = appStartupStateController.getAppStartupState()
+    val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -227,7 +228,7 @@ class AppStartupStateControllerTest {
     setUpOppiaApplication(expirationEnabled = true, expDate = dateStringAfterToday())
     simulateAppRestart()
 
-    val appStartupState = appStartupStateController.getAppStartupState()
+    val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -241,7 +242,7 @@ class AppStartupStateControllerTest {
     setUpOppiaApplication(expirationEnabled = true, expDate = dateStringBeforeToday())
     simulateAppRestart()
 
-    val appStartupState = appStartupStateController.getAppStartupState()
+    val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -257,7 +258,7 @@ class AppStartupStateControllerTest {
     testCoroutineDispatchers.runCurrent()
     simulateAppRestart()
 
-    val appStartupState = appStartupStateController.getAppStartupState()
+    val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -274,7 +275,7 @@ class AppStartupStateControllerTest {
     testCoroutineDispatchers.runCurrent()
     simulateAppRestart()
 
-    val appStartupState = appStartupStateController.getAppStartupState()
+    val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
     testCoroutineDispatchers.runCurrent()
 

--- a/domain/src/test/java/org/oppia/domain/onboarding/AppStartupStateControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/onboarding/AppStartupStateControllerTest.kt
@@ -14,7 +14,6 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -85,24 +84,10 @@ class AppStartupStateControllerTest {
 
   private val expirationDateFormat by lazy { SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()) }
 
-  @Before
-  fun setUp() {
-    setUpTestApplicationComponent()
-
-    // By default, set up the application to never expire.
-    setUpOppiaApplication(expirationEnabled = false, expDate = "9999-12-31")
-  }
-
-  private fun setUpTestApplicationComponent() {
-    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
-  }
-
-  private fun simulateAppRestart() {
-    setUpTestApplicationComponent()
-  }
-
   @Test
   fun testController_providesInitialLiveData_indicatesUserHasNotOnboardedTheApp() {
+    setUpDefaultTestApplicationComponent()
+
     val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
     testCoroutineDispatchers.runCurrent()
@@ -114,6 +99,7 @@ class AppStartupStateControllerTest {
 
   @Test
   fun testControllerObserver_observedAfterSettingAppOnboarded_providesLiveData_userDidNotOnboardApp() { // ktlint-disable max-line-length
+    setUpDefaultTestApplicationComponent()
     val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
 
     appStartupState.observeForever(mockOnboardingObserver)
@@ -129,12 +115,14 @@ class AppStartupStateControllerTest {
 
   @Test
   fun testController_settingAppOnboarded_observedNewController_userOnboardedApp() {
-    appStartupStateController.markOnboardingFlowCompleted()
-    testCoroutineDispatchers.runCurrent()
+    // Simulate the previous app already having completed onboarding.
+    executeInPreviousApp { testComponent ->
+      testComponent.getAppStartupStateController().markOnboardingFlowCompleted()
+      testComponent.getTestCoroutineDispatchers().runCurrent()
+    }
 
-    // Create the controller by creating another singleton graph and injecting it (simulating the
-    // app being recreated).
-    simulateAppRestart()
+    // Create the application after previous arrangement to simulate a re-creation.
+    setUpDefaultTestApplicationComponent()
     val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
     testCoroutineDispatchers.runCurrent()
@@ -149,17 +137,24 @@ class AppStartupStateControllerTest {
   @Test
   @Suppress("DeferredResultUnused")
   fun testController_onboardedApp_cleared_observeNewController_userDidNotOnboardApp() {
-    val onboardingFlowStore = cacheFactory.create(
-      "on_boarding_flow",
-      OnboardingState.getDefaultInstance()
-    )
-    appStartupStateController.markOnboardingFlowCompleted()
-    testCoroutineDispatchers.runCurrent()
-    // Clear, then recreate the controller.
-    onboardingFlowStore.clearCacheAsync()
-    testCoroutineDispatchers.runCurrent()
-    simulateAppRestart()
+    // Simulate the previous app already having completed onboarding, then cleared.
+    executeInPreviousApp { testComponent ->
+      testComponent.getAppStartupStateController().markOnboardingFlowCompleted()
+      testComponent.getTestCoroutineDispatchers().runCurrent()
 
+      val onboardingFlowStore = testComponent.getCacheFactory().create(
+        "on_boarding_flow",
+        OnboardingState.getDefaultInstance()
+      )
+      testComponent.getAppStartupStateController().markOnboardingFlowCompleted()
+      testComponent.getTestCoroutineDispatchers().runCurrent()
+      // Clear, then recreate the controller.
+      onboardingFlowStore.clearCacheAsync()
+      testComponent.getTestCoroutineDispatchers().runCurrent()
+    }
+
+    // Create the application after previous arrangement to simulate a re-creation.
+    setUpDefaultTestApplicationComponent()
     val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
     testCoroutineDispatchers.runCurrent()
@@ -172,6 +167,7 @@ class AppStartupStateControllerTest {
 
   @Test
   fun testInitialAppOpen_appDeprecationEnabled_beforeDeprecationDate_appNotDeprecated() {
+    setUpTestApplicationComponent()
     setUpOppiaApplication(expirationEnabled = true, expDate = dateStringAfterToday())
 
     val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
@@ -185,6 +181,7 @@ class AppStartupStateControllerTest {
 
   @Test
   fun testInitialAppOpen_appDeprecationEnabled_onDeprecationDate_appIsDeprecated() {
+    setUpTestApplicationComponent()
     setUpOppiaApplication(expirationEnabled = true, expDate = dateStringForToday())
 
     val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
@@ -198,6 +195,7 @@ class AppStartupStateControllerTest {
 
   @Test
   fun testInitialAppOpen_appDeprecationEnabled_afterDeprecationDate_appIsDeprecated() {
+    setUpTestApplicationComponent()
     setUpOppiaApplication(expirationEnabled = true, expDate = dateStringBeforeToday())
 
     val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
@@ -211,6 +209,7 @@ class AppStartupStateControllerTest {
 
   @Test
   fun testInitialAppOpen_appDeprecationDisabled_afterDeprecationDate_appIsNotDeprecated() {
+    setUpTestApplicationComponent()
     setUpOppiaApplication(expirationEnabled = false, expDate = dateStringBeforeToday())
 
     val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
@@ -224,8 +223,15 @@ class AppStartupStateControllerTest {
 
   @Test
   fun testSecondAppOpen_onboardingFlowNotDone_deprecationEnabled_beforeDepDate_appNotDeprecated() {
+    executeInPreviousApp { testComponent ->
+      setUpOppiaApplicationForContext(
+        context = testComponent.getContext(),
+        expirationEnabled = true,
+        expDate = dateStringAfterToday()
+      )
+    }
+    setUpTestApplicationComponent()
     setUpOppiaApplication(expirationEnabled = true, expDate = dateStringAfterToday())
-    simulateAppRestart()
 
     val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
@@ -238,8 +244,15 @@ class AppStartupStateControllerTest {
 
   @Test
   fun testSecondAppOpen_onboardingFlowNotDone_deprecationEnabled_afterDepDate_appIsDeprecated() {
+    executeInPreviousApp { testComponent ->
+      setUpOppiaApplicationForContext(
+        context = testComponent.getContext(),
+        expirationEnabled = true,
+        expDate = dateStringBeforeToday()
+      )
+    }
+    setUpTestApplicationComponent()
     setUpOppiaApplication(expirationEnabled = true, expDate = dateStringBeforeToday())
-    simulateAppRestart()
 
     val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
@@ -252,10 +265,18 @@ class AppStartupStateControllerTest {
 
   @Test
   fun testSecondAppOpen_onboardingFlowCompleted_depEnabled_beforeDepDate_appNotDeprecated() {
+    executeInPreviousApp { testComponent ->
+      setUpOppiaApplicationForContext(
+        context = testComponent.getContext(),
+        expirationEnabled = true,
+        expDate = dateStringAfterToday()
+      )
+
+      testComponent.getAppStartupStateController().markOnboardingFlowCompleted()
+      testComponent.getTestCoroutineDispatchers().runCurrent()
+    }
+    setUpTestApplicationComponent()
     setUpOppiaApplication(expirationEnabled = true, expDate = dateStringAfterToday())
-    appStartupStateController.markOnboardingFlowCompleted()
-    testCoroutineDispatchers.runCurrent()
-    simulateAppRestart()
 
     val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
@@ -269,10 +290,18 @@ class AppStartupStateControllerTest {
 
   @Test
   fun testSecondAppOpen_onboardingFlowCompleted_deprecationEnabled_afterDepDate_appIsDeprecated() {
+    executeInPreviousApp { testComponent ->
+      setUpOppiaApplicationForContext(
+        context = testComponent.getContext(),
+        expirationEnabled = true,
+        expDate = dateStringBeforeToday()
+      )
+
+      testComponent.getAppStartupStateController().markOnboardingFlowCompleted()
+      testComponent.getTestCoroutineDispatchers().runCurrent()
+    }
+    setUpTestApplicationComponent()
     setUpOppiaApplication(expirationEnabled = true, expDate = dateStringBeforeToday())
-    appStartupStateController.markOnboardingFlowCompleted()
-    testCoroutineDispatchers.runCurrent()
-    simulateAppRestart()
 
     val appStartupState = appStartupStateController.getAppStartupState().toLiveData()
     appStartupState.observeForever(mockOnboardingObserver)
@@ -282,6 +311,38 @@ class AppStartupStateControllerTest {
     verify(mockOnboardingObserver, atLeastOnce()).onChanged(appStartupStateCaptor.capture())
     assertThat(appStartupStateCaptor.value.isSuccess()).isTrue()
     assertThat(appStartupStateCaptor.getStartupMode()).isEqualTo(APP_IS_DEPRECATED)
+  }
+
+  private fun setUpTestApplicationComponent() {
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
+  }
+
+  private fun setUpDefaultTestApplicationComponent() {
+    setUpTestApplicationComponent()
+
+    // By default, set up the application to never expire.
+    setUpOppiaApplication(expirationEnabled = false, expDate = "9999-12-31")
+  }
+
+  /**
+   * Creates a separate test application component and executes the specified block. This should be
+   * called before [setUpTestApplicationComponent] to avoid undefined behavior in production code.
+   * This can be used to simulate arranging state in a "prior" run of the app.
+   *
+   * Note that only dependencies fetched from the specified [TestApplicationComponent] should be
+   * used, not any class-level injected dependencies.
+   */
+  private fun executeInPreviousApp(block: (TestApplicationComponent) -> Unit) {
+    val testApplication = TestApplication()
+    // The true application is hooked as a base context. This is to make sure the new application
+    // can behave like a real Android application class (per Robolectric) without having a shared
+    // Dagger dependency graph with the application under test.
+    testApplication.attachBaseContext(ApplicationProvider.getApplicationContext())
+    block(
+      DaggerAppStartupStateControllerTest_TestApplicationComponent.builder()
+        .setApplication(testApplication)
+        .build()
+    )
   }
 
   /** Returns a date string occurring before today. */
@@ -307,6 +368,14 @@ class AppStartupStateControllerTest {
   }
 
   private fun setUpOppiaApplication(expirationEnabled: Boolean, expDate: String) {
+    setUpOppiaApplicationForContext(context, expirationEnabled, expDate)
+  }
+
+  private fun setUpOppiaApplicationForContext(
+    context: Context,
+    expirationEnabled: Boolean,
+    expDate: String
+  ) {
     val packageManager = shadowOf(context.packageManager)
     val applicationInfo =
       ApplicationInfoBuilder.newBuilder()
@@ -369,6 +438,14 @@ class AppStartupStateControllerTest {
       fun build(): TestApplicationComponent
     }
 
+    fun getAppStartupStateController(): AppStartupStateController
+
+    fun getCacheFactory(): PersistentCacheStore.Factory
+
+    fun getTestCoroutineDispatchers(): TestCoroutineDispatchers
+
+    fun getContext(): Context
+
     fun inject(appStartupStateControllerTest: AppStartupStateControllerTest)
   }
 
@@ -381,6 +458,10 @@ class AppStartupStateControllerTest {
 
     fun inject(appStartupStateControllerTest: AppStartupStateControllerTest) {
       component.inject(appStartupStateControllerTest)
+    }
+
+    public override fun attachBaseContext(base: Context?) {
+      super.attachBaseContext(base)
     }
 
     override fun getDataProvidersInjector(): DataProvidersInjector = component

--- a/domain/src/test/java/org/oppia/domain/onboarding/AppStartupStateControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/onboarding/AppStartupStateControllerTest.kt
@@ -360,7 +360,7 @@ class AppStartupStateControllerTest {
       ExpirationMetaDataRetrieverModule::class // Use real implementation to test closer to prod.
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/domain/src/test/java/org/oppia/domain/oppialogger/analytics/AnalyticsControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/oppialogger/analytics/AnalyticsControllerTest.kt
@@ -39,6 +39,7 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -370,7 +371,7 @@ class AnalyticsControllerTest {
       )
     )
 
-    val eventLogs = dataProviders.convertToLiveData(analyticsController.getEventLogStore())
+    val eventLogs = analyticsController.getEventLogStore().toLiveData()
     eventLogs.observeForever(this.mockOppiaEventLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     verify(
@@ -400,7 +401,7 @@ class AnalyticsControllerTest {
       )
     )
 
-    val eventLogs = dataProviders.convertToLiveData(analyticsController.getEventLogStore())
+    val eventLogs = analyticsController.getEventLogStore().toLiveData()
     eventLogs.observeForever(this.mockOppiaEventLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     verify(
@@ -421,7 +422,7 @@ class AnalyticsControllerTest {
     networkConnectionUtil.setCurrentConnectionStatus(NONE)
     logMultipleEvents()
 
-    val eventLogs = dataProviders.convertToLiveData(analyticsController.getEventLogStore())
+    val eventLogs = analyticsController.getEventLogStore().toLiveData()
     eventLogs.observeForever(this.mockOppiaEventLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     verify(
@@ -457,7 +458,7 @@ class AnalyticsControllerTest {
       )
     )
 
-    val eventLogs = dataProviders.convertToLiveData(analyticsController.getEventLogStore())
+    val eventLogs = analyticsController.getEventLogStore().toLiveData()
     eventLogs.observeForever(this.mockOppiaEventLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     verify(
@@ -498,7 +499,7 @@ class AnalyticsControllerTest {
       )
     )
 
-    val cachedEventLogs = dataProviders.convertToLiveData(analyticsController.getEventLogStore())
+    val cachedEventLogs = analyticsController.getEventLogStore().toLiveData()
     cachedEventLogs.observeForever(this.mockOppiaEventLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     verify(
@@ -527,7 +528,7 @@ class AnalyticsControllerTest {
     networkConnectionUtil.setCurrentConnectionStatus(NONE)
     logMultipleEvents()
 
-    val cachedEventLogs = dataProviders.convertToLiveData(analyticsController.getEventLogStore())
+    val cachedEventLogs = analyticsController.getEventLogStore().toLiveData()
     cachedEventLogs.observeForever(this.mockOppiaEventLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     verify(

--- a/domain/src/test/java/org/oppia/domain/oppialogger/analytics/AnalyticsControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/oppialogger/analytics/AnalyticsControllerTest.kt
@@ -31,8 +31,6 @@ import org.oppia.app.model.EventLog.Context.ActivityContextCase.TOPIC_CONTEXT
 import org.oppia.app.model.EventLog.EventAction
 import org.oppia.app.model.EventLog.Priority
 import org.oppia.app.model.OppiaEventLogs
-import org.oppia.domain.onboarding.AppStartupStateControllerTest
-import org.oppia.domain.onboarding.DaggerAppStartupStateControllerTest_TestApplicationComponent
 import org.oppia.domain.oppialogger.EventLogStorageCacheSize
 import org.oppia.domain.oppialogger.OppiaLogger
 import org.oppia.testing.FakeEventLogger
@@ -646,7 +644,7 @@ class AnalyticsControllerTest {
 
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/domain/src/test/java/org/oppia/domain/oppialogger/analytics/AnalyticsControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/oppialogger/analytics/AnalyticsControllerTest.kt
@@ -31,6 +31,8 @@ import org.oppia.app.model.EventLog.Context.ActivityContextCase.TOPIC_CONTEXT
 import org.oppia.app.model.EventLog.EventAction
 import org.oppia.app.model.EventLog.Priority
 import org.oppia.app.model.OppiaEventLogs
+import org.oppia.domain.onboarding.AppStartupStateControllerTest
+import org.oppia.domain.onboarding.DaggerAppStartupStateControllerTest_TestApplicationComponent
 import org.oppia.domain.oppialogger.EventLogStorageCacheSize
 import org.oppia.domain.oppialogger.OppiaLogger
 import org.oppia.testing.FakeEventLogger
@@ -40,6 +42,8 @@ import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders
 import org.oppia.util.data.DataProviders.Companion.toLiveData
+import org.oppia.util.data.DataProvidersInjector
+import org.oppia.util.data.DataProvidersInjectorProvider
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -62,7 +66,7 @@ const val TEST_SUB_TOPIC_ID = 1
 
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
-@Config(manifest = Config.NONE)
+@Config(application = AnalyticsControllerTest.TestApplication::class)
 class AnalyticsControllerTest {
 
   @Rule
@@ -552,10 +556,7 @@ class AnalyticsControllerTest {
   }
 
   private fun setUpTestApplicationComponent() {
-    DaggerAnalyticsControllerTest_TestApplicationComponent.builder()
-      .setApplication(ApplicationProvider.getApplicationContext())
-      .build()
-      .inject(this)
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
   private fun logMultipleEvents() {
@@ -645,7 +646,7 @@ class AnalyticsControllerTest {
 
     ]
   )
-  interface TestApplicationComponent {
+  interface TestApplicationComponent: DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance
@@ -654,5 +655,19 @@ class AnalyticsControllerTest {
     }
 
     fun inject(analyticsControllerTest: AnalyticsControllerTest)
+  }
+
+  class TestApplication : Application(), DataProvidersInjectorProvider {
+    private val component: TestApplicationComponent by lazy {
+      DaggerAnalyticsControllerTest_TestApplicationComponent.builder()
+        .setApplication(this)
+        .build()
+    }
+
+    fun inject(analyticsControllerTest: AnalyticsControllerTest) {
+      component.inject(analyticsControllerTest)
+    }
+
+    override fun getDataProvidersInjector(): DataProvidersInjector = component
   }
 }

--- a/domain/src/test/java/org/oppia/domain/oppialogger/exceptions/ExceptionsControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/oppialogger/exceptions/ExceptionsControllerTest.kt
@@ -24,8 +24,6 @@ import org.mockito.junit.MockitoRule
 import org.oppia.app.model.ExceptionLog.ExceptionType
 import org.oppia.app.model.OppiaExceptionLogs
 import org.oppia.domain.oppialogger.ExceptionLogStorageCacheSize
-import org.oppia.domain.oppialogger.analytics.AnalyticsControllerTest
-import org.oppia.domain.oppialogger.analytics.DaggerAnalyticsControllerTest_TestApplicationComponent
 import org.oppia.testing.FakeExceptionLogger
 import org.oppia.testing.TestCoroutineDispatchers
 import org.oppia.testing.TestDispatcherModule
@@ -364,7 +362,7 @@ class ExceptionsControllerTest {
       TestLogStorageModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/domain/src/test/java/org/oppia/domain/oppialogger/exceptions/ExceptionsControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/oppialogger/exceptions/ExceptionsControllerTest.kt
@@ -30,6 +30,7 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -110,7 +111,7 @@ class ExceptionsControllerTest {
     exceptionsController.logNonFatalException(exceptionThrown, TEST_TIMESTAMP_IN_MILLIS_ONE)
 
     val cachedExceptions =
-      dataProviders.convertToLiveData(exceptionsController.getExceptionLogStore())
+      exceptionsController.getExceptionLogStore().toLiveData()
     cachedExceptions.observeForever(mockOppiaExceptionLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -135,7 +136,7 @@ class ExceptionsControllerTest {
     exceptionsController.logFatalException(exceptionThrown, TEST_TIMESTAMP_IN_MILLIS_ONE)
 
     val cachedExceptions =
-      dataProviders.convertToLiveData(exceptionsController.getExceptionLogStore())
+      exceptionsController.getExceptionLogStore().toLiveData()
     cachedExceptions.observeForever(mockOppiaExceptionLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -173,7 +174,7 @@ class ExceptionsControllerTest {
     )
 
     val cachedExceptions =
-      dataProviders.convertToLiveData(exceptionsController.getExceptionLogStore())
+      exceptionsController.getExceptionLogStore().toLiveData()
     cachedExceptions.observeForever(mockOppiaExceptionLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -215,7 +216,7 @@ class ExceptionsControllerTest {
     )
 
     val cachedExceptions =
-      dataProviders.convertToLiveData(exceptionsController.getExceptionLogStore())
+      exceptionsController.getExceptionLogStore().toLiveData()
     cachedExceptions.observeForever(mockOppiaExceptionLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -234,7 +235,7 @@ class ExceptionsControllerTest {
     exceptionsController.logFatalException(exceptionThrown, TEST_TIMESTAMP_IN_MILLIS_ONE)
 
     val cachedExceptions =
-      dataProviders.convertToLiveData(exceptionsController.getExceptionLogStore())
+      exceptionsController.getExceptionLogStore().toLiveData()
     cachedExceptions.observeForever(mockOppiaExceptionLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -261,7 +262,7 @@ class ExceptionsControllerTest {
     exceptionsController.logFatalException(exceptionThrown, TEST_TIMESTAMP_IN_MILLIS_ONE)
 
     val cachedExceptions =
-      dataProviders.convertToLiveData(exceptionsController.getExceptionLogStore())
+      exceptionsController.getExceptionLogStore().toLiveData()
     cachedExceptions.observeForever(mockOppiaExceptionLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -280,7 +281,7 @@ class ExceptionsControllerTest {
     exceptionsController.logNonFatalException(exceptionThrown, TEST_TIMESTAMP_IN_MILLIS_ONE)
 
     val cachedExceptions =
-      dataProviders.convertToLiveData(exceptionsController.getExceptionLogStore())
+      exceptionsController.getExceptionLogStore().toLiveData()
     cachedExceptions.observeForever(mockOppiaExceptionLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -301,7 +302,7 @@ class ExceptionsControllerTest {
     exceptionsController.logNonFatalException(exceptionThrown, TEST_TIMESTAMP_IN_MILLIS_ONE)
 
     val cachedExceptions =
-      dataProviders.convertToLiveData(exceptionsController.getExceptionLogStore())
+      exceptionsController.getExceptionLogStore().toLiveData()
     cachedExceptions.observeForever(mockOppiaExceptionLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 

--- a/domain/src/test/java/org/oppia/domain/oppialogger/exceptions/UncaughtExceptionLoggerStartupListenerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/oppialogger/exceptions/UncaughtExceptionLoggerStartupListenerTest.kt
@@ -29,6 +29,7 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -87,7 +88,7 @@ class UncaughtExceptionLoggerStartupListenerTest {
     )
 
     val cachedExceptions = exceptionsController.getExceptionLogStore()
-    dataProviders.convertToLiveData(cachedExceptions).observeForever(mockOppiaExceptionLogsObserver)
+    cachedExceptions.toLiveData().observeForever(mockOppiaExceptionLogsObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockOppiaExceptionLogsObserver, atLeastOnce())

--- a/domain/src/test/java/org/oppia/domain/oppialogger/exceptions/UncaughtExceptionLoggerStartupListenerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/oppialogger/exceptions/UncaughtExceptionLoggerStartupListenerTest.kt
@@ -164,7 +164,7 @@ class UncaughtExceptionLoggerStartupListenerTest {
       TestDispatcherModule::class, TestLogStorageModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/domain/src/test/java/org/oppia/domain/oppialogger/exceptions/UncaughtExceptionLoggerStartupListenerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/oppialogger/exceptions/UncaughtExceptionLoggerStartupListenerTest.kt
@@ -30,18 +30,22 @@ import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders
 import org.oppia.util.data.DataProviders.Companion.toLiveData
+import org.oppia.util.data.DataProvidersInjector
+import org.oppia.util.data.DataProvidersInjectorProvider
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
 import org.oppia.util.logging.LogLevel
 import org.oppia.util.networking.NetworkConnectionUtil
 import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @RunWith(AndroidJUnit4::class)
-@Config(manifest = Config.NONE)
+@LooperMode(LooperMode.Mode.PAUSED)
+@Config(application = UncaughtExceptionLoggerStartupListenerTest.TestApplication::class)
 class UncaughtExceptionLoggerStartupListenerTest {
 
   @Rule
@@ -114,10 +118,7 @@ class UncaughtExceptionLoggerStartupListenerTest {
   }
 
   private fun setUpTestApplicationComponent() {
-    DaggerUncaughtExceptionLoggerStartupListenerTest_TestApplicationComponent.builder()
-      .setApplication(ApplicationProvider.getApplicationContext())
-      .build()
-      .inject(this)
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
   @Qualifier
@@ -163,7 +164,7 @@ class UncaughtExceptionLoggerStartupListenerTest {
       TestDispatcherModule::class, TestLogStorageModule::class
     ]
   )
-  interface TestApplicationComponent {
+  interface TestApplicationComponent: DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance
@@ -171,8 +172,20 @@ class UncaughtExceptionLoggerStartupListenerTest {
       fun build(): TestApplicationComponent
     }
 
-    fun inject(
-      uncaughtExceptionLoggerStartupListenerTest: UncaughtExceptionLoggerStartupListenerTest
-    )
+    fun inject(startupListenerTest: UncaughtExceptionLoggerStartupListenerTest)
+  }
+
+  class TestApplication : Application(), DataProvidersInjectorProvider {
+    private val component: TestApplicationComponent by lazy {
+      DaggerUncaughtExceptionLoggerStartupListenerTest_TestApplicationComponent.builder()
+        .setApplication(this)
+        .build()
+    }
+
+    fun inject(startupListenerTest: UncaughtExceptionLoggerStartupListenerTest) {
+      component.inject(startupListenerTest)
+    }
+
+    override fun getDataProvidersInjector(): DataProvidersInjector = component
   }
 }

--- a/domain/src/test/java/org/oppia/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/profile/ProfileManagementControllerTest.kt
@@ -29,8 +29,6 @@ import org.oppia.app.model.ProfileDatabase
 import org.oppia.app.model.ProfileId
 import org.oppia.app.model.ReadingTextSize
 import org.oppia.domain.oppialogger.LogStorageModule
-import org.oppia.domain.oppialogger.exceptions.DaggerUncaughtExceptionLoggerStartupListenerTest_TestApplicationComponent
-import org.oppia.domain.oppialogger.exceptions.UncaughtExceptionLoggerStartupListenerTest
 import org.oppia.testing.TestCoroutineDispatchers
 import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
@@ -1033,7 +1031,7 @@ class ProfileManagementControllerTest {
       TestDispatcherModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/domain/src/test/java/org/oppia/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/profile/ProfileManagementControllerTest.kt
@@ -34,6 +34,7 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.testing.profile.ProfileTestHelper
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -125,7 +126,7 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     val profileDatabase = readProfileDatabase()
@@ -154,7 +155,7 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = false,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyUpdateFailed()
@@ -174,7 +175,7 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = false,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyUpdateFailed()
@@ -188,6 +189,7 @@ class ProfileManagementControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     profileManagementController.getProfile(ProfileId.newBuilder().setInternalId(3).build())
+      .toLiveData()
       .observeForever(mockProfileObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -207,7 +209,7 @@ class ProfileManagementControllerTest {
     addTestProfiles()
     testCoroutineDispatchers.runCurrent()
 
-    profileManagementController.getProfiles().observeForever(mockProfilesObserver)
+    profileManagementController.getProfiles().toLiveData().observeForever(mockProfilesObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetMultipleProfilesSucceeded()
@@ -231,8 +233,8 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = false,
       colorRgb = -10710042,
       isAdmin = false
-    )
-    profileManagementController.getProfiles().observeForever(mockProfilesObserver)
+    ).toLiveData()
+    profileManagementController.getProfiles().toLiveData().observeForever(mockProfilesObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetMultipleProfilesSucceeded()
@@ -249,9 +251,11 @@ class ProfileManagementControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     val profileId = ProfileId.newBuilder().setInternalId(2).build()
-    profileManagementController.updateName(profileId, "John")
+    profileManagementController.updateName(profileId, "John").toLiveData()
       .observeForever(mockUpdateResultObserver)
-    profileManagementController.getProfile(profileId).observeForever(mockProfileObserver)
+    profileManagementController.getProfile(
+      profileId
+    ).toLiveData().observeForever(mockProfileObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyUpdateSucceeded()
@@ -265,7 +269,7 @@ class ProfileManagementControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     val profileId = ProfileId.newBuilder().setInternalId(2).build()
-    profileManagementController.updateName(profileId, "James")
+    profileManagementController.updateName(profileId, "James").toLiveData()
       .observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -280,7 +284,7 @@ class ProfileManagementControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     val profileId = ProfileId.newBuilder().setInternalId(6).build()
-    profileManagementController.updateName(profileId, "John")
+    profileManagementController.updateName(profileId, "John").toLiveData()
       .observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -300,9 +304,11 @@ class ProfileManagementControllerTest {
         profileId,
         /* avatarImagePath = */ null,
         colorRgb = -10710042
-      )
+      ).toLiveData()
       .observeForever(mockUpdateResultObserver)
-    profileManagementController.getProfile(profileId).observeForever(mockProfileObserver)
+    profileManagementController.getProfile(
+      profileId
+    ).toLiveData().observeForever(mockProfileObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyUpdateSucceeded()
@@ -317,9 +323,11 @@ class ProfileManagementControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     val profileId = ProfileId.newBuilder().setInternalId(2).build()
-    profileManagementController.updatePin(profileId, "321")
+    profileManagementController.updatePin(profileId, "321").toLiveData()
       .observeForever(mockUpdateResultObserver)
-    profileManagementController.getProfile(profileId).observeForever(mockProfileObserver)
+    profileManagementController.getProfile(
+      profileId
+    ).toLiveData().observeForever(mockProfileObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyUpdateSucceeded()
@@ -333,7 +341,7 @@ class ProfileManagementControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     val profileId = ProfileId.newBuilder().setInternalId(6).build()
-    profileManagementController.updatePin(profileId, "321")
+    profileManagementController.updatePin(profileId, "321").toLiveData()
       .observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -348,9 +356,11 @@ class ProfileManagementControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     val profileId = ProfileId.newBuilder().setInternalId(2).build()
-    profileManagementController.updateAllowDownloadAccess(profileId, false)
+    profileManagementController.updateAllowDownloadAccess(profileId, false).toLiveData()
       .observeForever(mockUpdateResultObserver)
-    profileManagementController.getProfile(profileId).observeForever(mockProfileObserver)
+    profileManagementController.getProfile(
+      profileId
+    ).toLiveData().observeForever(mockProfileObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyUpdateSucceeded()
@@ -365,7 +375,7 @@ class ProfileManagementControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     val profileId = ProfileId.newBuilder().setInternalId(6).build()
-    profileManagementController.updateAllowDownloadAccess(profileId, false)
+    profileManagementController.updateAllowDownloadAccess(profileId, false).toLiveData()
       .observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -381,8 +391,11 @@ class ProfileManagementControllerTest {
 
     val profileId = ProfileId.newBuilder().setInternalId(2).build()
     profileManagementController.updateReadingTextSize(profileId, ReadingTextSize.MEDIUM_TEXT_SIZE)
+      .toLiveData()
       .observeForever(mockUpdateResultObserver)
-    profileManagementController.getProfile(profileId).observeForever(mockProfileObserver)
+    profileManagementController.getProfile(
+      profileId
+    ).toLiveData().observeForever(mockProfileObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyUpdateSucceeded()
@@ -398,8 +411,11 @@ class ProfileManagementControllerTest {
 
     val profileId = ProfileId.newBuilder().setInternalId(2).build()
     profileManagementController.updateAppLanguage(profileId, AppLanguage.CHINESE_APP_LANGUAGE)
+      .toLiveData()
       .observeForever(mockUpdateResultObserver)
-    profileManagementController.getProfile(profileId).observeForever(mockProfileObserver)
+    profileManagementController.getProfile(
+      profileId
+    ).toLiveData().observeForever(mockProfileObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyUpdateSucceeded()
@@ -415,9 +431,11 @@ class ProfileManagementControllerTest {
 
     val profileId = ProfileId.newBuilder().setInternalId(2).build()
     profileManagementController
-      .updateAudioLanguage(profileId, AudioLanguage.FRENCH_AUDIO_LANGUAGE)
+      .updateAudioLanguage(profileId, AudioLanguage.FRENCH_AUDIO_LANGUAGE).toLiveData()
       .observeForever(mockUpdateResultObserver)
-    profileManagementController.getProfile(profileId).observeForever(mockProfileObserver)
+    profileManagementController.getProfile(
+      profileId
+    ).toLiveData().observeForever(mockProfileObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyUpdateSucceeded()
@@ -432,8 +450,12 @@ class ProfileManagementControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     val profileId = ProfileId.newBuilder().setInternalId(2).build()
-    profileManagementController.deleteProfile(profileId).observeForever(mockUpdateResultObserver)
-    profileManagementController.getProfile(profileId).observeForever(mockProfileObserver)
+    profileManagementController.deleteProfile(
+      profileId
+    ).toLiveData().observeForever(mockUpdateResultObserver)
+    profileManagementController.getProfile(
+      profileId
+    ).toLiveData().observeForever(mockProfileObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyUpdateSucceeded()
@@ -449,8 +471,8 @@ class ProfileManagementControllerTest {
 
     val profileId3 = ProfileId.newBuilder().setInternalId(3).build()
     val profileId4 = ProfileId.newBuilder().setInternalId(4).build()
-    profileManagementController.deleteProfile(profileId3)
-    profileManagementController.deleteProfile(profileId4)
+    profileManagementController.deleteProfile(profileId3).toLiveData()
+    profileManagementController.deleteProfile(profileId4).toLiveData()
     profileManagementController.addProfile(
       name = "John",
       pin = "321",
@@ -458,8 +480,8 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = false,
       colorRgb = -10710042,
       isAdmin = true
-    )
-    profileManagementController.getProfiles().observeForever(mockProfilesObserver)
+    ).toLiveData()
+    profileManagementController.getProfiles().toLiveData().observeForever(mockProfilesObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetMultipleProfilesSucceeded()
@@ -482,12 +504,12 @@ class ProfileManagementControllerTest {
     val profileId1 = ProfileId.newBuilder().setInternalId(1).build()
     val profileId2 = ProfileId.newBuilder().setInternalId(2).build()
     val profileId3 = ProfileId.newBuilder().setInternalId(3).build()
-    profileManagementController.deleteProfile(profileId1)
-    profileManagementController.deleteProfile(profileId2)
-    profileManagementController.deleteProfile(profileId3)
+    profileManagementController.deleteProfile(profileId1).toLiveData()
+    profileManagementController.deleteProfile(profileId2).toLiveData()
+    profileManagementController.deleteProfile(profileId3).toLiveData()
     testCoroutineDispatchers.runCurrent()
     setUpTestApplicationComponent()
-    profileManagementController.getProfiles().observeForever(mockProfilesObserver)
+    profileManagementController.getProfiles().toLiveData().observeForever(mockProfilesObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetMultipleProfilesSucceeded()
@@ -506,8 +528,12 @@ class ProfileManagementControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     val profileId = ProfileId.newBuilder().setInternalId(2).build()
-    profileManagementController.loginToProfile(profileId).observeForever(mockUpdateResultObserver)
-    profileManagementController.getProfile(profileId).observeForever(mockProfileObserver)
+    profileManagementController.loginToProfile(
+      profileId
+    ).toLiveData().observeForever(mockUpdateResultObserver)
+    profileManagementController.getProfile(
+      profileId
+    ).toLiveData().observeForever(mockProfileObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyUpdateSucceeded()
@@ -524,7 +550,9 @@ class ProfileManagementControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     val profileId = ProfileId.newBuilder().setInternalId(6).build()
-    profileManagementController.loginToProfile(profileId).observeForever(mockUpdateResultObserver)
+    profileManagementController.loginToProfile(
+      profileId
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyUpdateFailed()
@@ -544,7 +572,7 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     val profileDatabase = readProfileDatabase()
@@ -562,10 +590,10 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
-    profileManagementController.getWasProfileEverAdded()
+    profileManagementController.getWasProfileEverAdded().toLiveData()
       .observeForever(mockWasProfileAddedResultObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -583,7 +611,7 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     profileManagementController.addProfile(
@@ -593,7 +621,7 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = false
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     val profileDatabase = readProfileDatabase()
@@ -612,7 +640,7 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     profileManagementController.addProfile(
@@ -622,10 +650,10 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = false
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
-    profileManagementController.getWasProfileEverAdded()
+    profileManagementController.getWasProfileEverAdded().toLiveData()
       .observeForever(mockWasProfileAddedResultObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -644,7 +672,7 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     profileManagementController.addProfile(
@@ -654,11 +682,11 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = false
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     val profileId1 = ProfileId.newBuilder().setInternalId(1).build()
-    profileManagementController.deleteProfile(profileId1)
+    profileManagementController.deleteProfile(profileId1).toLiveData()
     testCoroutineDispatchers.runCurrent()
 
     val profileDatabase = readProfileDatabase()
@@ -676,7 +704,7 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     profileManagementController.addProfile(
@@ -686,14 +714,14 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = false
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     val profileId1 = ProfileId.newBuilder().setInternalId(1).build()
-    profileManagementController.deleteProfile(profileId1)
+    profileManagementController.deleteProfile(profileId1).toLiveData()
     testCoroutineDispatchers.runCurrent()
 
-    profileManagementController.getWasProfileEverAdded()
+    profileManagementController.getWasProfileEverAdded().toLiveData()
       .observeForever(mockWasProfileAddedResultObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -711,10 +739,12 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
-    profileManagementController.getDeviceSettings().observeForever(mockDeviceSettingsObserver)
+    profileManagementController.getDeviceSettings()
+      .toLiveData()
+      .observeForever(mockDeviceSettingsObserver)
     testCoroutineDispatchers.runCurrent()
     verifyGetDeviceSettingsSucceeded()
 
@@ -732,19 +762,21 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     val adminProfileId = ProfileId.newBuilder().setInternalId(0).build()
     profileManagementController.updateWifiPermissionDeviceSettings(
       adminProfileId,
       /* downloadAndUpdateOnWifiOnly = */ true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyUpdateSucceeded()
 
-    profileManagementController.getDeviceSettings().observeForever(mockDeviceSettingsObserver)
+    profileManagementController.getDeviceSettings()
+      .toLiveData()
+      .observeForever(mockDeviceSettingsObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetDeviceSettingsSucceeded()
@@ -762,7 +794,7 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     val adminProfileId = ProfileId.newBuilder().setInternalId(0).build()
@@ -770,13 +802,15 @@ class ProfileManagementControllerTest {
       .updateTopicAutomaticallyPermissionDeviceSettings(
         adminProfileId,
         /* automaticallyUpdateTopics = */ true
-      )
+      ).toLiveData()
       .observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyUpdateSucceeded()
 
-    profileManagementController.getDeviceSettings().observeForever(mockDeviceSettingsObserver)
+    profileManagementController.getDeviceSettings()
+      .toLiveData()
+      .observeForever(mockDeviceSettingsObserver)
     testCoroutineDispatchers.runCurrent()
 
     verify(
@@ -799,25 +833,27 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     val adminProfileId = ProfileId.newBuilder().setInternalId(0).build()
     profileManagementController.updateWifiPermissionDeviceSettings(
       adminProfileId,
       /* downloadAndUpdateOnWifiOnly = */ true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
     verifyUpdateSucceeded()
 
     profileManagementController.updateTopicAutomaticallyPermissionDeviceSettings(
       adminProfileId,
       /* automaticallyUpdateTopics = */ true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
     verifyUpdateSucceeded()
 
-    profileManagementController.getDeviceSettings().observeForever(mockDeviceSettingsObserver)
+    profileManagementController.getDeviceSettings()
+      .toLiveData()
+      .observeForever(mockDeviceSettingsObserver)
     testCoroutineDispatchers.runCurrent()
     verifyGetDeviceSettingsSucceeded()
 
@@ -835,7 +871,7 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     profileManagementController.addProfile(
@@ -845,14 +881,14 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = false
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     val userProfileId = ProfileId.newBuilder().setInternalId(1).build()
     profileManagementController.updateWifiPermissionDeviceSettings(
       userProfileId,
       /* downloadAndUpdateOnWifiOnly = */ true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
     verifyUpdateFailed()
   }
@@ -866,7 +902,7 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     profileManagementController.addProfile(
@@ -876,14 +912,14 @@ class ProfileManagementControllerTest {
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = false
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
 
     val userProfileId = ProfileId.newBuilder().setInternalId(1).build()
     profileManagementController.updateTopicAutomaticallyPermissionDeviceSettings(
       userProfileId,
       /* automaticallyUpdateTopics = */ true
-    ).observeForever(mockUpdateResultObserver)
+    ).toLiveData().observeForever(mockUpdateResultObserver)
     testCoroutineDispatchers.runCurrent()
     verifyUpdateFailed()
   }
@@ -933,7 +969,7 @@ class ProfileManagementControllerTest {
         allowDownloadAccess = it.allowDownloadAccess,
         colorRgb = -10710042,
         isAdmin = false
-      )
+      ).toLiveData()
     }
   }
 

--- a/domain/src/test/java/org/oppia/domain/question/QuestionAssessmentProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/question/QuestionAssessmentProgressControllerTest.kt
@@ -10,7 +10,6 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -122,13 +121,10 @@ class QuestionAssessmentProgressControllerTest {
   @Captor
   lateinit var asyncAnswerOutcomeCaptor: ArgumentCaptor<AsyncResult<AnsweredQuestionOutcome>>
 
-  @Before
-  fun setUp() {
-    setUpTestApplicationWithSeed(questionSeed = 0)
-  }
-
   @Test
   fun testGetCurrentQuestion_noSessionStarted_returnsPendingResult() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
+
     val resultLiveData =
       questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     resultLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
@@ -140,6 +136,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testGetCurrentQuestion_sessionStarted_withEmptyQuestionList_fails() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     questionTrainingController.startQuestionTrainingSession(listOf())
 
     val resultLiveData =
@@ -159,6 +156,8 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testStartTrainingSession_succeeds() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
+
     val resultLiveData =
       questionTrainingController.startQuestionTrainingSession(TEST_SKILL_ID_LIST_012)
     resultLiveData.observeForever(mockAsyncResultLiveDataObserver)
@@ -170,6 +169,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testGetCurrentQuestion_playSession_returnsPendingResultFromLoadingSession() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     val currentQuestionLiveData =
       questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
@@ -188,6 +188,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testGetCurrentQuestion_playSession_loaded_returnsInitialQuestionPending() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     startTrainingSession(TEST_SKILL_ID_LIST_012)
 
     val currentQuestionLiveData =
@@ -210,6 +211,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testGetCurrentQuestion_playInvalidSession_thenPlayValidExp_returnsInitialPendingQuestion() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     // Start with starting an invalid training session.
     startTrainingSession(listOf())
     endTrainingSession()
@@ -236,6 +238,8 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testStopTrainingSession_withoutStartingSession_fails() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
+
     val resultLiveData =
       questionTrainingController.stopQuestionTrainingSession()
     testCoroutineDispatchers.runCurrent()
@@ -249,6 +253,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testStartTrainingSession_withoutFinishingPrevious_fails() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     questionTrainingController.startQuestionTrainingSession(TEST_SKILL_ID_LIST_012)
 
     val resultLiveData =
@@ -264,6 +269,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testStopTrainingSession_afterStartingPreviousSession_succeeds() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     questionTrainingController.startQuestionTrainingSession(TEST_SKILL_ID_LIST_012)
 
     val resultLiveData =
@@ -276,6 +282,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testGetCurrentQuestion_playSecondSession_afterFinishingPrev_loaded_returnsInitialQuestion() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     val currentQuestionLiveData =
       questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
@@ -301,6 +308,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testSubmitAnswer_beforePlaying_failsWithError() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     val result =
       questionAssessmentProgressController.submitAnswer(createMultipleChoiceAnswer(0))
     result.observeForever(mockAsyncAnswerOutcomeObserver)
@@ -489,6 +497,8 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testMoveToNext_beforePlaying_failsWithError() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
+
     val moveToStateResult =
       questionAssessmentProgressController.moveToNextQuestion()
     moveToStateResult.observeForever(mockAsyncNullableResultLiveDataObserver)
@@ -504,6 +514,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testMoveToNext_forPendingInitialQuestion_failsWithError() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     subscribeToCurrentQuestionToAllowSessionToLoad()
     startTrainingSession(TEST_SKILL_ID_LIST_2)
 
@@ -627,6 +638,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testGetCurrentQuestion_secondQuestion_submitRightAnswer_pendingQuestionBecomesCompleted() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     subscribeToCurrentQuestionToAllowSessionToLoad()
     startTrainingSession(TEST_SKILL_ID_LIST_2)
     submitNumericInputAnswerAndMoveToNextQuestion(3.0)
@@ -654,6 +666,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testGetCurrentQuestion_secondQuestion_submitWrongAnswer_updatePendingQuestion() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     subscribeToCurrentQuestionToAllowSessionToLoad()
     startTrainingSession(TEST_SKILL_ID_LIST_2)
     submitNumericInputAnswerAndMoveToNextQuestion(3.0)
@@ -681,6 +694,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testSubmitAnswer_forNumericInput_correctAnswer_returnsOutcomeWithTransition() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     subscribeToCurrentQuestionToAllowSessionToLoad()
     startTrainingSession(TEST_SKILL_ID_LIST_2)
 
@@ -701,6 +715,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testSubmitAnswer_forNumericInput_wrongAnswer_returnsOutcomeWithTransition() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     subscribeToCurrentQuestionToAllowSessionToLoad()
     startTrainingSession(TEST_SKILL_ID_LIST_2)
 
@@ -721,6 +736,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testGetCurrentQuestion_thirdQuestion_isTerminalQuestion() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     val currentQuestionLiveData =
       questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
@@ -743,6 +759,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testMoveToNext_onFinalQuestion_failsWithError() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     subscribeToCurrentQuestionToAllowSessionToLoad()
     startTrainingSession(TEST_SKILL_ID_LIST_2)
     submitNumericInputAnswerAndMoveToNextQuestion(3.0)
@@ -766,6 +783,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testGetCurrentQuestion_afterPlayingSecondSession_returnsTerminalQuestion() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     val currentQuestionLiveData =
       questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
@@ -786,6 +804,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testGetCurrentQuestion_afterPlayingThroughPrevSessions_returnsQuestionFromSecondSession() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     val currentQuestionLiveData =
       questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
@@ -811,6 +830,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testMoveToNext_onFinalQuestion_failsWithError_logsException() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     subscribeToCurrentQuestionToAllowSessionToLoad()
     startTrainingSession(TEST_SKILL_ID_LIST_2)
     submitNumericInputAnswerAndMoveToNextQuestion(3.0)
@@ -830,6 +850,8 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testSubmitAnswer_beforePlaying_failsWithError_logsException() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
+
     val result =
       questionAssessmentProgressController.submitAnswer(createMultipleChoiceAnswer(0))
     result.observeForever(mockAsyncAnswerOutcomeObserver)
@@ -844,6 +866,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testSubmitAnswer_forTextInput_wrongAnswer_returnsDefaultOutcome_showHint() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     subscribeToCurrentQuestionToAllowSessionToLoad()
     startTrainingSession(TEST_SKILL_ID_LIST_2)
 
@@ -882,6 +905,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testRevealHint_forWrongAnswer_showHint_returnHintIsRevealed() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     val currentQuestionLiveData =
       questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
@@ -938,6 +962,7 @@ class QuestionAssessmentProgressControllerTest {
 
   @Test
   fun testRevealSolution_forWrongAnswer_showSolution_returnSolutionIsRevealed() {
+    setUpTestApplicationWithSeed(questionSeed = 0)
     val currentQuestionLiveData =
       questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)

--- a/domain/src/test/java/org/oppia/domain/question/QuestionAssessmentProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/question/QuestionAssessmentProgressControllerTest.kt
@@ -51,6 +51,7 @@ import org.oppia.testing.TestCoroutineDispatchers
 import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -127,7 +128,7 @@ class QuestionAssessmentProgressControllerTest {
   @Test
   fun testGetCurrentQuestion_noSessionStarted_returnsPendingResult() {
     val resultLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     resultLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -140,7 +141,7 @@ class QuestionAssessmentProgressControllerTest {
     questionTrainingController.startQuestionTrainingSession(listOf())
 
     val resultLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     resultLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -168,7 +169,7 @@ class QuestionAssessmentProgressControllerTest {
   @Test
   fun testGetCurrentQuestion_playSession_returnsPendingResultFromLoadingSession() {
     val currentQuestionLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -188,7 +189,7 @@ class QuestionAssessmentProgressControllerTest {
     startTrainingSession(TEST_SKILL_ID_LIST_012)
 
     val currentQuestionLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -214,7 +215,7 @@ class QuestionAssessmentProgressControllerTest {
     // Then a valid one.
     startTrainingSession(TEST_SKILL_ID_LIST_012)
     val currentQuestionLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -274,7 +275,7 @@ class QuestionAssessmentProgressControllerTest {
   @Test
   fun testGetCurrentQuestion_playSecondSession_afterFinishingPrev_loaded_returnsInitialQuestion() {
     val currentQuestionLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     // Start with playing a valid session, then stop.
     startTrainingSession(TEST_SKILL_ID_LIST_012)
@@ -398,7 +399,7 @@ class QuestionAssessmentProgressControllerTest {
   fun testGetCurrentQuestion_afterSubmittingCorrectMultiChoiceAnswer_becomesCompletedQuestion() {
     setUpTestApplicationWithSeed(questionSeed = 6)
     val currentQuestionLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     startTrainingSession(TEST_SKILL_ID_LIST_2)
 
@@ -427,7 +428,7 @@ class QuestionAssessmentProgressControllerTest {
   fun testGetCurrentQuestion_afterSubmittingWrongMultiChoiceAnswer_updatesPendingQuestion() {
     setUpTestApplicationWithSeed(questionSeed = 6)
     val currentQuestionLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     startTrainingSession(TEST_SKILL_ID_LIST_2)
 
@@ -541,7 +542,7 @@ class QuestionAssessmentProgressControllerTest {
   fun testMoveToNext_forCompletedQuestion_movesToNextQuestion() {
     setUpTestApplicationWithSeed(questionSeed = 6)
     val currentQuestionLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     startTrainingSession(TEST_SKILL_ID_LIST_2)
     submitMultipleChoiceAnswer(1)
@@ -719,7 +720,7 @@ class QuestionAssessmentProgressControllerTest {
   @Test
   fun testGetCurrentQuestion_thirdQuestion_isTerminalQuestion() {
     val currentQuestionLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     startTrainingSession(TEST_SKILL_ID_LIST_2)
     submitNumericInputAnswerAndMoveToNextQuestion(3.0)
@@ -764,7 +765,7 @@ class QuestionAssessmentProgressControllerTest {
   @Test
   fun testGetCurrentQuestion_afterPlayingSecondSession_returnsTerminalQuestion() {
     val currentQuestionLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
 
     startTrainingSession(TEST_SKILL_ID_LIST_01)
@@ -784,7 +785,7 @@ class QuestionAssessmentProgressControllerTest {
   @Test
   fun testGetCurrentQuestion_afterPlayingThroughPrevSessions_returnsQuestionFromSecondSession() {
     val currentQuestionLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     playThroughSessionWithSkillList2()
 
@@ -859,7 +860,7 @@ class QuestionAssessmentProgressControllerTest {
     assertThat(answerOutcome.feedback.html).isEmpty()
 
     val currentQuestionLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -880,7 +881,7 @@ class QuestionAssessmentProgressControllerTest {
   @Test
   fun testRevealHint_forWrongAnswer_showHint_returnHintIsRevealed() {
     val currentQuestionLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     playThroughSessionWithSkillList2()
 
@@ -936,7 +937,7 @@ class QuestionAssessmentProgressControllerTest {
   @Test
   fun testRevealSolution_forWrongAnswer_showSolution_returnSolutionIsRevealed() {
     val currentQuestionLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     currentQuestionLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     playThroughSessionWithSkillList2()
 
@@ -1001,7 +1002,7 @@ class QuestionAssessmentProgressControllerTest {
    * only lazily load data based on whether there's an active subscription.
    */
   private fun subscribeToCurrentQuestionToAllowSessionToLoad() {
-    questionAssessmentProgressController.getCurrentQuestion()
+    questionAssessmentProgressController.getCurrentQuestion().toLiveData()
       .observeForever(mockCurrentQuestionLiveDataObserver)
   }
 

--- a/domain/src/test/java/org/oppia/domain/question/QuestionAssessmentProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/question/QuestionAssessmentProgressControllerTest.kt
@@ -43,8 +43,6 @@ import org.oppia.domain.classify.rules.numericinput.NumericInputRuleModule
 import org.oppia.domain.classify.rules.ratioinput.RatioInputModule
 import org.oppia.domain.classify.rules.textinput.TextInputRuleModule
 import org.oppia.domain.oppialogger.LogStorageModule
-import org.oppia.domain.profile.DaggerProfileManagementControllerTest_TestApplicationComponent
-import org.oppia.domain.profile.ProfileManagementControllerTest
 import org.oppia.domain.topic.TEST_SKILL_ID_0
 import org.oppia.domain.topic.TEST_SKILL_ID_1
 import org.oppia.domain.topic.TEST_SKILL_ID_2
@@ -1132,7 +1130,7 @@ class QuestionAssessmentProgressControllerTest {
       RatioInputModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/domain/src/test/java/org/oppia/domain/question/QuestionAssessmentProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/question/QuestionAssessmentProgressControllerTest.kt
@@ -43,6 +43,8 @@ import org.oppia.domain.classify.rules.numericinput.NumericInputRuleModule
 import org.oppia.domain.classify.rules.ratioinput.RatioInputModule
 import org.oppia.domain.classify.rules.textinput.TextInputRuleModule
 import org.oppia.domain.oppialogger.LogStorageModule
+import org.oppia.domain.profile.DaggerProfileManagementControllerTest_TestApplicationComponent
+import org.oppia.domain.profile.ProfileManagementControllerTest
 import org.oppia.domain.topic.TEST_SKILL_ID_0
 import org.oppia.domain.topic.TEST_SKILL_ID_1
 import org.oppia.domain.topic.TEST_SKILL_ID_2
@@ -52,6 +54,8 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders.Companion.toLiveData
+import org.oppia.util.data.DataProvidersInjector
+import org.oppia.util.data.DataProvidersInjectorProvider
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -64,7 +68,7 @@ import javax.inject.Singleton
 /** Tests for [QuestionAssessmentProgressController]. */
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
-@Config(manifest = Config.NONE)
+@Config(application = QuestionAssessmentProgressControllerTest.TestApplication::class)
 class QuestionAssessmentProgressControllerTest {
   private val TEST_SKILL_ID_LIST_012 =
     listOf(TEST_SKILL_ID_0, TEST_SKILL_ID_1, TEST_SKILL_ID_2) // questions 0, 1, 2, 3, 4, 5
@@ -990,10 +994,7 @@ class QuestionAssessmentProgressControllerTest {
 
   private fun setUpTestApplicationWithSeed(questionSeed: Long) {
     TestQuestionModule.questionSeed = questionSeed
-    DaggerQuestionAssessmentProgressControllerTest_TestApplicationComponent.builder()
-      .setApplication(ApplicationProvider.getApplicationContext())
-      .build()
-      .inject(this)
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
   /**
@@ -1131,7 +1132,7 @@ class QuestionAssessmentProgressControllerTest {
       RatioInputModule::class
     ]
   )
-  interface TestApplicationComponent {
+  interface TestApplicationComponent: DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance
@@ -1140,6 +1141,20 @@ class QuestionAssessmentProgressControllerTest {
       fun build(): TestApplicationComponent
     }
 
-    fun inject(questionAssessmentProgressControllerTest: QuestionAssessmentProgressControllerTest)
+    fun inject(controllerTest: QuestionAssessmentProgressControllerTest)
+  }
+
+  class TestApplication : Application(), DataProvidersInjectorProvider {
+    private val component: TestApplicationComponent by lazy {
+      DaggerQuestionAssessmentProgressControllerTest_TestApplicationComponent.builder()
+        .setApplication(this)
+        .build()
+    }
+
+    fun inject(controllerTest: QuestionAssessmentProgressControllerTest) {
+      component.inject(controllerTest)
+    }
+
+    override fun getDataProvidersInjector(): DataProvidersInjector = component
   }
 }

--- a/domain/src/test/java/org/oppia/domain/question/QuestionTrainingControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/question/QuestionTrainingControllerTest.kt
@@ -45,6 +45,7 @@ import org.oppia.testing.TestCoroutineDispatchers
 import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -123,7 +124,7 @@ class QuestionTrainingControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     val resultLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     resultLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -161,7 +162,7 @@ class QuestionTrainingControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     val resultLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     resultLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -195,7 +196,7 @@ class QuestionTrainingControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     val resultLiveData =
-      questionAssessmentProgressController.getCurrentQuestion()
+      questionAssessmentProgressController.getCurrentQuestion().toLiveData()
     resultLiveData.observeForever(mockCurrentQuestionLiveDataObserver)
     testCoroutineDispatchers.runCurrent()
 

--- a/domain/src/test/java/org/oppia/domain/question/QuestionTrainingControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/question/QuestionTrainingControllerTest.kt
@@ -10,7 +10,6 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -90,18 +89,9 @@ class QuestionTrainingControllerTest {
   @Captor
   lateinit var currentQuestionResultCaptor: ArgumentCaptor<AsyncResult<EphemeralQuestion>>
 
-  @Before
-  fun setUp() {
-    TestQuestionModule.questionSeed = 0
-    setUpTestApplicationComponent()
-  }
-
-  private fun setUpTestApplicationComponent() {
-    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
-  }
-
   @Test
   fun testController_startTrainingSession_succeeds() {
+    setUpTestApplicationComponent(questionSeed = 0)
     val questionListLiveData =
       questionTrainingController.startQuestionTrainingSession(
         listOf(TEST_SKILL_ID_0, TEST_SKILL_ID_1)
@@ -117,6 +107,7 @@ class QuestionTrainingControllerTest {
 
   @Test
   fun testController_startTrainingSession_sessionStartsWithInitialQuestion() {
+    setUpTestApplicationComponent(questionSeed = 0)
     questionTrainingController.startQuestionTrainingSession(
       listOf(TEST_SKILL_ID_0, TEST_SKILL_ID_1)
     )
@@ -136,8 +127,7 @@ class QuestionTrainingControllerTest {
 
   @Test
   fun testController_startTrainingSession_differentSeed_succeeds() {
-    TestQuestionModule.questionSeed = 2
-    setUpTestApplicationComponent() // Recreate with the new seed
+    setUpTestApplicationComponent(questionSeed = 2)
     val questionListLiveData =
       questionTrainingController.startQuestionTrainingSession(
         listOf(TEST_SKILL_ID_0, TEST_SKILL_ID_1)
@@ -153,8 +143,7 @@ class QuestionTrainingControllerTest {
 
   @Test
   fun testController_startTrainingSession_differentSeed_sessionStartsWithInitialQuestion() {
-    TestQuestionModule.questionSeed = 2
-    setUpTestApplicationComponent() // Recreate with the new seed
+    setUpTestApplicationComponent(questionSeed = 2)
     questionTrainingController.startQuestionTrainingSession(
       listOf(TEST_SKILL_ID_0, TEST_SKILL_ID_1)
     )
@@ -174,6 +163,7 @@ class QuestionTrainingControllerTest {
 
   @Test
   fun testController_startTrainingSession_differentSkills_succeeds() {
+    setUpTestApplicationComponent(questionSeed = 0)
     val questionListLiveData =
       questionTrainingController.startQuestionTrainingSession(
         listOf(TEST_SKILL_ID_1, TEST_SKILL_ID_2)
@@ -189,6 +179,7 @@ class QuestionTrainingControllerTest {
 
   @Test
   fun testController_startTrainingSession_differentSkills_sessionStartsWithInitialQuestion() {
+    setUpTestApplicationComponent(questionSeed = 0)
     questionTrainingController.startQuestionTrainingSession(
       listOf(TEST_SKILL_ID_1, TEST_SKILL_ID_2)
     )
@@ -208,6 +199,7 @@ class QuestionTrainingControllerTest {
 
   @Test
   fun testController_startTrainingSession_noSkills_fails() {
+    setUpTestApplicationComponent(questionSeed = 0)
     val questionListLiveData =
       questionTrainingController.startQuestionTrainingSession(listOf())
     testCoroutineDispatchers.runCurrent()
@@ -221,6 +213,7 @@ class QuestionTrainingControllerTest {
 
   @Test
   fun testController_startTrainingSession_noSkills_fails_logsException() {
+    setUpTestApplicationComponent(questionSeed = 0)
     questionTrainingController.startQuestionTrainingSession(listOf())
     questionTrainingController.startQuestionTrainingSession(listOf())
     testCoroutineDispatchers.runCurrent()
@@ -234,6 +227,7 @@ class QuestionTrainingControllerTest {
 
   @Test
   fun testStopTrainingSession_withoutStartingSession_fails_logsException() {
+    setUpTestApplicationComponent(questionSeed = 0)
     questionTrainingController.stopQuestionTrainingSession()
     testCoroutineDispatchers.runCurrent()
 
@@ -242,6 +236,11 @@ class QuestionTrainingControllerTest {
     assertThat(exception).isInstanceOf(IllegalStateException::class.java)
     assertThat(exception).hasMessageThat()
       .contains("Cannot stop a new training session which wasn't started")
+  }
+
+  private fun setUpTestApplicationComponent(questionSeed: Long) {
+    TestQuestionModule.questionSeed = questionSeed
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
   // TODO(#89): Move this to a common test application component.

--- a/domain/src/test/java/org/oppia/domain/question/QuestionTrainingControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/question/QuestionTrainingControllerTest.kt
@@ -46,6 +46,8 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders.Companion.toLiveData
+import org.oppia.util.data.DataProvidersInjector
+import org.oppia.util.data.DataProvidersInjectorProvider
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -58,7 +60,7 @@ import javax.inject.Singleton
 /** Tests for [QuestionTrainingController]. */
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
-@Config(manifest = Config.NONE)
+@Config(application = QuestionTrainingControllerTest.TestApplication::class)
 class QuestionTrainingControllerTest {
   @Rule
   @JvmField
@@ -95,10 +97,7 @@ class QuestionTrainingControllerTest {
   }
 
   private fun setUpTestApplicationComponent() {
-    DaggerQuestionTrainingControllerTest_TestApplicationComponent.builder()
-      .setApplication(ApplicationProvider.getApplicationContext())
-      .build()
-      .inject(this)
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
   @Test
@@ -296,7 +295,7 @@ class QuestionTrainingControllerTest {
       LogStorageModule::class, TestDispatcherModule::class, RatioInputModule::class
     ]
   )
-  interface TestApplicationComponent {
+  interface TestApplicationComponent: DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance
@@ -306,5 +305,19 @@ class QuestionTrainingControllerTest {
     }
 
     fun inject(questionTrainingControllerTest: QuestionTrainingControllerTest)
+  }
+
+  class TestApplication : Application(), DataProvidersInjectorProvider {
+    private val component: TestApplicationComponent by lazy {
+      DaggerQuestionTrainingControllerTest_TestApplicationComponent.builder()
+        .setApplication(this)
+        .build()
+    }
+
+    fun inject(questionTrainingControllerTest: QuestionTrainingControllerTest) {
+      component.inject(questionTrainingControllerTest)
+    }
+
+    override fun getDataProvidersInjector(): DataProvidersInjector = component
   }
 }

--- a/domain/src/test/java/org/oppia/domain/question/QuestionTrainingControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/question/QuestionTrainingControllerTest.kt
@@ -295,7 +295,7 @@ class QuestionTrainingControllerTest {
       LogStorageModule::class, TestDispatcherModule::class, RatioInputModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/domain/src/test/java/org/oppia/domain/topic/StoryProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/StoryProgressControllerTest.kt
@@ -92,7 +92,8 @@ class StoryProgressControllerTest {
       FRACTIONS_STORY_ID_0,
       FRACTIONS_EXPLORATION_ID_0,
       timestamp
-    ).observeForever(mockRecordProgressObserver)
+    )
+    Unit.observeForever(mockRecordProgressObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyRecordProgressSucceeded()
@@ -106,7 +107,8 @@ class StoryProgressControllerTest {
       FRACTIONS_STORY_ID_0,
       FRACTIONS_EXPLORATION_ID_0,
       timestamp
-    ).observeForever(mockRecordProgressObserver)
+    )
+    Unit.observeForever(mockRecordProgressObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyRecordProgressSucceeded()

--- a/domain/src/test/java/org/oppia/domain/topic/StoryProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/StoryProgressControllerTest.kt
@@ -23,8 +23,6 @@ import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoRule
 import org.oppia.app.model.ProfileId
 import org.oppia.domain.oppialogger.LogStorageModule
-import org.oppia.domain.question.DaggerQuestionTrainingControllerTest_TestApplicationComponent
-import org.oppia.domain.question.QuestionTrainingControllerTest
 import org.oppia.testing.TestCoroutineDispatchers
 import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
@@ -158,7 +156,7 @@ class StoryProgressControllerTest {
       TestDispatcherModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/domain/src/test/java/org/oppia/domain/topic/StoryProgressTestHelperTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/StoryProgressTestHelperTest.kt
@@ -34,6 +34,7 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.caching.CacheAssetsLocally
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.gcsresource.DefaultResourceBucketName
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
@@ -123,7 +124,9 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getTopic(profileId, FRACTIONS_TOPIC_ID).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId, FRACTIONS_TOPIC_ID
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicSucceeded()
@@ -144,7 +147,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getStory(profileId, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0)
+    topicController.getStory(profileId, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -166,7 +169,9 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getOngoingTopicList(profileId).observeForever(mockOngoingTopicListObserver)
+    topicController.getOngoingTopicList(
+      profileId
+    ).toLiveData().observeForever(mockOngoingTopicListObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetOngoingTopicListSucceeded()
@@ -184,7 +189,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getCompletedStoryList(profileId)
+    topicController.getCompletedStoryList(profileId).toLiveData()
       .observeForever(mockCompletedStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -202,7 +207,9 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getTopic(profileId, FRACTIONS_TOPIC_ID).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId, FRACTIONS_TOPIC_ID
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicSucceeded()
@@ -223,7 +230,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getStory(profileId, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0)
+    topicController.getStory(profileId, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -245,7 +252,9 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getOngoingTopicList(profileId).observeForever(mockOngoingTopicListObserver)
+    topicController.getOngoingTopicList(
+      profileId
+    ).toLiveData().observeForever(mockOngoingTopicListObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetOngoingTopicListSucceeded()
@@ -263,7 +272,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getCompletedStoryList(profileId)
+    topicController.getCompletedStoryList(profileId).toLiveData()
       .observeForever(mockCompletedStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -281,7 +290,9 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getTopic(profileId, FRACTIONS_TOPIC_ID).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId, FRACTIONS_TOPIC_ID
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicSucceeded()
@@ -302,7 +313,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getStory(profileId, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0)
+    topicController.getStory(profileId, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -322,7 +333,9 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getOngoingTopicList(profileId).observeForever(mockOngoingTopicListObserver)
+    topicController.getOngoingTopicList(
+      profileId
+    ).toLiveData().observeForever(mockOngoingTopicListObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetOngoingTopicListSucceeded()
@@ -339,7 +352,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getCompletedStoryList(profileId)
+    topicController.getCompletedStoryList(profileId).toLiveData()
       .observeForever(mockCompletedStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -358,7 +371,9 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getTopic(profileId, FRACTIONS_TOPIC_ID).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId, FRACTIONS_TOPIC_ID
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicSucceeded()
@@ -379,7 +394,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getStory(profileId, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0)
+    topicController.getStory(profileId, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -399,7 +414,9 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getOngoingTopicList(profileId).observeForever(mockOngoingTopicListObserver)
+    topicController.getOngoingTopicList(
+      profileId
+    ).toLiveData().observeForever(mockOngoingTopicListObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetOngoingTopicListSucceeded()
@@ -416,7 +433,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getCompletedStoryList(profileId)
+    topicController.getCompletedStoryList(profileId).toLiveData()
       .observeForever(mockCompletedStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -435,7 +452,9 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getTopic(profileId, RATIOS_TOPIC_ID).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId, RATIOS_TOPIC_ID
+    ).toLiveData().observeForever(mockTopicObserver)
 
     testCoroutineDispatchers.runCurrent()
 
@@ -461,7 +480,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getStory(profileId, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0)
+    topicController.getStory(profileId, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -481,7 +500,9 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getOngoingTopicList(profileId).observeForever(mockOngoingTopicListObserver)
+    topicController.getOngoingTopicList(
+      profileId
+    ).toLiveData().observeForever(mockOngoingTopicListObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetOngoingTopicListSucceeded()
@@ -499,7 +520,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getCompletedStoryList(profileId)
+    topicController.getCompletedStoryList(profileId).toLiveData()
       .observeForever(mockCompletedStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -518,7 +539,9 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getTopic(profileId, RATIOS_TOPIC_ID).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId, RATIOS_TOPIC_ID
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicSucceeded()
@@ -543,7 +566,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getStory(profileId, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0)
+    topicController.getStory(profileId, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -566,7 +589,9 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getOngoingTopicList(profileId).observeForever(mockOngoingTopicListObserver)
+    topicController.getOngoingTopicList(
+      profileId
+    ).toLiveData().observeForever(mockOngoingTopicListObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetOngoingTopicListSucceeded()
@@ -584,7 +609,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getCompletedStoryList(profileId)
+    topicController.getCompletedStoryList(profileId).toLiveData()
       .observeForever(mockCompletedStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -602,7 +627,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicListController.getOngoingStoryList(profileId)
+    topicListController.getOngoingStoryList(profileId).toLiveData()
       .observeForever(mockOngoingStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -625,7 +650,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicListController.getOngoingStoryList(profileId)
+    topicListController.getOngoingStoryList(profileId).toLiveData()
       .observeForever(mockOngoingStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -648,7 +673,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicListController.getOngoingStoryList(profileId)
+    topicListController.getOngoingStoryList(profileId).toLiveData()
       .observeForever(mockOngoingStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -676,7 +701,7 @@ class StoryProgressTestHelperTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicListController.getOngoingStoryList(profileId)
+    topicListController.getOngoingStoryList(profileId).toLiveData()
       .observeForever(mockOngoingStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 

--- a/domain/src/test/java/org/oppia/domain/topic/StoryProgressTestHelperTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/StoryProgressTestHelperTest.kt
@@ -35,6 +35,8 @@ import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.caching.CacheAssetsLocally
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders.Companion.toLiveData
+import org.oppia.util.data.DataProvidersInjector
+import org.oppia.util.data.DataProvidersInjectorProvider
 import org.oppia.util.gcsresource.DefaultResourceBucketName
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
@@ -50,7 +52,7 @@ import javax.inject.Singleton
 /** Tests for [StoryProgressTestHelper]. */
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
-@Config(manifest = Config.NONE)
+@Config(application = StoryProgressTestHelperTest.TestApplication::class)
 class StoryProgressTestHelperTest {
   @Rule
   @JvmField
@@ -110,10 +112,7 @@ class StoryProgressTestHelperTest {
   }
 
   private fun setUpTestApplicationComponent() {
-    DaggerStoryProgressTestHelperTest_TestApplicationComponent.builder()
-      .setApplication(ApplicationProvider.getApplicationContext())
-      .build()
-      .inject(this)
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
   @Test
@@ -819,7 +818,7 @@ class StoryProgressTestHelperTest {
       TestDispatcherModule::class
     ]
   )
-  interface TestApplicationComponent {
+  interface TestApplicationComponent: DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance
@@ -829,5 +828,19 @@ class StoryProgressTestHelperTest {
     }
 
     fun inject(storyProgressTestHelperTest: StoryProgressTestHelperTest)
+  }
+
+  class TestApplication : Application(), DataProvidersInjectorProvider {
+    private val component: TestApplicationComponent by lazy {
+      DaggerStoryProgressTestHelperTest_TestApplicationComponent.builder()
+        .setApplication(this)
+        .build()
+    }
+
+    fun inject(storyProgressTestHelperTest: StoryProgressTestHelperTest) {
+      component.inject(storyProgressTestHelperTest)
+    }
+
+    override fun getDataProvidersInjector(): DataProvidersInjector = component
   }
 }

--- a/domain/src/test/java/org/oppia/domain/topic/StoryProgressTestHelperTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/StoryProgressTestHelperTest.kt
@@ -818,7 +818,7 @@ class StoryProgressTestHelperTest {
       TestDispatcherModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
@@ -39,6 +39,7 @@ import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.caching.CacheAssetsLocally
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -128,7 +129,9 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveTopic_validSecondTopic_returnsCorrectTopic() {
-    topicController.getTopic(profileId1, TEST_TOPIC_ID_1).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId1, TEST_TOPIC_ID_1
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicSucceeded()
@@ -138,7 +141,9 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveTopic_validSecondTopic_returnsTopicWithThumbnail() {
-    topicController.getTopic(profileId1, TEST_TOPIC_ID_1).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId1, TEST_TOPIC_ID_1
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicSucceeded()
@@ -149,7 +154,9 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveTopic_fractionsTopic_returnsCorrectTopic() {
-    topicController.getTopic(profileId1, FRACTIONS_TOPIC_ID).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId1, FRACTIONS_TOPIC_ID
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicSucceeded()
@@ -160,7 +167,9 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveTopic_fractionsTopic_hasCorrectDescription() {
-    topicController.getTopic(profileId1, FRACTIONS_TOPIC_ID).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId1, FRACTIONS_TOPIC_ID
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicSucceeded()
@@ -171,7 +180,9 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveTopic_ratiosTopic_returnsCorrectTopic() {
-    topicController.getTopic(profileId1, RATIOS_TOPIC_ID).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId1, RATIOS_TOPIC_ID
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicSucceeded()
@@ -182,7 +193,9 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveTopic_ratiosTopic_hasCorrectDescription() {
-    topicController.getTopic(profileId1, RATIOS_TOPIC_ID).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId1, RATIOS_TOPIC_ID
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicSucceeded()
@@ -195,7 +208,9 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveTopic_invalidTopic_returnsFailure() {
-    topicController.getTopic(profileId1, INVALID_TOPIC_ID_1).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId1, INVALID_TOPIC_ID_1
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicFailed()
@@ -204,7 +219,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_validStory_isSuccessful() {
-    topicController.getStory(profileId1, TEST_TOPIC_ID_1, TEST_STORY_ID_2)
+    topicController.getStory(profileId1, TEST_TOPIC_ID_1, TEST_STORY_ID_2).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -216,7 +231,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_validStory_returnsCorrectStory() {
-    topicController.getStory(profileId1, TEST_TOPIC_ID_1, TEST_STORY_ID_2)
+    topicController.getStory(profileId1, TEST_TOPIC_ID_1, TEST_STORY_ID_2).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -227,7 +242,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_validStory_returnsStoryWithName() {
-    topicController.getStory(profileId1, TEST_TOPIC_ID_1, TEST_STORY_ID_2)
+    topicController.getStory(profileId1, TEST_TOPIC_ID_1, TEST_STORY_ID_2).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -238,7 +253,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_fractionsStory_returnsCorrectStory() {
-    topicController.getStory(profileId1, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0)
+    topicController.getStory(profileId1, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -249,7 +264,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_fractionsStory_returnsStoryWithName() {
-    topicController.getStory(profileId1, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0)
+    topicController.getStory(profileId1, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -260,7 +275,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_ratiosFirstStory_returnsCorrectStory() {
-    topicController.getStory(profileId1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0)
+    topicController.getStory(profileId1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -272,7 +287,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_ratiosFirstStory_returnsStoryWithMultipleChapters() {
-    topicController.getStory(profileId1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0)
+    topicController.getStory(profileId1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -286,7 +301,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_ratiosSecondStory_returnsCorrectStory() {
-    topicController.getStory(profileId1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_1)
+    topicController.getStory(profileId1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_1).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -298,7 +313,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_ratiosSecondStory_returnsStoryWithMultipleChapters() {
-    topicController.getStory(profileId1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_1)
+    topicController.getStory(profileId1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_1).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -312,7 +327,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_validStory_returnsStoryWithChapter() {
-    topicController.getStory(profileId1, TEST_TOPIC_ID_1, TEST_STORY_ID_2)
+    topicController.getStory(profileId1, TEST_TOPIC_ID_1, TEST_STORY_ID_2).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -323,7 +338,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_validStory_returnsStoryWithChapterName() {
-    topicController.getStory(profileId1, TEST_TOPIC_ID_1, TEST_STORY_ID_2)
+    topicController.getStory(profileId1, TEST_TOPIC_ID_1, TEST_STORY_ID_2).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -334,7 +349,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_validStory_returnsStoryWithChapterSummary() {
-    topicController.getStory(profileId1, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0)
+    topicController.getStory(profileId1, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -346,7 +361,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_validStory_returnsStoryWithChapterThumbnail() {
-    topicController.getStory(profileId1, TEST_TOPIC_ID_1, TEST_STORY_ID_2)
+    topicController.getStory(profileId1, TEST_TOPIC_ID_1, TEST_STORY_ID_2).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -359,7 +374,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_validSecondStory_isSuccessful() {
-    topicController.getStory(profileId1, TEST_TOPIC_ID_0, TEST_STORY_ID_1)
+    topicController.getStory(profileId1, TEST_TOPIC_ID_0, TEST_STORY_ID_1).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -371,7 +386,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_validSecondStory_returnsCorrectStory() {
-    topicController.getStory(profileId1, TEST_TOPIC_ID_0, TEST_STORY_ID_1)
+    topicController.getStory(profileId1, TEST_TOPIC_ID_0, TEST_STORY_ID_1).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -382,7 +397,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_validSecondStory_returnsStoryWithMultipleChapters() {
-    topicController.getStory(profileId1, TEST_TOPIC_ID_0, TEST_STORY_ID_1)
+    topicController.getStory(profileId1, TEST_TOPIC_ID_0, TEST_STORY_ID_1).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -397,7 +412,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_validSecondStory_returnsStoryWithProgress() {
-    topicController.getStory(profileId1, TEST_TOPIC_ID_0, TEST_STORY_ID_1)
+    topicController.getStory(profileId1, TEST_TOPIC_ID_0, TEST_STORY_ID_1).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -413,7 +428,7 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveStory_invalidStory_returnsFailure() {
-    topicController.getStory(profileId1, INVALID_TOPIC_ID_1, INVALID_STORY_ID_1)
+    topicController.getStory(profileId1, INVALID_TOPIC_ID_1, INVALID_STORY_ID_1).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -703,7 +718,9 @@ class TopicControllerTest {
 
   @Test
   fun testRetrieveSubtopicTopic_validSubtopic_returnsSubtopicWithThumbnail() {
-    topicController.getTopic(profileId1, FRACTIONS_TOPIC_ID).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId1, FRACTIONS_TOPIC_ID
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicSucceeded()
@@ -719,7 +736,7 @@ class TopicControllerTest {
       .retrieveQuestionsForSkillIds(
         listOf(TEST_SKILL_ID_0, TEST_SKILL_ID_1)
       )
-    dataProviders.convertToLiveData(questionsListProvider).observeForever(mockQuestionListObserver)
+    questionsListProvider.toLiveData().observeForever(mockQuestionListObserver)
     testCoroutineDispatchers.runCurrent()
     verify(mockQuestionListObserver).onChanged(questionListResultCaptor.capture())
 
@@ -741,7 +758,7 @@ class TopicControllerTest {
       .retrieveQuestionsForSkillIds(
         listOf(FRACTIONS_SKILL_ID_0)
       )
-    dataProviders.convertToLiveData(questionsListProvider)
+    questionsListProvider.toLiveData()
       .observeForever(mockQuestionListObserver)
     testCoroutineDispatchers.runCurrent()
     verify(mockQuestionListObserver).onChanged(questionListResultCaptor.capture())
@@ -764,7 +781,7 @@ class TopicControllerTest {
       .retrieveQuestionsForSkillIds(
         listOf(FRACTIONS_SKILL_ID_1)
       )
-    dataProviders.convertToLiveData(questionsListProvider)
+    questionsListProvider.toLiveData()
       .observeForever(mockQuestionListObserver)
     testCoroutineDispatchers.runCurrent()
     verify(mockQuestionListObserver).onChanged(questionListResultCaptor.capture())
@@ -786,7 +803,7 @@ class TopicControllerTest {
       .retrieveQuestionsForSkillIds(
         listOf(FRACTIONS_SKILL_ID_2)
       )
-    dataProviders.convertToLiveData(questionsListProvider)
+    questionsListProvider.toLiveData()
       .observeForever(mockQuestionListObserver)
     testCoroutineDispatchers.runCurrent()
     verify(mockQuestionListObserver).onChanged(questionListResultCaptor.capture())
@@ -809,7 +826,7 @@ class TopicControllerTest {
       .retrieveQuestionsForSkillIds(
         listOf(RATIOS_SKILL_ID_0)
       )
-    dataProviders.convertToLiveData(questionsListProvider)
+    questionsListProvider.toLiveData()
       .observeForever(mockQuestionListObserver)
     testCoroutineDispatchers.runCurrent()
     verify(mockQuestionListObserver).onChanged(questionListResultCaptor.capture())
@@ -831,7 +848,7 @@ class TopicControllerTest {
       .retrieveQuestionsForSkillIds(
         listOf(TEST_SKILL_ID_0, TEST_SKILL_ID_1, "NON_EXISTENT_SKILL_ID")
       )
-    dataProviders.convertToLiveData(questionsListProvider)
+    questionsListProvider.toLiveData()
       .observeForever(mockQuestionListObserver)
     testCoroutineDispatchers.runCurrent()
     verify(mockQuestionListObserver).onChanged(questionListResultCaptor.capture())
@@ -843,7 +860,9 @@ class TopicControllerTest {
 
   @Test
   fun testGetTopic_invalidTopicId_getTopic_noResultFound() {
-    topicController.getTopic(profileId1, INVALID_TOPIC_ID_1).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId1, INVALID_TOPIC_ID_1
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicFailed()
@@ -851,7 +870,9 @@ class TopicControllerTest {
 
   @Test
   fun testGetTopic_validTopicId_withoutAnyProgress_getTopicSucceedsWithCorrectProgress() {
-    topicController.getTopic(profileId1, FRACTIONS_TOPIC_ID).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId1, FRACTIONS_TOPIC_ID
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicSucceeded()
@@ -868,7 +889,9 @@ class TopicControllerTest {
     markFractionsStory0Chapter0AsCompleted()
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getTopic(profileId1, FRACTIONS_TOPIC_ID).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId1, FRACTIONS_TOPIC_ID
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicSucceeded()
@@ -882,7 +905,7 @@ class TopicControllerTest {
 
   @Test
   fun testGetStory_invalidData_getStory_noResultFound() {
-    topicController.getStory(profileId1, INVALID_TOPIC_ID_1, INVALID_STORY_ID_1)
+    topicController.getStory(profileId1, INVALID_TOPIC_ID_1, INVALID_STORY_ID_1).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -891,7 +914,7 @@ class TopicControllerTest {
 
   @Test
   fun testGetStory_validData_withoutAnyProgress_getStorySucceedsWithCorrectProgress() {
-    topicController.getStory(profileId1, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0)
+    topicController.getStory(profileId1, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -909,7 +932,9 @@ class TopicControllerTest {
     markFractionsStory0Chapter0AsCompleted()
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getTopic(profileId1, FRACTIONS_TOPIC_ID).observeForever(mockTopicObserver)
+    topicController.getTopic(
+      profileId1, FRACTIONS_TOPIC_ID
+    ).toLiveData().observeForever(mockTopicObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyRecordProgressSucceeded()
@@ -924,7 +949,9 @@ class TopicControllerTest {
 
   @Test
   fun testOngoingTopicList_validData_withoutAnyProgress_ongoingTopicListIsEmpty() {
-    topicController.getOngoingTopicList(profileId1).observeForever(mockOngoingTopicListObserver)
+    topicController.getOngoingTopicList(
+      profileId1
+    ).toLiveData().observeForever(mockOngoingTopicListObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetOngoingTopicListSucceeded()
@@ -937,7 +964,9 @@ class TopicControllerTest {
     markFractionsStory0Chapter0AsCompleted()
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getOngoingTopicList(profileId1).observeForever(mockOngoingTopicListObserver)
+    topicController.getOngoingTopicList(
+      profileId1
+    ).toLiveData().observeForever(mockOngoingTopicListObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetOngoingTopicListSucceeded()
@@ -954,7 +983,9 @@ class TopicControllerTest {
     markFractionsStory0Chapter1AsCompleted()
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getOngoingTopicList(profileId1).observeForever(mockOngoingTopicListObserver)
+    topicController.getOngoingTopicList(
+      profileId1
+    ).toLiveData().observeForever(mockOngoingTopicListObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetOngoingTopicListSucceeded()
@@ -975,7 +1006,9 @@ class TopicControllerTest {
     markRatiosStory0Chapter0AsCompleted()
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getOngoingTopicList(profileId1).observeForever(mockOngoingTopicListObserver)
+    topicController.getOngoingTopicList(
+      profileId1
+    ).toLiveData().observeForever(mockOngoingTopicListObserver)
     testCoroutineDispatchers.runCurrent()
 
     verifyGetOngoingTopicListSucceeded()
@@ -986,7 +1019,7 @@ class TopicControllerTest {
 
   @Test
   fun testCompletedStoryList_validData_withoutAnyProgress_completedStoryListIsEmpty() {
-    topicController.getCompletedStoryList(profileId1)
+    topicController.getCompletedStoryList(profileId1).toLiveData()
       .observeForever(mockCompletedStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -1000,7 +1033,7 @@ class TopicControllerTest {
     markFractionsStory0Chapter0AsCompleted()
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getCompletedStoryList(profileId1)
+    topicController.getCompletedStoryList(profileId1).toLiveData()
       .observeForever(mockCompletedStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -1017,7 +1050,7 @@ class TopicControllerTest {
     markFractionsStory0Chapter1AsCompleted()
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getCompletedStoryList(profileId1)
+    topicController.getCompletedStoryList(profileId1).toLiveData()
       .observeForever(mockCompletedStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -1036,7 +1069,7 @@ class TopicControllerTest {
     markFractionsStory0Chapter1AsCompleted()
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getStory(profileId1, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0)
+    topicController.getStory(profileId1, FRACTIONS_TOPIC_ID, FRACTIONS_STORY_ID_0).toLiveData()
       .observeForever(mockStorySummaryObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -1058,7 +1091,7 @@ class TopicControllerTest {
     markRatiosStory0Chapter1AsCompleted()
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getCompletedStoryList(profileId1)
+    topicController.getCompletedStoryList(profileId1).toLiveData()
       .observeForever(mockCompletedStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -1083,7 +1116,7 @@ class TopicControllerTest {
     markRatiosStory0Chapter1AsCompleted()
     testCoroutineDispatchers.runCurrent()
 
-    topicController.getCompletedStoryList(profileId1)
+    topicController.getCompletedStoryList(profileId1).toLiveData()
       .observeForever(mockCompletedStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -1117,7 +1150,8 @@ class TopicControllerTest {
       FRACTIONS_STORY_ID_0,
       FRACTIONS_EXPLORATION_ID_0,
       currentTimestamp
-    ).observeForever(mockRecordProgressObserver)
+    )
+    Unit.observeForever(mockRecordProgressObserver)
   }
 
   private fun markFractionsStory0Chapter1AsCompleted() {
@@ -1127,7 +1161,8 @@ class TopicControllerTest {
       FRACTIONS_STORY_ID_0,
       FRACTIONS_EXPLORATION_ID_1,
       currentTimestamp
-    ).observeForever(mockRecordProgressObserver)
+    )
+    Unit.observeForever(mockRecordProgressObserver)
   }
 
   private fun markRatiosStory0Chapter0AsCompleted() {
@@ -1137,7 +1172,8 @@ class TopicControllerTest {
       RATIOS_STORY_ID_0,
       RATIOS_EXPLORATION_ID_0,
       currentTimestamp
-    ).observeForever(mockRecordProgressObserver)
+    )
+    Unit.observeForever(mockRecordProgressObserver)
   }
 
   private fun markRatiosStory0Chapter1AsCompleted() {
@@ -1147,7 +1183,8 @@ class TopicControllerTest {
       RATIOS_STORY_ID_0,
       RATIOS_EXPLORATION_ID_1,
       currentTimestamp
-    ).observeForever(mockRecordProgressObserver)
+    )
+    Unit.observeForever(mockRecordProgressObserver)
   }
 
   private fun verifyRecordProgressSucceeded() {

--- a/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
@@ -1266,7 +1266,7 @@ class TopicControllerTest {
       TestDispatcherModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicControllerTest.kt
@@ -40,6 +40,8 @@ import org.oppia.util.caching.CacheAssetsLocally
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders
 import org.oppia.util.data.DataProviders.Companion.toLiveData
+import org.oppia.util.data.DataProvidersInjector
+import org.oppia.util.data.DataProvidersInjectorProvider
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -57,7 +59,7 @@ private const val INVALID_TOPIC_ID_1 = "INVALID_TOPIC_ID_1"
 /** Tests for [TopicController]. */
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
-@Config(manifest = Config.NONE)
+@Config(application = TopicControllerTest.TestApplication::class)
 class TopicControllerTest {
 
   @Inject
@@ -1137,10 +1139,7 @@ class TopicControllerTest {
   }
 
   private fun setUpTestApplicationComponent() {
-    DaggerTopicControllerTest_TestApplicationComponent.builder()
-      .setApplication(ApplicationProvider.getApplicationContext())
-      .build()
-      .inject(this)
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
   private fun markFractionsStory0Chapter0AsCompleted() {
@@ -1150,8 +1149,7 @@ class TopicControllerTest {
       FRACTIONS_STORY_ID_0,
       FRACTIONS_EXPLORATION_ID_0,
       currentTimestamp
-    )
-    Unit.observeForever(mockRecordProgressObserver)
+    ).toLiveData().observeForever(mockRecordProgressObserver)
   }
 
   private fun markFractionsStory0Chapter1AsCompleted() {
@@ -1161,8 +1159,7 @@ class TopicControllerTest {
       FRACTIONS_STORY_ID_0,
       FRACTIONS_EXPLORATION_ID_1,
       currentTimestamp
-    )
-    Unit.observeForever(mockRecordProgressObserver)
+    ).toLiveData().observeForever(mockRecordProgressObserver)
   }
 
   private fun markRatiosStory0Chapter0AsCompleted() {
@@ -1172,8 +1169,7 @@ class TopicControllerTest {
       RATIOS_STORY_ID_0,
       RATIOS_EXPLORATION_ID_0,
       currentTimestamp
-    )
-    Unit.observeForever(mockRecordProgressObserver)
+    ).toLiveData().observeForever(mockRecordProgressObserver)
   }
 
   private fun markRatiosStory0Chapter1AsCompleted() {
@@ -1183,8 +1179,7 @@ class TopicControllerTest {
       RATIOS_STORY_ID_0,
       RATIOS_EXPLORATION_ID_1,
       currentTimestamp
-    )
-    Unit.observeForever(mockRecordProgressObserver)
+    ).toLiveData().observeForever(mockRecordProgressObserver)
   }
 
   private fun verifyRecordProgressSucceeded() {
@@ -1271,7 +1266,7 @@ class TopicControllerTest {
       TestDispatcherModule::class
     ]
   )
-  interface TestApplicationComponent {
+  interface TestApplicationComponent: DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance
@@ -1281,5 +1276,19 @@ class TopicControllerTest {
     }
 
     fun inject(topicControllerTest: TopicControllerTest)
+  }
+
+  class TestApplication : Application(), DataProvidersInjectorProvider {
+    private val component: TestApplicationComponent by lazy {
+      DaggerTopicControllerTest_TestApplicationComponent.builder()
+        .setApplication(this)
+        .build()
+    }
+
+    fun inject(topicControllerTest: TopicControllerTest) {
+      component.inject(topicControllerTest)
+    }
+
+    override fun getDataProvidersInjector(): DataProvidersInjector = component
   }
 }

--- a/domain/src/test/java/org/oppia/domain/topic/TopicListControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicListControllerTest.kt
@@ -32,6 +32,7 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.caching.CacheAssetsLocally
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.gcsresource.DefaultResourceBucketName
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
@@ -229,7 +230,7 @@ class TopicListControllerTest {
 
   @Test
   fun testRetrieveOngoingStoryList_defaultLesson_hasCorrectInfo() {
-    topicListController.getOngoingStoryList(profileId0)
+    topicListController.getOngoingStoryList(profileId0).toLiveData()
       .observeForever(mockOngoingStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -249,7 +250,7 @@ class TopicListControllerTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicListController.getOngoingStoryList(profileId0)
+    topicListController.getOngoingStoryList(profileId0).toLiveData()
       .observeForever(mockOngoingStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -271,7 +272,7 @@ class TopicListControllerTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicListController.getOngoingStoryList(profileId0)
+    topicListController.getOngoingStoryList(profileId0).toLiveData()
       .observeForever(mockOngoingStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -302,7 +303,7 @@ class TopicListControllerTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicListController.getOngoingStoryList(profileId0)
+    topicListController.getOngoingStoryList(profileId0).toLiveData()
       .observeForever(mockOngoingStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -334,7 +335,7 @@ class TopicListControllerTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicListController.getOngoingStoryList(profileId0)
+    topicListController.getOngoingStoryList(profileId0).toLiveData()
       .observeForever(mockOngoingStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -365,7 +366,7 @@ class TopicListControllerTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicListController.getOngoingStoryList(profileId0)
+    topicListController.getOngoingStoryList(profileId0).toLiveData()
       .observeForever(mockOngoingStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -397,7 +398,7 @@ class TopicListControllerTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicListController.getOngoingStoryList(profileId0)
+    topicListController.getOngoingStoryList(profileId0).toLiveData()
       .observeForever(mockOngoingStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -438,7 +439,7 @@ class TopicListControllerTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicListController.getOngoingStoryList(profileId0)
+    topicListController.getOngoingStoryList(profileId0).toLiveData()
       .observeForever(mockOngoingStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 
@@ -480,7 +481,7 @@ class TopicListControllerTest {
     )
     testCoroutineDispatchers.runCurrent()
 
-    topicListController.getOngoingStoryList(profileId0)
+    topicListController.getOngoingStoryList(profileId0).toLiveData()
       .observeForever(mockOngoingStoryListObserver)
     testCoroutineDispatchers.runCurrent()
 

--- a/domain/src/test/java/org/oppia/domain/topic/TopicListControllerTest.kt
+++ b/domain/src/test/java/org/oppia/domain/topic/TopicListControllerTest.kt
@@ -671,7 +671,7 @@ class TopicListControllerTest {
       TestDispatcherModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/testing/src/main/java/org/oppia/testing/profile/ProfileTestHelper.kt
+++ b/testing/src/main/java/org/oppia/testing/profile/ProfileTestHelper.kt
@@ -5,6 +5,7 @@ import org.oppia.app.model.ProfileId
 import org.oppia.domain.profile.ProfileManagementController
 import org.oppia.testing.TestCoroutineDispatchers
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import javax.inject.Inject
 
 /** This helper allows tests to easily create new profiles and switch between them. */
@@ -41,7 +42,7 @@ class ProfileTestHelper @Inject constructor(
     val result = profileManagementController.loginToProfile(
       ProfileId.newBuilder().setInternalId(0)
         .build()
-    )
+    ).toLiveData()
     testCoroutineDispatchers.runCurrent()
     return result
   }
@@ -55,10 +56,10 @@ class ProfileTestHelper @Inject constructor(
       allowDownloadAccess = true,
       colorRgb = -10710042,
       isAdmin = true
-    )
+    ).toLiveData()
     val result = profileManagementController.loginToProfile(
       ProfileId.newBuilder().setInternalId(0).build()
-    )
+    ).toLiveData()
     testCoroutineDispatchers.runCurrent()
     return result
   }
@@ -87,7 +88,7 @@ class ProfileTestHelper @Inject constructor(
   private fun logIntoProfile(internalProfileId: Int): LiveData<AsyncResult<Any?>> {
     val result = profileManagementController.loginToProfile(
       ProfileId.newBuilder().setInternalId(internalProfileId).build()
-    )
+    ).toLiveData()
     testCoroutineDispatchers.runCurrent()
     return result
   }

--- a/testing/src/test/java/org/oppia/testing/profile/ProfileTestHelperTest.kt
+++ b/testing/src/test/java/org/oppia/testing/profile/ProfileTestHelperTest.kt
@@ -29,6 +29,8 @@ import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
 import org.oppia.util.data.DataProviders.Companion.toLiveData
+import org.oppia.util.data.DataProvidersInjector
+import org.oppia.util.data.DataProvidersInjectorProvider
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -41,7 +43,7 @@ import javax.inject.Singleton
 /** Tests for [ProfileTestHelperTest]. */
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
-@Config(manifest = Config.NONE)
+@Config(application = ProfileTestHelperTest.TestApplication::class)
 class ProfileTestHelperTest {
   @Rule
   @JvmField
@@ -77,10 +79,7 @@ class ProfileTestHelperTest {
   }
 
   private fun setUpTestApplicationComponent() {
-    DaggerProfileTestHelperTest_TestApplicationComponent.builder()
-      .setApplication(ApplicationProvider.getApplicationContext())
-      .build()
-      .inject(this)
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
   @Test
@@ -186,7 +185,7 @@ class ProfileTestHelperTest {
       TestDispatcherModule::class
     ]
   )
-  interface TestApplicationComponent {
+  interface TestApplicationComponent: DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance
@@ -196,5 +195,19 @@ class ProfileTestHelperTest {
     }
 
     fun inject(profileTestHelperTest: ProfileTestHelperTest)
+  }
+
+  class TestApplication : Application(), DataProvidersInjectorProvider {
+    private val component: TestApplicationComponent by lazy {
+      DaggerProfileTestHelperTest_TestApplicationComponent.builder()
+        .setApplication(this)
+        .build()
+    }
+
+    fun inject(profileTestHelperTest: ProfileTestHelperTest) {
+      component.inject(profileTestHelperTest)
+    }
+
+    override fun getDataProvidersInjector(): DataProvidersInjector = component
   }
 }

--- a/testing/src/test/java/org/oppia/testing/profile/ProfileTestHelperTest.kt
+++ b/testing/src/test/java/org/oppia/testing/profile/ProfileTestHelperTest.kt
@@ -185,7 +185,7 @@ class ProfileTestHelperTest {
       TestDispatcherModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance

--- a/testing/src/test/java/org/oppia/testing/profile/ProfileTestHelperTest.kt
+++ b/testing/src/test/java/org/oppia/testing/profile/ProfileTestHelperTest.kt
@@ -28,6 +28,7 @@ import org.oppia.testing.TestCoroutineDispatchers
 import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
 import org.oppia.util.data.AsyncResult
+import org.oppia.util.data.DataProviders.Companion.toLiveData
 import org.oppia.util.logging.EnableConsoleLog
 import org.oppia.util.logging.EnableFileLog
 import org.oppia.util.logging.GlobalLogLevel
@@ -85,7 +86,7 @@ class ProfileTestHelperTest {
   @Test
   fun testInitializeProfiles_initializeProfiles_checkProfilesAreAddedAndCurrentIsSet() {
     profileTestHelper.initializeProfiles().observeForever(mockUpdateResultObserver)
-    profileManagementController.getProfiles().observeForever(mockProfilesObserver)
+    profileManagementController.getProfiles().toLiveData().observeForever(mockProfilesObserver)
     testCoroutineDispatchers.runCurrent()
 
     verify(mockProfilesObserver, atLeastOnce()).onChanged(profilesResultCaptor.capture())
@@ -103,7 +104,7 @@ class ProfileTestHelperTest {
   @Test
   fun testInitializeProfiles_addOnlyAdminProfile_checkProfileIsAddedAndCurrentIsSet() {
     profileTestHelper.addOnlyAdminProfile().observeForever(mockUpdateResultObserver)
-    profileManagementController.getProfiles().observeForever(mockProfilesObserver)
+    profileManagementController.getProfiles().toLiveData().observeForever(mockProfilesObserver)
     testCoroutineDispatchers.runCurrent()
 
     verify(mockProfilesObserver, atLeastOnce()).onChanged(profilesResultCaptor.capture())
@@ -121,7 +122,7 @@ class ProfileTestHelperTest {
   fun testAddMoreProfiles_addMoreProfiles_checkProfilesAreAdded() {
     profileTestHelper.addMoreProfiles(10)
     testCoroutineDispatchers.runCurrent()
-    profileManagementController.getProfiles().observeForever(mockProfilesObserver)
+    profileManagementController.getProfiles().toLiveData().observeForever(mockProfilesObserver)
     testCoroutineDispatchers.runCurrent()
 
     verify(mockProfilesObserver, atLeastOnce()).onChanged(profilesResultCaptor.capture())

--- a/utility/src/main/java/org/oppia/util/data/DataProvider.kt
+++ b/utility/src/main/java/org/oppia/util/data/DataProvider.kt
@@ -1,11 +1,13 @@
 package org.oppia.util.data
 
+import android.content.Context
+
 /**
  * Represents a provider of data that can be delivered and changed asynchronously.
  *
  * @param <T> The type of data being provided.
  */
-interface DataProvider<T> {
+abstract class DataProvider<T>(internal val context: Context) {
   // TODO(#6): Finalize the interfaces for this API beyond a basic prototype for the initial project intro.
 
   /**
@@ -13,7 +15,7 @@ interface DataProvider<T> {
    * immutable object. This ID is used to determine which data provider subscribers should be notified of changes to the
    * data.
    */
-  fun getId(): Any
+  abstract fun getId(): Any
 
   /**
    * Returns the latest copy of data available by the provider, potentially performing a blocking call in order to
@@ -22,5 +24,5 @@ interface DataProvider<T> {
    * particular subscription since this can be highly error-prone when considering that subscribers may be bound to
    * Android UI component lifecycles).
    */
-  suspend fun retrieveData(): AsyncResult<T>
+  abstract suspend fun retrieveData(): AsyncResult<T>
 }

--- a/utility/src/main/java/org/oppia/util/data/DataProvider.kt
+++ b/utility/src/main/java/org/oppia/util/data/DataProvider.kt
@@ -8,21 +8,23 @@ import android.content.Context
  * @param <T> The type of data being provided.
  */
 abstract class DataProvider<T>(internal val context: Context) {
-  // TODO(#6): Finalize the interfaces for this API beyond a basic prototype for the initial project intro.
+  // TODO(#6): Finalize the interfaces for this API beyond a basic prototype for the initial project
+  //  intro.
 
   /**
-   * Returns a unique identifier that corresponds to this data provider. This should be a trivially copyable and
-   * immutable object. This ID is used to determine which data provider subscribers should be notified of changes to the
-   * data.
+   * Returns a unique identifier that corresponds to this data provider. This should be a trivially
+   * copyable and immutable object. This ID is used to determine which data provider subscribers
+   * should be notified of changes to the data.
    */
   abstract fun getId(): Any
 
   /**
-   * Returns the latest copy of data available by the provider, potentially performing a blocking call in order to
-   * retrieve the data. It's up to the implementation to decide how caching should work. Implementations should remain
-   * agnostic of the specific subscribers associated with them (ie, they should not perform logic corresponding to a
-   * particular subscription since this can be highly error-prone when considering that subscribers may be bound to
-   * Android UI component lifecycles).
+   * Returns the latest copy of data available by the provider, potentially performing a blocking
+   * call in order to retrieve the data. It's up to the implementation to decide how caching should
+   * work. Implementations should remain agnostic of the specific subscribers associated with them
+   * (ie, they should not perform logic corresponding to a particular subscription since this can be
+   * highly error-prone when considering that subscribers may be bound to Android UI component
+   * lifecycles).
    */
   abstract suspend fun retrieveData(): AsyncResult<T>
 }

--- a/utility/src/main/java/org/oppia/util/data/DataProviders.kt
+++ b/utility/src/main/java/org/oppia/util/data/DataProviders.kt
@@ -163,7 +163,8 @@ class DataProviders @Inject constructor(
     }
 
     private fun <T> DataProvider<T>.getDataProviders(): DataProviders {
-      return (context as DataProvidersInjector).getDataProviders()
+      val injectorProvider = context.applicationContext as DataProvidersInjectorProvider
+      return injectorProvider.getDataProvidersInjector().getDataProviders()
     }
   }
 

--- a/utility/src/main/java/org/oppia/util/data/DataProviders.kt
+++ b/utility/src/main/java/org/oppia/util/data/DataProviders.kt
@@ -1,6 +1,8 @@
 package org.oppia.util.data
 
+import android.content.Context
 import androidx.lifecycle.LiveData
+import dagger.Reusable
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -10,160 +12,174 @@ import org.oppia.util.threading.BackgroundDispatcher
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * Various functions to create or manipulate [DataProvider]s.
  *
- * It's recommended to transform providers rather than [LiveData] since the latter occurs on the main thread, and the
- * former can occur safely on background threads to reduce UI lag and user perceived latency.
+ * It's recommended to transform providers rather than [LiveData] since the latter occurs on the
+ * main thread, and the former can occur safely on background threads to reduce UI lag and user
+ * perceived latency.
  */
-@Singleton
+@Reusable // Since otherwise a new provider will be created for each companion object call.
 class DataProviders @Inject constructor(
+  private val context: Context,
   @BackgroundDispatcher private val backgroundDispatcher: CoroutineDispatcher,
   private val asyncDataSubscriptionManager: AsyncDataSubscriptionManager,
   private val exceptionLogger: ExceptionLogger
 ) {
+  companion object {
+    /**
+     * Returns a new [DataProvider] that applies the specified function each time new data is
+     * available to this data provider, and provides the transformed data to its own subscribers.
+     *
+     * Notifications to the original data provider will also notify subscribers to the transformed
+     * data provider of changes, but not vice versa.
+     *
+     * Note that the input transformation function should be non-blocking, have no side effects, and
+     * be thread-safe since it may be called on different background threads at different times. It
+     * should perform no UI operations or otherwise interact with UI components.
+     */
+    fun <I, O> DataProvider<I>.transform(newId: Any, function: (I) -> O): DataProvider<O> {
+      val dataProviders = getDataProviders()
+      dataProviders.asyncDataSubscriptionManager.associateIds(newId, getId())
+      return object : DataProvider<O>(context) {
+        override fun getId(): Any = newId
 
-  /**
-   * Returns a new [DataProvider] that applies the specified function each time new data is available to it, and
-   * provides it to its own subscribers.
-   *
-   * Notifications to the original data provider will also notify subscribers to the transformed data provider of
-   * changes, but not vice versa.
-   *
-   * Note that the input transformation function should be non-blocking, have no side effects, and be thread-safe since
-   * it may be called on different background threads at different times. It should perform no UI operations or
-   * otherwise interact with UI components.
-   */
-  fun <T1, T2> transform(
-    newId: Any,
-    dataProvider: DataProvider<T1>,
-    function: (T1) -> T2
-  ): DataProvider<T2> {
-    asyncDataSubscriptionManager.associateIds(newId, dataProvider.getId())
-    return object : DataProvider<T2> {
-      override fun getId(): Any {
-        return newId
-      }
-
-      override suspend fun retrieveData(): AsyncResult<T2> {
-        return try {
-          dataProvider.retrieveData().transform(function)
-        } catch (e: Exception) {
-          exceptionLogger.logException(e)
-          AsyncResult.failed(e)
+        override suspend fun retrieveData(): AsyncResult<O> {
+          return try {
+            this@transform.retrieveData().transform(function)
+          } catch (e: Exception) {
+            dataProviders.exceptionLogger.logException(e)
+            AsyncResult.failed(e)
+          }
         }
       }
     }
-  }
 
-  /**
-   * Returns a transformed [DataProvider] in the same way as [transform] except the transformation function can be
-   * blocking.
-   */
-  fun <T1, T2> transformAsync(
-    newId: Any,
-    dataProvider: DataProvider<T1>,
-    function: suspend (T1) -> AsyncResult<T2>
-  ): DataProvider<T2> {
-    asyncDataSubscriptionManager.associateIds(newId, dataProvider.getId())
-    return object : DataProvider<T2> {
-      override fun getId(): Any {
-        return newId
-      }
+    /**
+     * Returns a transformed [DataProvider] in the same way as [transform] except the transformation
+     * function can be blocking.
+     */
+    fun <I, O> DataProvider<I>.transformAsync(
+      newId: Any,
+      function: suspend (I) -> AsyncResult<O>
+    ): DataProvider<O> {
+      val dataProviders = getDataProviders()
+      dataProviders.asyncDataSubscriptionManager.associateIds(newId, getId())
+      return object : DataProvider<O>(context) {
+        override fun getId(): Any = newId
 
-      override suspend fun retrieveData(): AsyncResult<T2> {
-        return dataProvider.retrieveData().transformAsync(function)
-      }
-    }
-  }
-
-  /**
-   * Returns a new [NestedTransformedDataProvider]. By default, the data provider returned by this function behaves the
-   * same as [transformAsync]'s, except this one supports changing its based provider. If callers do not plan to change
-   * the underlying base provider, [transformAsync] should be used, instead.
-   */
-  fun <T1, T2> createNestedTransformedDataProvider(
-    newId: Any,
-    dataProvider: DataProvider<T1>,
-    function: suspend (T1) -> AsyncResult<T2>
-  ): NestedTransformedDataProvider<T2> {
-    return NestedTransformedDataProvider.createNestedTransformedDataProvider(
-      newId, dataProvider, function, asyncDataSubscriptionManager
-    )
-  }
-
-  /**
-   * Returns a new [DataProvider] that combines two other providers by applying the specified function to produce a new
-   * value each time either data provider changes.
-   *
-   * Notifications to the original data providers will also notify subscribers to the combined data provider of
-   * changes, but not vice versa.
-   *
-   * Note that the combine function should be non-blocking, have no side effects, and be thread-safe since it may be
-   * called on different background threads at different times. It should perform no UI operations or otherwise interact
-   * with UI components.
-   */
-  fun <O, T1, T2> combine(
-    newId: Any,
-    dataProvider1: DataProvider<T1>,
-    dataProvider2: DataProvider<T2>,
-    function: (T1, T2) -> O
-  ): DataProvider<O> {
-    asyncDataSubscriptionManager.associateIds(newId, dataProvider1.getId())
-    asyncDataSubscriptionManager.associateIds(newId, dataProvider2.getId())
-    return object : DataProvider<O> {
-      override fun getId(): Any {
-        return newId
-      }
-
-      override suspend fun retrieveData(): AsyncResult<O> {
-        return try {
-          dataProvider1.retrieveData().combineWith(dataProvider2.retrieveData(), function)
-        } catch (e: Exception) {
-          exceptionLogger.logException(e)
-          AsyncResult.failed(e)
+        override suspend fun retrieveData(): AsyncResult<O> {
+          return this@transformAsync.retrieveData().transformAsync(function)
         }
       }
     }
-  }
 
-  /**
-   * Returns a transformed [DataProvider] in the same way as [combine] except the combine function can be blocking.
-   */
-  fun <O, T1, T2> combineAsync(
-    newId: Any,
-    dataProvider1: DataProvider<T1>,
-    dataProvider2: DataProvider<T2>,
-    function: suspend (T1, T2) -> AsyncResult<O>
-  ): DataProvider<O> {
-    asyncDataSubscriptionManager.associateIds(newId, dataProvider1.getId())
-    asyncDataSubscriptionManager.associateIds(newId, dataProvider2.getId())
-    return object : DataProvider<O> {
-      override fun getId(): Any {
-        return newId
-      }
+    /**
+     * Returns a new [NestedTransformedDataProvider] based on the current provider. By default, the
+     * data provider returned by this function behaves the same as [transformAsync]'s, except this
+     * one supports changing its based provider. If callers do not plan to change the underlying
+     * base provider, [transformAsync] should be used, instead.
+     */
+    fun <I, O> DataProvider<I>.transformNested(
+      newId: Any,
+      function: suspend (I) -> AsyncResult<O>
+    ): NestedTransformedDataProvider<O> {
+      return NestedTransformedDataProvider.createNestedTransformedDataProvider(
+        context, newId, this, function, getDataProviders().asyncDataSubscriptionManager
+      )
+    }
 
-      override suspend fun retrieveData(): AsyncResult<O> {
-        return dataProvider1.retrieveData().combineWithAsync(dataProvider2.retrieveData(), function)
+    /**
+     * Returns a new [DataProvider] that combines this provider with another by applying the
+     * specified function to produce a new value each time either data provider changes.
+     *
+     * Notifications to the original data providers will also notify subscribers to the combined
+     * data provider of changes, but not vice versa.
+     *
+     * Note that the combine function should be non-blocking, have no side effects, and be
+     * thread-safe since it may be called on different background threads at different times. It
+     * should perform no UI operations or otherwise interact with UI components.
+     */
+    fun <O, T1, T2> DataProvider<T1>.combineWith(
+      dataProvider: DataProvider<T2>,
+      newId: Any,
+      function: (T1, T2) -> O
+    ): DataProvider<O> {
+      val dataProviders = getDataProviders()
+      dataProviders.asyncDataSubscriptionManager.associateIds(newId, getId())
+      dataProviders.asyncDataSubscriptionManager.associateIds(newId, dataProvider.getId())
+      return object : DataProvider<O>(context) {
+        override fun getId(): Any {
+          return newId
+        }
+
+        override suspend fun retrieveData(): AsyncResult<O> {
+          return try {
+            this@combineWith.retrieveData().combineWith(dataProvider.retrieveData(), function)
+          } catch (e: Exception) {
+            dataProviders.exceptionLogger.logException(e)
+            AsyncResult.failed(e)
+          }
+        }
       }
+    }
+
+    /**
+     * Returns a transformed [DataProvider] in the same way as [combineWith] except the combine
+     * function can be blocking.
+     */
+    fun <O, T1, T2> DataProvider<T1>.combineWithAsync(
+      dataProvider: DataProvider<T2>,
+      newId: Any,
+      function: suspend (T1, T2) -> AsyncResult<O>
+    ): DataProvider<O> {
+      val dataProviders = getDataProviders()
+      dataProviders.asyncDataSubscriptionManager.associateIds(newId, getId())
+      dataProviders.asyncDataSubscriptionManager.associateIds(newId, dataProvider.getId())
+      return object : DataProvider<O>(context) {
+        override fun getId(): Any {
+          return newId
+        }
+
+        override suspend fun retrieveData(): AsyncResult<O> {
+          return this@combineWithAsync.retrieveData().combineWithAsync(
+            dataProvider.retrieveData(), function
+          )
+        }
+      }
+    }
+
+    /**
+     * Converts a [DataProvider] to [LiveData]. This will use a background executor to handle
+     * processing of the coroutine, but [LiveData] guarantees that final delivery of the result will
+     * happen on the main thread.
+     */
+    fun <T> DataProvider<T>.toLiveData(): LiveData<AsyncResult<T>> {
+      val dataProviders = getDataProviders()
+      return NotifiableAsyncLiveData(
+        dataProviders.backgroundDispatcher, dataProviders.asyncDataSubscriptionManager, this
+      )
+    }
+
+    private fun <T> DataProvider<T>.getDataProviders(): DataProviders {
+      return (context as DataProvidersInjector).getDataProviders()
     }
   }
 
   /**
-   * Returns a new in-memory [DataProvider] with the specified function being called each time the provider's data is
-   * retrieved, and the specified identifier.
+   * Returns a new in-memory [DataProvider] with the specified function being called each time the
+   * provider's data is retrieved, and the specified identifier.
    *
-   * Note that the loadFromMemory function should be non-blocking, and have no side effects. It should also be thread
-   * safe since it can be called from different background threads. It also should never interact with UI components or
-   * perform UI operations.
+   * Note that the loadFromMemory function should be non-blocking, and have no side effects. It
+   * should also be thread safe since it can be called from different background threads. It also
+   * should never interact with UI components or perform UI operations.
    *
-   * Changes to the returned data provider can be propagated using calls to [AsyncDataSubscriptionManager.notifyChange]
-   * with the in-memory provider's identifier.
+   * Changes to the returned data provider can be propagated using calls to
+   * [AsyncDataSubscriptionManager.notifyChange] with the in-memory provider's identifier.
    */
   fun <T> createInMemoryDataProvider(id: Any, loadFromMemory: () -> T): DataProvider<T> {
-    return object : DataProvider<T> {
+    return object : DataProvider<T>(context) {
       override fun getId(): Any {
         return id
       }
@@ -180,14 +196,14 @@ class DataProviders @Inject constructor(
   }
 
   /**
-   * Returns a new in-memory [DataProvider] in the same way as [createInMemoryDataProvider] except the load function can
-   * be blocking.
+   * Returns a new in-memory [DataProvider] in the same way as [createInMemoryDataProvider] except
+   * the load function can be blocking.
    */
   fun <T> createInMemoryDataProviderAsync(
     id: Any,
     loadFromMemoryAsync: suspend () -> AsyncResult<T>
   ): DataProvider<T> {
-    return object : DataProvider<T> {
+    return object : DataProvider<T>(context) {
       override fun getId(): Any {
         return id
       }
@@ -199,30 +215,23 @@ class DataProviders @Inject constructor(
   }
 
   /**
-   * Converts a [DataProvider] to [LiveData]. This will use a background executor to handle processing of the coroutine,
-   * but [LiveData] guarantees that final delivery of the result will happen on the main thread.
-   */
-  fun <T> convertToLiveData(dataProvider: DataProvider<T>): LiveData<AsyncResult<T>> {
-    return NotifiableAsyncLiveData(backgroundDispatcher, asyncDataSubscriptionManager, dataProvider)
-  }
-
-  /**
    * A [DataProvider] that acts in the same way as [transformAsync] except the underlying base data
    * provider can change.
    */
-  class NestedTransformedDataProvider<T2> private constructor(
+  class NestedTransformedDataProvider<O> private constructor(
+    context: Context,
     private val id: Any,
     private var baseId: Any,
     private val asyncDataSubscriptionManager: AsyncDataSubscriptionManager,
-    private var retrieveTransformedData: suspend () -> AsyncResult<T2>
-  ) : DataProvider<T2> {
+    private var retrieveTransformedData: suspend () -> AsyncResult<O>
+  ) : DataProvider<O>(context) {
     init {
       initializeTransformer()
     }
 
     override fun getId(): Any = id
 
-    override suspend fun retrieveData(): AsyncResult<T2> {
+    override suspend fun retrieveData(): AsyncResult<O> {
       return retrieveTransformedData()
     }
 
@@ -233,9 +242,9 @@ class DataProviders @Inject constructor(
      * Note that this will notify any observers of this provider so that they receive the latest
      * transformed value.
      */
-    fun <T1> setBaseDataProvider(
-      dataProvider: DataProvider<T1>,
-      transform: suspend (T1) -> AsyncResult<T2>
+    fun <I> setBaseDataProvider(
+      dataProvider: DataProvider<I>,
+      transform: suspend (I) -> AsyncResult<O>
     ) {
       asyncDataSubscriptionManager.dissociateIds(id, baseId)
       baseId = dataProvider.getId()
@@ -252,14 +261,15 @@ class DataProviders @Inject constructor(
 
     companion object {
       /** Returns a new [NestedTransformedDataProvider]. */
-      internal fun <T1, T2> createNestedTransformedDataProvider(
+      internal fun <I, O> createNestedTransformedDataProvider(
+        context: Context,
         id: Any,
-        baseDataProvider: DataProvider<T1>,
-        transform: suspend (T1) -> AsyncResult<T2>,
+        baseDataProvider: DataProvider<I>,
+        transform: suspend (I) -> AsyncResult<O>,
         asyncDataSubscriptionManager: AsyncDataSubscriptionManager
-      ): NestedTransformedDataProvider<T2> {
+      ): NestedTransformedDataProvider<O> {
         return NestedTransformedDataProvider(
-          id, baseDataProvider.getId(), asyncDataSubscriptionManager
+          context, id, baseDataProvider.getId(), asyncDataSubscriptionManager
         ) {
           baseDataProvider.retrieveData().transformAsync(transform)
         }

--- a/utility/src/main/java/org/oppia/util/data/DataProvidersInjector.kt
+++ b/utility/src/main/java/org/oppia/util/data/DataProvidersInjector.kt
@@ -1,0 +1,7 @@
+package org.oppia.util.data
+
+/** Injector for [DataProviders]. Implemented by a generated Dagger application component. */
+interface DataProvidersInjector {
+  /** Returns the [DataProviders] corresponding to the current application context. */
+  fun getDataProviders(): DataProviders
+}

--- a/utility/src/main/java/org/oppia/util/data/DataProvidersInjectorProvider.kt
+++ b/utility/src/main/java/org/oppia/util/data/DataProvidersInjectorProvider.kt
@@ -1,0 +1,7 @@
+package org.oppia.util.data
+
+/** Provider for [DataProvidersInjector]s. To be implemented by the application class. */
+interface DataProvidersInjectorProvider {
+  /** Returns the [DataProvidersInjector] corresponding to the current application context. */
+  fun getDataProvidersInjector(): DataProvidersInjector
+}

--- a/utility/src/test/java/org/oppia/util/data/DataProvidersTest.kt
+++ b/utility/src/test/java/org/oppia/util/data/DataProvidersTest.kt
@@ -30,6 +30,12 @@ import org.oppia.testing.FakeExceptionLogger
 import org.oppia.testing.TestCoroutineDispatchers
 import org.oppia.testing.TestDispatcherModule
 import org.oppia.testing.TestLogReportingModule
+import org.oppia.util.data.DataProviders.Companion.combineWith
+import org.oppia.util.data.DataProviders.Companion.combineWithAsync
+import org.oppia.util.data.DataProviders.Companion.toLiveData
+import org.oppia.util.data.DataProviders.Companion.transform
+import org.oppia.util.data.DataProviders.Companion.transformAsync
+import org.oppia.util.data.DataProviders.Companion.transformNested
 import org.oppia.util.threading.BackgroundDispatcher
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -61,6 +67,9 @@ class DataProvidersTest {
   @Rule
   @JvmField
   val mockitoRule: MockitoRule = MockitoJUnit.rule()
+
+  @Inject
+  lateinit var context: Context
 
   @Inject
   lateinit var dataProviders: DataProviders
@@ -102,12 +111,13 @@ class DataProvidersTest {
     setUpTestApplicationComponent()
   }
 
-  // Note: custom data providers aren't explicitly tested since their interaction with the infrastructure is tested
-  // through the providers created by DataProviders, and through other custom data providers in the stack.
+  // Note: custom data providers aren't explicitly tested since their interaction with the
+  // infrastructure is tested through the providers created by DataProviders, and through other
+  // custom data providers in the stack.
 
   @Test
   fun testConvertToLiveData_fakeDataProvider_noObserver_doesNotCallRetrieve() {
-    val fakeDataProvider = object : DataProvider<Int> {
+    val fakeDataProvider = object : DataProvider<Int>(context) {
       var hasRetrieveBeenCalled = false
 
       override fun getId(): Any = "fake_data_provider"
@@ -118,7 +128,7 @@ class DataProvidersTest {
       }
     }
 
-    dataProviders.convertToLiveData(fakeDataProvider)
+    fakeDataProvider.toLiveData()
     testCoroutineDispatchers.advanceUntilIdle()
 
     assertThat(fakeDataProvider.hasRetrieveBeenCalled).isFalse()
@@ -126,7 +136,7 @@ class DataProvidersTest {
 
   @Test
   fun testConvertToLiveData_fakeDataProvider_withObserver_callsRetrieve() {
-    val fakeDataProvider = object : DataProvider<Int> {
+    val fakeDataProvider = object : DataProvider<Int>(context) {
       var hasRetrieveBeenCalled = false
 
       override fun getId(): Any = "fake_data_provider"
@@ -137,7 +147,7 @@ class DataProvidersTest {
       }
     }
 
-    dataProviders.convertToLiveData(fakeDataProvider).observeForever(mockIntLiveDataObserver)
+    fakeDataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     assertThat(fakeDataProvider.hasRetrieveBeenCalled).isTrue()
@@ -145,13 +155,13 @@ class DataProvidersTest {
 
   @Test
   fun testConvertToLiveData_trivialDataProvider_withObserver_observerReceivesValue() {
-    val simpleDataProvider = object : DataProvider<Int> {
+    val simpleDataProvider = object : DataProvider<Int>(context) {
       override fun getId(): Any = "simple_data_provider"
 
       override suspend fun retrieveData(): AsyncResult<Int> = AsyncResult.success(123)
     }
 
-    dataProviders.convertToLiveData(simpleDataProvider).observeForever(mockIntLiveDataObserver)
+    simpleDataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockIntLiveDataObserver).onChanged(intResultCaptor.capture())
@@ -162,12 +172,12 @@ class DataProvidersTest {
   @Test
   fun testConvertToLiveData_dataProviderChanges_withObserver_observerReceivesUpdatedValue() {
     var providerValue = 123
-    val simpleDataProvider = object : DataProvider<Int> {
+    val simpleDataProvider = object : DataProvider<Int>(context) {
       override fun getId(): Any = "simple_data_provider"
 
       override suspend fun retrieveData(): AsyncResult<Int> = AsyncResult.success(providerValue)
     }
-    dataProviders.convertToLiveData(simpleDataProvider).observeForever(mockIntLiveDataObserver)
+    simpleDataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
 
     providerValue = 456
     asyncDataSubscriptionManager.notifyChangeAsync(simpleDataProvider.getId())
@@ -181,7 +191,7 @@ class DataProvidersTest {
   @Test
   fun testConvertToLiveData_providerChanges_withoutObserver_newObserver_newObserverReceivesValue() {
     var providerValue = 123
-    val simpleDataProvider = object : DataProvider<Int> {
+    val simpleDataProvider = object : DataProvider<Int>(context) {
       override fun getId(): Any = "simple_data_provider"
 
       override suspend fun retrieveData(): AsyncResult<Int> = AsyncResult.success(providerValue)
@@ -191,7 +201,7 @@ class DataProvidersTest {
     testCoroutineDispatchers.advanceUntilIdle()
 
     // Add an observer after the data provider has changed.
-    dataProviders.convertToLiveData(simpleDataProvider).observeForever(mockIntLiveDataObserver)
+    simpleDataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // The newer value should be observed.
@@ -202,12 +212,12 @@ class DataProvidersTest {
 
   @Test
   fun testConvertToLiveData_dataProviderNotified_sameValue_withObserver_observerNotCalledAgain() {
-    val simpleDataProvider = object : DataProvider<Int> {
+    val simpleDataProvider = object : DataProvider<Int>(context) {
       override fun getId(): Any = "simple_data_provider"
 
       override suspend fun retrieveData(): AsyncResult<Int> = AsyncResult.success(123)
     }
-    dataProviders.convertToLiveData(simpleDataProvider).observeForever(mockIntLiveDataObserver)
+    simpleDataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // Reset the observer and notify the provider has changed without providing a new value.
@@ -224,7 +234,7 @@ class DataProvidersTest {
     val providerOldResult = AsyncResult.success(123)
     testCoroutineDispatchers.advanceTimeBy(10)
     val providerNewResult = AsyncResult.success(456)
-    val simpleDataProvider = object : DataProvider<Int> {
+    val simpleDataProvider = object : DataProvider<Int>(context) {
       var callCount = 0
 
       override fun getId(): Any = "simple_data_provider"
@@ -242,7 +252,7 @@ class DataProvidersTest {
       }
     }
     // Ensure the initial value is retrieved to ensure multiple retrievals occur.
-    dataProviders.convertToLiveData(simpleDataProvider).observeForever(mockIntLiveDataObserver)
+    simpleDataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     asyncDataSubscriptionManager.notifyChangeAsync(simpleDataProvider.getId())
@@ -259,7 +269,7 @@ class DataProvidersTest {
   fun testInMemoryDataProvider_toLiveData_deliversInMemoryValue() {
     val dataProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -270,7 +280,7 @@ class DataProvidersTest {
   @Test
   fun testInMemoryDataProvider_toLiveData_notifies_doesNotDeliverSameValueAgain() {
     val dataProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     reset(mockStringLiveDataObserver)
@@ -288,7 +298,7 @@ class DataProvidersTest {
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
 
     inMemoryCachedStr = STR_VALUE_1
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -303,7 +313,7 @@ class DataProvidersTest {
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
 
     // Ensure the initial state is sent before changing the cache.
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     // Now change the cache & give it time to propagate.
     inMemoryCachedStr = STR_VALUE_1
@@ -320,7 +330,7 @@ class DataProvidersTest {
     val dataProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_1
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_0)
     testCoroutineDispatchers.advanceUntilIdle()
@@ -337,7 +347,7 @@ class DataProvidersTest {
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
 
     // Ensure the initial state is sent before changing the cache.
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     // Now change the cache & give it time to propagate.
     inMemoryCachedStr = STR_VALUE_1
@@ -352,8 +362,9 @@ class DataProvidersTest {
 
   @Test
   fun testInMemoryDataProvider_toLiveData_withObserver_doesCallFunction() {
-    // It would be nice to use a mock of the lambda (e.g. https://stackoverflow.com/a/53306974/3689782), but this
-    // apparently does not work with Robolectric: https://github.com/robolectric/robolectric/issues/3688.
+    // It would be nice to use a mock of the lambda (e.g.
+    // https://stackoverflow.com/a/53306974/3689782), but this apparently does not work with
+    // Robolectric: https://github.com/robolectric/robolectric/issues/3688.
     var fakeLoadMemoryCallbackCalled = false
     val fakeLoadMemoryCallback: () -> String = {
       fakeLoadMemoryCallbackCalled = true
@@ -362,7 +373,7 @@ class DataProvidersTest {
     val dataProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0, fakeLoadMemoryCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // With a LiveData observer, the load memory callback should be called.
@@ -379,7 +390,7 @@ class DataProvidersTest {
     val dataProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0, fakeLoadMemoryCallback)
 
-    dataProviders.convertToLiveData(dataProvider)
+    dataProvider.toLiveData()
     testCoroutineDispatchers.advanceUntilIdle()
 
     // Without a LiveData observer, the load memory callback should never be called.
@@ -390,7 +401,7 @@ class DataProvidersTest {
   fun testInMemoryDataProvider_toLiveData_throwsException_deliversFailure() {
     val dataProvider =
       createThrowingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Failed"))
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -406,7 +417,7 @@ class DataProvidersTest {
       AsyncResult.success(STR_VALUE_0)
     }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -422,7 +433,7 @@ class DataProvidersTest {
     }
 
     inMemoryCachedStr = STR_VALUE_1
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -438,7 +449,7 @@ class DataProvidersTest {
     }
 
     // Ensure the initial state is sent before changing the cache.
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     // Now change the cache & give it time to propagate.
     inMemoryCachedStr = STR_VALUE_1
@@ -456,7 +467,7 @@ class DataProvidersTest {
       AsyncResult.success(inMemoryCachedStr!!)
     }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_1
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_0)
     testCoroutineDispatchers.advanceUntilIdle()
@@ -474,7 +485,7 @@ class DataProvidersTest {
       AsyncResult.success(blockingOperation.await())
     }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
 
     // The observer should never be called since the underlying async function hasn't yet completed.
     verifyZeroInteractions(mockStringLiveDataObserver)
@@ -489,12 +500,12 @@ class DataProvidersTest {
     }
 
     // Start observing the provider, then complete its suspend function.
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     // Finish the blocking operation.
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // The provider will deliver a value immediately when the suspend function completes (no additional notification is
-    // needed).
+    // The provider will deliver a value immediately when the suspend function completes (no
+    // additional notification is needed).
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(STR_VALUE_0)
@@ -510,7 +521,7 @@ class DataProvidersTest {
     val dataProvider =
       dataProviders.createInMemoryDataProviderAsync(BASE_PROVIDER_ID_0, fakeLoadMemoryCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // With a LiveData observer, the load memory callback should be called.
@@ -527,7 +538,7 @@ class DataProvidersTest {
     val dataProvider =
       dataProviders.createInMemoryDataProviderAsync(BASE_PROVIDER_ID_0, fakeLoadMemoryCallback)
 
-    dataProviders.convertToLiveData(dataProvider)
+    dataProvider.toLiveData()
     testCoroutineDispatchers.advanceUntilIdle()
 
     // Without a LiveData observer, the load memory callback should never be called.
@@ -538,7 +549,7 @@ class DataProvidersTest {
   fun testAsyncInMemoryDataProvider_toLiveData_pendingResult_deliversPendingResult() {
     val dataProvider = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -550,7 +561,7 @@ class DataProvidersTest {
     val dataProvider =
       createFailingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Failure"))
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -563,10 +574,9 @@ class DataProvidersTest {
   @Test
   fun testTransform_toLiveData_deliversTransformedValue() {
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.transform(TRANSFORMED_PROVIDER_ID, baseProvider) { transformString(it) }
+    val dataProvider = baseProvider.transform(TRANSFORMED_PROVIDER_ID) { transformString(it) }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockIntLiveDataObserver).onChanged(intResultCaptor.capture())
@@ -579,10 +589,9 @@ class DataProvidersTest {
     inMemoryCachedStr = STR_VALUE_0
     val baseProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
-    val dataProvider =
-      dataProviders.transform(TRANSFORMED_PROVIDER_ID, baseProvider) { transformString(it) }
+    val dataProvider = baseProvider.transform(TRANSFORMED_PROVIDER_ID) { transformString(it) }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_1
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_0)
     testCoroutineDispatchers.advanceUntilIdle()
@@ -598,10 +607,9 @@ class DataProvidersTest {
     inMemoryCachedStr = STR_VALUE_0
     val baseProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
-    val dataProvider =
-      dataProviders.transform(TRANSFORMED_PROVIDER_ID, baseProvider) { transformString(it) }
+    val dataProvider = baseProvider.transform(TRANSFORMED_PROVIDER_ID) { transformString(it) }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_1
     asyncDataSubscriptionManager.notifyChangeAsync(TRANSFORMED_PROVIDER_ID)
     testCoroutineDispatchers.advanceUntilIdle()
@@ -617,16 +625,16 @@ class DataProvidersTest {
     inMemoryCachedStr = STR_VALUE_0
     val baseProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
-    val dataProvider =
-      dataProviders.transform(TRANSFORMED_PROVIDER_ID, baseProvider) { transformString(it) }
+    val dataProvider = baseProvider.transform(TRANSFORMED_PROVIDER_ID) { transformString(it) }
 
-    dataProviders.convertToLiveData(baseProvider).observeForever(mockStringLiveDataObserver)
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    baseProvider.toLiveData().observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_1
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_0)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Having a transformed data provider with an observer does not change the base's notification behavior.
+    // Having a transformed data provider with an observer does not change the base's notification
+    // behavior.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(STR_VALUE_1)
@@ -637,20 +645,19 @@ class DataProvidersTest {
     inMemoryCachedStr = STR_VALUE_0
     val baseProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
-    val dataProvider =
-      dataProviders.transform(TRANSFORMED_PROVIDER_ID, baseProvider) { transformString(it) }
+    val dataProvider = baseProvider.transform(TRANSFORMED_PROVIDER_ID) { transformString(it) }
 
     // Ensure the initial state is sent before changing the cache.
-    dataProviders.convertToLiveData(baseProvider).observeForever(mockStringLiveDataObserver)
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    baseProvider.toLiveData().observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     // Now change the cache & give it time to propagate.
     inMemoryCachedStr = STR_VALUE_1
     asyncDataSubscriptionManager.notifyChangeAsync(TRANSFORMED_PROVIDER_ID)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // However, notifying that the transformed provider has changed should not affect base subscriptions even if the
-    // base has changed.
+    // However, notifying that the transformed provider has changed should not affect base
+    // subscriptions even if the base has changed.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(STR_VALUE_0)
@@ -659,10 +666,9 @@ class DataProvidersTest {
   @Test
   fun testTransform_toLiveData_basePending_deliversPending() {
     val baseProvider = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
-    val dataProvider =
-      dataProviders.transform(TRANSFORMED_PROVIDER_ID, baseProvider) { transformString(it) }
+    val dataProvider = baseProvider.transform(TRANSFORMED_PROVIDER_ID) { transformString(it) }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockIntLiveDataObserver).onChanged(intResultCaptor.capture())
@@ -673,10 +679,9 @@ class DataProvidersTest {
   fun testTransform_toLiveData_baseFailure_deliversFailure() {
     val baseProvider =
       createFailingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Failure"))
-    val dataProvider =
-      dataProviders.transform(TRANSFORMED_PROVIDER_ID, baseProvider) { transformString(it) }
+    val dataProvider = baseProvider.transform(TRANSFORMED_PROVIDER_ID) { transformString(it) }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockIntLiveDataObserver).onChanged(intResultCaptor.capture())
@@ -696,13 +701,13 @@ class DataProvidersTest {
       transformString(it)
     }
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.transform(TRANSFORMED_PROVIDER_ID, baseProvider, fakeTransformCallback)
+    val dataProvider = baseProvider.transform(TRANSFORMED_PROVIDER_ID, fakeTransformCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // A successful base provider with a LiveData observer should result in the transform function being called.
+    // A successful base provider with a LiveData observer should result in the transform function
+    // being called.
     assertThat(fakeTransformCallbackCalled).isTrue()
   }
 
@@ -714,10 +719,9 @@ class DataProvidersTest {
       transformString(it)
     }
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.transform(TRANSFORMED_PROVIDER_ID, baseProvider, fakeTransformCallback)
+    val dataProvider = baseProvider.transform(TRANSFORMED_PROVIDER_ID, fakeTransformCallback)
 
-    dataProviders.convertToLiveData(dataProvider)
+    dataProvider.toLiveData()
     testCoroutineDispatchers.advanceUntilIdle()
 
     // Without an observer, the transform method should not be called.
@@ -732,10 +736,9 @@ class DataProvidersTest {
       transformString(it)
     }
     val baseProvider = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
-    val dataProvider =
-      dataProviders.transform(TRANSFORMED_PROVIDER_ID, baseProvider, fakeTransformCallback)
+    val dataProvider = baseProvider.transform(TRANSFORMED_PROVIDER_ID, fakeTransformCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // The transform method shouldn't be called if the base provider is in a pending state.
@@ -751,10 +754,9 @@ class DataProvidersTest {
     }
     val baseProvider =
       createFailingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Base failure"))
-    val dataProvider =
-      dataProviders.transform(TRANSFORMED_PROVIDER_ID, baseProvider, fakeTransformCallback)
+    val dataProvider = baseProvider.transform(TRANSFORMED_PROVIDER_ID, fakeTransformCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // The transform method shouldn't be called if the base provider is in a failure state.
@@ -764,14 +766,15 @@ class DataProvidersTest {
   @Test
   fun testTransform_toLiveData_throwsException_deliversFailure() {
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider = dataProviders.transform<String, Int>(TRANSFORMED_PROVIDER_ID, baseProvider) {
+    val dataProvider = baseProvider.transform<String, Int>(TRANSFORMED_PROVIDER_ID) {
       throw IllegalStateException("Transform failure")
     }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Note that the exception type here is not chained since the failure occurred in the transform function.
+    // Note that the exception type here is not chained since the failure occurred in the transform
+    // function.
     verify(mockIntLiveDataObserver).onChanged(intResultCaptor.capture())
     assertThat(intResultCaptor.value.isFailure()).isTrue()
     assertThat(intResultCaptor.value.getErrorOrNull()).isInstanceOf(
@@ -785,11 +788,9 @@ class DataProvidersTest {
   fun testTransform_toLiveData_baseThrowsException_deliversFailure() {
     val baseProvider =
       createThrowingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Base failure"))
-    val dataProvider = dataProviders.transform(TRANSFORMED_PROVIDER_ID, baseProvider) {
-      transformString(it)
-    }
+    val dataProvider = baseProvider.transform(TRANSFORMED_PROVIDER_ID) { transformString(it) }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockIntLiveDataObserver).onChanged(intResultCaptor.capture())
@@ -806,12 +807,11 @@ class DataProvidersTest {
   @Test
   fun testTransformAsync_toLiveData_deliversTransformedValue() {
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider = dataProviders.transformAsync(
-      TRANSFORMED_PROVIDER_ID,
-      baseProvider
-    ) { transformStringAsync(it) }
+    val dataProvider = baseProvider.transformAsync(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockIntLiveDataObserver).onChanged(intResultCaptor.capture())
@@ -824,12 +824,11 @@ class DataProvidersTest {
     inMemoryCachedStr = STR_VALUE_0
     val baseProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
-    val dataProvider = dataProviders.transformAsync(
-      TRANSFORMED_PROVIDER_ID,
-      baseProvider
-    ) { transformStringAsync(it) }
+    val dataProvider = baseProvider.transformAsync(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_1
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_0)
     testCoroutineDispatchers.advanceUntilIdle()
@@ -845,12 +844,11 @@ class DataProvidersTest {
     inMemoryCachedStr = STR_VALUE_0
     val baseProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
-    val dataProvider = dataProviders.transformAsync(
-      TRANSFORMED_PROVIDER_ID,
-      baseProvider
-    ) { transformStringAsync(it) }
+    val dataProvider = baseProvider.transformAsync(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_1
     asyncDataSubscriptionManager.notifyChangeAsync(TRANSFORMED_PROVIDER_ID)
     testCoroutineDispatchers.advanceUntilIdle()
@@ -866,18 +864,18 @@ class DataProvidersTest {
     inMemoryCachedStr = STR_VALUE_0
     val baseProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
-    val dataProvider = dataProviders.transformAsync(
-      TRANSFORMED_PROVIDER_ID,
-      baseProvider
-    ) { transformStringAsync(it) }
+    val dataProvider = baseProvider.transformAsync(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(baseProvider).observeForever(mockStringLiveDataObserver)
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    baseProvider.toLiveData().observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_1
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_0)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Having a transformed data provider with an observer does not change the base's notification behavior.
+    // Having a transformed data provider with an observer does not change the base's notification
+    // behavior.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(STR_VALUE_1)
@@ -888,22 +886,21 @@ class DataProvidersTest {
     inMemoryCachedStr = STR_VALUE_0
     val baseProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
-    val dataProvider = dataProviders.transformAsync(
-      TRANSFORMED_PROVIDER_ID,
-      baseProvider
-    ) { transformStringAsync(it) }
+    val dataProvider = baseProvider.transformAsync(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
     // Ensure the initial state is sent before changing the cache.
-    dataProviders.convertToLiveData(baseProvider).observeForever(mockStringLiveDataObserver)
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    baseProvider.toLiveData().observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     // Now change the cache & give it time to propagate.
     inMemoryCachedStr = STR_VALUE_1
     asyncDataSubscriptionManager.notifyChangeAsync(TRANSFORMED_PROVIDER_ID)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // However, notifying that the transformed provider has changed should not affect base subscriptions even if the
-    // base has changed.
+    // However, notifying that the transformed provider has changed should not affect base
+    // subscriptions even if the base has changed.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(STR_VALUE_0)
@@ -913,12 +910,11 @@ class DataProvidersTest {
   fun testTransformAsync_toLiveData_blockingFunction_doesNotDeliverValue() {
     // Block transformStringAsync().
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider = dataProviders.transformAsync(
-      TRANSFORMED_PROVIDER_ID,
-      baseProvider
-    ) { transformStringAsync(it) }
+    val dataProvider = baseProvider.transformAsync(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
 
     // No value should be delivered since the async function is blocked.
     verifyZeroInteractions(mockIntLiveDataObserver)
@@ -928,12 +924,11 @@ class DataProvidersTest {
   fun testTransformAsync_toLiveData_blockingFunction_completed_deliversXformedVal() {
     // Block transformStringAsync().
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider = dataProviders.transformAsync(
-      TRANSFORMED_PROVIDER_ID,
-      baseProvider
-    ) { transformStringAsync(it) }
+    val dataProvider = baseProvider.transformAsync(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle() // Run transformStringAsync()
 
     // The value should now be delivered since the async function was unblocked.
@@ -946,17 +941,17 @@ class DataProvidersTest {
   fun testTransformAsync_toLiveData_blockingFunction_baseObserved_deliversFirstVal() {
     // Block transformStringAsync().
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider = dataProviders.transformAsync(
-      TRANSFORMED_PROVIDER_ID,
-      baseProvider
-    ) { transformStringAsync(it) }
+    val dataProvider = baseProvider.transformAsync(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
     // Observe the base provider & let it complete, but don't complete the derived data provider.
-    dataProviders.convertToLiveData(baseProvider).observeForever(mockStringLiveDataObserver)
+    baseProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
 
-    // Verify that even though the transformed provider is blocked, the base can still properly publish changes.
+    // Verify that even though the transformed provider is blocked, the base can still properly
+    // publish changes.
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(STR_VALUE_0)
@@ -965,12 +960,11 @@ class DataProvidersTest {
   @Test
   fun testTransformAsync_toLiveData_transformedPending_deliversPending() {
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.transformAsync<String, Int>(TRANSFORMED_PROVIDER_ID, baseProvider) {
-        AsyncResult.pending()
-      }
+    val dataProvider = baseProvider.transformAsync<String, Int>(TRANSFORMED_PROVIDER_ID) {
+      AsyncResult.pending()
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // The transformation result yields a pending delivered result.
@@ -981,15 +975,15 @@ class DataProvidersTest {
   @Test
   fun testTransformAsync_toLiveData_transformedFailure_deliversFailure() {
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.transformAsync<String, Int>(TRANSFORMED_PROVIDER_ID, baseProvider) {
-        AsyncResult.failed(IllegalStateException("Transform failure"))
-      }
+    val dataProvider = baseProvider.transformAsync<String, Int>(TRANSFORMED_PROVIDER_ID) {
+      AsyncResult.failed(IllegalStateException("Transform failure"))
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Note that the failure exception in this case is not chained since the failure occurred in the transform function.
+    // Note that the failure exception in this case is not chained since the failure occurred in the
+    // transform function.
     verify(mockIntLiveDataObserver).onChanged(intResultCaptor.capture())
     assertThat(intResultCaptor.value.isFailure()).isTrue()
     assertThat(intResultCaptor.value.getErrorOrNull()).isInstanceOf(
@@ -1002,12 +996,11 @@ class DataProvidersTest {
   @Test
   fun testTransformAsync_toLiveData_basePending_deliversPending() {
     val baseProvider = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
-    val dataProvider = dataProviders.transformAsync(
-      TRANSFORMED_PROVIDER_ID,
-      baseProvider
-    ) { transformStringAsync(it) }
+    val dataProvider = baseProvider.transformAsync(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // Since the base provider is pending, so is the transformed provider.
@@ -1019,14 +1012,15 @@ class DataProvidersTest {
   fun testTransformAsync_toLiveData_baseFailure_deliversFailure() {
     val baseProvider =
       createThrowingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Base failure"))
-    val dataProvider = dataProviders.transformAsync(TRANSFORMED_PROVIDER_ID, baseProvider) {
+    val dataProvider = baseProvider.transformAsync(TRANSFORMED_PROVIDER_ID) {
       transformStringAsync(it)
     }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Note that the failure exception in this case is not chained since the failure occurred in the transform function.
+    // Note that the failure exception in this case is not chained since the failure occurred in the
+    // transform function.
     verify(mockIntLiveDataObserver).onChanged(intResultCaptor.capture())
     assertThat(intResultCaptor.value.isFailure()).isTrue()
     assertThat(intResultCaptor.value.getErrorOrNull()).isInstanceOf(
@@ -1046,10 +1040,9 @@ class DataProvidersTest {
       transformStringAsync(it)
     }
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.transformAsync(TRANSFORMED_PROVIDER_ID, baseProvider, fakeTransformCallback)
+    val dataProvider = baseProvider.transformAsync(TRANSFORMED_PROVIDER_ID, fakeTransformCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // Since there's an observer, the transform method should be called.
@@ -1064,10 +1057,9 @@ class DataProvidersTest {
       transformStringAsync(it)
     }
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.transformAsync(TRANSFORMED_PROVIDER_ID, baseProvider, fakeTransformCallback)
+    val dataProvider = baseProvider.transformAsync(TRANSFORMED_PROVIDER_ID, fakeTransformCallback)
 
-    dataProviders.convertToLiveData(dataProvider)
+    dataProvider.toLiveData()
     testCoroutineDispatchers.advanceUntilIdle()
 
     // Without an observer, the transform method should not be called.
@@ -1082,10 +1074,9 @@ class DataProvidersTest {
       transformStringAsync(it)
     }
     val baseProvider = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
-    val dataProvider =
-      dataProviders.transformAsync(TRANSFORMED_PROVIDER_ID, baseProvider, fakeTransformCallback)
+    val dataProvider = baseProvider.transformAsync(TRANSFORMED_PROVIDER_ID, fakeTransformCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // A pending base provider should result in the transform method not being called.
@@ -1101,10 +1092,9 @@ class DataProvidersTest {
     }
     val baseProvider =
       createThrowingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Base failure"))
-    val dataProvider =
-      dataProviders.transformAsync(TRANSFORMED_PROVIDER_ID, baseProvider, fakeTransformCallback)
+    val dataProvider = baseProvider.transformAsync(TRANSFORMED_PROVIDER_ID, fakeTransformCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // A base provider failure should result in the transform method not being called.
@@ -1115,12 +1105,11 @@ class DataProvidersTest {
   fun testCombine_toLiveData_deliversCombinedValue() {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
-        combineStrings(v1, v2)
-      }
+    val dataProvider = baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+      combineStrings(v1, v2)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1134,17 +1123,17 @@ class DataProvidersTest {
     val baseProvider1 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
-        combineStrings(v1, v2)
-      }
+    val dataProvider = baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+      combineStrings(v1, v2)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_0)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Notifying the first base provider results in observers of the combined provider also being called.
+    // Notifying the first base provider results in observers of the combined provider also being
+    // called.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(COMBINED_STR_VALUE_21)
@@ -1156,17 +1145,17 @@ class DataProvidersTest {
     val baseProvider1 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
-        combineStrings(v1, v2)
-      }
+    val dataProvider = baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+      combineStrings(v1, v2)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(COMBINED_PROVIDER_ID)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Notifying the combined provider results in observers of the combined provider also being called.
+    // Notifying the combined provider results in observers of the combined provider also being
+    // called.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(COMBINED_STR_VALUE_21)
@@ -1178,11 +1167,11 @@ class DataProvidersTest {
     val baseProvider1 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+    baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
       combineStrings(v1, v2)
     }
 
-    dataProviders.convertToLiveData(baseProvider1).observeForever(mockStringLiveDataObserver)
+    baseProvider1.toLiveData().observeForever(mockStringLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_0)
     testCoroutineDispatchers.advanceUntilIdle()
@@ -1199,20 +1188,20 @@ class DataProvidersTest {
     val baseProvider1 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+    baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
       combineStrings(v1, v2)
     }
 
     // Ensure the initial state is sent before changing the cache.
-    dataProviders.convertToLiveData(baseProvider1).observeForever(mockStringLiveDataObserver)
+    baseProvider1.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     // Now change the cache & give it time to propagate.
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(COMBINED_PROVIDER_ID)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Notifying the combined data provider will not trigger observers of the changed provider becoming aware of the
-    // change.
+    // Notifying the combined data provider will not trigger observers of the changed provider
+    // becoming aware of the change.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(STR_VALUE_0)
@@ -1224,17 +1213,17 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_1) { inMemoryCachedStr!! }
-    val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
-        combineStrings(v1, v2)
-      }
+    val dataProvider = baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+      combineStrings(v1, v2)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_1)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Notifying the second base provider results in observers of the combined provider also being called.
+    // Notifying the second base provider results in observers of the combined provider also being
+    // called.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(COMBINED_STR_VALUE_02)
@@ -1246,17 +1235,17 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_1) { inMemoryCachedStr!! }
-    val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
-        combineStrings(v1, v2)
-      }
+    val dataProvider = baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+      combineStrings(v1, v2)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(COMBINED_PROVIDER_ID)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Notifying the combined provider results in observers of the combined provider also being called.
+    // Notifying the combined provider results in observers of the combined provider also being
+    // called.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(COMBINED_STR_VALUE_02)
@@ -1268,11 +1257,11 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_1) { inMemoryCachedStr!! }
-    dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+    baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
       combineStrings(v1, v2)
     }
 
-    dataProviders.convertToLiveData(baseProvider2).observeForever(mockStringLiveDataObserver)
+    baseProvider2.toLiveData().observeForever(mockStringLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_1)
     testCoroutineDispatchers.advanceUntilIdle()
@@ -1289,20 +1278,20 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_1) { inMemoryCachedStr!! }
-    dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+    baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
       combineStrings(v1, v2)
     }
 
     // Ensure the initial state is sent before changing the cache.
-    dataProviders.convertToLiveData(baseProvider2).observeForever(mockStringLiveDataObserver)
+    baseProvider2.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     // Now change the cache & give it time to propagate.
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(COMBINED_PROVIDER_ID)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Notifying the combined data provider will not trigger observers of the changed provider becoming aware of the
-    // change.
+    // Notifying the combined data provider will not trigger observers of the changed provider
+    // becoming aware of the change.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(STR_VALUE_1)
@@ -1312,12 +1301,11 @@ class DataProvidersTest {
   fun testCombine_firstProviderPending_deliversPending() {
     val baseProvider1 = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
-        combineStrings(v1, v2)
-      }
+    val dataProvider = baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+      combineStrings(v1, v2)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1328,12 +1316,11 @@ class DataProvidersTest {
   fun testCombine_secondProviderPending_deliversPending() {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createPendingDataProvider<String>(BASE_PROVIDER_ID_1)
-    val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
-        combineStrings(v1, v2)
-      }
+    val dataProvider = baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+      combineStrings(v1, v2)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1344,12 +1331,11 @@ class DataProvidersTest {
   fun testCombine_bothProvidersPending_deliversPending() {
     val baseProvider1 = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
     val baseProvider2 = createPendingDataProvider<String>(BASE_PROVIDER_ID_1)
-    val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
-        combineStrings(v1, v2)
-      }
+    val dataProvider = baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+      combineStrings(v1, v2)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1361,12 +1347,11 @@ class DataProvidersTest {
     val baseProvider1 =
       createFailingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Base 1 failure"))
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
-        combineStrings(v1, v2)
-      }
+    val dataProvider = baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+      combineStrings(v1, v2)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1383,12 +1368,11 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 =
       createFailingDataProvider<String>(BASE_PROVIDER_ID_1, IllegalStateException("Base 2 failure"))
-    val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
-        combineStrings(v1, v2)
-      }
+    val dataProvider = baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+      combineStrings(v1, v2)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1406,12 +1390,11 @@ class DataProvidersTest {
       createFailingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Base 1 failure"))
     val baseProvider2 =
       createFailingDataProvider<String>(BASE_PROVIDER_ID_1, IllegalStateException("Base 2 failure"))
-    val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
-        combineStrings(v1, v2)
-      }
+    val dataProvider = baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+      combineStrings(v1, v2)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1433,12 +1416,13 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
     val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2, fakeCombineCallback)
+      baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID, fakeCombineCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Successful base providers with a LiveData observer present should result in the combine function being called.
+    // Successful base providers with a LiveData observer present should result in the combine
+    // function being called.
     assertThat(fakeCombineCallbackCalled).isTrue()
   }
 
@@ -1452,12 +1436,13 @@ class DataProvidersTest {
     val baseProvider1 = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
     val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2, fakeCombineCallback)
+      baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID, fakeCombineCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // One of the base providers not completing should result in the combine function not being called.
+    // One of the base providers not completing should result in the combine function not being
+    // called.
     assertThat(fakeCombineCallbackCalled).isFalse()
   }
 
@@ -1471,12 +1456,13 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createPendingDataProvider<String>(BASE_PROVIDER_ID_1)
     val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2, fakeCombineCallback)
+      baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID, fakeCombineCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // One of the base providers not completing should result in the combine function not being called.
+    // One of the base providers not completing should result in the combine function not being
+    // called.
     assertThat(fakeCombineCallbackCalled).isFalse()
   }
 
@@ -1490,12 +1476,13 @@ class DataProvidersTest {
     val baseProvider1 = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
     val baseProvider2 = createPendingDataProvider<String>(BASE_PROVIDER_ID_1)
     val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2, fakeCombineCallback)
+      baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID, fakeCombineCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Both of the base providers not completing should result in the combine function not being called.
+    // Both of the base providers not completing should result in the combine function not being
+    // called.
     assertThat(fakeCombineCallbackCalled).isFalse()
   }
 
@@ -1510,12 +1497,13 @@ class DataProvidersTest {
       createFailingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Base 1 failure"))
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
     val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2, fakeCombineCallback)
+      baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID, fakeCombineCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // One of the base providers not completing should result in the combine function not being called.
+    // One of the base providers not completing should result in the combine function not being
+    // called.
     assertThat(fakeCombineCallbackCalled).isFalse()
   }
 
@@ -1530,12 +1518,13 @@ class DataProvidersTest {
     val baseProvider2 =
       createFailingDataProvider<String>(BASE_PROVIDER_ID_1, IllegalStateException("Base 2 failure"))
     val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2, fakeCombineCallback)
+      baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID, fakeCombineCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // One of the base providers not completing should result in the combine function not being called.
+    // One of the base providers not completing should result in the combine function not being
+    // called.
     assertThat(fakeCombineCallbackCalled).isFalse()
   }
 
@@ -1551,12 +1540,13 @@ class DataProvidersTest {
     val baseProvider2 =
       createFailingDataProvider<String>(BASE_PROVIDER_ID_1, IllegalStateException("Base 2 failure"))
     val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2, fakeCombineCallback)
+      baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID, fakeCombineCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Both of the base providers not completing should result in the combine function not being called.
+    // Both of the base providers not completing should result in the combine function not being
+    // called.
     assertThat(fakeCombineCallbackCalled).isFalse()
   }
 
@@ -1567,12 +1557,11 @@ class DataProvidersTest {
       IllegalStateException("Base 1 failure")
     )
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
-        combineStrings(v1, v2)
-      }
+    val dataProvider = baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+      combineStrings(v1, v2)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1591,12 +1580,11 @@ class DataProvidersTest {
       BASE_PROVIDER_ID_1,
       IllegalStateException("Base 2 failure")
     )
-    val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
-        combineStrings(v1, v2)
-      }
+    val dataProvider = baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+      combineStrings(v1, v2)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1618,12 +1606,11 @@ class DataProvidersTest {
       BASE_PROVIDER_ID_1,
       IllegalStateException("Base 2 failure")
     )
-    val dataProvider =
-      dataProviders.combine(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
-        combineStrings(v1, v2)
-      }
+    val dataProvider = baseProvider1.combineWith(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+      combineStrings(v1, v2)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1639,13 +1626,14 @@ class DataProvidersTest {
   fun testCombine_combinerThrowsException_deliversFailure() {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider = dataProviders.combine<String, String, String>(
-      COMBINED_PROVIDER_ID, baseProvider1, baseProvider2
-    ) { _, _ ->
+    val dataProvider = baseProvider1.combineWith<String, String, String>(
+      baseProvider2,
+      COMBINED_PROVIDER_ID
+    ) { _: String, _: String ->
       throw IllegalStateException("Combine failure")
     }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1660,11 +1648,11 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1679,16 +1667,17 @@ class DataProvidersTest {
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_0)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Notifying the first base provider results in observers of the combined provider also being called.
+    // Notifying the first base provider results in observers of the combined provider also being
+    // called.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(COMBINED_STR_VALUE_21)
@@ -1701,16 +1690,17 @@ class DataProvidersTest {
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(COMBINED_PROVIDER_ID)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Notifying the combined provider results in observers of the combined provider also being called.
+    // Notifying the combined provider results in observers of the combined provider also being
+    // called.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(COMBINED_STR_VALUE_21)
@@ -1722,11 +1712,11 @@ class DataProvidersTest {
     val baseProvider1 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+    baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
       combineStringsAsync(v1, v2)
     }
 
-    dataProviders.convertToLiveData(baseProvider1).observeForever(mockStringLiveDataObserver)
+    baseProvider1.toLiveData().observeForever(mockStringLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_0)
     testCoroutineDispatchers.advanceUntilIdle()
@@ -1743,20 +1733,20 @@ class DataProvidersTest {
     val baseProvider1 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+    baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
       combineStringsAsync(v1, v2)
     }
 
     // Ensure the initial state is sent before changing the cache.
-    dataProviders.convertToLiveData(baseProvider1).observeForever(mockStringLiveDataObserver)
+    baseProvider1.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     // Now change the cache & give it time to propagate.
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(COMBINED_PROVIDER_ID)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Notifying the combined data provider will not trigger observers of the changed provider becoming aware of the
-    // change.
+    // Notifying the combined data provider will not trigger observers of the changed provider
+    // becoming aware of the change.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(STR_VALUE_0)
@@ -1769,16 +1759,17 @@ class DataProvidersTest {
     val baseProvider2 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_1) { inMemoryCachedStr!! }
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_1)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Notifying the second base provider results in observers of the combined provider also being called.
+    // Notifying the second base provider results in observers of the combined provider also being
+    // called.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(COMBINED_STR_VALUE_02)
@@ -1791,16 +1782,17 @@ class DataProvidersTest {
     val baseProvider2 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_1) { inMemoryCachedStr!! }
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(COMBINED_PROVIDER_ID)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Notifying the combined provider results in observers of the combined provider also being called.
+    // Notifying the combined provider results in observers of the combined provider also being
+    // called.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(COMBINED_STR_VALUE_02)
@@ -1812,11 +1804,11 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_1) { inMemoryCachedStr!! }
-    dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+    baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
       combineStringsAsync(v1, v2)
     }
 
-    dataProviders.convertToLiveData(baseProvider2).observeForever(mockStringLiveDataObserver)
+    baseProvider2.toLiveData().observeForever(mockStringLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_1)
     testCoroutineDispatchers.advanceUntilIdle()
@@ -1833,20 +1825,20 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_1) { inMemoryCachedStr!! }
-    dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+    baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
       combineStringsAsync(v1, v2)
     }
 
     // Ensure the initial state is sent before changing the cache.
-    dataProviders.convertToLiveData(baseProvider2).observeForever(mockStringLiveDataObserver)
+    baseProvider2.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     // Now change the cache & give it time to propagate.
     inMemoryCachedStr = STR_VALUE_2
     asyncDataSubscriptionManager.notifyChangeAsync(COMBINED_PROVIDER_ID)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Notifying the combined data provider will not trigger observers of the changed provider becoming aware of the
-    // change.
+    // Notifying the combined data provider will not trigger observers of the changed provider
+    // becoming aware of the change.
     verify(mockStringLiveDataObserver, atLeastOnce()).onChanged(stringResultCaptor.capture())
     assertThat(stringResultCaptor.value.isSuccess()).isTrue()
     assertThat(stringResultCaptor.value.getOrThrow()).isEqualTo(STR_VALUE_1)
@@ -1857,11 +1849,11 @@ class DataProvidersTest {
     val baseProvider1 = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1873,11 +1865,11 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createPendingDataProvider<String>(BASE_PROVIDER_ID_1)
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1889,11 +1881,11 @@ class DataProvidersTest {
     val baseProvider1 = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
     val baseProvider2 = createPendingDataProvider<String>(BASE_PROVIDER_ID_1)
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1906,11 +1898,11 @@ class DataProvidersTest {
       createFailingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Base 1 failure"))
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1928,11 +1920,11 @@ class DataProvidersTest {
     val baseProvider2 =
       createFailingDataProvider<String>(BASE_PROVIDER_ID_1, IllegalStateException("Base 2 failure"))
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1951,11 +1943,11 @@ class DataProvidersTest {
     val baseProvider2 =
       createFailingDataProvider<String>(BASE_PROVIDER_ID_1, IllegalStateException("Base 2 failure"))
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -1976,14 +1968,14 @@ class DataProvidersTest {
     }
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider = dataProviders.combineAsync(
-      COMBINED_PROVIDER_ID, baseProvider1, baseProvider2, fakeCombineCallback
-    )
+    val dataProvider =
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID, fakeCombineCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Successful base providers with a LiveData observer present should result in the combine function being called.
+    // Successful base providers with a LiveData observer present should result in the combine
+    // function being called.
     assertThat(fakeCombineCallbackCalled).isTrue()
   }
 
@@ -1996,14 +1988,14 @@ class DataProvidersTest {
     }
     val baseProvider1 = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider = dataProviders.combineAsync(
-      COMBINED_PROVIDER_ID, baseProvider1, baseProvider2, fakeCombineCallback
-    )
+    val dataProvider =
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID, fakeCombineCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // One of the base providers not completing should result in the combine function not being called.
+    // One of the base providers not completing should result in the combine function not being
+    // called.
     assertThat(fakeCombineCallbackCalled).isFalse()
   }
 
@@ -2016,14 +2008,14 @@ class DataProvidersTest {
     }
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createPendingDataProvider<String>(BASE_PROVIDER_ID_1)
-    val dataProvider = dataProviders.combineAsync(
-      COMBINED_PROVIDER_ID, baseProvider1, baseProvider2, fakeCombineCallback
-    )
+    val dataProvider =
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID, fakeCombineCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // One of the base providers not completing should result in the combine function not being called.
+    // One of the base providers not completing should result in the combine function not being
+    // called.
     assertThat(fakeCombineCallbackCalled).isFalse()
   }
 
@@ -2036,14 +2028,14 @@ class DataProvidersTest {
     }
     val baseProvider1 = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
     val baseProvider2 = createPendingDataProvider<String>(BASE_PROVIDER_ID_1)
-    val dataProvider = dataProviders.combineAsync(
-      COMBINED_PROVIDER_ID, baseProvider1, baseProvider2, fakeCombineCallback
-    )
+    val dataProvider =
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID, fakeCombineCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Both of the base providers not completing should result in the combine function not being called.
+    // Both of the base providers not completing should result in the combine function not being
+    // called.
     assertThat(fakeCombineCallbackCalled).isFalse()
   }
 
@@ -2057,14 +2049,14 @@ class DataProvidersTest {
     val baseProvider1 =
       createFailingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Base 1 failure"))
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider = dataProviders.combineAsync(
-      COMBINED_PROVIDER_ID, baseProvider1, baseProvider2, fakeCombineCallback
-    )
+    val dataProvider =
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID, fakeCombineCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // One of the base providers not completing should result in the combine function not being called.
+    // One of the base providers not completing should result in the combine function not being
+    // called.
     assertThat(fakeCombineCallbackCalled).isFalse()
   }
 
@@ -2078,14 +2070,14 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 =
       createFailingDataProvider<String>(BASE_PROVIDER_ID_1, IllegalStateException("Base 2 failure"))
-    val dataProvider = dataProviders.combineAsync(
-      COMBINED_PROVIDER_ID, baseProvider1, baseProvider2, fakeCombineCallback
-    )
+    val dataProvider =
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID, fakeCombineCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // One of the base providers not completing should result in the combine function not being called.
+    // One of the base providers not completing should result in the combine function not being
+    // called.
     assertThat(fakeCombineCallbackCalled).isFalse()
   }
 
@@ -2100,14 +2092,14 @@ class DataProvidersTest {
       createFailingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Base 1 failure"))
     val baseProvider2 =
       createFailingDataProvider<String>(BASE_PROVIDER_ID_1, IllegalStateException("Base 2 failure"))
-    val dataProvider = dataProviders.combineAsync(
-      COMBINED_PROVIDER_ID, baseProvider1, baseProvider2, fakeCombineCallback
-    )
+    val dataProvider =
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID, fakeCombineCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
-    // Both of the base providers not completing should result in the combine function not being called.
+    // Both of the base providers not completing should result in the combine function not being
+    // called.
     assertThat(fakeCombineCallbackCalled).isFalse()
   }
 
@@ -2119,11 +2111,11 @@ class DataProvidersTest {
     )
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -2143,11 +2135,11 @@ class DataProvidersTest {
       IllegalStateException("Base 2 failure")
     )
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -2170,11 +2162,11 @@ class DataProvidersTest {
       IllegalStateException("Base 2 failure")
     )
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -2192,13 +2184,13 @@ class DataProvidersTest {
     val baseProvider1 = createBlockingDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         // Note that this doesn't use combineStringsAsync since that relies on the blocked
         // backgroundTestCoroutineDispatcher.
         AsyncResult.success(combineStrings(v1, v2))
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
 
     // The value should not yet be delivered since the first provider is blocked.
     verifyZeroInteractions(mockStringLiveDataObserver)
@@ -2210,13 +2202,13 @@ class DataProvidersTest {
     val baseProvider1 = createBlockingDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         // Note that this doesn't use combineStringsAsync since that relies on the blocked
         // backgroundTestCoroutineDispatcher.
         AsyncResult.success(combineStrings(v1, v2))
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     // Resume the test thread after registration.
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -2232,13 +2224,13 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createBlockingDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         // Note that this doesn't use combineStringsAsync since that relies on the blocked
         // backgroundTestCoroutineDispatcher.
         AsyncResult.success(combineStrings(v1, v2))
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
 
     // The value should not yet be delivered since the first provider is blocked.
     verifyZeroInteractions(mockStringLiveDataObserver)
@@ -2250,13 +2242,13 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createBlockingDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         // Note that this doesn't use combineStringsAsync since that relies on the blocked
         // backgroundTestCoroutineDispatcher.
         AsyncResult.success(combineStrings(v1, v2))
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     // Resume the test thread after registration.
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -2272,11 +2264,11 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
     val dataProvider =
-      dataProviders.combineAsync(COMBINED_PROVIDER_ID, baseProvider1, baseProvider2) { v1, v2 ->
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
         combineStringsAsync(v1, v2)
       }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
 
     // The value should not yet be delivered.
     verifyZeroInteractions(mockStringLiveDataObserver)
@@ -2287,13 +2279,12 @@ class DataProvidersTest {
     // Block combineStringsAsync().
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider = dataProviders.combineAsync(
-      COMBINED_PROVIDER_ID, baseProvider1, baseProvider2
-    ) { v1, v2 ->
-      combineStringsAsync(v1, v2)
-    }
+    val dataProvider =
+      baseProvider1.combineWithAsync(baseProvider2, COMBINED_PROVIDER_ID) { v1, v2 ->
+        combineStringsAsync(v1, v2)
+      }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     // Allow the async function to complete.
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -2307,13 +2298,14 @@ class DataProvidersTest {
   fun testCombineAsync_combineReturnsPending_deliversPending() {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider = dataProviders.combineAsync<String, String, String>(
-      COMBINED_PROVIDER_ID, baseProvider1, baseProvider2
-    ) { _, _ ->
+    val dataProvider = baseProvider1.combineWithAsync<String, String, String>(
+      baseProvider2,
+      COMBINED_PROVIDER_ID
+    ) { _: String, _: String ->
       AsyncResult.pending()
     }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -2324,13 +2316,14 @@ class DataProvidersTest {
   fun testCombineAsync_combineReturnsFailure_deliversFailure() {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider = dataProviders.combineAsync<String, String, String>(
-      COMBINED_PROVIDER_ID, baseProvider1, baseProvider2
-    ) { _, _ ->
+    val dataProvider = baseProvider1.combineWithAsync<String, String, String>(
+      baseProvider2,
+      COMBINED_PROVIDER_ID
+    ) { _: String, _: String ->
       AsyncResult.failed(IllegalStateException("Combine failure"))
     }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockStringLiveDataObserver).onChanged(stringResultCaptor.capture())
@@ -2343,12 +2336,11 @@ class DataProvidersTest {
   @Test
   fun testNestedXformedProvider_toLiveData_deliversTransformedValue() {
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider) {
-        transformStringAsync(it)
-      }
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     verify(mockIntLiveDataObserver).onChanged(intResultCaptor.capture())
@@ -2361,12 +2353,11 @@ class DataProvidersTest {
     inMemoryCachedStr = STR_VALUE_0
     val baseProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider) {
-        transformStringAsync(it)
-      }
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_1
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_0)
     testCoroutineDispatchers.advanceUntilIdle()
@@ -2382,12 +2373,11 @@ class DataProvidersTest {
     inMemoryCachedStr = STR_VALUE_0
     val baseProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider) {
-        transformStringAsync(it)
-      }
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_1
     asyncDataSubscriptionManager.notifyChangeAsync(TRANSFORMED_PROVIDER_ID)
     testCoroutineDispatchers.advanceUntilIdle()
@@ -2403,13 +2393,12 @@ class DataProvidersTest {
     inMemoryCachedStr = STR_VALUE_0
     val baseProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider) {
-        transformStringAsync(it)
-      }
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(baseProvider).observeForever(mockStringLiveDataObserver)
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    baseProvider.toLiveData().observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     inMemoryCachedStr = STR_VALUE_1
     asyncDataSubscriptionManager.notifyChangeAsync(BASE_PROVIDER_ID_0)
     testCoroutineDispatchers.advanceUntilIdle()
@@ -2426,14 +2415,13 @@ class DataProvidersTest {
     inMemoryCachedStr = STR_VALUE_0
     val baseProvider =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider) {
-        transformStringAsync(it)
-      }
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
     // Ensure the initial state is sent before changing the cache.
-    dataProviders.convertToLiveData(baseProvider).observeForever(mockStringLiveDataObserver)
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    baseProvider.toLiveData().observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     // Now change the cache & give it time to propagate.
     inMemoryCachedStr = STR_VALUE_1
@@ -2451,12 +2439,11 @@ class DataProvidersTest {
   fun testNestedXformedProvider_toLiveData_blockingFunction_doesNotDeliverValue() {
     // Block transformStringAsync().
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider) {
-        transformStringAsync(it)
-      }
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
 
     // No value should be delivered since the async function is blocked.
     verifyZeroInteractions(mockIntLiveDataObserver)
@@ -2466,12 +2453,11 @@ class DataProvidersTest {
   fun testNestedXformedProvider_toLiveData_blockingFunction_completed_deliversXformedVal() {
     // Block transformStringAsync().
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider) {
-        transformStringAsync(it)
-      }
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle() // Run transformStringAsync()
 
     // The value should now be delivered since the async function was unblocked.
@@ -2484,15 +2470,14 @@ class DataProvidersTest {
   fun testNestedXformedProvider_toLiveData_blockingFunction_baseObserved_deliversFirstVal() {
     // Block transformStringAsync().
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider) {
-        transformStringAsync(it)
-      }
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
     // Observe the base provider & let it complete, but don't complete the derived data provider.
-    dataProviders.convertToLiveData(baseProvider).observeForever(mockStringLiveDataObserver)
+    baseProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
 
     // Verify that even though the transformed provider is blocked, the base can still properly
     // publish changes.
@@ -2504,15 +2489,11 @@ class DataProvidersTest {
   @Test
   fun testNestedXformedProvider_toLiveData_transformedPending_deliversPending() {
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider<String, Int>(
-        TRANSFORMED_PROVIDER_ID,
-        baseProvider
-      ) {
-        AsyncResult.pending()
-      }
+    val dataProvider = baseProvider.transformNested<String, Int>(TRANSFORMED_PROVIDER_ID) {
+      AsyncResult.pending()
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // The transformation result yields a pending delivered result.
@@ -2523,15 +2504,11 @@ class DataProvidersTest {
   @Test
   fun testNestedXformedProvider_toLiveData_transformedFailure_deliversFailure() {
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider<String, Int>(
-        TRANSFORMED_PROVIDER_ID,
-        baseProvider
-      ) {
-        AsyncResult.failed(IllegalStateException("Transform failure"))
-      }
+    val dataProvider = baseProvider.transformNested<String, Int>(TRANSFORMED_PROVIDER_ID) {
+      AsyncResult.failed(IllegalStateException("Transform failure"))
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // Note that the failure exception in this case is not chained since the failure occurred in the
@@ -2547,12 +2524,11 @@ class DataProvidersTest {
   @Test
   fun testNestedXformedProvider_toLiveData_basePending_deliversPending() {
     val baseProvider = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider) {
-        transformStringAsync(it)
-      }
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // Since the base provider is pending, so is the transformed provider.
@@ -2564,12 +2540,11 @@ class DataProvidersTest {
   fun testNestedXformedProvider_toLiveData_baseFailure_deliversFailure() {
     val baseProvider =
       createThrowingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Base failure"))
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider) {
-        transformStringAsync(it)
-      }
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // Note that the failure exception in this case is not chained since the failure occurred in the
@@ -2592,12 +2567,9 @@ class DataProvidersTest {
       transformStringAsync(it)
     }
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(
-        TRANSFORMED_PROVIDER_ID, baseProvider, fakeTransformCallback
-      )
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID, fakeTransformCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // Since there's an observer, the transform method should be called.
@@ -2612,12 +2584,9 @@ class DataProvidersTest {
       transformStringAsync(it)
     }
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(
-        TRANSFORMED_PROVIDER_ID, baseProvider, fakeTransformCallback
-      )
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID, fakeTransformCallback)
 
-    dataProviders.convertToLiveData(dataProvider)
+    dataProvider.toLiveData()
     testCoroutineDispatchers.advanceUntilIdle()
 
     // Without an observer, the transform method should not be called.
@@ -2632,12 +2601,9 @@ class DataProvidersTest {
       transformStringAsync(it)
     }
     val baseProvider = createPendingDataProvider<String>(BASE_PROVIDER_ID_0)
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(
-        TRANSFORMED_PROVIDER_ID, baseProvider, fakeTransformCallback
-      )
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID, fakeTransformCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // A pending base provider should result in the transform method not being called.
@@ -2653,12 +2619,9 @@ class DataProvidersTest {
     }
     val baseProvider =
       createThrowingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Base failure"))
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(
-        TRANSFORMED_PROVIDER_ID, baseProvider, fakeTransformCallback
-      )
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID, fakeTransformCallback)
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // A base provider failure should result in the transform method not being called.
@@ -2669,14 +2632,13 @@ class DataProvidersTest {
   fun testNestedXformedProvider_toLiveData_newBaseProvider_newObserver_receivesLatestValue() {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider1) {
-        transformStringAsync(it)
-      }
+    val dataProvider = baseProvider1.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
     // Replace the base data provider with something new, then register an observer.
     dataProvider.setBaseDataProvider(baseProvider2) { transformStringAsync(it) }
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // The observer should get the newest value immediately.
@@ -2689,14 +2651,13 @@ class DataProvidersTest {
   fun testNestedXformedProvider_toLiveData_newBaseAndTransform_newObserver_receivesLatestValue() {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_0)
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider1) {
-        transformStringAsync(it)
-      }
+    val dataProvider = baseProvider1.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
     // Replace the base data provider with something new, then register an observer.
     dataProvider.setBaseDataProvider(baseProvider2) { transformStringDoubledAsync(it) }
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // The observer should get the newest value immediately.
@@ -2709,11 +2670,10 @@ class DataProvidersTest {
   fun testNestedXformedProvider_toLiveData_newBaseProvider_notifiesObservers() {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider1) {
-        transformStringAsync(it)
-      }
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    val dataProvider = baseProvider1.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
 
     // Replace the base data provider with something new. It should automatically notify observers.
@@ -2731,11 +2691,10 @@ class DataProvidersTest {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_1) { inMemoryCachedStr!! }
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider1) {
-        transformStringAsync(it)
-      }
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    val dataProvider = baseProvider1.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     dataProvider.setBaseDataProvider(baseProvider2) { transformStringAsync(it) }
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -2756,11 +2715,10 @@ class DataProvidersTest {
     val baseProvider1 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_2)
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider1) {
-        transformStringAsync(it)
-      }
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    val dataProvider = baseProvider1.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     dataProvider.setBaseDataProvider(baseProvider2) { transformStringAsync(it) }
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -2783,11 +2741,10 @@ class DataProvidersTest {
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_0) { inMemoryCachedStr!! }
     val baseProvider2 =
       dataProviders.createInMemoryDataProvider(BASE_PROVIDER_ID_1) { inMemoryCachedStr2!! }
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider1) {
-        transformStringAsync(it)
-      }
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    val dataProvider = baseProvider1.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     dataProvider.setBaseDataProvider(baseProvider2) { transformStringAsync(it) }
     testCoroutineDispatchers.advanceUntilIdle()
 
@@ -2807,12 +2764,11 @@ class DataProvidersTest {
   fun testNestedXformedProvider_toLiveData_baseFailure_logsException() {
     val baseProvider =
       createThrowingDataProvider<String>(BASE_PROVIDER_ID_0, IllegalStateException("Base failure"))
-    val dataProvider =
-      dataProviders.createNestedTransformedDataProvider(TRANSFORMED_PROVIDER_ID, baseProvider) {
-        transformStringAsync(it)
-      }
+    val dataProvider = baseProvider.transformNested(TRANSFORMED_PROVIDER_ID) {
+      transformStringAsync(it)
+    }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     val exception = fakeExceptionLogger.getMostRecentException()
 
@@ -2823,11 +2779,11 @@ class DataProvidersTest {
   @Test
   fun testTransform_toLiveData_throwsException_deliversFailure_logsException() {
     val baseProvider = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
-    val dataProvider = dataProviders.transform<String, Int>(TRANSFORMED_PROVIDER_ID, baseProvider) {
+    val dataProvider = baseProvider.transform<String, Int>(TRANSFORMED_PROVIDER_ID) {
       throw IllegalStateException("Transform failure")
     }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockIntLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     val exception = fakeExceptionLogger.getMostRecentException()
 
@@ -2839,13 +2795,14 @@ class DataProvidersTest {
   fun testCombine_combinerThrowsException_deliversFailure_logsException() {
     val baseProvider1 = createSuccessfulDataProvider(BASE_PROVIDER_ID_0, STR_VALUE_0)
     val baseProvider2 = createSuccessfulDataProvider(BASE_PROVIDER_ID_1, STR_VALUE_1)
-    val dataProvider = dataProviders.combine<String, String, String>(
-      COMBINED_PROVIDER_ID, baseProvider1, baseProvider2
-    ) { _, _ ->
+    val dataProvider = baseProvider1.combineWith<String, String, String>(
+      baseProvider2,
+      COMBINED_PROVIDER_ID
+    ) { _: String, _: String ->
       throw IllegalStateException("Combine failure")
     }
 
-    dataProviders.convertToLiveData(dataProvider).observeForever(mockStringLiveDataObserver)
+    dataProvider.toLiveData().observeForever(mockStringLiveDataObserver)
     testCoroutineDispatchers.advanceUntilIdle()
     val exception = fakeExceptionLogger.getMostRecentException()
 
@@ -2858,8 +2815,8 @@ class DataProvidersTest {
   }
 
   /**
-   * Transforms the specified string into an integer in the same way as [transformString], except in a blocking context
-   * using [backgroundCoroutineDispatcher].
+   * Transforms the specified string into an integer in the same way as [transformString], except in
+   * a blocking context using [backgroundCoroutineDispatcher].
    */
   private suspend fun transformStringAsync(str: String): AsyncResult<Int> {
     val deferred = backgroundCoroutineScope.async { transformString(str) }
@@ -2882,8 +2839,8 @@ class DataProvidersTest {
   }
 
   /**
-   * Combines the specified strings into a new string in the same way as [combineStrings], except in a blocking context
-   * using [backgroundCoroutineDispatcher].
+   * Combines the specified strings into a new string in the same way as [combineStrings], except in
+   * a blocking context using [backgroundCoroutineDispatcher].
    */
   private suspend fun combineStringsAsync(str1: String, str2: String): AsyncResult<String> {
     val deferred = backgroundCoroutineScope.async { combineStrings(str1, str2) }

--- a/utility/src/test/java/org/oppia/util/data/DataProvidersTest.kt
+++ b/utility/src/test/java/org/oppia/util/data/DataProvidersTest.kt
@@ -61,7 +61,7 @@ private const val COMBINED_STR_VALUE_02 = "I used to be indecisive. At least I t
 /** Tests for [DataProviders], [DataProvider]s, and [AsyncDataSubscriptionManager]. */
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
-@Config(manifest = Config.NONE)
+@Config(application = DataProvidersTest.TestApplication::class)
 class DataProvidersTest {
 
   @Rule
@@ -2882,10 +2882,7 @@ class DataProvidersTest {
   }
 
   private fun setUpTestApplicationComponent() {
-    DaggerDataProvidersTest_TestApplicationComponent.builder()
-      .setApplication(ApplicationProvider.getApplicationContext())
-      .build()
-      .inject(this)
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
   // TODO(#89): Move this to a common test application component.
@@ -2906,7 +2903,7 @@ class DataProvidersTest {
       TestLogReportingModule::class
     ]
   )
-  interface TestApplicationComponent {
+  interface TestApplicationComponent: DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance
@@ -2915,5 +2912,19 @@ class DataProvidersTest {
     }
 
     fun inject(dataProvidersTest: DataProvidersTest)
+  }
+
+  class TestApplication : Application(), DataProvidersInjectorProvider {
+    private val component: TestApplicationComponent by lazy {
+      DaggerDataProvidersTest_TestApplicationComponent.builder()
+        .setApplication(this)
+        .build()
+    }
+
+    fun inject(dataProvidersTest: DataProvidersTest) {
+      component.inject(dataProvidersTest)
+    }
+
+    override fun getDataProvidersInjector(): DataProvidersInjector = component
   }
 }

--- a/utility/src/test/java/org/oppia/util/data/DataProvidersTest.kt
+++ b/utility/src/test/java/org/oppia/util/data/DataProvidersTest.kt
@@ -2903,7 +2903,7 @@ class DataProvidersTest {
       TestLogReportingModule::class
     ]
   )
-  interface TestApplicationComponent: DataProvidersInjector {
+  interface TestApplicationComponent : DataProvidersInjector {
     @Component.Builder
     interface Builder {
       @BindsInstance


### PR DESCRIPTION
This PR is a proof-of-concept I thought of earlier today: it replaces most DataProviders methods with DataProvider extension functions to improve readability. In general, the readability aspects of this change seem nice, but it comes with a few costs:
- The extension functions don't have access to the Dagger graph, so an application component injector needed to be added to retrieve access to application dependencies
- Accessing the injector required making DataProvider an abstract class and passing around a context object (which is a bit gross)
- The new injector needs to be a separate interface from the existing application injector since it's defined in a different module
- Introducing new injectors requires many tests to be updated to properly support injector overriding
- Subsequently, many non-app module tests needed to be updated to use a test application (which is probably preferred, anyway, since it's more correct)

I took the liberty to update most domain-level LiveData functions to return DataProviders, instead, and expect that the UI convert them to LiveData. This is a more robust approach since it lets us chain data providers at the domain level, and only convert to LiveData at the very end. Some more tricky cases & LiveData-only cases weren't updated.

Note that I also fixed a bunch of cases when comments or KDocs were exceeding 100 characters. Note also that some tests are initially failing for reasons I'm not sure of--more investigation is needed.

Please let me know what your initial thoughts are on the approach given the caveats mentioned above. Here's a map of the old to new functionality:

| *DataProviders version*                                                          | *Extension function version*                                   |
|--------------------------------------------------------------------------------|--------------------------------------------------------------|
| ``dataProviders.transform(newId, dataProvider) { ... }``                           | ``dataProvider.transform(newId) { ... }``                        |
| ``dataProviders.transformAsync(newId, dataProvider) { ... }``                      | ``dataProvider.transformAsync(newId) { ... }``                   |
| ``dataProviders.createNestedTransformedDataProvider(newId, dataProvider) { ... }`` | ``dataProvider.transformNested(newId) { ... }``                  |
| ``dataProviders.combine(newId, dataProvider1, dataProvider2) { ... }``             | ``dataProvider1.combineWith(dataProvider2, newId) { ... }``      |
| ``dataProviders.combineAsync(newId, dataProvider1, dataProvider2) { ... }``        | ``dataProvider1.combineWithAsync(dataProvider2, newId) { ... }`` |
| ``dataProviders.convertToLiveData(dataProvider)``                                  | ``dataProvider.toLiveData()``                                    |

Note that there was some minor rearrangement of logic in ProfileManagementController to better fit with this pattern. It should be a functional no-op.

Further, some extra test changes included:
- Adding additional synchronization points since the profile changes were moving a previously synchronous check to a data provider
- Redefinining flows that simulated application re-creation since the test application lifecycle changes with this PR