### PR TITLE
Fix #1887: Thoroughly test FractionInputHasNumeratorEqualToRuleClassifierProvider

### DIFF
--- a/domain/src/main/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProvider.kt
+++ b/domain/src/main/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProvider.kt
@@ -26,7 +26,6 @@ internal class FractionInputHasNumeratorEqualToRuleClassifierProvider @Inject co
     )
   }
 
-  // TODO(#210): Add tests for this classifier.
   override fun matches(answer: Fraction, input: Int): Boolean {
     return answer.numerator == input
   }

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProviderTest.kt
@@ -28,6 +28,8 @@ class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
   private val NON_NEGATIVE_VALUE_0 = createNonNegativeInt(value = 0)
   private val WHOLE_NUMBER_123 = createWholeNumber(isNegative = false, value = 123)
   private val FRACTION_2_OVER_4 = createFraction(isNegative = false, numerator = 2, denominator = 4)
+  private val FRACTION_NEGATIVE_2_OVER_4 =
+    createFraction(isNegative = true, numerator = -2, denominator = 4)
   private val SIGNED_INT_1 = createSignedInt(1)
   private val SIGNED_INT_2 = createSignedInt(2)
   private val SIGNED_INT_NEGATIVE_2 = createSignedInt(-2)
@@ -41,7 +43,20 @@ class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquals_wholeNumber123Answer_withSignedInt1Input_bothValuesDoNotMatch() {
+  fun testNumeratorEquals_negativeNumerators_bothValuesMatch() {
+    val inputs = mapOf("x" to SIGNED_INT_NEGATIVE_2)
+
+    val matches =
+      numeratorIsEqualClassifierProvider.matches(
+        answer = FRACTION_NEGATIVE_2_OVER_4,
+        inputs = inputs
+      )
+
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testNumeratorEquals_wholeNumber123Answer_withSignedInt1Input_bothValuesDoNotMatch() {
     val inputs = mapOf("x" to SIGNED_INT_1)
 
     val matches =
@@ -54,7 +69,7 @@ class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquals_fraction2Over4Answer_withSignedInt1Input_bothValuesDoNotMatch() {
+  fun testNumeratorEquals_fraction2Over4Answer_withSignedInt1Input_bothValuesDoNotMatch() {
     val inputs = mapOf("x" to SIGNED_INT_1)
 
     val matches =
@@ -67,7 +82,7 @@ class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquals_fraction2Over4Answer_withSignedIntNegative2Input_bothValuesDoNotMatch() {
+  fun testNumeratorEquals_fraction2Over4Answer_withSignedIntNegative2Input_bothValuesDoNotMatch() {
     val inputs = mapOf("x" to SIGNED_INT_NEGATIVE_2)
 
     val matches =
@@ -80,7 +95,7 @@ class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquals_fraction2Over4Answer_withSignedInt2Input_bothValuesMatch() {
+  fun testNumeratorEquals_fraction2Over4Answer_withSignedInt2Input_bothValuesMatch() {
     val inputs = mapOf("x" to SIGNED_INT_2)
 
     val matches =
@@ -93,7 +108,7 @@ class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquals_nonNegativeInput_inputWithIncorrectType_throwsException() {
+  fun testNumeratorEquals_nonNegativeInput_inputWithIncorrectType_throwsException() {
     val inputs = mapOf("x" to NON_NEGATIVE_VALUE_0)
 
     val exception = assertThrows(IllegalStateException::class) {
@@ -111,7 +126,7 @@ class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquals_missingInputF_throwsException() {
+  fun testNumeratorEquals_missingInputF_throwsException() {
     val inputs = mapOf("y" to FRACTION_2_OVER_4)
 
     val exception = assertThrows(IllegalStateException::class) {

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProviderTest.kt
@@ -1,0 +1,203 @@
+package org.oppia.android.domain.classify.rules.fractioninput
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import dagger.BindsInstance
+import dagger.Component
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.oppia.android.app.model.Fraction
+import org.oppia.android.app.model.InteractionObject
+import org.oppia.android.domain.classify.RuleClassifier
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.reflect.KClass
+import kotlin.reflect.full.cast
+import kotlin.test.fail
+
+/** Tests for [FractionInputHasNumeratorEqualToRuleClassifierProvider]. */
+@RunWith(AndroidJUnit4::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+@Config(manifest = Config.NONE)
+class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
+  private val NON_NEGATIVE_VALUE_0 = createNonNegativeInt(value = 0)
+  private val WHOLE_NUMBER_123 = createWholeNumber(isNegative = false, value = 123)
+  private val FRACTION_2_OVER_4 = createFraction(isNegative = false, numerator = 2, denominator = 4)
+  private val SIGNED_INT_1 = createSignedInt(1);
+  private val SIGNED_INT_2 = createSignedInt(2);
+  private val SIGNED_INT_NEGATIVE_2 = createSignedInt(-2);
+
+  @Inject
+  internal lateinit var fractionInputHasNumeratorEqualToRuleClassifierProvider:
+    FractionInputHasNumeratorEqualToRuleClassifierProvider
+
+  private val numeratorIsEqualClassifierProvider: RuleClassifier by lazy {
+    fractionInputHasNumeratorEqualToRuleClassifierProvider.createRuleClassifier()
+  }
+
+  @Test
+  fun testEquals_wholeNumber123Answer_withSignedInt1Input_bothValuesDoNotMatch() {
+    val inputs = mapOf("x" to SIGNED_INT_1)
+
+    val matches =
+      numeratorIsEqualClassifierProvider.matches(
+        answer = WHOLE_NUMBER_123,
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testEquals_fraction2Over4Answer_withSignedInt1Input_bothValuesDoNotMatch() {
+    val inputs = mapOf("x" to SIGNED_INT_1)
+
+    val matches =
+      numeratorIsEqualClassifierProvider.matches(
+        answer = FRACTION_2_OVER_4,
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testEquals_fraction2Over4Answer_withSignedIntNegative2Input_bothValuesDoNotMatch() {
+    val inputs = mapOf("x" to SIGNED_INT_NEGATIVE_2)
+
+    val matches =
+      numeratorIsEqualClassifierProvider.matches(
+        answer = FRACTION_2_OVER_4,
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testEquals_fraction2Over4Answer_withSignedInt2Input_bothValuesMatch() {
+    val inputs = mapOf("x" to SIGNED_INT_2)
+
+    val matches =
+      numeratorIsEqualClassifierProvider.matches(
+        answer = FRACTION_2_OVER_4,
+        inputs = inputs
+      )
+
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testEquals_nonNegativeInput_inputWithIncorrectType_throwsException() {
+    val inputs = mapOf("x" to NON_NEGATIVE_VALUE_0)
+
+    val exception = assertThrows(IllegalStateException::class) {
+      numeratorIsEqualClassifierProvider.matches(
+        answer = FRACTION_2_OVER_4,
+        inputs = inputs
+      )
+    }
+
+    assertThat(exception)
+      .hasMessageThat()
+      .contains(
+        "Expected input value to be of type SIGNED_INT not NON_NEGATIVE_INT"
+      )
+  }
+
+  @Test
+  fun testEquals_missingInputF_throwsException() {
+    val inputs = mapOf("y" to FRACTION_2_OVER_4)
+
+    val exception = assertThrows(IllegalStateException::class) {
+      numeratorIsEqualClassifierProvider.matches(
+        answer = FRACTION_2_OVER_4,
+        inputs = inputs
+      )
+    }
+
+    assertThat(exception)
+      .hasMessageThat()
+      .contains("Expected classifier inputs to contain parameter with name 'x' but had: [y]")
+  }
+
+  private fun createFraction(
+    isNegative: Boolean,
+    numerator: Int,
+    denominator: Int
+  ): InteractionObject {
+    // Fraction-only numbers imply no whole number.
+    return InteractionObject.newBuilder().setFraction(
+      Fraction.newBuilder()
+        .setIsNegative(isNegative)
+        .setNumerator(numerator)
+        .setDenominator(denominator)
+        .build()
+    ).build()
+  }
+
+  private fun createWholeNumber(isNegative: Boolean, value: Int): InteractionObject {
+    // Whole number fractions imply '0/1' fractional parts.
+    return InteractionObject.newBuilder().setFraction(
+      Fraction.newBuilder()
+        .setIsNegative(isNegative)
+        .setWholeNumber(value)
+        .setNumerator(0)
+        .setDenominator(1)
+        .build()
+    ).build()
+  }
+
+  private fun createSignedInt(value: Int): InteractionObject {
+    return InteractionObject.newBuilder().setSignedInt(value).build()
+  }
+
+  private fun createNonNegativeInt(value: Int): InteractionObject {
+    return InteractionObject.newBuilder().setNonNegativeInt(value).build()
+  }
+
+  @Before
+  fun setUp() {
+    setUpTestApplicationComponent()
+  }
+
+  private fun setUpTestApplicationComponent() {
+    DaggerFractionInputHasNumeratorEqualToRuleClassifierProviderTest_TestApplicationComponent
+      .builder()
+      .setApplication(ApplicationProvider.getApplicationContext()).build().inject(this)
+  }
+
+  // TODO(#89): Move to a common test library.
+  private fun <T : Throwable> assertThrows(type: KClass<T>, operation: () -> Unit): T {
+    try {
+      operation()
+      fail("Expected to encounter exception of $type")
+    } catch (t: Throwable) {
+      if (type.isInstance(t)) {
+        return type.cast(t)
+      }
+      // Unexpected exception; throw it.
+      throw t
+    }
+  }
+
+  // TODO(#89): Move this to a common test application component.
+  @Singleton
+  @Component(modules = [])
+  interface TestApplicationComponent {
+    @Component.Builder
+    interface Builder {
+      @BindsInstance
+      fun setApplication(application: Application): Builder
+
+      fun build(): TestApplicationComponent
+    }
+
+    fun inject(test: FractionInputHasNumeratorEqualToRuleClassifierProviderTest)
+  }
+}

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProviderTest.kt
@@ -28,9 +28,9 @@ class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
   private val NON_NEGATIVE_VALUE_0 = createNonNegativeInt(value = 0)
   private val WHOLE_NUMBER_123 = createWholeNumber(isNegative = false, value = 123)
   private val FRACTION_2_OVER_4 = createFraction(isNegative = false, numerator = 2, denominator = 4)
-  private val SIGNED_INT_1 = createSignedInt(1);
-  private val SIGNED_INT_2 = createSignedInt(2);
-  private val SIGNED_INT_NEGATIVE_2 = createSignedInt(-2);
+  private val SIGNED_INT_1 = createSignedInt(1)
+  private val SIGNED_INT_2 = createSignedInt(2)
+  private val SIGNED_INT_NEGATIVE_2 = createSignedInt(-2)
 
   @Inject
   internal lateinit var fractionInputHasNumeratorEqualToRuleClassifierProvider:


### PR DESCRIPTION
@BenHenning PTAL

##  Explanation
Fixes #1887 by adding unit tests for FractionInputHasNumeratorEqualToRuleClassifierProvider.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.