### PR TITLE
Fix #1942: Fix CI app module test flakiness/failures due to shared test processes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,15 +66,15 @@ jobs:
 
      - name: Install Dependencies
        if: steps.cache.outputs.cache-hit != 'true'
-       run: ./gradlew androidDependencies
+       run: ./gradlew --full-stacktrace androidDependencies
      
      - name: Build App
        # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
-       run: sudo ./gradlew assembleDebug
+       run: sudo ./gradlew --full-stacktrace assembleDebug
     
      - name: Utility tests
        # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
-       run:  sudo ./gradlew :utility:testDebugUnitTest
+       run:  sudo ./gradlew --full-stacktrace :utility:testDebugUnitTest
      - name: Upload Utility Test Reports
        uses: actions/upload-artifact@v2
        if: ${{ always() }} # IMPORTANT: Upload reports regardless of status
@@ -84,7 +84,7 @@ jobs:
      
      - name: Domain tests
        # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
-       run:  sudo ./gradlew :domain:testDebugUnitTest
+       run:  sudo ./gradlew --full-stacktrace :domain:testDebugUnitTest
      - name: Upload Domain Test Reports
        uses: actions/upload-artifact@v2
        if: ${{ always() }} # IMPORTANT: Upload reports regardless of status
@@ -94,7 +94,7 @@ jobs:
 
      - name: Testing tests
        # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
-       run:  sudo ./gradlew :testing:testDebugUnitTest
+       run:  sudo ./gradlew --full-stacktrace :testing:testDebugUnitTest
      - name: Upload Testing Test Reports
        uses: actions/upload-artifact@v2
        if: ${{ always() }} # IMPORTANT: Upload reports regardless of status
@@ -124,7 +124,7 @@ jobs:
       - name: Robolectric tests - App Module
         # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
         run: |
