### PR TITLE
Fix part of #1633: Removed textview reference from RevisionCardViewmodel

### DIFF
--- a/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentPresenter.kt
@@ -43,7 +43,7 @@ class RevisionCardFragmentPresenter @Inject constructor(
     val view = binding.revisionCardExplanationText
     val viewModel = getReviewCardViewModel()
 
-    viewModel.setSubtopicIdAndBinding(topicId, subtopicId)
+    viewModel.setTopicAndSubtopicId(topicId, subtopicId)
     logRevisionCardEvent(topicId, subtopicId)
 
     binding.let {
@@ -54,12 +54,9 @@ class RevisionCardFragmentPresenter @Inject constructor(
     viewModel.revisionCardLiveData.observe(
       fragment,
       Observer {
-
-        val explanation = htmlParserFactory.create(
+        view.text = htmlParserFactory.create(
           resourceBucketName, entityType, topicId, /* imageCenterAlign= */ true
         ).parseOppiaHtml(it.pageContents.html, view)
-
-        view.text = explanation
       }
     )
 

--- a/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentPresenter.kt
@@ -4,11 +4,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
 import org.oppia.android.app.fragment.FragmentScope
 import org.oppia.android.app.model.EventLog
 import org.oppia.android.app.viewmodel.ViewModelProvider
 import org.oppia.android.databinding.RevisionCardFragmentBinding
 import org.oppia.android.domain.oppialogger.OppiaLogger
+import org.oppia.android.util.gcsresource.DefaultResourceBucketName
+import org.oppia.android.util.parser.HtmlParser
+import org.oppia.android.util.parser.TopicHtmlParserEntityType
 import org.oppia.android.util.system.OppiaClock
 import javax.inject.Inject
 
@@ -18,6 +22,9 @@ class RevisionCardFragmentPresenter @Inject constructor(
   private val fragment: Fragment,
   private val oppiaLogger: OppiaLogger,
   private val oppiaClock: OppiaClock,
+  private val htmlParserFactory: HtmlParser.Factory,
+  @DefaultResourceBucketName private val resourceBucketName: String,
+  @TopicHtmlParserEntityType private val entityType: String,
   private val viewModelProvider: ViewModelProvider<RevisionCardViewModel>
 ) {
 
@@ -36,13 +43,26 @@ class RevisionCardFragmentPresenter @Inject constructor(
     val view = binding.revisionCardExplanationText
     val viewModel = getReviewCardViewModel()
 
-    viewModel.setSubtopicIdAndBinding(topicId, subtopicId, view)
+    viewModel.setSubtopicIdAndBinding(topicId, subtopicId)
     logRevisionCardEvent(topicId, subtopicId)
 
     binding.let {
       it.viewModel = viewModel
       it.lifecycleOwner = fragment
     }
+
+    viewModel.revisionCardLiveData.observe(
+      fragment,
+      Observer {
+
+        val explanation = htmlParserFactory.create(
+          resourceBucketName, entityType, topicId, /* imageCenterAlign= */ true
+        ).parseOppiaHtml(it.pageContents.html, view)
+
+        view.text = explanation
+      }
+    )
+
     return binding.root
   }
 

--- a/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentPresenter.kt
@@ -55,7 +55,7 @@ class RevisionCardFragmentPresenter @Inject constructor(
       fragment,
       Observer {
         view.text = htmlParserFactory.create(
-          resourceBucketName, entityType, topicId, /* imageCenterAlign= */ true
+          resourceBucketName, entityType, topicId, imageCenterAlign = true
         ).parseOppiaHtml(it.pageContents.html, view)
       }
     )

--- a/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardViewModel.kt
@@ -33,8 +33,8 @@ class RevisionCardViewModel @Inject constructor(
     returnToTopicClickListener.onReturnToTopicClicked()
   }
 
-  /** Sets the value of topicId, subtopicId and binding before anything else. */
-  fun setSubtopicIdAndBinding(
+  /** Sets the value of topicId, subtopicId before anything else. */
+  fun setTopicAndSubtopicId(
     topicId: String,
     subtopicId: Int
   ) {

--- a/app/src/main/res/layout-land/revision_card_fragment.xml
+++ b/app/src/main/res/layout-land/revision_card_fragment.xml
@@ -30,7 +30,6 @@
         android:layout_marginTop="24dp"
         android:layout_marginEnd="52dp"
         android:fontFamily="sans-serif"
-        android:text="@{viewModel.explanationLiveData}"
         android:textColor="@color/oppiaPrimaryText"
         android:textSize="16sp" />
 

--- a/app/src/main/res/layout/revision_card_fragment.xml
+++ b/app/src/main/res/layout/revision_card_fragment.xml
@@ -30,7 +30,6 @@
         android:layout_marginTop="36dp"
         android:layout_marginEnd="28dp"
         android:fontFamily="sans-serif"
-        android:text="@{viewModel.explanationLiveData}"
         android:textColor="@color/oppiaPrimaryText"
         android:textSize="16sp" />
 


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
This PR fixes part of #1633 

Removed usage of TextView from RevisionCardViewModel and used existing RevisionCardLiveData variable to update the explanation text.

Current changes passed all the existing tests of RevisionCardFragmentTest class.
![Screenshot 2020-10-11 230514](https://user-images.githubusercontent.com/26787263/95685887-53d2bb80-0c18-11eb-8d79-8fe2da137bb4.png)



## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
