### PR TITLE
Fix #1887: Thoroughly test FractionInputHasNumeratorEqualToRuleClassifier

### DIFF
--- a/domain/src/main/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProvider.kt
+++ b/domain/src/main/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProvider.kt
@@ -26,7 +26,6 @@ internal class FractionInputHasNumeratorEqualToRuleClassifierProvider @Inject co
     )
   }
 
-  // TODO(#210): Add tests for this classifier.
   override fun matches(answer: Fraction, input: Int): Boolean {
     return answer.numerator == input
   }

--- a/domain/src/main/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputIsExactlyEqualToRuleClassifierProvider.kt
+++ b/domain/src/main/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputIsExactlyEqualToRuleClassifierProvider.kt
@@ -25,7 +25,6 @@ internal class FractionInputIsExactlyEqualToRuleClassifierProvider @Inject const
     )
   }
 
-  // TODO(#210): Add tests for this classifier.
   override fun matches(answer: Fraction, input: Fraction): Boolean {
     return answer == input
   }

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProviderTest.kt
@@ -1,0 +1,203 @@
+package org.oppia.android.domain.classify.rules.fractioninput
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import dagger.BindsInstance
+import dagger.Component
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.oppia.android.app.model.Fraction
+import org.oppia.android.app.model.InteractionObject
+import org.oppia.android.domain.classify.RuleClassifier
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.reflect.KClass
+import kotlin.reflect.full.cast
+import kotlin.test.fail
+
+/** Tests for [FractionInputHasNumeratorEqualToRuleClassifierProvider]. */
+@RunWith(AndroidJUnit4::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+@Config(manifest = Config.NONE)
+class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
+  private val NON_NEGATIVE_VALUE_0 = createNonNegativeInt(value = 0)
+  private val WHOLE_NUMBER_123 = createWholeNumber(isNegative = false, value = 123)
+  private val FRACTION_2_OVER_4 = createFraction(isNegative = false, numerator = 2, denominator = 4)
+  private val SIGNED_INT_1 = createSignedInt(1);
+  private val SIGNED_INT_2 = createSignedInt(2);
+  private val SIGNED_INT_NEGATIVE_2 = createSignedInt(-2);
+
+  @Inject
+  internal lateinit var fractionInputHasNumeratorEqualToRuleClassifierProvider:
+    FractionInputHasNumeratorEqualToRuleClassifierProvider
+
+  private val numeratorIsEqualClassifierProvider: RuleClassifier by lazy {
+    fractionInputHasNumeratorEqualToRuleClassifierProvider.createRuleClassifier()
+  }
+
+  @Test
+  fun testEquals_wholeNumber123Answer_withSignedInt1Input_bothValuesDoNotMatch() {
+    val inputs = mapOf("x" to SIGNED_INT_1)
+
+    val matches =
+      numeratorIsEqualClassifierProvider.matches(
+        answer = WHOLE_NUMBER_123,
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testEquals_fraction2Over4Answer_withSignedInt1Input_bothValuesDoNotMatch() {
+    val inputs = mapOf("x" to SIGNED_INT_1)
+
+    val matches =
+      numeratorIsEqualClassifierProvider.matches(
+        answer = FRACTION_2_OVER_4,
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testEquals_fraction2Over4Answer_withSignedIntNegative2Input_bothValuesDoNotMatch() {
+    val inputs = mapOf("x" to SIGNED_INT_NEGATIVE_2)
+
+    val matches =
+      numeratorIsEqualClassifierProvider.matches(
+        answer = FRACTION_2_OVER_4,
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testEquals_fraction2Over4Answer_withSignedInt2Input_bothValuesMatch() {
+    val inputs = mapOf("x" to SIGNED_INT_2)
+
+    val matches =
+      numeratorIsEqualClassifierProvider.matches(
+        answer = FRACTION_2_OVER_4,
+        inputs = inputs
+      )
+
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testEquals_nonNegativeInput_inputWithIncorrectType_throwsException() {
+    val inputs = mapOf("x" to NON_NEGATIVE_VALUE_0)
+
+    val exception = assertThrows(IllegalStateException::class) {
+      numeratorIsEqualClassifierProvider.matches(
+        answer = FRACTION_2_OVER_4,
+        inputs = inputs
+      )
+    }
+
+    assertThat(exception)
+      .hasMessageThat()
+      .contains(
+        "Expected input value to be of type SIGNED_INT not NON_NEGATIVE_INT"
+      )
+  }
+
+  @Test
+  fun testEquals_missingInputF_throwsException() {
+    val inputs = mapOf("y" to FRACTION_2_OVER_4)
+
+    val exception = assertThrows(IllegalStateException::class) {
+      numeratorIsEqualClassifierProvider.matches(
+        answer = FRACTION_2_OVER_4,
+        inputs = inputs
+      )
+    }
+
+    assertThat(exception)
+      .hasMessageThat()
+      .contains("Expected classifier inputs to contain parameter with name 'x' but had: [y]")
+  }
+
+  private fun createFraction(
+    isNegative: Boolean,
+    numerator: Int,
+    denominator: Int
+  ): InteractionObject {
+    // Fraction-only numbers imply no whole number.
+    return InteractionObject.newBuilder().setFraction(
+      Fraction.newBuilder()
+        .setIsNegative(isNegative)
+        .setNumerator(numerator)
+        .setDenominator(denominator)
+        .build()
+    ).build()
+  }
+
+  private fun createWholeNumber(isNegative: Boolean, value: Int): InteractionObject {
+    // Whole number fractions imply '0/1' fractional parts.
+    return InteractionObject.newBuilder().setFraction(
+      Fraction.newBuilder()
+        .setIsNegative(isNegative)
+        .setWholeNumber(value)
+        .setNumerator(0)
+        .setDenominator(1)
+        .build()
+    ).build()
+  }
+
+  private fun createSignedInt(value: Int): InteractionObject {
+    return InteractionObject.newBuilder().setSignedInt(value).build()
+  }
+
+  private fun createNonNegativeInt(value: Int): InteractionObject {
+    return InteractionObject.newBuilder().setNonNegativeInt(value).build()
+  }
+
+  @Before
+  fun setUp() {
+    setUpTestApplicationComponent()
+  }
+
+  private fun setUpTestApplicationComponent() {
+    DaggerFractionInputHasNumeratorEqualToRuleClassifierProviderTest_TestApplicationComponent
+      .builder()
+      .setApplication(ApplicationProvider.getApplicationContext()).build().inject(this)
+  }
+
+  // TODO(#89): Move to a common test library.
+  private fun <T : Throwable> assertThrows(type: KClass<T>, operation: () -> Unit): T {
+    try {
+      operation()
+      fail("Expected to encounter exception of $type")
+    } catch (t: Throwable) {
+      if (type.isInstance(t)) {
+        return type.cast(t)
+      }
+      // Unexpected exception; throw it.
+      throw t
+    }
+  }
+
+  // TODO(#89): Move this to a common test application component.
+  @Singleton
+  @Component(modules = [])
+  interface TestApplicationComponent {
+    @Component.Builder
+    interface Builder {
+      @BindsInstance
+      fun setApplication(application: Application): Builder
+
+      fun build(): TestApplicationComponent
+    }
+
+    fun inject(test: FractionInputHasNumeratorEqualToRuleClassifierProviderTest)
+  }
+}

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputIsExactlyEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputIsExactlyEqualToRuleClassifierProviderTest.kt
@@ -25,26 +25,19 @@ import kotlin.test.fail
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(manifest = Config.NONE)
 class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
-  /**
-   * Store fractions in format:
-   *    <0 or 1 indicating whether it's negative>, <numerator>, <denominator>
-   *    e.g. -1/2 would be {1, 1, 2}
-   * Store whole numbers in format:
-   *    <0 or 1 indicating whether it's negative>, <whole number>
-   *    e.g. 1234 would be {0, 1234}
-   * Store mixed numbers in format:
-   *    <0 or 1 indicating whether it's negative>, <whole number>, <numerator>, <denominator>
-   *    e.g. -1234 1/2 would be {1, 1234, 1, 2}
-   */
   private val NON_NEGATIVE_VALUE_0 = createNonNegativeInt(value = 0)
-  private val WHOLE_POS_1 = listOf(0, 123)
-  private val WHOLE_POS_2 = listOf(0, 321)
-  private val FRAC_POS_1 = listOf(0, 2, 4)
-  private val FRAC_POS_2 = listOf(0, 1, 2)
-  private val FRAC_POS_3 = listOf(0, 123, 1)
-  private val MIXED_POS_1 = listOf(0, 123, 1, 2)
-  private val MIXED_POS_2 = listOf(0, 123, 1, 3)
-  private val MIXED_NEG_1 = listOf(1, 123, 1, 2)
+  private val WHOLE_NUMBER_123 = createWholeNumber(isNegative = false, value = 123)
+  private val WHOLE_NUMBER_321 = createWholeNumber(isNegative = false, value = 321)
+  private val FRACTION_2_OVER_4 = createFraction(isNegative = false, numerator = 2, denominator = 4)
+  private val FRACTION_1_OVER_2 = createFraction(isNegative = false, numerator = 1, denominator = 2)
+  private val FRACTION_123_OVER_1 =
+    createFraction(isNegative = false, numerator = 123, denominator = 1)
+  private val MIXED_NUMBER_123_1_OVER_2 =
+    createMixedNumber(isNegative = false, wholeNumber = 123, numerator = 1, denominator = 2)
+  private val MIXED_NUMBER_123_1_OVER_3 =
+    createMixedNumber(isNegative = false, wholeNumber = 123, numerator = 1, denominator = 3)
+  private val MIXED_NUMBER_NEGATIVE_123_1_OVER_2 =
+    createMixedNumber(isNegative = true, wholeNumber = 123, numerator = 1, denominator = 2)
 
   @Inject
   internal lateinit var fractionInputIsExactlyEqualToRuleClassifierProvider:
@@ -55,12 +48,12 @@ class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testAnswer_testFraction_bothWholeNumbers_bothValuesMatch() {
-    val inputs = mapOf("f" to createWholeNumberOnly(WHOLE_POS_1))
+  fun testEquals_wholeNumber123Answer_withWholeNumber123Input_bothValuesMatch() {
+    val inputs = mapOf("f" to WHOLE_NUMBER_123)
 
     val matches =
       isExactlyEqualClassifierProvider.matches(
-        answer = createWholeNumberOnly(WHOLE_POS_1),
+        answer = WHOLE_NUMBER_123,
         inputs = inputs
       )
 
@@ -68,12 +61,12 @@ class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testAnswer_testFraction_bothWholeNumbers_bothValuesDoNotMatch() {
-    val inputs = mapOf("f" to createWholeNumberOnly(WHOLE_POS_1))
+  fun testEquals_wholeNumber321Answer_withWholeNumber123Input_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to WHOLE_NUMBER_123)
 
     val matches =
       isExactlyEqualClassifierProvider.matches(
-        answer = createWholeNumberOnly(WHOLE_POS_2),
+        answer = WHOLE_NUMBER_321,
         inputs = inputs
       )
 
@@ -81,12 +74,12 @@ class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testAnswer_testFraction_bothFractions_bothValuesMatch() {
-    val inputs = mapOf("f" to createFractionOnly(FRAC_POS_1))
+  fun testEquals_fraction2Over4Answer_withFraction2Over4Input_bothValuesMatch() {
+    val inputs = mapOf("f" to FRACTION_2_OVER_4)
 
     val matches =
       isExactlyEqualClassifierProvider.matches(
-        answer = createFractionOnly(FRAC_POS_1),
+        answer = FRACTION_2_OVER_4,
         inputs = inputs
       )
 
@@ -94,12 +87,12 @@ class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testAnswer_testFraction_bothFractions_oneFractionReduced_bothValuesDoNotMatch() {
-    val inputs = mapOf("f" to createFractionOnly(FRAC_POS_1))
+  fun testEquals_bothAnswerAndInputFractions_oneFractionReduced_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to FRACTION_2_OVER_4)
 
     val matches =
       isExactlyEqualClassifierProvider.matches(
-        answer = createFractionOnly(FRAC_POS_2),
+        answer = FRACTION_1_OVER_2,
         inputs = inputs
       )
 
@@ -107,12 +100,12 @@ class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testAnswer_testFraction_bothMixed_bothValuesMatch() {
-    val inputs = mapOf("f" to createMixedNumber(MIXED_POS_1))
+  fun testEquals_mixedNumber123And1Over2Answer_withMixedNumber123And1Over2Input_bothValuesMatch() {
+    val inputs = mapOf("f" to MIXED_NUMBER_123_1_OVER_2)
 
     val matches =
       isExactlyEqualClassifierProvider.matches(
-        answer = createMixedNumber(MIXED_POS_1),
+        answer = MIXED_NUMBER_123_1_OVER_2,
         inputs = inputs
       )
 
@@ -120,12 +113,12 @@ class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testAnswer_testFraction_bothMixed_bothValuesDoNotMatch() {
-    val inputs = mapOf("f" to createMixedNumber(MIXED_POS_1))
+  fun testEquals_mixedNum123And1Over3Answer_withMixedNum123And1Over2Input_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to MIXED_NUMBER_123_1_OVER_2)
 
     val matches =
       isExactlyEqualClassifierProvider.matches(
-        answer = createMixedNumber(MIXED_POS_2),
+        answer = MIXED_NUMBER_123_1_OVER_3,
         inputs = inputs
       )
 
@@ -133,12 +126,12 @@ class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testAnswer_testFraction_bothMixedDiffSign_bothValuesDoNotMatch() {
-    val inputs = mapOf("f" to createMixedNumber(MIXED_POS_1))
+  fun testEquals_negativeMixedNumberAnswer_withPositiveMixedNumberInput_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to MIXED_NUMBER_123_1_OVER_2)
 
     val matches =
       isExactlyEqualClassifierProvider.matches(
-        answer = createMixedNumber(MIXED_NEG_1),
+        answer = MIXED_NUMBER_NEGATIVE_123_1_OVER_2,
         inputs = inputs
       )
 
@@ -146,12 +139,12 @@ class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testAnswer_testFraction_wholeAndMixed_bothValuesDoNotMatch() {
-    val inputs = mapOf("f" to createMixedNumber(MIXED_POS_1))
+  fun testEquals_wholeNumberAnswer_withMixedNumberInput_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to MIXED_NUMBER_123_1_OVER_2)
 
     val matches =
       isExactlyEqualClassifierProvider.matches(
-        answer = createWholeNumberOnly(WHOLE_POS_1),
+        answer = WHOLE_NUMBER_123,
         inputs = inputs
       )
 
@@ -159,12 +152,12 @@ class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testAnswer_testFraction_wholeAndFraction_bothValuesDoNotMatch() {
-    val inputs = mapOf("f" to createFractionOnly(FRAC_POS_3))
+  fun testEquals_wholeNumber123Answer_withFraction123Over1Input_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to FRACTION_123_OVER_1)
 
     val matches =
       isExactlyEqualClassifierProvider.matches(
-        answer = createWholeNumberOnly(WHOLE_POS_1),
+        answer = WHOLE_NUMBER_123,
         inputs = inputs
       )
 
@@ -172,12 +165,12 @@ class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testAnswer_testFraction_fractionAndMixed_bothValuesDoNotMatch() {
-    val inputs = mapOf("f" to createFractionOnly(FRAC_POS_2))
+  fun testEquals_mixedNumberAnswer_withFractionInput_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to FRACTION_1_OVER_2)
 
     val matches =
       isExactlyEqualClassifierProvider.matches(
-        answer = createMixedNumber(MIXED_POS_1),
+        answer = MIXED_NUMBER_123_1_OVER_2,
         inputs = inputs
       )
 
@@ -185,12 +178,12 @@ class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testAnswer_nonNegativeInput_inputWithIncorrectType_throwsException() {
+  fun testEquals_nonNegativeInput_inputWithIncorrectType_throwsException() {
     val inputs = mapOf("f" to NON_NEGATIVE_VALUE_0)
 
     val exception = assertThrows(IllegalStateException::class) {
       isExactlyEqualClassifierProvider.matches(
-        answer = createFractionOnly(FRAC_POS_1),
+        answer = FRACTION_2_OVER_4,
         inputs = inputs
       )
     }
@@ -203,12 +196,12 @@ class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testAnswer_testRatio_missingInputF_throwsException() {
-    val inputs = mapOf("y" to createFractionOnly(FRAC_POS_1))
+  fun testEquals_missingInputF_throwsException() {
+    val inputs = mapOf("y" to FRACTION_2_OVER_4)
 
     val exception = assertThrows(IllegalStateException::class) {
       isExactlyEqualClassifierProvider.matches(
-        answer = createFractionOnly(FRAC_POS_1),
+        answer = FRACTION_2_OVER_4,
         inputs = inputs
       )
     }
@@ -218,36 +211,45 @@ class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
       .contains("Expected classifier inputs to contain parameter with name 'f' but had: [y]")
   }
 
-  private fun createFractionOnly(value: List<Int>): InteractionObject {
+  private fun createFraction(
+    isNegative: Boolean,
+    numerator: Int,
+    denominator: Int
+  ): InteractionObject {
     // Fraction-only numbers imply no whole number.
     return InteractionObject.newBuilder().setFraction(
       Fraction.newBuilder()
-        .setIsNegative(value[0] == 1)
-        .setNumerator(value[1])
-        .setDenominator(value[2])
+        .setIsNegative(isNegative)
+        .setNumerator(numerator)
+        .setDenominator(denominator)
         .build()
     ).build()
   }
 
-  private fun createWholeNumberOnly(value: List<Int>): InteractionObject {
+  private fun createWholeNumber(isNegative: Boolean, value: Int): InteractionObject {
     // Whole number fractions imply '0/1' fractional parts.
     return InteractionObject.newBuilder().setFraction(
       Fraction.newBuilder()
-        .setIsNegative(value[0] == 1)
-        .setWholeNumber(value[1])
+        .setIsNegative(isNegative)
+        .setWholeNumber(value)
         .setNumerator(0)
         .setDenominator(1)
         .build()
     ).build()
   }
 
-  private fun createMixedNumber(value: List<Int>): InteractionObject {
+  private fun createMixedNumber(
+    isNegative: Boolean,
+    wholeNumber: Int,
+    numerator: Int,
+    denominator: Int
+  ): InteractionObject {
     return InteractionObject.newBuilder().setFraction(
       Fraction.newBuilder()
-        .setIsNegative(value[0] == 1)
-        .setWholeNumber(value[1])
-        .setNumerator(value[2])
-        .setDenominator(value[3])
+        .setIsNegative(isNegative)
+        .setWholeNumber(wholeNumber)
+        .setNumerator(numerator)
+        .setDenominator(denominator)
         .build()
     ).build()
   }

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputIsExactlyEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputIsExactlyEqualToRuleClassifierProviderTest.kt
@@ -1,0 +1,298 @@
+package org.oppia.android.domain.classify.rules.fractioninput
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import dagger.BindsInstance
+import dagger.Component
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.oppia.android.app.model.Fraction
+import org.oppia.android.app.model.InteractionObject
+import org.oppia.android.domain.classify.RuleClassifier
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.reflect.KClass
+import kotlin.reflect.full.cast
+import kotlin.test.fail
+
+/** Tests for [FractionInputIsExactlyEqualToRuleClassifierProvider]. */
+@RunWith(AndroidJUnit4::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+@Config(manifest = Config.NONE)
+class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
+  /**
+   * Store fractions in format:
+   *    <0 or 1 indicating whether it's negative>, <numerator>, <denominator>
+   *    e.g. -1/2 would be {1, 1, 2}
+   * Store whole numbers in format:
+   *    <0 or 1 indicating whether it's negative>, <whole number>
+   *    e.g. 1234 would be {0, 1234}
+   * Store mixed numbers in format:
+   *    <0 or 1 indicating whether it's negative>, <whole number>, <numerator>, <denominator>
+   *    e.g. -1234 1/2 would be {1, 1234, 1, 2}
+   */
+  private val NON_NEGATIVE_VALUE_0 = createNonNegativeInt(value = 0)
+  private val WHOLE_POS_1 = listOf(0, 123)
+  private val WHOLE_POS_2 = listOf(0, 321)
+  private val FRAC_POS_1 = listOf(0, 2, 4)
+  private val FRAC_POS_2 = listOf(0, 1, 2)
+  private val FRAC_POS_3 = listOf(0, 123, 1)
+  private val MIXED_POS_1 = listOf(0, 123, 1, 2)
+  private val MIXED_POS_2 = listOf(0, 123, 1, 3)
+  private val MIXED_NEG_1 = listOf(1, 123, 1, 2)
+
+  @Inject
+  internal lateinit var fractionInputIsExactlyEqualToRuleClassifierProvider:
+    FractionInputIsExactlyEqualToRuleClassifierProvider
+
+  private val isExactlyEqualClassifierProvider: RuleClassifier by lazy {
+    fractionInputIsExactlyEqualToRuleClassifierProvider.createRuleClassifier()
+  }
+
+  @Test
+  fun testAnswer_testFraction_bothWholeNumbers_bothValuesMatch() {
+    val inputs = mapOf("f" to createWholeNumberOnly(WHOLE_POS_1))
+
+    val matches =
+      isExactlyEqualClassifierProvider.matches(
+        answer = createWholeNumberOnly(WHOLE_POS_1),
+        inputs = inputs
+      )
+
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testAnswer_testFraction_bothWholeNumbers_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to createWholeNumberOnly(WHOLE_POS_1))
+
+    val matches =
+      isExactlyEqualClassifierProvider.matches(
+        answer = createWholeNumberOnly(WHOLE_POS_2),
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testAnswer_testFraction_bothFractions_bothValuesMatch() {
+    val inputs = mapOf("f" to createFractionOnly(FRAC_POS_1))
+
+    val matches =
+      isExactlyEqualClassifierProvider.matches(
+        answer = createFractionOnly(FRAC_POS_1),
+        inputs = inputs
+      )
+
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testAnswer_testFraction_bothFractions_oneFractionReduced_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to createFractionOnly(FRAC_POS_1))
+
+    val matches =
+      isExactlyEqualClassifierProvider.matches(
+        answer = createFractionOnly(FRAC_POS_2),
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testAnswer_testFraction_bothMixed_bothValuesMatch() {
+    val inputs = mapOf("f" to createMixedNumber(MIXED_POS_1))
+
+    val matches =
+      isExactlyEqualClassifierProvider.matches(
+        answer = createMixedNumber(MIXED_POS_1),
+        inputs = inputs
+      )
+
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testAnswer_testFraction_bothMixed_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to createMixedNumber(MIXED_POS_1))
+
+    val matches =
+      isExactlyEqualClassifierProvider.matches(
+        answer = createMixedNumber(MIXED_POS_2),
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testAnswer_testFraction_bothMixedDiffSign_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to createMixedNumber(MIXED_POS_1))
+
+    val matches =
+      isExactlyEqualClassifierProvider.matches(
+        answer = createMixedNumber(MIXED_NEG_1),
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testAnswer_testFraction_wholeAndMixed_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to createMixedNumber(MIXED_POS_1))
+
+    val matches =
+      isExactlyEqualClassifierProvider.matches(
+        answer = createWholeNumberOnly(WHOLE_POS_1),
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testAnswer_testFraction_wholeAndFraction_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to createFractionOnly(FRAC_POS_3))
+
+    val matches =
+      isExactlyEqualClassifierProvider.matches(
+        answer = createWholeNumberOnly(WHOLE_POS_1),
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testAnswer_testFraction_fractionAndMixed_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to createFractionOnly(FRAC_POS_2))
+
+    val matches =
+      isExactlyEqualClassifierProvider.matches(
+        answer = createMixedNumber(MIXED_POS_1),
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testAnswer_nonNegativeInput_inputWithIncorrectType_throwsException() {
+    val inputs = mapOf("f" to NON_NEGATIVE_VALUE_0)
+
+    val exception = assertThrows(IllegalStateException::class) {
+      isExactlyEqualClassifierProvider.matches(
+        answer = createFractionOnly(FRAC_POS_1),
+        inputs = inputs
+      )
+    }
+
+    assertThat(exception)
+      .hasMessageThat()
+      .contains(
+        "Expected input value to be of type FRACTION not NON_NEGATIVE_INT"
+      )
+  }
+
+  @Test
+  fun testAnswer_testRatio_missingInputF_throwsException() {
+    val inputs = mapOf("y" to createFractionOnly(FRAC_POS_1))
+
+    val exception = assertThrows(IllegalStateException::class) {
+      isExactlyEqualClassifierProvider.matches(
+        answer = createFractionOnly(FRAC_POS_1),
+        inputs = inputs
+      )
+    }
+
+    assertThat(exception)
+      .hasMessageThat()
+      .contains("Expected classifier inputs to contain parameter with name 'f' but had: [y]")
+  }
+
+  private fun createFractionOnly(value: List<Int>): InteractionObject {
+    // Fraction-only numbers imply no whole number.
+    return InteractionObject.newBuilder().setFraction(
+      Fraction.newBuilder()
+        .setIsNegative(value[0] == 1)
+        .setNumerator(value[1])
+        .setDenominator(value[2])
+        .build()
+    ).build()
+  }
+
+  private fun createWholeNumberOnly(value: List<Int>): InteractionObject {
+    // Whole number fractions imply '0/1' fractional parts.
+    return InteractionObject.newBuilder().setFraction(
+      Fraction.newBuilder()
+        .setIsNegative(value[0] == 1)
+        .setWholeNumber(value[1])
+        .setNumerator(0)
+        .setDenominator(1)
+        .build()
+    ).build()
+  }
+
+  private fun createMixedNumber(value: List<Int>): InteractionObject {
+    return InteractionObject.newBuilder().setFraction(
+      Fraction.newBuilder()
+        .setIsNegative(value[0] == 1)
+        .setWholeNumber(value[1])
+        .setNumerator(value[2])
+        .setDenominator(value[3])
+        .build()
+    ).build()
+  }
+
+  private fun createNonNegativeInt(value: Int): InteractionObject {
+    return InteractionObject.newBuilder().setNonNegativeInt(value).build()
+  }
+
+  @Before
+  fun setUp() {
+    setUpTestApplicationComponent()
+  }
+
+  private fun setUpTestApplicationComponent() {
+    DaggerFractionInputIsExactlyEqualToRuleClassifierProviderTest_TestApplicationComponent
+      .builder()
+      .setApplication(ApplicationProvider.getApplicationContext()).build().inject(this)
+  }
+
+  // TODO(#89): Move to a common test library.
+  private fun <T : Throwable> assertThrows(type: KClass<T>, operation: () -> Unit): T {
+    try {
+      operation()
+      fail("Expected to encounter exception of $type")
+    } catch (t: Throwable) {
+      if (type.isInstance(t)) {
+        return type.cast(t)
+      }
+      // Unexpected exception; throw it.
+      throw t
+    }
+  }
+
+  // TODO(#89): Move this to a common test application component.
+  @Singleton
+  @Component(modules = [])
+  interface TestApplicationComponent {
+    @Component.Builder
+    interface Builder {
+      @BindsInstance
+      fun setApplication(application: Application): Builder
+
+      fun build(): TestApplicationComponent
+    }
+
+    fun inject(test: FractionInputIsExactlyEqualToRuleClassifierProviderTest)
+  }
+}


### PR DESCRIPTION
@BenHenning PTAL

##  Explanation
Fixes #1887 by adding unit tests for FractionInputHasNumeratorEqualToRuleClassifierProvider.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
