### PR TITLE
Fix #1881: Thoroughly test FractionInputHasFractionalPartExactlyEqualToRuleClassifier

### DIFF
--- a/domain/src/main/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasFractionalPartExactlyEqualToRuleClassifierProvider.kt
+++ b/domain/src/main/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasFractionalPartExactlyEqualToRuleClassifierProvider.kt
@@ -26,7 +26,6 @@ internal class FractionInputHasFractionalPartExactlyEqualToRuleClassifierProvide
     )
   }
 
-  // TODO(#210): Add tests for this classifier.
   override fun matches(answer: Fraction, input: Fraction): Boolean {
     return answer.numerator == input.numerator && answer.denominator == input.denominator
   }

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest.kt
@@ -30,8 +30,12 @@ class FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest {
   private val WHOLE_NUMBER_321 = createWholeNumber(isNegative = false, value = 321)
   private val FRACTION_2_OVER_4 = createFraction(isNegative = false, numerator = 2, denominator = 4)
   private val FRACTION_1_OVER_2 = createFraction(isNegative = false, numerator = 1, denominator = 2)
+  private val FRACTION_NEGATIVE_1_OVER_2 =
+    createFraction(isNegative = true, numerator = -1, denominator = 2)
   private val MIXED_NUMBER_123_1_OVER_2 =
     createMixedNumber(isNegative = false, wholeNumber = 123, numerator = 1, denominator = 2)
+  private val MIXED_NUMBER_NEGATIVE_123_1_OVER_2 =
+    createMixedNumber(isNegative = true, wholeNumber = 123, numerator = 1, denominator = 2)
   private val MIXED_NUMBER_123_1_OVER_3 =
     createMixedNumber(isNegative = false, wholeNumber = 123, numerator = 1, denominator = 3)
 
@@ -44,7 +48,33 @@ class FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquals_wholeNumber123Answer_withWholeNumber123Input_bothValuesMatch() {
+  fun testFractionalEquals_neg123And1Over2Answer_withNeg1Over2Input_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to FRACTION_NEGATIVE_1_OVER_2)
+
+    val matches =
+      fractionalPartIsExactlyEqualClassifierProvider.matches(
+        answer = MIXED_NUMBER_NEGATIVE_123_1_OVER_2,
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testFractionalEquals_negativeIdentityCheck_bothValuesMatch() {
+    val inputs = mapOf("f" to FRACTION_NEGATIVE_1_OVER_2)
+
+    val matches =
+      fractionalPartIsExactlyEqualClassifierProvider.matches(
+        answer = FRACTION_NEGATIVE_1_OVER_2,
+        inputs = inputs
+      )
+
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testFractionalEquals_wholeNumber123Answer_withWholeNumber123Input_bothValuesMatch() {
     val inputs = mapOf("f" to WHOLE_NUMBER_123)
 
     val matches =
@@ -57,7 +87,7 @@ class FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquals_wholeNumber321Answer_withWholeNumber123Input_bothValuesMatch() {
+  fun testFractionalEquals_wholeNumber321Answer_withWholeNumber123Input_bothValuesMatch() {
     val inputs = mapOf("f" to WHOLE_NUMBER_123)
 
     val matches =
@@ -66,11 +96,12 @@ class FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest {
         inputs = inputs
       )
 
+    // 123 and 321 match because they have the same fractional parts: 0/1.
     assertThat(matches).isTrue()
   }
 
   @Test
-  fun testEquals_fraction2Over4Answer_withFraction1Over2Input_bothValuesDoNotMatch() {
+  fun testFractionalEquals_fraction2Over4Answer_withFraction1Over2Input_bothValuesDoNotMatch() {
     val inputs = mapOf("f" to FRACTION_1_OVER_2)
 
     val matches =
@@ -83,7 +114,7 @@ class FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquals_mixedNum123And1Over2Answer_withMixedNum123And1Over3Input_bothValuesDoNotMatch() {
+  fun testFractionalEquals_123And1Over2Answer_with123And1Over3Input_bothValuesDoNotMatch() {
     val inputs = mapOf("f" to MIXED_NUMBER_123_1_OVER_3)
 
     val matches =
@@ -96,7 +127,7 @@ class FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquals_mixedNum123And1Over2Answer_withFraction1Over2Input_bothValuesMatch() {
+  fun testFractionalEquals_mixedNum123And1Over2Answer_withFraction1Over2Input_bothValuesMatch() {
     val inputs = mapOf("f" to FRACTION_1_OVER_2)
 
     val matches =
@@ -109,7 +140,7 @@ class FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquals_wholeNumberAnswer_withMixedNumberInput_bothValuesDoNotMatch() {
+  fun testFractionalEquals_wholeNumberAnswer_withMixedNumberInput_bothValuesDoNotMatch() {
     val inputs = mapOf("f" to MIXED_NUMBER_123_1_OVER_2)
 
     val matches =
@@ -122,7 +153,7 @@ class FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquals_nonNegativeInput_inputWithIncorrectType_throwsException() {
+  fun testFractionalEquals_nonNegativeInput_inputWithIncorrectType_throwsException() {
     val inputs = mapOf("f" to NON_NEGATIVE_VALUE_0)
 
     val exception = assertThrows(IllegalStateException::class) {
@@ -140,7 +171,7 @@ class FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquals_missingInputF_throwsException() {
+  fun testFractionalEquals_missingInputF_throwsException() {
     val inputs = mapOf("y" to FRACTION_2_OVER_4)
 
     val exception = assertThrows(IllegalStateException::class) {

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest.kt
@@ -208,9 +208,11 @@ class FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest {
   }
 
   private fun setUpTestApplicationComponent() {
+    /* ktlint-disable max-line-length */
     DaggerFractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest_TestApplicationComponent
       .builder()
       .setApplication(ApplicationProvider.getApplicationContext()).build().inject(this)
+    /* ktlint-enable max-line-length */
   }
 
   // TODO(#89): Move to a common test library.

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest.kt
@@ -1,0 +1,244 @@
+package org.oppia.android.domain.classify.rules.fractioninput
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import dagger.BindsInstance
+import dagger.Component
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.oppia.android.app.model.Fraction
+import org.oppia.android.app.model.InteractionObject
+import org.oppia.android.domain.classify.RuleClassifier
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.reflect.KClass
+import kotlin.reflect.full.cast
+import kotlin.test.fail
+
+/** Tests for [FractionInputHasFractionalPartExactlyEqualToRuleClassifierProvider]. */
+@RunWith(AndroidJUnit4::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+@Config(manifest = Config.NONE)
+class FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest {
+  private val NON_NEGATIVE_VALUE_0 = createNonNegativeInt(value = 0)
+  private val WHOLE_NUMBER_123 = createWholeNumber(isNegative = false, value = 123)
+  private val WHOLE_NUMBER_321 = createWholeNumber(isNegative = false, value = 321)
+  private val FRACTION_2_OVER_4 = createFraction(isNegative = false, numerator = 2, denominator = 4)
+  private val FRACTION_1_OVER_2 = createFraction(isNegative = false, numerator = 1, denominator = 2)
+  private val MIXED_NUMBER_123_1_OVER_2 =
+    createMixedNumber(isNegative = false, wholeNumber = 123, numerator = 1, denominator = 2)
+  private val MIXED_NUMBER_123_1_OVER_3 =
+    createMixedNumber(isNegative = false, wholeNumber = 123, numerator = 1, denominator = 3)
+
+  @Inject
+  internal lateinit var fractionInputHasFractionalPartExactlyEqualToRuleClassifierProvider:
+    FractionInputHasFractionalPartExactlyEqualToRuleClassifierProvider
+
+  private val fractionalPartIsExactlyEqualClassifierProvider: RuleClassifier by lazy {
+    fractionInputHasFractionalPartExactlyEqualToRuleClassifierProvider.createRuleClassifier()
+  }
+
+  @Test
+  fun testEquals_wholeNumber123Answer_withWholeNumber123Input_bothValuesMatch() {
+    val inputs = mapOf("f" to WHOLE_NUMBER_123)
+
+    val matches =
+      fractionalPartIsExactlyEqualClassifierProvider.matches(
+        answer = WHOLE_NUMBER_123,
+        inputs = inputs
+      )
+
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testEquals_wholeNumber321Answer_withWholeNumber123Input_bothValuesMatch() {
+    val inputs = mapOf("f" to WHOLE_NUMBER_123)
+
+    val matches =
+      fractionalPartIsExactlyEqualClassifierProvider.matches(
+        answer = WHOLE_NUMBER_321,
+        inputs = inputs
+      )
+
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testEquals_fraction2Over4Answer_withFraction1Over2Input_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to FRACTION_1_OVER_2)
+
+    val matches =
+      fractionalPartIsExactlyEqualClassifierProvider.matches(
+        answer = FRACTION_2_OVER_4,
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testEquals_mixedNum123And1Over2Answer_withMixedNum123And1Over3Input_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to MIXED_NUMBER_123_1_OVER_3)
+
+    val matches =
+      fractionalPartIsExactlyEqualClassifierProvider.matches(
+        answer = MIXED_NUMBER_123_1_OVER_2,
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testEquals_mixedNum123And1Over2Answer_withFraction1Over2Input_bothValuesMatch() {
+    val inputs = mapOf("f" to FRACTION_1_OVER_2)
+
+    val matches =
+      fractionalPartIsExactlyEqualClassifierProvider.matches(
+        answer = MIXED_NUMBER_123_1_OVER_2,
+        inputs = inputs
+      )
+
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testEquals_wholeNumberAnswer_withMixedNumberInput_bothValuesDoNotMatch() {
+    val inputs = mapOf("f" to MIXED_NUMBER_123_1_OVER_2)
+
+    val matches =
+      fractionalPartIsExactlyEqualClassifierProvider.matches(
+        answer = WHOLE_NUMBER_123,
+        inputs = inputs
+      )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testEquals_nonNegativeInput_inputWithIncorrectType_throwsException() {
+    val inputs = mapOf("f" to NON_NEGATIVE_VALUE_0)
+
+    val exception = assertThrows(IllegalStateException::class) {
+      fractionalPartIsExactlyEqualClassifierProvider.matches(
+        answer = FRACTION_2_OVER_4,
+        inputs = inputs
+      )
+    }
+
+    assertThat(exception)
+      .hasMessageThat()
+      .contains(
+        "Expected input value to be of type FRACTION not NON_NEGATIVE_INT"
+      )
+  }
+
+  @Test
+  fun testEquals_missingInputF_throwsException() {
+    val inputs = mapOf("y" to FRACTION_2_OVER_4)
+
+    val exception = assertThrows(IllegalStateException::class) {
+      fractionalPartIsExactlyEqualClassifierProvider.matches(
+        answer = FRACTION_2_OVER_4,
+        inputs = inputs
+      )
+    }
+
+    assertThat(exception)
+      .hasMessageThat()
+      .contains("Expected classifier inputs to contain parameter with name 'f' but had: [y]")
+  }
+
+  private fun createFraction(
+    isNegative: Boolean,
+    numerator: Int,
+    denominator: Int
+  ): InteractionObject {
+    // Fraction-only numbers imply no whole number.
+    return InteractionObject.newBuilder().setFraction(
+      Fraction.newBuilder()
+        .setIsNegative(isNegative)
+        .setNumerator(numerator)
+        .setDenominator(denominator)
+        .build()
+    ).build()
+  }
+
+  private fun createWholeNumber(isNegative: Boolean, value: Int): InteractionObject {
+    // Whole number fractions imply '0/1' fractional parts.
+    return InteractionObject.newBuilder().setFraction(
+      Fraction.newBuilder()
+        .setIsNegative(isNegative)
+        .setWholeNumber(value)
+        .setNumerator(0)
+        .setDenominator(1)
+        .build()
+    ).build()
+  }
+
+  private fun createMixedNumber(
+    isNegative: Boolean,
+    wholeNumber: Int,
+    numerator: Int,
+    denominator: Int
+  ): InteractionObject {
+    return InteractionObject.newBuilder().setFraction(
+      Fraction.newBuilder()
+        .setIsNegative(isNegative)
+        .setWholeNumber(wholeNumber)
+        .setNumerator(numerator)
+        .setDenominator(denominator)
+        .build()
+    ).build()
+  }
+
+  private fun createNonNegativeInt(value: Int): InteractionObject {
+    return InteractionObject.newBuilder().setNonNegativeInt(value).build()
+  }
+
+  @Before
+  fun setUp() {
+    setUpTestApplicationComponent()
+  }
+
+  private fun setUpTestApplicationComponent() {
+    DaggerFractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest_TestApplicationComponent
+      .builder()
+      .setApplication(ApplicationProvider.getApplicationContext()).build().inject(this)
+  }
+
+  // TODO(#89): Move to a common test library.
+  private fun <T : Throwable> assertThrows(type: KClass<T>, operation: () -> Unit): T {
+    try {
+      operation()
+      fail("Expected to encounter exception of $type")
+    } catch (t: Throwable) {
+      if (type.isInstance(t)) {
+        return type.cast(t)
+      }
+      // Unexpected exception; throw it.
+      throw t
+    }
+  }
+
+  // TODO(#89): Move this to a common test application component.
+  @Singleton
+  @Component(modules = [])
+  interface TestApplicationComponent {
+    @Component.Builder
+    interface Builder {
+      @BindsInstance
+      fun setApplication(application: Application): Builder
+
+      fun build(): TestApplicationComponent
+    }
+
+    fun inject(test: FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest)
+  }
+}


### PR DESCRIPTION
@BenHenning PTAL

## Explanation
Fixed #1881 by adding unit tests for FractionInputHasFractionalPartExactlyEqualToRuleClassifier

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
