### PR TITLE
Enable full stack traces for all Robolectric tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,15 +66,15 @@ jobs:
 
      - name: Install Dependencies
        if: steps.cache.outputs.cache-hit != 'true'
-       run: ./gradlew androidDependencies
+       run: ./gradlew --full-stacktrace androidDependencies
      
      - name: Build App
        # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
-       run: sudo ./gradlew assembleDebug
+       run: sudo ./gradlew --full-stacktrace assembleDebug
     
      - name: Utility tests
        # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
-       run:  sudo ./gradlew :utility:testDebugUnitTest
+       run:  sudo ./gradlew --full-stacktrace :utility:testDebugUnitTest
      - name: Upload Utility Test Reports
        uses: actions/upload-artifact@v2
        if: ${{ always() }} # IMPORTANT: Upload reports regardless of status
@@ -84,7 +84,7 @@ jobs:
      
      - name: Domain tests
        # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
-       run:  sudo ./gradlew :domain:testDebugUnitTest
+       run:  sudo ./gradlew --full-stacktrace :domain:testDebugUnitTest
      - name: Upload Domain Test Reports
        uses: actions/upload-artifact@v2
        if: ${{ always() }} # IMPORTANT: Upload reports regardless of status
@@ -94,7 +94,7 @@ jobs:
 
      - name: Testing tests
        # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
-       run:  sudo ./gradlew :testing:testDebugUnitTest
+       run:  sudo ./gradlew --full-stacktrace :testing:testDebugUnitTest
      - name: Upload Testing Test Reports
        uses: actions/upload-artifact@v2
        if: ${{ always() }} # IMPORTANT: Upload reports regardless of status
@@ -124,7 +124,7 @@ jobs:
       - name: Robolectric tests - App Module
         # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
         run: |
-          sudo ./gradlew :app:testDebugUnitTest
+          sudo ./gradlew --full-stacktrace :app:testDebugUnitTest
       - name: Upload App Test Reports
         uses: actions/upload-artifact@v2
         if: ${{ always() }} # IMPORTANT: Upload reports regardless of status

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,15 @@ android {
       includeAndroidResources = true
       all {
         maxHeapSize = "1024m"
+        // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
+        testLogging {
+          events "passed", "skipped", "failed"
+          showExceptions true
+          exceptionFormat "full"
+          showCauses true
+          showStackTraces true
+          showStandardStreams = false
+        }
       }
     }
     animationsDisabled = true

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -33,6 +33,17 @@ android {
   testOptions {
     unitTests {
       includeAndroidResources = true
+      all {
+        // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
+        testLogging {
+          events "passed", "skipped", "failed"
+          showExceptions true
+          exceptionFormat "full"
+          showCauses true
+          showStackTraces true
+          showStandardStreams = false
+        }
+      }
     }
   }
 

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -31,6 +31,17 @@ android {
   testOptions {
     unitTests {
       includeAndroidResources = true
+      all {
+        // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
+        testLogging {
+          events "passed", "skipped", "failed"
+          showExceptions true
+          exceptionFormat "full"
+          showCauses true
+          showStackTraces true
+          showStandardStreams = false
+        }
+      }
     }
   }
 

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -22,6 +22,22 @@ android {
   kotlinOptions {
     jvmTarget = JavaVersion.VERSION_1_8
   }
+
+  testOptions {
+    unitTests {
+      all {
+        // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
+        testLogging {
+          events "passed", "skipped", "failed"
+          showExceptions true
+          exceptionFormat "full"
+          showCauses true
+          showStackTraces true
+          showStandardStreams = false
+        }
+      }
+    }
+  }
 }
 
 dependencies {

--- a/utility/build.gradle
+++ b/utility/build.gradle
@@ -31,6 +31,17 @@ android {
   testOptions {
     unitTests {
       includeAndroidResources = true
+      all {
+        // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
+        testLogging {
+          events "passed", "skipped", "failed"
+          showExceptions true
+          exceptionFormat "full"
+          showCauses true
+          showStackTraces true
+          showStandardStreams = false
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Enables full stack traces for all Robolectric tests to ensure failures can actually be understood when they occur in CI.

Note that ``full-stacktrace`` will specifically show Gradle task failures which is especially useful when running Espresso tests from the CLI (per #1831). The Gradle changes are needed for Robolectric tests to show full stack traces when failing.

Note also that the Gradle configuration is resulting in all passed & skipped tests to print out which is resulting in much more output. That seems like a nice addition since it makes the results clearer, but please let me know if you disagree.

This is being done as part of trying to figure out #1942.

Sample of failures showing up with stack traces after this change: https://github.com/oppia/oppia-android/pull/1939/checks?check_run_id=1222719700.