### PR TITLE
Fix #1908:Changed comments in Proto files

### DIFF
--- a/model/src/main/proto/exploration.proto
+++ b/model/src/main/proto/exploration.proto
@@ -12,7 +12,7 @@ option java_package = "org.oppia.android.app.model";
 option java_multiple_files = true;
 
 // Structure for a single exploration.
-// Maps from: data/src/main/java/org.oppia.android.android/data/backends/gae/model/GaeExploration.kt
+// Maps from: data/src/main/java/org/oppia/android/android/data/backends/gae/model/GaeExploration.kt
 message Exploration {
   // The ID of the exploration.
   string id = 1;
@@ -29,7 +29,7 @@ message Exploration {
 }
 
 // Structure for a param change.
-// Maps from: data/src/main/java/org.oppia.android.android/data/backends/gae/model/GaeParamChange.kt
+// Maps from: data/src/main/java/org/oppia/android/android/data/backends/gae/model/GaeParamChange.kt
 message ParamChange {
   string generator_id = 1;
   string name = 2;
@@ -37,7 +37,7 @@ message ParamChange {
 }
 
 // Structure for a param spec.
-// Maps from: data/src/main/java/org.oppia.android.android/data/backends/gae/model/GaeParamSpec.kt
+// Maps from: data/src/main/java/org/oppia/android/android/data/backends/gae/model/GaeParamSpec.kt
 message ParamSpec {
   ObjectType obj_type = 1;
 }
@@ -49,7 +49,7 @@ enum ObjectType {
 }
 
 // Structure for a single state
-// Maps from: data/src/main/java/org.oppia.android.android/data/backends/gae/model/GaeState.kt
+// Maps from: data/src/main/java/org/oppia/android/android/data/backends/gae/model/GaeState.kt
 message State {
   // The name of the State.
   string name = 1;
@@ -76,7 +76,7 @@ message ParamChangeCustomizationArgs {
 }
 
 // Structure for a single interaction
-// Maps from: data/src/main/java/org.oppia.android.android/data/backends/gae/model/GaeInteractionInstance.kt
+// Maps from: data/src/main/java/org/oppia/android/android/data/backends/gae/model/GaeInteractionInstance.kt
 message Interaction {
   string id = 1;
   repeated AnswerGroup answer_groups = 2;
@@ -117,7 +117,7 @@ message CustomSchemaValue {
 }
 
 // Structure for a single answer group
-// Maps from: data/src/main/java/org.oppia.android.android/data/backends/gae/model/GaeAnswerGroup.kt
+// Maps from: data/src/main/java/org/oppia/android/android/data/backends/gae/model/GaeAnswerGroup.kt
 message AnswerGroup {
   string tagged_skill_misconception_id = 1;
   Outcome outcome = 2;
@@ -132,7 +132,7 @@ message TrainingData {
 }
 
 // Structure for a single solution
-// Maps from: data/src/main/java/org.oppia.android.android/data/backends/gae/model/GaeSolution.kt
+// Maps from: data/src/main/java/org/oppia/android/android/data/backends/gae/model/GaeSolution.kt
 message Solution {
   string interaction_id = 1;
   // Flag that is true if correct_answer is the only correct answer of the question.
@@ -146,7 +146,7 @@ message Solution {
 }
 
 // Structure for a Correct answer in Solution
-// Maps from: data/src/main/java/org.oppia.android.android/data/backends/gae/model/GaeSolution.kt
+// Maps from: data/src/main/java/org/oppia/android/android/data/backends/gae/model/GaeSolution.kt
 message CorrectAnswer {
   int32 denominator = 1;
   int32 numerator = 2;
@@ -156,7 +156,7 @@ message CorrectAnswer {
 }
 
 // Structure for a single hint
-// Maps from: data/src/main/java/org.oppia.android.android/data/backends/gae/model/GaeHint.kt
+// Maps from: data/src/main/java/org/oppia/android/android/data/backends/gae/model/GaeHint.kt
 message Hint {
   // Hint data.
   SubtitledHtml hint_content = 1;
@@ -167,7 +167,7 @@ message Hint {
 }
 
 // Structure for a single outcome
-// Maps from: data/src/main/java/org.oppia.android.android/data/backends/gae/model/GaeOutcome.kt
+// Maps from: data/src/main/java/org/oppia/android/android/data/backends/gae/model/GaeOutcome.kt
 message Outcome {
   string dest_state_name = 1;
   string refresher_exploration_id = 2;

--- a/model/src/main/proto/translation.proto
+++ b/model/src/main/proto/translation.proto
@@ -11,7 +11,7 @@ message TranslationMapping {
 }
 
 // Structure for a single translation
-// Maps from: data/src/main/java/org.oppia.android.android/data/backends/gae/model/GaeWrittenTranslation.kt
+// Maps from: data/src/main/java/org/oppia/android/android/data/backends/gae/model/GaeWrittenTranslation.kt
 message Translation {
   string html = 1;
   bool needs_update = 2;

--- a/model/src/main/proto/voiceover.proto
+++ b/model/src/main/proto/voiceover.proto
@@ -11,7 +11,7 @@ message VoiceoverMapping {
 }
 
 // Structure for a single voiceover
-// Maps from: data/src/main/java/org.oppia.android.android/data/backends/gae/model/GaeVoiceover.kt
+// Maps from: data/src/main/java/org/oppia/android/android/data/backends/gae/model/GaeVoiceover.kt
 message Voiceover {
   int64 file_size_bytes = 1;
   bool needs_update = 2;


### PR DESCRIPTION
## Explanation
- Fixes #1908
- Changed org.oppia.android.android/ to org/oppia/android/android/ in the comments of the proto files
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
