### PR TITLE
Fix #1952 tools:context in home_activity.xml

### DIFF
--- a/app/src/main/res/layout-land/home_activity.xml
+++ b/app/src/main/res/layout-land/home_activity.xml
@@ -4,7 +4,7 @@
   android:id="@+id/home_activity_drawer_layout"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  tools:context=".home.HomeActivity">
+  tools:context=".app.home.HomeActivity">
 
   <LinearLayout
     android:layout_width="match_parent"

--- a/app/src/main/res/layout-sw600dp-port/home_activity.xml
+++ b/app/src/main/res/layout-sw600dp-port/home_activity.xml
@@ -4,7 +4,7 @@
   android:id="@+id/home_activity_drawer_layout"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  tools:context=".home.HomeActivity">
+  tools:context=".app.home.HomeActivity">
 
   <LinearLayout
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/home_activity.xml
+++ b/app/src/main/res/layout/home_activity.xml
@@ -4,7 +4,7 @@
   android:id="@+id/home_activity_drawer_layout"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  tools:context=".home.HomeActivity">
+  tools:context=".app.home.HomeActivity">
 
   <LinearLayout
     android:layout_width="match_parent"


### PR DESCRIPTION
## Explanation
This PR fixes #1952 
Wrong tools:context path has been corrected in all 3 varients of `home_activity.xml`

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