-          sudo ./gradlew :app:testDebugUnitTest
+          sudo ./gradlew --full-stacktrace :app:testDebugUnitTest
       - name: Upload App Test Reports
         uses: actions/upload-artifact@v2
         if: ${{ always() }} # IMPORTANT: Upload reports regardless of status

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,13 +54,19 @@ android {
       includeAndroidResources = true
       all {
         maxHeapSize = "1024m"
+
+        // Enable forking to ensure each test is properly run in isolation. For context, see:
+        // https://discuss.gradle.org/t/36066/2 & https://github.com/oppia/oppia-android/issues/1942
+        forkEvery = 1
+        maxParallelForks = Runtime.getRuntime().availableProcessors()
+
         // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
         testLogging {
           events "passed", "skipped", "failed"
-          showExceptions true
-          exceptionFormat "full"
-          showCauses true
-          showStackTraces true
+          showExceptions = true
+          exceptionFormat = "full"
+          showCauses = true
+          showStackTraces = true
           showStandardStreams = false
         }
       }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,15 @@ android {
       includeAndroidResources = true
       all {
         maxHeapSize = "1024m"
+        // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
+        testLogging {
+          events "passed", "skipped", "failed"
+          showExceptions true
+          exceptionFormat "full"
+          showCauses true
+          showStackTraces true
+          showStandardStreams = false
+        }
       }
     }
     animationsDisabled = true

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -33,6 +33,17 @@ android {
   testOptions {
     unitTests {
       includeAndroidResources = true
+      all {
+        // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
+        testLogging {
+          events "passed", "skipped", "failed"
+          showExceptions true
+          exceptionFormat "full"
+          showCauses true
+          showStackTraces true
+          showStandardStreams = false
+        }
+      }
     }
   }
 

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -34,13 +34,18 @@ android {
     unitTests {
       includeAndroidResources = true
       all {
+        // Enable forking to ensure each test is properly run in isolation. For context, see:
+        // https://discuss.gradle.org/t/36066/2 & https://github.com/oppia/oppia-android/issues/1942
+        forkEvery = 1
+        maxParallelForks = Runtime.getRuntime().availableProcessors()
+
         // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
         testLogging {
           events "passed", "skipped", "failed"
-          showExceptions true
-          exceptionFormat "full"
-          showCauses true
-          showStackTraces true
+          showExceptions = true
+          exceptionFormat = "full"
+          showCauses = true
+          showStackTraces = true
           showStandardStreams = false
         }
       }

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -31,6 +31,17 @@ android {
   testOptions {
     unitTests {
       includeAndroidResources = true
+      all {
+        // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
+        testLogging {
+          events "passed", "skipped", "failed"
+          showExceptions true
+          exceptionFormat "full"
+          showCauses true
+          showStackTraces true
+          showStandardStreams = false
+        }
+      }
     }
   }
 

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -32,13 +32,18 @@ android {
     unitTests {
       includeAndroidResources = true
       all {
+        // Enable forking to ensure each test is properly run in isolation. For context, see:
+        // https://discuss.gradle.org/t/36066/2 & https://github.com/oppia/oppia-android/issues/1942
+        forkEvery = 1
+        maxParallelForks = Runtime.getRuntime().availableProcessors()
+
         // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
         testLogging {
           events "passed", "skipped", "failed"
-          showExceptions true
-          exceptionFormat "full"
-          showCauses true
-          showStackTraces true
+          showExceptions = true
+          exceptionFormat = "full"
+          showCauses = true
+          showStackTraces = true
           showStandardStreams = false
         }
       }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -26,13 +26,18 @@ android {
   testOptions {
     unitTests {
       all {
+        // Enable forking to ensure each test is properly run in isolation. For context, see:
+        // https://discuss.gradle.org/t/36066/2 & https://github.com/oppia/oppia-android/issues/1942
+        forkEvery = 1
+        maxParallelForks = Runtime.getRuntime().availableProcessors()
+
         // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
         testLogging {
           events "passed", "skipped", "failed"
-          showExceptions true
-          exceptionFormat "full"
-          showCauses true
-          showStackTraces true
+          showExceptions = true
+          exceptionFormat = "full"
+          showCauses = true
+          showStackTraces = true
           showStandardStreams = false
         }
       }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -22,6 +22,22 @@ android {
   kotlinOptions {
     jvmTarget = JavaVersion.VERSION_1_8
   }
+
+  testOptions {
+    unitTests {
+      all {
+        // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
+        testLogging {
+          events "passed", "skipped", "failed"
+          showExceptions true
+          exceptionFormat "full"
+          showCauses true
+          showStackTraces true
+          showStandardStreams = false
+        }
+      }
+    }
+  }
 }
 
 dependencies {

--- a/utility/build.gradle
+++ b/utility/build.gradle
@@ -31,6 +31,17 @@ android {
   testOptions {
     unitTests {
       includeAndroidResources = true
+      all {
+        // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
+        testLogging {
+          events "passed", "skipped", "failed"
+          showExceptions true
+          exceptionFormat "full"
+          showCauses true
+          showStackTraces true
+          showStandardStreams = false
+        }
+      }
     }
   }
 

--- a/utility/build.gradle
+++ b/utility/build.gradle
@@ -32,13 +32,18 @@ android {
     unitTests {
       includeAndroidResources = true
       all {
+        // Enable forking to ensure each test is properly run in isolation. For context, see:
+        // https://discuss.gradle.org/t/36066/2 & https://github.com/oppia/oppia-android/issues/1942
+        forkEvery = 1
+        maxParallelForks = Runtime.getRuntime().availableProcessors()
+
         // https://discuss.gradle.org/t/29495/2 & https://stackoverflow.com/a/34299238.
         testLogging {
           events "passed", "skipped", "failed"
-          showExceptions true
-          exceptionFormat "full"
-          showCauses true
-          showStackTraces true
+          showExceptions = true
+          exceptionFormat = "full"
+          showCauses = true
+          showStackTraces = true
           showStandardStreams = false
         }
       }


### PR DESCRIPTION
Fix #1942

This started as #1939, but since the CI failure was also affecting that PR I decided to create a new PR that adds additional debugging information and fixes the issue.

The PR fixes CI tests by requiring each one run in its own process. Note that this was an existing issue, but it only recently started affecting CI tests (https://github.com/oppia/oppia-android/actions). This will result in tests running **significantly slower** than before because subsequent test suites cannot benefit from from previous tests' resources setup in Robolectric. This is exactly how Bazel works, so this is the correct long-term strategy for the tests. #1942 contains much more information, but the summary is that static state being shared and not properly synchronized across test suites was causing later suites to fail. Running tests in their own process fully mitigates the problem.

Note that parallelization is needed to run the tests locally, but it does **not** work in Android Studio's test runner UI which means that running whole modules of tests via the UI will take 3-4x longer than before. Running from the CLI is still quite fast since it does properly use Gradle's parallelization configuration introduced in this PR.

The debugging changes enable full stack traces for all Robolectric tests to ensure failures can actually be understood when they occur in CI. Note that full-stacktrace will specifically show Gradle task failures which is especially useful when running Espresso tests from the CLI (per #1831). The Gradle changes are needed for Robolectric tests to show full stack traces when failing. Note also that the Gradle configuration is resulting in all passed & skipped tests to print out which is resulting in much more output. That seems like a nice addition since it makes the results clearer, but please let me know if you disagree.

Sample of failures showing up with stack traces after this change: https://github.com/oppia/oppia-android/pull/1939/checks?check_run_id=1222719700.

Compared test times:

| CI job                                     | Runtime without process forking (per #1939) | Runtime with process forking |
|--------------------------------------------|---------------------------------------------|------------------------------|
| Robolectric Tests (Non-App Modules)        | 8m 14s                                      | 15m 38s                      |
| Robolectric Tests - App Module (Non-Flaky) | 8m 52s (with failures), 9-12m (passing)     | 21m 55s                      |