### PR TITLE
Fix #1855: Resolve ktlint max line length in app module test files

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -99,7 +99,7 @@ class AdministratorControlsActivityTest {
   @Test
   // TODO(#973): Fix AdministratorControlsActivityTest
   @Ignore
-  fun testAdministratorControlsActivity_withAdminProfile_openAdministratorControlsActivityFromNavigationDrawer_onBackPressed_showsHomeActivity() { // ktlint-disable max-line-length
+  fun testAdminCtrls_withAdminProfile_openAdminCtrlsFromNavDrawer_onBackPressed_showsHome() {
     ActivityScenario
       .launch<NavigationDrawerTestActivity>(
         createNavigationDrawerActivityIntent(0)
@@ -283,7 +283,7 @@ class AdministratorControlsActivityTest {
   }
 
   @Test
-  fun testAdministratorControlsFragment_loadFragment_topicUpdateOnWifiSwitchIsNotChecked_autoUpdateTopicSwitchIsNotChecked() { // ktlint-disable max-line-length
+  fun testAdminCtrls_topicUpdateOnWifiSwitchIsNotChecked_autoUpdateTopicSwitchIsNotChecked() {
     ActivityScenario.launch<AdministratorControlsActivity>(
       createAdministratorControlsActivityIntent(
         profileId = 0
@@ -315,7 +315,7 @@ class AdministratorControlsActivityTest {
   @Test
   // TODO(#973): Fix AdministratorControlsActivityTest
   @Ignore
-  fun testAdministratorControlsFragment_topicUpdateOnWifiSwitchIsChecked_configurationChange_checkIfSwitchIsChecked() { // ktlint-disable max-line-length
+  fun testAdminCtrls_topicUpdateOnWifiSwitchIsChecked_configChange_checkIfSwitchIsChecked() {
     ActivityScenario.launch<AdministratorControlsActivity>(
       createAdministratorControlsActivityIntent(
         profileId = 0
@@ -392,7 +392,7 @@ class AdministratorControlsActivityTest {
   @Test
   // TODO(#973): Fix AdministratorControlsActivityTest
   @Ignore
-  fun testAdministratorControlsFragment_loadFragment_onClickTopicUpdateOnWifiSwitch_checkSwitchRemainsChecked_onOpeningAdministratorControlsFragmentAgain() { // ktlint-disable max-line-length
+  fun testAdminCtrls_onClickTopicUpdateOnWifiSwitch_checkSwitchRemainsCheckedOnRecreate() {
     ActivityScenario
       .launch<NavigationDrawerTestActivity>(
         createNavigationDrawerActivityIntent(profileId = 0)
@@ -437,7 +437,7 @@ class AdministratorControlsActivityTest {
   @Test
   // TODO(#973): Fix AdministratorControlsActivityTest
   @Ignore
-  fun testAdministratorControlsFragment_loadFragment_clickEditProfile_checkOpensProfileListActivity() { // ktlint-disable max-line-length
+  fun testAdminCtrls_clickEditProfile_checkOpensProfileListActivity() {
     ActivityScenario.launch<AdministratorControlsActivity>(
       createAdministratorControlsActivityIntent(
         0

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -392,7 +392,7 @@ class AdministratorControlsActivityTest {
   @Test
   // TODO(#973): Fix AdministratorControlsActivityTest
   @Ignore
-  fun testAdminControls_onClickTopicUpdateOnWifiSwitch_switchRemainsCheckedOnRecreate() {
+  fun testAdminControls_onClickTopicUpdateOnWifiSwitch_reopen_switchRemainsChecked() {
     ActivityScenario
       .launch<NavigationDrawerTestActivity>(
         createNavigationDrawerActivityIntent(profileId = 0)

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -99,7 +99,7 @@ class AdministratorControlsActivityTest {
   @Test
   // TODO(#973): Fix AdministratorControlsActivityTest
   @Ignore
-  fun testAdminCtrls_withAdminProfile_openAdminCtrlsFromNavDrawer_onBackPressed_showsHome() {
+  fun testAdminControls_withAdminProfile_openAdminControlsFromNavDrawer_onBackPressed_showsHome() {
     ActivityScenario
       .launch<NavigationDrawerTestActivity>(
         createNavigationDrawerActivityIntent(0)
@@ -283,7 +283,7 @@ class AdministratorControlsActivityTest {
   }
 
   @Test
-  fun testAdminCtrls_topicUpdateOnWifiSwitchIsNotChecked_autoUpdateTopicSwitchIsNotChecked() {
+  fun testAdminControls_topicUpdateOnWifiSwitchIsNotChecked_autoUpdateTopicSwitchIsNotChecked() {
     ActivityScenario.launch<AdministratorControlsActivity>(
       createAdministratorControlsActivityIntent(
         profileId = 0
@@ -315,7 +315,7 @@ class AdministratorControlsActivityTest {
   @Test
   // TODO(#973): Fix AdministratorControlsActivityTest
   @Ignore
-  fun testAdminCtrls_topicUpdateOnWifiSwitchIsChecked_configChange_checkIfSwitchIsChecked() {
+  fun testAdminControls_topicUpdateOnWifiSwitchIsChecked_configChange_checkIfSwitchIsChecked() {
     ActivityScenario.launch<AdministratorControlsActivity>(
       createAdministratorControlsActivityIntent(
         profileId = 0
@@ -392,7 +392,7 @@ class AdministratorControlsActivityTest {
   @Test
   // TODO(#973): Fix AdministratorControlsActivityTest
   @Ignore
-  fun testAdminCtrls_onClickTopicUpdateOnWifiSwitch_checkSwitchRemainsCheckedOnRecreate() {
+  fun testAdminControls_onClickTopicUpdateOnWifiSwitch_switchRemainsCheckedOnRecreate() {
     ActivityScenario
       .launch<NavigationDrawerTestActivity>(
         createNavigationDrawerActivityIntent(profileId = 0)
@@ -437,7 +437,7 @@ class AdministratorControlsActivityTest {
   @Test
   // TODO(#973): Fix AdministratorControlsActivityTest
   @Ignore
-  fun testAdminCtrls_clickEditProfile_checkOpensProfileListActivity() {
+  fun testAdminControls_clickEditProfile_opensProfileListActivity() {
     ActivityScenario.launch<AdministratorControlsActivity>(
       createAdministratorControlsActivityIntent(
         0

--- a/app/src/sharedTest/java/org/oppia/android/app/help/HelpFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/help/HelpFragmentTest.kt
@@ -139,7 +139,7 @@ class HelpFragmentTest {
   }
 
   @Test
-  fun openHelpActivity_configurationChanged_scrollRecyclerViewToZeroPosition_showsFAQSuccessfully() { // ktlint-disable max-line-length
+  fun openHelpActivity_configChanged_scrollRecyclerViewToZeroPosition_showsFAQSuccessfully() {
     launch<HelpActivity>(createHelpActivityIntent(0, true)).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.help_fragment_recycler_view)).perform(
@@ -174,7 +174,7 @@ class HelpFragmentTest {
   }
 
   @Test
-  fun openHelpActivity_openNavigationDrawerAndClose_closingOfNavigationDrawerIsVerifiedSuccessfully() { // ktlint-disable max-line-length
+  fun openHelpActivity_openNavDrawerAndClose_closingOfNavDrawerIsVerifiedSuccessfully() {
     launch<HelpActivity>(createHelpActivityIntent(0, true)).use {
       onView(withContentDescription(R.string.drawer_open_content_description)).perform(click())
       onView(withId(R.id.help_activity_drawer_layout)).perform(close())

--- a/app/src/sharedTest/java/org/oppia/android/app/help/HelpFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/help/HelpFragmentTest.kt
@@ -139,7 +139,7 @@ class HelpFragmentTest {
   }
 
   @Test
-  fun openHelpActivity_configChanged_scrollRecyclerViewToZeroPosition_showsFAQSuccessfully() {
+  fun openHelpActivity_configChanged_scrollRecyclerViewToZeroPosition_showsFaqSuccessfully() {
     launch<HelpActivity>(createHelpActivityIntent(0, true)).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.help_fragment_recycler_view)).perform(

--- a/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
@@ -178,7 +178,7 @@ class HomeActivityTest {
     "This test case is incorrect as it depends on internalProfileId " +
       "which is not guaranteed to be 0 for admin."
   )
-  fun testHome_rvIndex0_withProfileId0_displayProfileName_profileNameDisplayedSuccessfully() {
+  fun testActivity_litemItem0_withProfileId0_displayProfileName_profileNameDisplayedSuccessfully() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
       onView(
         atPositionOnView(
@@ -193,7 +193,7 @@ class HomeActivityTest {
   @Test
   // TODO(#973): Fix HomeActivityTest
   @Ignore
-  fun testHome_rvIndex0_displayGreetingMsgBasedOnTime_goodMorningMsgDisplaySuccessful() {
+  fun testActivity_litemItem0_displayGreetingMsgBasedOnTime_goodMorningMsgDisplaySuccessful() {
     getApplicationDependencies()
     oppiaClock.setCurrentTimeMs(MORNING_TIMESTAMP)
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
@@ -213,7 +213,7 @@ class HomeActivityTest {
   @Test
   // TODO (#973): Fix HomeActivityTest
   @Ignore
-  fun testHome_rvIndex0_displayGreetingMsgBasedOnTime_goodAfternoonMsgDisplaySuccessful() {
+  fun testActivity_litemItem0_displayGreetingMsgBasedOnTime_goodAfternoonMsgDisplaySuccessful() {
     getApplicationDependencies()
     oppiaClock.setCurrentTimeMs(AFTERNOON_TIMESTAMP)
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
@@ -233,7 +233,7 @@ class HomeActivityTest {
   @Test
   // TODO (#973): Fix HomeActivityTest
   @Ignore
-  fun testHome_rvIndex0_displayGreetingMsgBasedOnTime_goodEveningMsgDisplaySuccessful() {
+  fun testActivity_litemItem0_displayGreetingMsgBasedOnTime_goodEveningMsgDisplaySuccessful() {
     getApplicationDependencies()
     oppiaClock.setCurrentTimeMs(EVENING_TIMESTAMP)
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {

--- a/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
@@ -178,7 +178,7 @@ class HomeActivityTest {
     "This test case is incorrect as it depends on internalProfileId " +
       "which is not guaranteed to be 0 for admin."
   )
-  fun testHomeActivity_recyclerViewIndex0_withProfileId0_displayProfileName_profileNameDisplayedSuccessfully() { // ktlint-disable max-line-length
+  fun testHome_rvIndex0_withProfileId0_displayProfileName_profileNameDisplayedSuccessfully() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
       onView(
         atPositionOnView(
@@ -193,7 +193,7 @@ class HomeActivityTest {
   @Test
   // TODO(#973): Fix HomeActivityTest
   @Ignore
-  fun testHomeActivity_recyclerViewIndex0_displayGreetingMessageBasedOnTime_goodMorningMessageDisplayedSuccessful() { // ktlint-disable max-line-length
+  fun testHome_rvIndex0_displayGreetingMsgBasedOnTime_goodMorningMsgDisplaySuccessful() {
     getApplicationDependencies()
     oppiaClock.setCurrentTimeMs(MORNING_TIMESTAMP)
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
@@ -213,7 +213,7 @@ class HomeActivityTest {
   @Test
   // TODO (#973): Fix HomeActivityTest
   @Ignore
-  fun testHomeActivity_recyclerViewIndex0_displayGreetingMessageBasedOnTime_goodAfternoonMessageDisplayedSuccessful() { // ktlint-disable max-line-length
+  fun testHome_rvIndex0_displayGreetingMsgBasedOnTime_goodAfternoonMsgDisplaySuccessful() {
     getApplicationDependencies()
     oppiaClock.setCurrentTimeMs(AFTERNOON_TIMESTAMP)
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
@@ -233,7 +233,7 @@ class HomeActivityTest {
   @Test
   // TODO (#973): Fix HomeActivityTest
   @Ignore
-  fun testHomeActivity_recyclerViewIndex0_displayGreetingMessageBasedOnTime_goodEveningMessageDisplayedSuccessful() { // ktlint-disable max-line-length
+  fun testHome_rvIndex0_displayGreetingMsgBasedOnTime_goodEveningMsgDisplaySuccessful() {
     getApplicationDependencies()
     oppiaClock.setCurrentTimeMs(EVENING_TIMESTAMP)
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {

--- a/app/src/sharedTest/java/org/oppia/android/app/home/RecentlyPlayedFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/RecentlyPlayedFragmentTest.kt
@@ -409,7 +409,7 @@ class RecentlyPlayedFragmentTest {
   @Test
   // TODO(#973): Fix RecentlyPlayedFragmentTest
   @Ignore
-  fun testRecentlyPlayedTest_changeConfig_rvItem0_doesNotShowSectionDivider() {
+  fun testActivity_changeConfig_litemItem0_doesNotShowSectionDivider() {
     ActivityScenario.launch<RecentlyPlayedActivity>(
       createRecentlyPlayedActivityIntent(
         internalProfileId
@@ -431,7 +431,7 @@ class RecentlyPlayedFragmentTest {
   @Test
   // TODO(#973): Fix RecentlyPlayedFragmentTest
   @Ignore
-  fun testRecentlyPlayedTest_changeConfig_rvItem0_showsLastWeekSectionTitle() {
+  fun testActivity_changeConfig_litemItem0_showsLastWeekSectionTitle() {
     ActivityScenario.launch<RecentlyPlayedActivity>(
       createRecentlyPlayedActivityIntent(
         internalProfileId
@@ -503,7 +503,7 @@ class RecentlyPlayedFragmentTest {
   @Test
   // TODO(#973): Fix RecentlyPlayedFragmentTest
   @Ignore
-  fun testRecentlyPlayedTest_changeConfig_rvItem1_lessonThumbnailIsCorrect() {
+  fun testActivity_changeConfig_litemItem1_lessonThumbnailIsCorrect() {
     ActivityScenario.launch<RecentlyPlayedActivity>(
       createRecentlyPlayedActivityIntent(
         internalProfileId
@@ -527,7 +527,7 @@ class RecentlyPlayedFragmentTest {
   @Test
   // TODO(#973): Fix RecentlyPlayedFragmentTest
   @Ignore
-  fun testRecentlyPlayedTest_changeConfig_rvItem2_showsLastMonthSectionTitle() {
+  fun testActivity_changeConfig_litemItem2_showsLastMonthSectionTitle() {
     ActivityScenario.launch<RecentlyPlayedActivity>(
       createRecentlyPlayedActivityIntent(
         internalProfileId

--- a/app/src/sharedTest/java/org/oppia/android/app/home/RecentlyPlayedFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/RecentlyPlayedFragmentTest.kt
@@ -409,7 +409,7 @@ class RecentlyPlayedFragmentTest {
   @Test
   // TODO(#973): Fix RecentlyPlayedFragmentTest
   @Ignore
-  fun testRecentlyPlayedTestActivity_changeConfiguration_recyclerViewItem0_doesNotShowSectionDivider() { // ktlint-disable max-line-length
+  fun testRecentlyPlayedTest_changeConfig_rvItem0_doesNotShowSectionDivider() {
     ActivityScenario.launch<RecentlyPlayedActivity>(
       createRecentlyPlayedActivityIntent(
         internalProfileId
@@ -431,7 +431,7 @@ class RecentlyPlayedFragmentTest {
   @Test
   // TODO(#973): Fix RecentlyPlayedFragmentTest
   @Ignore
-  fun testRecentlyPlayedTestActivity_changeConfiguration_recyclerViewItem0_showsLastWeekSectionTitle() { // ktlint-disable max-line-length
+  fun testRecentlyPlayedTest_changeConfig_rvItem0_showsLastWeekSectionTitle() {
     ActivityScenario.launch<RecentlyPlayedActivity>(
       createRecentlyPlayedActivityIntent(
         internalProfileId
@@ -503,7 +503,7 @@ class RecentlyPlayedFragmentTest {
   @Test
   // TODO(#973): Fix RecentlyPlayedFragmentTest
   @Ignore
-  fun testRecentlyPlayedTestActivity_changeConfiguration_recyclerViewItem1_lessonThumbnailIsCorrect() { // ktlint-disable max-line-length
+  fun testRecentlyPlayedTest_changeConfig_rvItem1_lessonThumbnailIsCorrect() {
     ActivityScenario.launch<RecentlyPlayedActivity>(
       createRecentlyPlayedActivityIntent(
         internalProfileId
@@ -527,7 +527,7 @@ class RecentlyPlayedFragmentTest {
   @Test
   // TODO(#973): Fix RecentlyPlayedFragmentTest
   @Ignore
-  fun testRecentlyPlayedTestActivity_changeConfiguration_recyclerViewItem2_showsLastMonthSectionTitle() { // ktlint-disable max-line-length
+  fun testRecentlyPlayedTest_changeConfig_rvItem2_showsLastMonthSectionTitle() {
     ActivityScenario.launch<RecentlyPlayedActivity>(
       createRecentlyPlayedActivityIntent(
         internalProfileId

--- a/app/src/sharedTest/java/org/oppia/android/app/player/audio/AudioFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/audio/AudioFragmentTest.kt
@@ -165,7 +165,7 @@ class AudioFragmentTest {
   }
 
   @Test
-  fun testAudioFragment_openFragment_showsEnglishAudioLanguageWhenDefaultAudioLanguageNotAvailable() { // ktlint-disable max-line-length
+  fun testAudioFragment_openFragment_showsEnglishWhenDefaultAudioLanguageNotAvailable() {
     launch<AudioFragmentTestActivity>(
       createHomeActivityIntent(
         PROFILE_ID_INVALID_AUDIO_LANGUAGE

--- a/app/src/sharedTest/java/org/oppia/android/app/player/audio/AudioFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/audio/AudioFragmentTest.kt
@@ -165,7 +165,7 @@ class AudioFragmentTest {
   }
 
   @Test
-  fun testAudioFragment_openFragment_showsEnglishWhenDefaultAudioLanguageNotAvailable() {
+  fun testAudioFragment_openFragment_defaultAudioLanguageNotAvailable_showsEnglish() {
     launch<AudioFragmentTestActivity>(
       createHomeActivityIntent(
         PROFILE_ID_INVALID_AUDIO_LANGUAGE

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -284,7 +284,7 @@ class ExplorationActivityTest {
   }
 
   @Test
-  fun testAudioWithNoVoiceover_openPrototypeExploration_configChange_checkAudioButtonIsHidden() {
+  fun testAudioWithNoVoiceover_openPrototypeExploration_configChange_audioButtonIsHidden() {
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
         internalProfileId,
@@ -345,7 +345,7 @@ class ExplorationActivityTest {
   }
 
   @Test
-  fun testAudioWithCell_openRatioExploration_clickAudio_changeConfig_opensCellAudioDialog() {
+  fun testAudioWithCellular_openRatioExp_clickAudioIcon_changeConfig_opensCellAudioDialog() {
     setupAudio()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
@@ -368,7 +368,7 @@ class ExplorationActivityTest {
   }
 
   @Test
-  fun testAudioWithCell_openRatioExploration_clickAudio_clickNeg_checkAudioFragmentIsHidden() {
+  fun testAudioWithCellular_openRatioExp_clickAudioIcon_clickNegative_audioFragmentIsHidden() {
     setupAudio()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
@@ -400,7 +400,7 @@ class ExplorationActivityTest {
   }
 
   @Test
-  fun testAudioWithCell_openRatioExploration_clickAudio_clickPos_checkAudioFragmentIsVisible() {
+  fun testAudioWithCellular_openRatioExp_clickAudioIcon_clickPositive_audioFragmentIsVisible() {
     setupAudio()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
@@ -441,7 +441,7 @@ class ExplorationActivityTest {
   }
 
   @Test
-  fun testAudioWithCell_openRatioExploration_clickBoxNeg_clickAudio_AudioHiddenDlgNotDisplayed() {
+  fun testAudioWithCell_ratioExp_clickBoxAndNegative_clickAudio_audioHiddenDialogNotDisplayed() {
     setupAudio()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
@@ -477,7 +477,7 @@ class ExplorationActivityTest {
   }
 
   @Test
-  fun testAudioWithCell_openRatioExploration_clickBoxPos_clickAudioTwice_AudioVisibleDlgNotDisp() {
+  fun testAudioWithCell_ratioExp_clickBoxPositive_clickAudioTwice_audioVisibleDialogNotDisplayed() {
     setupAudio()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
@@ -516,7 +516,7 @@ class ExplorationActivityTest {
   // TODO(#89): The ExplorationActivity takes time to finish. This test case is failing currently.
   @Test
   @Ignore("The ExplorationActivity takes time to finish, needs to fixed in #89.")
-  fun testAudioWithWifi_openRatioExploration_clickAudio_AudioHasDefaultLangAndAutoPlays() {
+  fun testAudioWithWifi_openRatioExp_clickAudioIcon_audioHasDefaultLanguageAndAutoPlays() {
     getApplicationDependencies(RATIOS_EXPLORATION_ID_0)
     networkConnectionUtil.setCurrentConnectionStatus(NetworkConnectionUtil.ConnectionStatus.LOCAL)
     launch<ExplorationActivity>(
@@ -549,7 +549,7 @@ class ExplorationActivityTest {
   }
 
   @Test
-  fun testAudioWithWifi_openFractionsExploration_changeLang_clickNext_checkLangIsHinglish() {
+  fun testAudioWithWifi_openFractionsExp_changeLanguage_clickNext_languageIsHinglish() {
     setupAudioForFraction()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
@@ -597,7 +597,7 @@ class ExplorationActivityTest {
   // TODO(#89): The ExplorationActivity takes time to finish. This test case is failing currently.
   @Test
   @Ignore("The ExplorationActivity takes time to finish, needs to fixed in #89.")
-  fun testAudioWithWifi_openRatioExploration_ToInteraction_clickAudio_submit_FeedbackAudioPlays() {
+  fun testAudioWithWifi_openRatioExp_continueToInteraction_clickAudio_submit_feedbackAudioPlays() {
     getApplicationDependencies(RATIOS_EXPLORATION_ID_0)
     networkConnectionUtil.setCurrentConnectionStatus(NetworkConnectionUtil.ConnectionStatus.LOCAL)
     launch<ExplorationActivity>(
@@ -676,7 +676,7 @@ class ExplorationActivityTest {
 
   // TODO(#89): Check this test case too. It works in pair with below test case.
   @Test
-  fun testExplorationActivity_onBack_showsStopExplorationDialog_clickCancel_dismissesDialog() {
+  fun testActivity_onBackPressed_showsStopExplorationDialog_clickCancel_dismissesDialog() {
     explorationActivityTestRule.launchActivity(
       createExplorationActivityIntent(
         internalProfileId,
@@ -694,7 +694,7 @@ class ExplorationActivityTest {
   // TODO(#89): The ExplorationActivity takes time to finish. This test case is failing currently.
   @Test
   @Ignore("The ExplorationActivity takes time to finish, needs to fixed in #89.")
-  fun testExplorationActivity_onBack_showStopExplorationDlg_clickLeave_closeExplorationActivity() {
+  fun testActivity_onBackPressed_showStopExplorationDialog_clickLeave_closeExplorationActivity() {
     explorationActivityTestRule.launchActivity(
       createExplorationActivityIntent(
         internalProfileId,

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -283,9 +283,8 @@ class ExplorationActivityTest {
     explorationDataController.stopPlayingExploration()
   }
 
-  // TODO (#1855): Resolve ktlint max line in app module test
   @Test
-  fun testAudioWithNoVoiceover_openPrototypeExploration_configurationChange_checkAudioButtonIsHidden() { // ktlint-disable max-line-length
+  fun testAudioWithNoVoiceover_openPrototypeExploration_configChange_checkAudioButtonIsHidden() {
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
         internalProfileId,
@@ -345,9 +344,8 @@ class ExplorationActivityTest {
     explorationDataController.stopPlayingExploration()
   }
 
-  // TODO (#1855): Resolve ktlint max line in app module test
   @Test
-  fun testAudioWithCellular_openRatioExploration_clickAudioIcon_changeConfiguration_checkOpensCellularAudioDialog() { // ktlint-disable max-line-length
+  fun testAudioWithCell_openRatioExploration_clickAudio_changeConfig_opensCellAudioDialog() {
     setupAudio()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
@@ -369,9 +367,8 @@ class ExplorationActivityTest {
     explorationDataController.stopPlayingExploration()
   }
 
-  // TODO (#1855): Resolve ktlint max line in app module test
   @Test
-  fun testAudioWithCellular_openRatioExploration_clickAudioIcon_clickNegative_checkAudioFragmentIsHidden() { // ktlint-disable max-line-length
+  fun testAudioWithCell_openRatioExploration_clickAudio_clickNeg_checkAudioFragmentIsHidden() {
     setupAudio()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
@@ -402,9 +399,8 @@ class ExplorationActivityTest {
     explorationDataController.stopPlayingExploration()
   }
 
-  // TODO (#1855): Resolve ktlint max line in app module test
   @Test
-  fun testAudioWithCellular_openRatioExploration_clickAudioIcon_clickPositive_checkAudioFragmentIsVisible() { // ktlint-disable max-line-length
+  fun testAudioWithCell_openRatioExploration_clickAudio_clickPos_checkAudioFragmentIsVisible() {
     setupAudio()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
@@ -444,9 +440,8 @@ class ExplorationActivityTest {
     explorationDataController.stopPlayingExploration()
   }
 
-  // TODO (#1855): Resolve ktlint max line in app module test
   @Test
-  fun testAudioWithCellular_openRatioExploration_clickCheckboxAndNegative_clickAudioIcon_checkAudioFragmentIsHiddenAndDialogIsNotDisplayed() { // ktlint-disable max-line-length
+  fun testAudioWithCell_openRatioExploration_clickBoxNeg_clickAudio_AudioHiddenDlgNotDisplayed() {
     setupAudio()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
@@ -481,9 +476,8 @@ class ExplorationActivityTest {
     explorationDataController.stopPlayingExploration()
   }
 
-  // TODO (#1855): Resolve ktlint max line in app module test
   @Test
-  fun testAudioWithCellular_openRatioExploration_clickCheckboxAndPositive_clickAudioIconTwice_checkAudioFragmentIsVisibleAndDialogIsNotDisplayed() { // ktlint-disable max-line-length
+  fun testAudioWithCell_openRatioExploration_clickBoxPos_clickAudioTwice_AudioVisibleDlgNotDisp() {
     setupAudio()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
@@ -519,11 +513,10 @@ class ExplorationActivityTest {
     explorationDataController.stopPlayingExploration()
   }
 
-  // TODO (#1855): Resolve ktlint max line in app module test
   // TODO(#89): The ExplorationActivity takes time to finish. This test case is failing currently.
   @Test
   @Ignore("The ExplorationActivity takes time to finish, needs to fixed in #89.")
-  fun testAudioWithWifi_openRatioExploration_clickAudioIcon_checkAudioFragmentHasDefaultLanguageAndAutoPlays() { // ktlint-disable max-line-length
+  fun testAudioWithWifi_openRatioExploration_clickAudio_AudioHasDefaultLangAndAutoPlays() {
     getApplicationDependencies(RATIOS_EXPLORATION_ID_0)
     networkConnectionUtil.setCurrentConnectionStatus(NetworkConnectionUtil.ConnectionStatus.LOCAL)
     launch<ExplorationActivity>(
@@ -555,9 +548,8 @@ class ExplorationActivityTest {
     explorationDataController.stopPlayingExploration()
   }
 
-  // TODO (#1855): Resolve ktlint max line in app module test
   @Test
-  fun testAudioWithWifi_openFractionsExploration_changeLanguage_clickNext_checkLanguageIsHinglish() { // ktlint-disable max-line-length
+  fun testAudioWithWifi_openFractionsExploration_changeLang_clickNext_checkLangIsHinglish() {
     setupAudioForFraction()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
@@ -602,11 +594,10 @@ class ExplorationActivityTest {
     explorationDataController.stopPlayingExploration()
   }
 
-  // TODO (#1855): Resolve ktlint max line in app module test
   // TODO(#89): The ExplorationActivity takes time to finish. This test case is failing currently.
   @Test
   @Ignore("The ExplorationActivity takes time to finish, needs to fixed in #89.")
-  fun testAudioWithWifi_openRatioExploration_continueToInteraction_clickAudioButton_submitAnswer_checkFeedbackAudioPlays() { // ktlint-disable max-line-length
+  fun testAudioWithWifi_openRatioExploration_ToInteraction_clickAudio_submit_FeedbackAudioPlays() {
     getApplicationDependencies(RATIOS_EXPLORATION_ID_0)
     networkConnectionUtil.setCurrentConnectionStatus(NetworkConnectionUtil.ConnectionStatus.LOCAL)
     launch<ExplorationActivity>(
@@ -683,10 +674,9 @@ class ExplorationActivityTest {
     }
   }
 
-  // TODO (#1855): Resolve ktlint max line in app module test
   // TODO(#89): Check this test case too. It works in pair with below test case.
   @Test
-  fun testExplorationActivity_onBackPressed_showsStopExplorationDialog_clickCancel_dismissesDialog() { // ktlint-disable max-line-length
+  fun testExplorationActivity_onBack_showsStopExplorationDialog_clickCancel_dismissesDialog() {
     explorationActivityTestRule.launchActivity(
       createExplorationActivityIntent(
         internalProfileId,
@@ -701,11 +691,10 @@ class ExplorationActivityTest {
     assertThat(explorationActivityTestRule.activity.isFinishing).isFalse()
   }
 
-  // TODO (#1855): Resolve ktlint max line in app module test
   // TODO(#89): The ExplorationActivity takes time to finish. This test case is failing currently.
   @Test
   @Ignore("The ExplorationActivity takes time to finish, needs to fixed in #89.")
-  fun testExplorationActivity_onBackPressed_showsStopExplorationDialog_clickLeave_closesExplorationActivity() { // ktlint-disable max-line-length
+  fun testExplorationActivity_onBack_showStopExplorationDlg_clickLeave_closeExplorationActivity() {
     explorationActivityTestRule.launchActivity(
       createExplorationActivityIntent(
         internalProfileId,

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
@@ -146,7 +146,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_changeConfiguration_inputName_clickCreate_checkOpensProfileChooserActivity() { // ktlint-disable max-line-length
+  fun testAddProfile_changeConfig_inputName_clickCreate_checkOpensProfileChooserActivity() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(allOf(withId(R.id.add_profile_activity_pin_check_box))).perform(scrollTo())
@@ -269,7 +269,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_changeConfiguration_inputName_inputPin_clickCreate_checkOpensProfileActivity() { // ktlint-disable max-line-length
+  fun testAddProfile_changeConfig_inputName_inputPin_clickCreate_checkOpensProfileActivity() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(allOf(withId(R.id.add_profile_activity_pin_check_box))).perform(scrollTo())
@@ -401,7 +401,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_changeConfiguration_inputNotUniqueName_clickCreate_checkNameNotUniqueError() { // ktlint-disable max-line-length
+  fun testAddProfile_changeConfig_inputNotUniqueName_clickCreate_checkNameNotUniqueError() {
     profileTestHelper.initializeProfiles()
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
@@ -461,7 +461,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_changeConfiguration_inputNotUniqueName_clickCreate_inputName_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testAddProfile_changeConfig_inputNotUniqueName_clickCreate_inputName_checkErrorIsCleared() {
     profileTestHelper.initializeProfiles()
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
@@ -528,7 +528,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_changeConfiguration_inputNameWithNumbers_clickCreate_checkNameOnlyLettersError() { // ktlint-disable max-line-length
+  fun testAddProfile_changeConfig_inputNameWithNumbers_clickCreate_checkNameOnlyLettersError() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       testCoroutineDispatchers.runCurrent()
@@ -589,7 +589,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_changeConfiguration_inputNameWithNumbers_clickCreate_inputName_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testAddProfile_changeConfig_inputNameWithNos_clickCreate_inputName_checkErrorIsCleared() {
     launch(AddProfileActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
@@ -666,7 +666,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_changeConfiguration_inputShortPin_clickCreate_checkPinLengthError() { // ktlint-disable max-line-length
+  fun testAddProfile_changeConfig_inputShortPin_clickCreate_checkPinLengthError() {
     launch(AddProfileActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
@@ -748,7 +748,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_changeConfiguration_inputShortPin_clickCreate_inputPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testAddProfile_changeConfig_inputShortPin_clickCreate_inputPin_checkErrorIsCleared() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
@@ -978,7 +978,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_changeConfiguration_inputWrongConfirmPin_inputConfirmPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testAddProfile_changeConfig_inputWrongConfirmPin_inputConfirmPin_checkErrorIsCleared() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
@@ -1119,7 +1119,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_changeConfiguration_inputPin_inputConfirmPin_checkAllowDownloadClickable() { // ktlint-disable max-line-length
+  fun testAddProfile_changeConfig_inputPin_inputConfirmPin_checkAllowDownloadClickable() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
@@ -1292,7 +1292,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_inputName_inputPin_inputConfirmPin_changeConfiguration_checkName_checkPin_checkConfirmPin_IsDisplayed() { // ktlint-disable max-line-length
+  fun testAddProfile_inputName_Pin_ConfirmPin_changeConfig_checkName_Pin_ConfirmPin_Displayed() {
     launch(AddProfileActivity::class.java).use {
       onView(
         allOf(
@@ -1365,7 +1365,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_inputName_inputPin_inputConfirmPin_deselectPIN_clickCreate_checkOpensProfileActivity() { // ktlint-disable max-line-length
+  fun testAddProfile_inputName_Pin_inputConfirmPin_deselectPIN_clickCreate_OpensProfileActivity() {
     launch(AddProfileActivity::class.java).use {
       onView(
         allOf(
@@ -1407,7 +1407,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_inputNotUniqueName_clickCreate_changeConfiguration_checkErrorMessageDisplayed() { // ktlint-disable max-line-length
+  fun testAddProfile_inputNotUniqueName_clickCreate_changeConfig_checkErrorMsgDisplayed() {
     profileTestHelper.initializeProfiles()
     launch(AddProfileActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
@@ -1446,7 +1446,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_inputPin_inputConfirmPin_changeConfiguration_checkPin_checkConfirmPin_IsDisplayed() { // ktlint-disable max-line-length
+  fun testAddProfile_inputPin_inputConfirmPin_changeConfig_checkPin_checkConfirmPin_Displayed() {
     launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(click())
       onView(
@@ -1500,7 +1500,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_inputPin_inputDifferentConfirmPin_clickCreate_changeConfiguration_checkErrorMessageDisplayed() { // ktlint-disable max-line-length
+  fun testAddProfile_inputPin_inputDfrntConfirmPin_clickCreate_changeConfig_ErrorMsgDisplayed() {
     launch(AddProfileActivity::class.java).use {
       onView(
         allOf(
@@ -1559,7 +1559,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_inputPin_inputConfirmPin_turnOnDownloadAccessSwitch_changeConfiguration_checkDownloadAccessSwitchIsOn() { // ktlint-disable max-line-length
+  fun testAddProfile_inputPin_ConfirmPin_OnDnldAccessSwitch_changeConfig_DnldAccessSwitchIsOn() {
     launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(click())
       onView(

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
@@ -146,7 +146,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_changeConfig_inputName_clickCreate_checkOpensProfileChooserActivity() {
+  fun testAddProfileActivity_changeConfig_inputName_clickCreate_opensProfileChooserActivity() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(allOf(withId(R.id.add_profile_activity_pin_check_box))).perform(scrollTo())
@@ -269,7 +269,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_changeConfig_inputName_inputPin_clickCreate_checkOpensProfileActivity() {
+  fun testAddProfileActivity_changeConfig_inputName_inputPin_clickCreate_opensProfileActivity() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(allOf(withId(R.id.add_profile_activity_pin_check_box))).perform(scrollTo())
@@ -401,7 +401,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_changeConfig_inputNotUniqueName_clickCreate_checkNameNotUniqueError() {
+  fun testAddProfileActivity_changeConfig_inputNotUniqueName_clickCreate_nameNotUniqueError() {
     profileTestHelper.initializeProfiles()
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
@@ -461,7 +461,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_changeConfig_inputNotUniqueName_clickCreate_inputName_checkErrorIsCleared() {
+  fun testActivity_changeConfig_inputNotUniqueName_clickCreate_inputName_errorIsCleared() {
     profileTestHelper.initializeProfiles()
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
@@ -528,7 +528,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_changeConfig_inputNameWithNumbers_clickCreate_checkNameOnlyLettersError() {
+  fun testAddProfileActivity_changeConfig_inputNameWithNumbers_clickCreate_nameOnlyLettersError() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       testCoroutineDispatchers.runCurrent()
@@ -589,7 +589,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_changeConfig_inputNameWithNos_clickCreate_inputName_checkErrorIsCleared() {
+  fun testActivity_changeConfig_inputNameWithNumbers_clickCreate_inputName_errorIsCleared() {
     launch(AddProfileActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
@@ -666,7 +666,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_changeConfig_inputShortPin_clickCreate_checkPinLengthError() {
+  fun testAddProfileActivity_changeConfig_inputShortPin_clickCreate_pinLengthError() {
     launch(AddProfileActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
@@ -748,7 +748,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_changeConfig_inputShortPin_clickCreate_inputPin_checkErrorIsCleared() {
+  fun testAddProfileActivity_changeConfig_inputShortPin_clickCreate_inputPin_errorIsCleared() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
@@ -978,7 +978,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_changeConfig_inputWrongConfirmPin_inputConfirmPin_checkErrorIsCleared() {
+  fun testAddProfileActivity_changeConfig_inputWrongConfirmPin_inputConfirmPin_errorIsCleared() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
@@ -1119,7 +1119,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_changeConfig_inputPin_inputConfirmPin_checkAllowDownloadClickable() {
+  fun testAddProfileActivity_changeConfig_inputPin_inputConfirmPin_allowDownloadIsClickable() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
@@ -1292,7 +1292,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_inputName_Pin_ConfirmPin_changeConfig_checkName_Pin_ConfirmPin_Displayed() {
+  fun testActivity_inputNameAndPinAndConfirm_changeConfig_checkNameAndPinAndConfirm_isDisplayed() {
     launch(AddProfileActivity::class.java).use {
       onView(
         allOf(
@@ -1407,7 +1407,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_inputNotUniqueName_clickCreate_changeConfig_checkErrorMsgDisplayed() {
+  fun testAddProfileActivity_inputNotUniqueName_clickCreate_changeConfig_errorMessageDisplayed() {
     profileTestHelper.initializeProfiles()
     launch(AddProfileActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
@@ -1446,7 +1446,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_inputPin_inputConfirmPin_changeConfig_checkPin_checkConfirmPin_Displayed() {
+  fun testActivity_inputPin_inputConfirmPin_changeConfig_checkPin_checkConfirmPin_Displayed() {
     launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(click())
       onView(
@@ -1500,7 +1500,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_inputPin_inputDfrntConfirmPin_clickCreate_changeConfig_ErrorMsgDisplayed() {
+  fun testActivity_inputPin_inputDifferentConfirm_clickCreate_changeConfig_errorMessageDisplayed() {
     launch(AddProfileActivity::class.java).use {
       onView(
         allOf(
@@ -1559,7 +1559,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfile_inputPin_ConfirmPin_OnDnldAccessSwitch_changeConfig_DnldAccessSwitchIsOn() {
+  fun testActivity_inputPin_inputConfirmPin_turnOnDownloadAccessSwitch_changeConfig_switchIsOn() {
     launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(click())
       onView(

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
@@ -177,7 +177,7 @@ class AdminAuthActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminAuthActivity_inputCorrectPassword_clickImeActionButton_opensAddAdministratorControlsActivity() { // ktlint-disable max-line-length
+  fun testAdminAuth_inputCorrectPassword_clickImeActionButton_opensAddAdminControlsActivity() {
     launch<AdminAuthActivity>(
       AdminAuthActivity.createAdminAuthActivityIntent(
         context,
@@ -279,7 +279,7 @@ class AdminAuthActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminAuthActivity_inputIncorrectPassword_inputAgain_clickImeActionButton_checkErrorIsGone() { // ktlint-disable max-line-length
+  fun testAdminAuth_inputIncorrectPassword_inputAgain_clickImeActionButton_checkErrorIsGone() {
     launch<AdminAuthActivity>(
       AdminAuthActivity.createAdminAuthActivityIntent(
         context,
@@ -327,7 +327,7 @@ class AdminAuthActivityTest {
   }
 
   @Test
-  fun testAdminAuthActivity_openedFromAdminControls_configurationChanged_checkHeadingSubHeadingIsPreserved() { // ktlint-disable max-line-length
+  fun testAdminAuth_openedFromAdminCtrls_configChanged_checkHeadingSubHeadingIsPreserved() {
     launch<AdminAuthActivity>(
       AdminAuthActivity.createAdminAuthActivityIntent(
         context,
@@ -378,7 +378,7 @@ class AdminAuthActivityTest {
   }
 
   @Test
-  fun testAdminAuthActivity_openedFromProfile_configurationChanged_checkHeadingSubHeadingIsPreserved() { // ktlint-disable max-line-length
+  fun testAdminAuthActivity_openedFromProfile_configChanged_checkHeadingSubHeadingIsPreserved() {
     launch<AdminAuthActivity>(
       AdminAuthActivity.createAdminAuthActivityIntent(
         context,

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
@@ -279,7 +279,7 @@ class AdminAuthActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminAuth_inputIncorrectPassword_inputAgain_clickImeActionButton_checkErrorIsGone() {
+  fun testAdminAuth_inputIncorrectPassword_inputAgain_clickImeActionButton_errorIsGone() {
     launch<AdminAuthActivity>(
       AdminAuthActivity.createAdminAuthActivityIntent(
         context,
@@ -327,7 +327,7 @@ class AdminAuthActivityTest {
   }
 
   @Test
-  fun testAdminAuth_openedFromAdminCtrls_configChanged_checkHeadingSubHeadingIsPreserved() {
+  fun testAdminAuth_openedFromAdminControls_configChanged_headingSubHeadingIsPreserved() {
     launch<AdminAuthActivity>(
       AdminAuthActivity.createAdminAuthActivityIntent(
         context,
@@ -378,7 +378,7 @@ class AdminAuthActivityTest {
   }
 
   @Test
-  fun testAdminAuthActivity_openedFromProfile_configChanged_checkHeadingSubHeadingIsPreserved() {
+  fun testAdminAuthActivity_openedFromProfile_configChanged_headingSubHeadingIsPreserved() {
     launch<AdminAuthActivity>(
       AdminAuthActivity.createAdminAuthActivityIntent(
         context,

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
@@ -150,7 +150,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_inputPin_inputConfirmPin_clickImeActionButton_checkOpensAddProfileActivity() { // ktlint-disable max-line-length
+  fun testAdminPin_inputPin_inputConfirmPin_clickImeActionButton_checkOpensAddProfile() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -173,7 +173,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminAuthActivity_inputPin_inputConfirmPin_clickSubmit_checkOpensAdministratorControlsActivity() { // ktlint-disable max-line-length
+  fun testAdminAuth_inputPin_inputConfirmPin_clickSubmit_checkOpensAdminCtrlsActivity() {
     launch<AdminAuthActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -204,7 +204,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminAuthActivity_inputPin_inputConfirmPin_clickImeActionButton_checkOpensAdministratorControlsActivity() { // ktlint-disable max-line-length
+  fun testAdminAuth_inputPin_inputConfirmPin_clickImeActionButton_checkOpensAdminCtrlsActivity() {
     launch<AdminAuthActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -308,7 +308,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_inputPin_inputWrongConfirmPin_clickImeActionButton_checkConfirmWrongError() { // ktlint-disable max-line-length
+  fun testAdminPin_inputPin_inputWrongConfirmPin_clickImeActionButton_checkConfirmWrongError() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -336,7 +336,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_inputPin_inputWrongConfirmPin_clickSubmit_inputConfirmPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testAdminPin_inputPin_inputWrongConfirmPin_clickSubmit_inputConfirmPin_checkErrorCleared() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -370,7 +370,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_inputPin_inputWrongConfirmPin_clickImeActionButton_inputConfirmPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testAdminPin_inputPin_inputWrongConfirmPin_clickImeAction_inputConfirmPin_errorCleared() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -401,7 +401,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputConfirmPin_clickSubmit_checkOpensAddProfileActivity() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_inputConfirmPin_clickSubmit_checkOpensAddProfile() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -432,7 +432,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputConfirmPin_clickImeActionButton_checkOpensAddProfileActivity() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_inputConfirmPin_clickImeActionBtn_checkOpensAddProfile() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -457,7 +457,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputConfirmPin_clickSubmit_checkOpensAdministratorControlsActivity() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_inputConfirmPin_clickSubmit_checkOpensAdminCtrls() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -489,7 +489,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputConfirmPin_clickImeActionButton_checkOpensAdministratorControlsActivity() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_inputConfirmPin_clickImeActionBtn_checkOpensAdminCtrls() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -534,7 +534,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_configurationChange_inputShortPin_clickSubmit_inputPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputShortPin_clickSubmit_inputPin_checkErrorIsCleared() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -562,7 +562,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputWrongConfirmPin_clickSubmit_checkConfirmWrongError() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_inputWrongConfirmPin_clickSubmit_checkConfirmWrongError() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -600,7 +600,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputWrongConfirmPin_clickImeActionButton_checkConfirmWrongError() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_inputWrongConfirmPin_clickImeAction_confirmWrongError() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -631,7 +631,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputWrongConfirmPin_clickSubmit_inputConfirmPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_inputWrongConfirmPin_submit_inputConfirmPin_errorClrd() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -669,7 +669,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputWrongConfirmPin_clickImeActionButton_inputConfirmPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_WrongConfirmPin_clickImeAction_ConfirmPin_ErrorClrd() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -704,7 +704,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_inputPin_inputWrongConfirmPin_clickSubmit_configurationChange_checkConfirmWrongError() { // ktlint-disable max-line-length
+  fun testAdminPin_inputPin_inputWrongConfirmPin_submit_configChange_checkConfirmWrongError() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -740,7 +740,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_inputPin_inputWrongConfirmPin_clickImeActionButton_configurationChange_checkConfirmWrongError() { // ktlint-disable max-line-length
+  fun testAdminPin_inputPin_inputWrongConfirmPin_clickImeAction_configChange_confirmWrongError() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
@@ -142,7 +142,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_inputPin_inputConfirmPin_clickImeActionButton_checkOpensAddProfileActivity() { // ktlint-disable max-line-length
+  fun testAdminPin_inputPin_inputConfirmPin_clickImeActionButton_checkOpensAddProfile() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -165,7 +165,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminAuthActivity_inputPin_inputConfirmPin_clickSubmit_checkOpensAdministratorControlsActivity() { // ktlint-disable max-line-length
+  fun testAdminAuth_inputPin_inputConfirmPin_clickSubmit_checkOpensAdminCtrlsActivity() {
     launch<AdminAuthActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -196,7 +196,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminAuthActivity_inputPin_inputConfirmPin_clickImeActionButton_checkOpensAdministratorControlsActivity() { // ktlint-disable max-line-length
+  fun testAdminAuth_inputPin_inputConfirmPin_clickImeActionButton_checkOpensAdminCtrlsActivity() {
     launch<AdminAuthActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -300,7 +300,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_inputPin_inputWrongConfirmPin_clickImeActionButton_checkConfirmWrongError() { // ktlint-disable max-line-length
+  fun testAdminPin_inputPin_inputWrongConfirmPin_clickImeActionButton_checkConfirmWrongError() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -328,7 +328,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_inputPin_inputWrongConfirmPin_clickSubmit_inputConfirmPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testAdminPin_inputPin_inputWrongConfirmPin_clickSubmit_inputConfirmPin_checkErrorCleared() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -362,7 +362,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_inputPin_inputWrongConfirmPin_clickImeActionButton_inputConfirmPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testAdminPin_inputPin_inputWrongConfirmPin_clickImeAction_inputConfirmPin_errorCleared() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -393,7 +393,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputConfirmPin_clickSubmit_checkOpensAddProfileActivity() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_inputConfirmPin_clickSubmit_checkOpensAddProfile() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -424,7 +424,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputConfirmPin_clickImeActionButton_checkOpensAddProfileActivity() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_inputConfirmPin_clickImeActionBtn_checkOpensAddProfile() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -449,7 +449,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputConfirmPin_clickSubmit_checkOpensAdministratorControlsActivity() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_inputConfirmPin_clickSubmit_checkOpensAdminCtrls() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -481,7 +481,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputConfirmPin_clickImeActionButton_checkOpensAdministratorControlsActivity() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_inputConfirmPin_clickImeActionBtn_checkOpensAdminCtrls() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -526,7 +526,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_configurationChange_inputShortPin_clickSubmit_inputPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputShortPin_clickSubmit_inputPin_checkErrorIsCleared() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -554,7 +554,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputWrongConfirmPin_clickSubmit_checkConfirmWrongError() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_inputWrongConfirmPin_clickSubmit_checkConfirmWrongError() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -592,7 +592,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputWrongConfirmPin_clickImeActionButton_checkConfirmWrongError() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_inputWrongConfirmPin_clickImeAction_confirmWrongError() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -623,7 +623,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputWrongConfirmPin_clickSubmit_inputConfirmPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_inputWrongConfirmPin_submit_inputConfirmPin_errorClrd() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -661,7 +661,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_configurationChange_inputPin_inputWrongConfirmPin_clickImeActionButton_inputConfirmPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testAdminPin_configChange_inputPin_WrongConfirmPin_clickImeAction_ConfirmPin_ErrorClrd() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -696,7 +696,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_inputPin_inputWrongConfirmPin_clickSubmit_configurationChange_checkConfirmWrongError() { // ktlint-disable max-line-length
+  fun testAdminPin_inputPin_inputWrongConfirmPin_submit_configChange_checkConfirmWrongError() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -732,7 +732,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPinActivity_inputPin_inputWrongConfirmPin_clickImeActionButton_configurationChange_checkConfirmWrongError() { // ktlint-disable max-line-length
+  fun testAdminPin_inputPin_inputWrongConfirmPin_clickImeAction_configChange_confirmWrongError() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
@@ -173,7 +173,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminAuth_inputPin_inputConfirmPin_clickSubmit_checkOpensAdminCtrlsActivity() {
+  fun testAdminAuthActivity_inputPin_inputConfirmPin_clickSubmit_opensAdminControlsActivity() {
     launch<AdminAuthActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -204,7 +204,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminAuth_inputPin_inputConfirmPin_clickImeActionButton_checkOpensAdminCtrlsActivity() {
+  fun testAdminAuth_inputPin_inputConfirmPin_clickImeActionButton_opensAdminControlsActivity() {
     launch<AdminAuthActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -336,7 +336,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPin_inputPin_inputWrongConfirmPin_clickSubmit_inputConfirmPin_checkErrorCleared() {
+  fun testAdminPin_inputPin_inputWrongConfirmPin_clickSubmit_inputConfirmPin_errorIsCleared() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -370,7 +370,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPin_inputPin_inputWrongConfirmPin_clickImeAction_inputConfirmPin_errorCleared() {
+  fun testAdminPin_inputPin_inputWrongConfirmPin_clickImeAction_inputConfirmPin_errorIsCleared() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -631,7 +631,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPin_configChange_inputPin_inputWrongConfirmPin_submit_inputConfirmPin_errorClrd() {
+  fun testActivity_configChange_inputPin_inputWrongConfirmPin_submit_inputConfirm_errorIsCleared() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -669,7 +669,7 @@ class AdminPinActivityTest {
   // TODO(#962): Reenable once IME_ACTIONS work correctly on ProfileInputView.
   @Ignore("IME_ACTIONS doesn't work properly in ProfileInputView")
   @Test
-  fun testAdminPin_configChange_inputPin_WrongConfirmPin_clickImeAction_ConfirmPin_ErrorClrd() {
+  fun testActivity_configChange_inputPin_wrongConfirm_clickImeAction_inputConfirm_errorIsCleared() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,
@@ -704,7 +704,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPin_inputPin_inputWrongConfirmPin_submit_configChange_checkConfirmWrongError() {
+  fun testAdminPin_inputPin_inputWrongConfirmPin_clickSubmit_configChange_confirmWrongError() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context,

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
@@ -319,7 +319,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPswdWithUser_clickForgot_inputAdminPin_inputNewPin_inputOldPin_checkWrongPinError() {
+  fun testActivityWithUser_clickForgot_inputAdminPin_inputNewPin_inputOldPin_wrongPinError() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -358,7 +358,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPswdWithUser_clickForgot_inputAdminPin_inputNewPin_inputNewPin_checkOpensHome() {
+  fun testActivityWithUser_clickForgot_inputAdminPin_inputNewPin_inputNewPin_opensHome() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -393,7 +393,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPswdWithUser_clickForgot_inputAdminPin_changeConfig_checkInputPinIsPresent() {
+  fun testActivityWithUser_clickForgot_inputAdminPin_changeConfig_inputPinIsPresent() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -414,7 +414,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPswdWithUser_clickForgot_inputAdminPin_clickSubmit_changeConfig_restPinDlgDisplayed() {
+  fun testActivityWithUser_clickForgot_inputAdminPin_submit_changeConfig_restPinDialogDisplayed() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -438,7 +438,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPswdWithUser_forgot_inputAdminPin_submit_inputNewPin_changeConfig_submit_Success() {
+  fun testActivityWithUser_forgot_inputAdminPin_submit_inputNewPin_changeConfig_submit_success() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -470,7 +470,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPswdWithAdmin_clickForgot_changeConfig_checkOpensAdminForgotDialog() {
+  fun testActivityWithAdmin_clickForgot_changeConfig_opensAdminForgotDialog() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -489,7 +489,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPswdWithUser_clickForgot_inputWrongAdminPin_changeConfig_checkWrongAdminPinError() {
+  fun testActivityWithUser_clickForgot_inputWrongAdminPin_changeConfig_wrongAdminPinError() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -524,7 +524,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPswdWithUser_forgot_inputAdminPin_inputWrongPin_submit_changeConfig_errorDisplayed() {
+  fun testActivityWithUser_forgot_inputAdminPin_inputWrongPin_submit_changeConfig_errorDisplayed() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -618,7 +618,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPswdWithAdmin_checkShowHidePassword_clickShowHidePassword_textChangesToHide() {
+  fun testActivityWithAdmin_checkShowHidePassword_clickShowHidePassword_textChangesToHide() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -634,7 +634,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPswdWithAdmin_checkShowHidePassword_clickShowHidePassword_imageChangesToHide() {
+  fun testActivityWithAdmin_checkShowHidePassword_clickShowHidePassword_imageChangesToHide() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -657,7 +657,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPswdWithAdmin_checkShowHidePswd_clickShowHidePswd_changeConfig_hideViewIsShown() {
+  fun testActivityWithAdmin_checkAndClickShowHidePassword_changeConfig_hideViewIsShown() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
@@ -274,7 +274,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPasswordActivityWithUser_clickForgot_inputAdminPin_inputShortPin_checkPinLengthError() { // ktlint-disable max-line-length
+  fun testPinPasswordWithUser_clickForgot_inputAdminPin_inputShortPin_checkPinLengthError() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -319,7 +319,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPasswordActivityWithUser_clickForgot_inputAdminPin_inputNewPin_inputOldPin_checkWrongPinError() { // ktlint-disable max-line-length
+  fun testPinPswdWithUser_clickForgot_inputAdminPin_inputNewPin_inputOldPin_checkWrongPinError() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -358,7 +358,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPasswordActivityWithUser_clickForgot_inputAdminPin_inputNewPin_inputNewPin_checkOpensHomeActivity() { // ktlint-disable max-line-length
+  fun testPinPswdWithUser_clickForgot_inputAdminPin_inputNewPin_inputNewPin_checkOpensHome() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -393,7 +393,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPasswordActivityWithUser_clickForgot_inputAdminPin_changeConfiguration_checkInputPinIsPresent() { // ktlint-disable max-line-length
+  fun testPinPswdWithUser_clickForgot_inputAdminPin_changeConfig_checkInputPinIsPresent() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -414,7 +414,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPasswordActivityWithUser_clickForgot_inputAdminPin_clickSubmit_changeConfiguration_restPinDialogIsDisplayed() { // ktlint-disable max-line-length
+  fun testPinPswdWithUser_clickForgot_inputAdminPin_clickSubmit_changeConfig_restPinDlgDisplayed() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -438,7 +438,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPasswordActivityWithUser_clickForgot_inputAdminPin_clickSubmit_inputNewPin_changeConfiguration_clickSubmit_pinChangeIsSuccessful() { // ktlint-disable max-line-length
+  fun testPinPswdWithUser_forgot_inputAdminPin_submit_inputNewPin_changeConfig_submit_Success() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -470,7 +470,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPasswordActivityWithAdmin_clickForgot_changeConfiguration_checkOpensAdminForgotDialog() { // ktlint-disable max-line-length
+  fun testPinPswdWithAdmin_clickForgot_changeConfig_checkOpensAdminForgotDialog() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -489,7 +489,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPasswordActivityWithUser_clickForgot_inputWrongAdminPin_changeConfiguration_checkWrongAdminPinError() { // ktlint-disable max-line-length
+  fun testPinPswdWithUser_clickForgot_inputWrongAdminPin_changeConfig_checkWrongAdminPinError() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -524,7 +524,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPasswordActivityWithUser_clickForgot_inputAdminPin_inputIncorrectPin_clickSubmit_changeConfiguration_errorIsDisplayed() { // ktlint-disable max-line-length
+  fun testPinPswdWithUser_forgot_inputAdminPin_inputWrongPin_submit_changeConfig_errorDisplayed() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -618,7 +618,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPasswordActivityWithAdmin_checkShowHidePassword_clickShowHidePassword_textChangesToHide() { // ktlint-disable max-line-length
+  fun testPinPswdWithAdmin_checkShowHidePassword_clickShowHidePassword_textChangesToHide() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -634,7 +634,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPasswordActivityWithAdmin_checkShowHidePassword_clickShowHidePassword_imageChangesToHide() { // ktlint-disable max-line-length
+  fun testPinPswdWithAdmin_checkShowHidePassword_clickShowHidePassword_imageChangesToHide() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,
@@ -657,7 +657,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPasswordActivityWithAdmin_checkShowHidePassword_clickShowHidePassword_changeConfiguration_hideViewIsShown() { // ktlint-disable max-line-length
+  fun testPinPswdWithAdmin_checkShowHidePswd_clickShowHidePswd_changeConfig_hideViewIsShown() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context,

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
@@ -244,7 +244,7 @@ class ProfileChooserFragmentTest {
   @Test
   // TODO(#973): Fix ProfileChooserFragmentTest
   @Ignore
-  fun testProfileChooser_initializeProfiles_changeConfig_checkProfilesLastVisitedTimeIsShown() {
+  fun testProfileChooserFragment_initializeProfiles_changeConfig_profilesLastVisitedTimeIsShown() {
     profileTestHelper.initializeProfiles()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       onView(
@@ -475,7 +475,7 @@ class ProfileChooserFragmentTest {
   @Test
   // TODO(#973): Fix ProfileChooserFragmentTest
   @Ignore
-  fun testProfileChooser_clickAddProfile_checkOpensAdminAuth_onBackButton_opensProfileChooser() {
+  fun testProfileChooserFragment_clickAddProfile_opensAdminAuth_onBackButton_opensProfileChooser() {
     profileTestHelper.initializeProfiles()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       onView(atPosition(R.id.profile_recycler_view, 3)).perform(click())
@@ -501,7 +501,7 @@ class ProfileChooserFragmentTest {
   @Test
   // TODO(#973): Fix ProfileChooserFragmentTest
   @Ignore
-  fun testProfileChooser_clickAdminControls_checkOpensAdminAuth_onBackButton_opensProfileChooser() {
+  fun testProfileChooser_clickAdminControls_opensAdminAuth_onBackButton_opensProfileChooser() {
     profileTestHelper.initializeProfiles()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       onView(withId(R.id.administrator_controls_linear_layout)).perform(click())

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
@@ -244,7 +244,7 @@ class ProfileChooserFragmentTest {
   @Test
   // TODO(#973): Fix ProfileChooserFragmentTest
   @Ignore
-  fun testProfileChooserFragment_initializeProfiles_changeConfiguration_checkProfilesLastVisitedTimeIsShown() { // ktlint-disable max-length-line
+  fun testProfileChooser_initializeProfiles_changeConfig_checkProfilesLastVisitedTimeIsShown() {
     profileTestHelper.initializeProfiles()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       onView(
@@ -475,7 +475,7 @@ class ProfileChooserFragmentTest {
   @Test
   // TODO(#973): Fix ProfileChooserFragmentTest
   @Ignore
-  fun testProfileChooserFragment_clickAddProfile_checkOpensAdminAuthActivity_onBackButton_opensProfileChooserFragment() { // ktlint-disable max-line-length
+  fun testProfileChooser_clickAddProfile_checkOpensAdminAuth_onBackButton_opensProfileChooser() {
     profileTestHelper.initializeProfiles()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       onView(atPosition(R.id.profile_recycler_view, 3)).perform(click())
@@ -501,7 +501,7 @@ class ProfileChooserFragmentTest {
   @Test
   // TODO(#973): Fix ProfileChooserFragmentTest
   @Ignore
-  fun testProfileChooserFragment_clickAdminControls_checkOpensAdminAuthActivity_onBackButton_opensProfileChooserFragment() { // ktlint-disable max-line-length
+  fun testProfileChooser_clickAdminControls_checkOpensAdminAuth_onBackButton_opensProfileChooser() {
     profileTestHelper.initializeProfiles()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       onView(withId(R.id.administrator_controls_linear_layout)).perform(click())

--- a/app/src/sharedTest/java/org/oppia/android/app/profileprogress/ProfileProgressFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profileprogress/ProfileProgressFragmentTest.kt
@@ -202,7 +202,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressFragment_openProfilePictureEditDialog_configurationChange_dialogIsStillOpen() { // ktlint-disable max-line-length
+  fun testProfileProgress_openProfilePictureEditDialog_configChange_dialogStillOpen() {
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()
       waitForTheView(withText("Admin"))
@@ -291,7 +291,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressFragmentNoProgress_recyclerViewItem0_checkOngoingTopicsCount_countIsZero() { // ktlint-disable max-line-length
+  fun testProfileProgressNoProgress_rvItem0_checkOngoingTopicsCount_countIsZero() {
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()
       waitForTheView(withText("0"))
@@ -304,7 +304,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressFragmentWithProgress_recyclerViewItem0_checkOngoingTopicsCount_countIsTwo() { // ktlint-disable max-line-length */
+  fun testProfileProgressWithProgress_rvItem0_checkOngoingTopicsCount_countIsTwo() {
     storyProgressTestHelper.markPartialTopicProgressForFractions(
       profileId,
       timestampOlderThanAWeek = false
@@ -326,7 +326,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressFragmentWithProgress_change_configuration_recyclerViewItem0_checkOngoingTopicsCount_countIsTwo() { // ktlint-disable max-line-length
+  fun testProfileProgressWithProgress_changeConfig_rvItem0_checkOngoingTopicsCount_countIsTwo() {
     storyProgressTestHelper.markPartialTopicProgressForFractions(
       profileId,
       timestampOlderThanAWeek = false
@@ -350,7 +350,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressFragmentNoProgress_recyclerViewItem0_checkOngoingTopicsString_descriptionIsCorrect() { // ktlint-disable max-line-length
+  fun testProfileProgressNoProgress_rvItem0_checkOngoingTopicsString_descriptionIsCorrect() {
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()
       waitForTheView(withText(R.string.topics_in_progress))
@@ -366,7 +366,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressFragmentWithProgress_recyclerViewItem0_checkOngoingTopicsString_descriptionIsCorrect() { // ktlint-disable max-line-length
+  fun testProfileProgressWithProgress_rvItem0_checkOngoingTopicsString_descriptionIsCorrect() {
     storyProgressTestHelper.markPartialTopicProgressForFractions(
       profileId,
       timestampOlderThanAWeek = false
@@ -391,7 +391,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressFragmentWithProgress_changeConfiguration_recyclerViewItem0_checkOngoingTopicsString_descriptionIsCorrect() { // ktlint-disable max-line-length
+  fun testProfileProgressWithProgress_changeConfig_rvItem0_checkOngoingTopicsString_descCorrect() {
     storyProgressTestHelper.markPartialTopicProgressForFractions(
       profileId,
       timestampOlderThanAWeek = false
@@ -418,7 +418,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressFragmentNoProgress_recyclerViewItem0_checkCompletedStoriesCount_countIsZero() { // ktlint-disable max-line-length
+  fun testProfileProgressNoProgress_rvItem0_checkCompletedStoriesCount_countIsZero() {
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()
       waitForTheView(withText("0"))
@@ -431,7 +431,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressFragmentWithProgress_recyclerViewItem0_checkCompletedStoriesCount_countIsTwo() { // ktlint-disable max-line-length
+  fun testProfileProgressWithProgress_rvItem0_checkCompletedStoriesCount_countIsTwo() {
     storyProgressTestHelper.markFullStoryPartialTopicProgressForRatios(
       profileId,
       timestampOlderThanAWeek = false
@@ -453,7 +453,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressFragmentNoProgress_recyclerViewItem0_checkCompletedStoriesString_descriptionIsCorrect() { // ktlint-disable max-line-length
+  fun testProfileProgressNoProgress_rvItem0_checkCompletedStoriesString_descriptionIsCorrect() {
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()
       waitForTheView(withText(R.string.stories_completed))
@@ -470,7 +470,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressFragmentWithProgress_recyclerViewItem0_checkCompletedStoriesString_descriptionIsCorrect() { // ktlint-disable max-line-length
+  fun testProfileProgressWithProgress_rvItem0_checkCompletedStoriesString_descriptionIsCorrect() {
     storyProgressTestHelper.markFullStoryPartialTopicProgressForRatios(
       profileId,
       timestampOlderThanAWeek = false
@@ -632,7 +632,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressActivityNoProgress_recyclerViewIndex0_changeConfiguration_clickStoryCount_isNotClickable() { // ktlint-disable max-line-length
+  fun testProfileProgressActivityNoProgress_rvIndex0_changeConfig_clickStoryCount_isNotClickable() {
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
@@ -650,7 +650,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressActivityWithProgress_recyclerViewIndex0_clickTopicCount_opensOngoingTopicListActivity() { // ktlint-disable max-line-length
+  fun testProfileProgressActivityWithProgress_rvIndex0_clickTopicCount_opensOngoingTopicList() {
     storyProgressTestHelper.markPartialTopicProgressForFractions(
       profileId,
       timestampOlderThanAWeek = false
@@ -682,7 +682,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressActivityWithProgress_recyclerViewIndex0_clickStoryCount_opensCompletedStoryListActivity() { // ktlint-disable max-line-length
+  fun testProfileProgressActivityWithProgress_rvIndex0_clickStoryCount_opensCompletedStoryList() {
     storyProgressTestHelper.markFullStoryPartialTopicProgressForRatios(
       profileId,
       timestampOlderThanAWeek = false

--- a/app/src/sharedTest/java/org/oppia/android/app/profileprogress/ProfileProgressFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profileprogress/ProfileProgressFragmentTest.kt
@@ -202,7 +202,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgress_openProfilePictureEditDialog_configChange_dialogStillOpen() {
+  fun testProfileProgress_openProfilePictureEditDialog_configChange_dialogIsStillOpen() {
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()
       waitForTheView(withText("Admin"))
@@ -291,7 +291,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressNoProgress_rvItem0_checkOngoingTopicsCount_countIsZero() {
+  fun testProfileProgressFragmentNoProgress_litemItem0_ongoingTopicsCountIsZero() {
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()
       waitForTheView(withText("0"))
@@ -304,7 +304,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressWithProgress_rvItem0_checkOngoingTopicsCount_countIsTwo() {
+  fun testProfileProgressFragmentWithProgress_litemItem0_ongoingTopicsCountIsTwo() {
     storyProgressTestHelper.markPartialTopicProgressForFractions(
       profileId,
       timestampOlderThanAWeek = false
@@ -326,7 +326,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressWithProgress_changeConfig_rvItem0_checkOngoingTopicsCount_countIsTwo() {
+  fun testProfileProgressFragmentWithProgress_changeConfig_litemItem0_ongoingTopicsCountIsTwo() {
     storyProgressTestHelper.markPartialTopicProgressForFractions(
       profileId,
       timestampOlderThanAWeek = false
@@ -350,7 +350,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressNoProgress_rvItem0_checkOngoingTopicsString_descriptionIsCorrect() {
+  fun testProfileProgressFragmentNoProgress_litemItem0_ongoingTopicsDescriptionIsCorrect() {
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()
       waitForTheView(withText(R.string.topics_in_progress))
@@ -366,7 +366,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressWithProgress_rvItem0_checkOngoingTopicsString_descriptionIsCorrect() {
+  fun testProfileProgressFragmentWithProgress_litemItem0_ongoingTopicsDescriptionIsCorrect() {
     storyProgressTestHelper.markPartialTopicProgressForFractions(
       profileId,
       timestampOlderThanAWeek = false
@@ -391,7 +391,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressWithProgress_changeConfig_rvItem0_checkOngoingTopicsString_descCorrect() {
+  fun testFragmentWithProgress_changeConfig_litemItem0_ongoingTopicsDescriptionIsCorrect() {
     storyProgressTestHelper.markPartialTopicProgressForFractions(
       profileId,
       timestampOlderThanAWeek = false
@@ -418,7 +418,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressNoProgress_rvItem0_checkCompletedStoriesCount_countIsZero() {
+  fun testProfileProgressFragmentNoProgress_litemItem0_completedStoriesCountIsZero() {
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()
       waitForTheView(withText("0"))
@@ -431,7 +431,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressWithProgress_rvItem0_checkCompletedStoriesCount_countIsTwo() {
+  fun testProfileProgressFragmentWithProgress_litemItem0_completedStoriesCountIsTwo() {
     storyProgressTestHelper.markFullStoryPartialTopicProgressForRatios(
       profileId,
       timestampOlderThanAWeek = false
@@ -453,7 +453,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressNoProgress_rvItem0_checkCompletedStoriesString_descriptionIsCorrect() {
+  fun testProfileProgressFragmentNoProgress_litemItem0_completedStoriesDescriptionIsCorrect() {
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()
       waitForTheView(withText(R.string.stories_completed))
@@ -470,7 +470,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressWithProgress_rvItem0_checkCompletedStoriesString_descriptionIsCorrect() {
+  fun testProfileProgressFragmentWithProgress_litemItem0_completedStoriesDescriptionIsCorrect() {
     storyProgressTestHelper.markFullStoryPartialTopicProgressForRatios(
       profileId,
       timestampOlderThanAWeek = false
@@ -632,7 +632,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressActivityNoProgress_rvIndex0_changeConfig_clickStoryCount_isNotClickable() {
+  fun testProfileProgressActivityNoProgress_litemItem0_changeConfig_storyCountIsNotClickable() {
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
@@ -650,7 +650,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressActivityWithProgress_rvIndex0_clickTopicCount_opensOngoingTopicList() {
+  fun testProfileProgressActivityWithProgress_litemItem0_clickTopicCount_opensOngoingTopicList() {
     storyProgressTestHelper.markPartialTopicProgressForFractions(
       profileId,
       timestampOlderThanAWeek = false
@@ -682,7 +682,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
-  fun testProfileProgressActivityWithProgress_rvIndex0_clickStoryCount_opensCompletedStoryList() {
+  fun testProfileProgressActivityWithProgress_litemItem0_clickStoryCount_opensCompletedStoryList() {
     storyProgressTestHelper.markFullStoryPartialTopicProgressForRatios(
       profileId,
       timestampOlderThanAWeek = false

--- a/app/src/sharedTest/java/org/oppia/android/app/recyclerview/BindableAdapterTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/recyclerview/BindableAdapterTest.kt
@@ -382,20 +382,27 @@ class BindableAdapterTest {
     textView.text = "Value: " + data.intValue
   }
 
-  private fun getRecyclerViewListLiveData(activity: BindableAdapterTestActivity): MutableLiveData<List<TestModel>> { // ktlint-disable max-line-length
+  private fun getRecyclerViewListLiveData(
+    activity: BindableAdapterTestActivity
+  ): MutableLiveData<List<TestModel>> {
     return getTestViewModel(activity).dataListLiveData
   }
 
-  private fun getTestViewModel(activity: BindableAdapterTestActivity): BindableAdapterTestViewModel { // ktlint-disable max-line-length
+  private fun getTestViewModel(
+    activity: BindableAdapterTestActivity
+  ): BindableAdapterTestViewModel {
     return getTestFragmentPresenter(activity).viewModel
   }
 
-  private fun getTestFragmentPresenter(activity: BindableAdapterTestActivity): BindableAdapterTestFragmentPresenter { // ktlint-disable max-line-length
+  private fun getTestFragmentPresenter(
+    activity: BindableAdapterTestActivity
+  ): BindableAdapterTestFragmentPresenter {
     return getTestFragment(activity).bindableAdapterTestFragmentPresenter
   }
 
   private fun getTestFragment(activity: BindableAdapterTestActivity): BindableAdapterTestFragment {
-    return activity.supportFragmentManager.findFragmentByTag(BINDABLE_TEST_FRAGMENT_TAG) as BindableAdapterTestFragment // ktlint-disable max-line-length
+    return activity.supportFragmentManager.findFragmentByTag(BINDABLE_TEST_FRAGMENT_TAG)
+      as BindableAdapterTestFragment
   }
 
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -187,7 +187,7 @@ class ProfileEditActivityTest {
   }
 
   @Test
-  fun testProfileEdit_startActivityWithUserProfile_clickRenameBtn_checkOpensProfileRename() {
+  fun testProfileEdit_startActivityWithUserProfile_clickRenameButton_checkOpensProfileRename() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -200,7 +200,7 @@ class ProfileEditActivityTest {
   }
 
   @Test
-  fun testProfileEdit_configChange_startWithUserProfile_clickRename_checkOpensProfileRename() {
+  fun testProfileEdit_configChange_startActivityWithUserProfile_clickRename_opensProfileRename() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -214,7 +214,7 @@ class ProfileEditActivityTest {
   }
 
   @Test
-  fun testProfileEdit_startWithUserProfile_clickResetPin_checkOpensProfileResetPin() {
+  fun testProfileEdit_startActivityWithUserProfile_clickResetPin_opensProfileResetPin() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -229,7 +229,7 @@ class ProfileEditActivityTest {
   @Test
   // TODO(#973): Fix ProfileEditActivityTest
   @Ignore
-  fun testProfileEdit_configChange_startWithUserProfile_clickResetPin_checkOpensProfileResetPin() {
+  fun testActivity_configChange_startActivityWithUserProfile_clickResetPin_opensProfileResetPin() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -245,7 +245,7 @@ class ProfileEditActivityTest {
   @Test
   // TODO(#973): Fix ProfileEditActivityTest
   @Ignore
-  fun testProfileEdit_startActivityWithUserProfile_clickProfileDeletion_checkOpensDeletionDialog() {
+  fun testActivity_startActivityWithUserProfile_clickProfileDeletionButton_opensDeletionDialog() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -265,7 +265,7 @@ class ProfileEditActivityTest {
   @Test
   // TODO(#973): Fix ProfileEditActivityTest
   @Ignore
-  fun testProfileEdit_configChange_startWithUserProfile_clickProfileDeletion_checkOpensDelDialog() {
+  fun testActivity_configChange_startWithUserProfile_clickProfileDeletion_opensDeletionDialog() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -286,7 +286,7 @@ class ProfileEditActivityTest {
   @Test
   // TODO(#973): Fix ProfileEditActivityTest
   @Ignore
-  fun testProfileEdit_startWithUserProfile_clickProfileDel_clickDel_checkReturnsToProfileList() {
+  fun testActivity_startWithUserProfile_clickProfileDeletion_clickDelete_returnsToProfileList() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -302,7 +302,7 @@ class ProfileEditActivityTest {
   @Test
   // TODO(#973): Fix ProfileEditActivityTest
   @Ignore
-  fun testProfileEdit_configChange_withUserProfile_clickProfileDel_clickDel_returnsToProfileList() {
+  fun testActivityWithUserProfile_configChange_clickProfileDeletion_delete_returnsToProfileList() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -341,7 +341,7 @@ class ProfileEditActivityTest {
   @Test
   // TODO(#973): Fix ProfileEditActivityTest
   @Ignore
-  fun testProfileEdit_configChange_startWithUserHasDownloadAccess_checkSwitchIsChecked() {
+  fun testProfileEdit_configChange_startActivityWithUserHasDownloadAccess_checkSwitchIsChecked() {
     profileManagementController.addProfile(
       name = "James",
       pin = "123",

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -127,7 +127,7 @@ class ProfileEditActivityTest {
   @Test
   // TODO(#973): Fix ProfileEditActivityTest
   @Ignore
-  fun testProfileEditActivity_configurationChange_startActivityWithAdminProfile_checkAdminInfoIsDisplayed() { // ktlint-disable max-line-length
+  fun testProfileEdit_configChange_startActivityWithAdminProfile_checkAdminInfoIsDisplayed() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -162,7 +162,7 @@ class ProfileEditActivityTest {
   @Test
   // TODO(#973): Fix ProfileEditActivityTest
   @Ignore
-  fun testProfileEditActivity_configurationChange_startActivityWithUserProfile_checkUserInfoIsDisplayed() { // ktlint-disable max-line-length
+  fun testProfileEdit_configChange_startActivityWithUserProfile_checkUserInfoIsDisplayed() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -187,7 +187,7 @@ class ProfileEditActivityTest {
   }
 
   @Test
-  fun testProfileEditActivity_startActivityWithUserProfile_clickRenameButton_checkOpensProfileRenameActivity() { // ktlint-disable max-line-length
+  fun testProfileEdit_startActivityWithUserProfile_clickRenameBtn_checkOpensProfileRename() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -200,7 +200,7 @@ class ProfileEditActivityTest {
   }
 
   @Test
-  fun testProfileEditActivity_configurationChange_startActivityWithUserProfile_clickRenameButton_checkOpensProfileRenameActivity() { // ktlint-disable max-line-length
+  fun testProfileEdit_configChange_startWithUserProfile_clickRename_checkOpensProfileRename() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -214,7 +214,7 @@ class ProfileEditActivityTest {
   }
 
   @Test
-  fun testProfileEditActivity_startActivityWithUserProfile_clickResetPin_checkOpensProfileResetPinActivity() { // ktlint-disable max-line-length
+  fun testProfileEdit_startWithUserProfile_clickResetPin_checkOpensProfileResetPin() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -229,7 +229,7 @@ class ProfileEditActivityTest {
   @Test
   // TODO(#973): Fix ProfileEditActivityTest
   @Ignore
-  fun testProfileEditActivity_configurationChange_startActivityWithUserProfile_clickResetPin_checkOpensProfileResetPinActivity() { // ktlint-disable max-line-length
+  fun testProfileEdit_configChange_startWithUserProfile_clickResetPin_checkOpensProfileResetPin() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -245,7 +245,7 @@ class ProfileEditActivityTest {
   @Test
   // TODO(#973): Fix ProfileEditActivityTest
   @Ignore
-  fun testProfileEditActivity_startActivityWithUserProfile_clickProfileDeletionButton_checkOpensDeletionDialog() { // ktlint-disable max-line-length
+  fun testProfileEdit_startActivityWithUserProfile_clickProfileDeletion_checkOpensDeletionDialog() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -265,7 +265,7 @@ class ProfileEditActivityTest {
   @Test
   // TODO(#973): Fix ProfileEditActivityTest
   @Ignore
-  fun testProfileEditActivity_configurationChange_startActivityWithUserProfile_clickProfileDeletionButton_checkOpensDeletionDialog() { // ktlint-disable max-line-length
+  fun testProfileEdit_configChange_startWithUserProfile_clickProfileDeletion_checkOpensDelDialog() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -286,7 +286,7 @@ class ProfileEditActivityTest {
   @Test
   // TODO(#973): Fix ProfileEditActivityTest
   @Ignore
-  fun testProfileEditActivity_startActivityWithUserProfile_clickProfileDeletionButton_clickDelete_checkReturnsToProfileListActivity() { // ktlint-disable max-line-length
+  fun testProfileEdit_startWithUserProfile_clickProfileDel_clickDel_checkReturnsToProfileList() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -302,7 +302,7 @@ class ProfileEditActivityTest {
   @Test
   // TODO(#973): Fix ProfileEditActivityTest
   @Ignore
-  fun testProfileEditActivity_configurationChange_startActivityWithUserProfile_clickProfileDeletionButton_clickDelete_checkReturnsToProfileListActivity() { // ktlint-disable max-line-length
+  fun testProfileEdit_configChange_withUserProfile_clickProfileDel_clickDel_returnsToProfileList() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -341,7 +341,7 @@ class ProfileEditActivityTest {
   @Test
   // TODO(#973): Fix ProfileEditActivityTest
   @Ignore
-  fun testProfileEditActivity_configurationChange_startActivityWithUserHasDownloadAccess_checkSwitchIsChecked() { // ktlint-disable max-line-length
+  fun testProfileEdit_configChange_startWithUserHasDownloadAccess_checkSwitchIsChecked() {
     profileManagementController.addProfile(
       name = "James",
       pin = "123",

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileResetPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileResetPinActivityTest.kt
@@ -284,7 +284,7 @@ class ProfileResetPinActivityTest {
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
         0,
-        true; 
+        true
       )
     ).use {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileResetPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileResetPinActivityTest.kt
@@ -115,7 +115,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_startActivityWithAdmin_inputPin_inputConfirmPin_clickSave_checkReturnsToProfileEditActivity() { // ktlint-disable max-line-length
+  fun testProfileResetPin_startWithAdmin_inputPin_inputConfirm_save_checkReturnsToProfileEdit() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -139,7 +139,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_startActivityWithAdmin_changeConfiguration_inputPin_inputConfirmPin_clickSave_checkReturnsToProfileEditActivity() { // ktlint-disable max-line-length
+  fun testProfileResetPin_withAdmin_changeConfig_inputPin_inputConfirm_save_returnsToProfileEdit() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -168,7 +168,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_startActivityWithUser_inputPin_inputConfirmPin_clickSave_checkReturnsToProfileEditActivity() { // ktlint-disable max-line-length
+  fun testProfileResetPin_withUser_inputPin_inputConfirm_save_checkReturnsToProfileEdit() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -192,7 +192,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_startActivityWithAdmin_inputShortPin_clickSave_checkPinLengthError() { // ktlint-disable max-line-length
+  fun testProfileResetPin_startActivityWithAdmin_inputShortPin_clickSave_checkPinLengthError() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -222,7 +222,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_startActivityWithAdmin_inputShortPin_clickSave_changeConfiguration_checkPinLengthError() { // ktlint-disable max-line-length
+  fun testProfileResetPin_startWithAdmin_inputShortPin_save_changeConfig_checkPinLengthError() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -253,7 +253,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_startActivityWithAdmin_inputShortPin_clickSave_inputPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testProfileResetPin_startWithAdmin_inputShortPin_clickSave_inputPin_checkErrorIsCleared() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -279,7 +279,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_startActivityWithAdmin_inputShortPin_clickSave_inputPin_configurationChange_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testProfileResetPin_withAdmin_inputShortPin_save_inputPin_configChange_checkErrorIsCleared() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -306,7 +306,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_startActivityWithAdmin_inputWrongConfirmPin_clickSave_checkConfirmWrongError() { // ktlint-disable max-line-length
+  fun testProfileResetPin_startWithAdmin_inputWrongConfirmPin_clickSave_checkConfirmWrongError() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -335,7 +335,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_startActivityWithAdmin_inputWrongConfirmPin_clickSave_changeConfiguration_checkConfirmWrongError() { // ktlint-disable max-line-length
+  fun testProfileResetPin_withAdmin_inputWrongConfirm_save_changeConfig_checkConfirmWrongError() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -370,7 +370,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_inputPin_inputConfirmPin_changeConfiguration_inputPinExists_confirmInputPinExists_saveButtonIsClickable() { // ktlint-disable max-line-length
+  fun testProfileResetPin_inputPin_inputCnfrm_changeConfig_inputExists_cnfrmExists_saveClickable() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -402,7 +402,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_startActivityWithAdmin_inputWrongConfirmPin_clickSave_inputConfirmPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testProfileResetPin_startWithAdmin_inputWrongConfirmPin_save_inputConfirmPin_errorCleared() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -433,7 +433,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_startActivityWithUser_inputShortPin_clickSave_checkPinLengthError() { // ktlint-disable max-line-length
+  fun testProfileResetPin_startWithUser_inputShortPin_clickSave_checkPinLengthError() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -463,7 +463,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_startActivityWithUser_inputShortPin_clickSave_inputPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testProfileResetPin_startWithUser_inputShortPin_clickSave_inputPin_checkErrorIsCleared() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -489,7 +489,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_startActivityWithUser_inputWrongConfirmPin_clickSave_checkConfirmWrongError() { // ktlint-disable max-line-length
+  fun testProfileResetPin_startWithUser_inputWrongConfirmPin_clickSave_checkConfirmWrongError() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -518,7 +518,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_startActivityWithUser_inputWrongConfirmPin_clickSave_inputConfirmPin_checkErrorIsCleared() { // ktlint-disable max-line-length
+  fun testProfileResetPin_startWithUser_inputWrongConfirmPin_save_inputConfirmPin_errorIsCleared() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -635,7 +635,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_inputPin_inputConfirmPin_saveButtonIsClickable_clearInputPin_saveButtonIsNotClickable() { // ktlint-disable max-line-length
+  fun testProfileResetPin_inputPin_inputConfirmPin_saveClickable_clearInputPin_saveNotClickable() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -662,7 +662,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_inputPin_inputConfirmPin_saveButtonIsClickable_clearConfirmInputPin_saveButtonIsNotClickable() { // ktlint-disable max-line-length
+  fun testProfileResetPin_inputPin_inputConfirmPin_saveClickable_clearConfirm_saveNotClickable() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -689,7 +689,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPinActivity_inputPin_inputConfirmPin_saveButtonIsClickable_clearConfirmInputPin_changeConfiguration_saveButtonIsNotClickable() { // ktlint-disable max-line-length
+  fun testProfileResetPin_inputPin_inputcnfrm_saveClkble_clearcnfrm_changeConfig_saveNotClkable() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileResetPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileResetPinActivityTest.kt
@@ -115,7 +115,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPin_startWithAdmin_inputPin_inputConfirm_save_checkReturnsToProfileEdit() {
+  fun testActivity_startWithAdmin_inputPin_inputConfirmPin_clickSave_returnsToProfileEdit() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -139,7 +139,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPin_withAdmin_changeConfig_inputPin_inputConfirm_save_returnsToProfileEdit() {
+  fun testActivityWithAdmin_changeConfig_inputPin_inputConfirmPin_clickSave_returnsToProfileEdit() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -168,7 +168,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPin_withUser_inputPin_inputConfirm_save_checkReturnsToProfileEdit() {
+  fun testActivityWithUser_inputPin_inputConfirmPin_clickSave_returnsToProfileEdit() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -222,7 +222,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPin_startWithAdmin_inputShortPin_save_changeConfig_checkPinLengthError() {
+  fun testActivity_startActivityWithAdmin_inputShortPin_clicksave_changeConfig_pinLengthError() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -279,12 +279,12 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPin_withAdmin_inputShortPin_save_inputPin_configChange_checkErrorIsCleared() {
+  fun testActivityWithAdmin_inputShortPin_clickSave_inputPin_configChange_errorIsCleared() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
         0,
-        true
+        true; 
       )
     ).use {
       onView(allOf(withId(R.id.input), isDescendantOfA(withId(R.id.input_pin)))).perform(
@@ -335,7 +335,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPin_withAdmin_inputWrongConfirm_save_changeConfig_checkConfirmWrongError() {
+  fun testActivity_startWithAdmin_inputWrongConfirm_clickSave_changeConfig_confirmWrongError() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -370,7 +370,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPin_inputPin_inputCnfrm_changeConfig_inputExists_cnfrmExists_saveClickable() {
+  fun testActivity_inputPinAndConfirm_changeConfig_inputAndConfirmInputPinExists_saveIsClickable() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -402,7 +402,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPin_startWithAdmin_inputWrongConfirmPin_save_inputConfirmPin_errorCleared() {
+  fun testActivity_startWithAdmin_inputWrongConfirmPin_save_inputConfirmPin_errorIsCleared() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -518,7 +518,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPin_startWithUser_inputWrongConfirmPin_save_inputConfirmPin_errorIsCleared() {
+  fun testactivity_startWithUser_inputWrongConfirmPin_clickSave_inputConfirmPin_errorIsCleared() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -635,7 +635,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPin_inputPin_inputConfirmPin_saveClickable_clearInputPin_saveNotClickable() {
+  fun testActivity_inputPinAndConfirmPin_saveIsClickable_clearInputPin_saveIsNotClickable() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -662,7 +662,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPin_inputPin_inputConfirmPin_saveClickable_clearConfirm_saveNotClickable() {
+  fun testActivity_inputPin_inputConfirmPin_saveIsClickable_clearConfirm_saveIsNotClickable() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,
@@ -689,7 +689,7 @@ class ProfileResetPinActivityTest {
   }
 
   @Test
-  fun testProfileResetPin_inputPin_inputcnfrm_saveClkble_clearcnfrm_changeConfig_saveNotClkable() {
+  fun testActivity_inputAndConfirm_saveIsClickable_clearConfirm_changeConfig_saveIsNotClickable() {
     launch<ProfileResetPinActivity>(
       ProfileResetPinActivity.createProfileResetPinActivity(
         context,

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/InputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/InputInteractionViewTestActivityTest.kt
@@ -231,7 +231,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputNegSymbolOtherThanAt0_numberFormatErrorDisplayed() {
+  fun testFractionInputView_withInputNegativeSymbolOtherThanAt0_numberFormatErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
@@ -250,7 +250,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputNegSymbolAt0MoreThanOnce_numFormatErrorDisplayed() {
+  fun testFractionInputView_withInputNegativeSymbolAt0MoreThanOnce_numberFormatErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
@@ -269,7 +269,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputDividerMoreThanOnce_numberFormatErrorDisplayed() {
+  fun testFractionInputInteractionView_withInputDividerMoreThanOnce_numberFormatErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
@@ -319,7 +319,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputPartialValue_clickSubmit_numFormatErrorDisplayed() {
+  fun testFractionInputView_withInputPartialValue_clickSubmitButton_numberFormatErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
@@ -366,7 +366,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputDivByZero_clickSubmit_divideByZeroErrorDisplayed() {
+  fun testFractionInputView_withInputDivideByZero_clickSubmit_divideByZeroErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
@@ -387,7 +387,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputInvalidCharacter_invalidCharacterErrorDisplayed() {
+  fun testFractionInputView_withInputInvalidCharacter_invalidCharacterErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_fraction_input_interaction_view))
         .perform(
@@ -407,7 +407,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputLongNumber_clickSubmit_numTooLongErrorDisplayed() {
+  fun testFractionInputView_withInputLongNumber_clickSubmit_numberTooLongErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_fraction_input_interaction_view))
         .perform(
@@ -482,7 +482,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputNegDecimal_hasCorrectPendingAnsWithDecimalValues() {
+  fun testNumericInputView_withInputNegativeDecimal_hasCorrectPendingAnswerWithDecimalValues() {
     val activityScenario = ActivityScenario.launch(
       InputInteractionViewTestActivity::class.java
     )
@@ -517,7 +517,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputInvalidCharacter_invalidCharacterErrorDisplayed() {
+  fun testNumericInputInteractionView_withInputInvalidCharacter_invalidCharacterErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
@@ -537,7 +537,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputLongNumber_clickSubmit_numTooLongErrorIsDisplayed() {
+  fun testNumericInputView_withInputLongNumber_clickSubmitButton_numberTooLongErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
@@ -559,7 +559,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputLongNonDecNum_submit_numTooLongErrorDisplayed() {
+  fun testNumericInputView_withInputLongNonDecimalNumber_clickSubmit_numTooLongErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
@@ -581,7 +581,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputMinusSymbol_clickSubmit_numFormatErrorDisplayed() {
+  fun testNumericInputView_withInputMinusSymbol_clickSubmitButton_numberFormatErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
@@ -602,7 +602,7 @@ class InputInteractionViewTestActivityTest {
     }
   }
 
-  fun testNumericInputInteractionView_withInputNegSymbolOtherThanAt0_numFormatErrorDisplayed() {
+  fun testNumericInputView_withInputNegativeSymbolOtherThanAt0_numberFormatIsErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view)).perform(typeText("55-"))
     onView(withId(R.id.number_input_error))
@@ -616,7 +616,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputNegSymbolAt0MoreThanOnce_numFormatErrorDisplayed() {
+  fun testNumericInputView_withInputNegativeSymbolAt0MoreThanOnce_numberFormatErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view))
       .perform(
@@ -635,7 +635,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputFloatPointMoreThanOnce_numFormatErrorDisplayed() {
+  fun testNumericInputView_withInputFloatPointMoreThanOnce_numberFormatErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view))
       .perform(
@@ -654,7 +654,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputFloatPtAtStart_numStartsWithFloatPtErrorDisplayed() {
+  fun testNumericInputView_withInputFloatPointAtStart_numberStartsWithFloatPointErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view)).perform(typeText(".5"))
     onView(withId(R.id.number_input_error))

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/InputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/InputInteractionViewTestActivityTest.kt
@@ -84,7 +84,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputtedNegativeWholeNumberText_hasCorrectPendingAnswer() { // ktlint-disable max-line-length
+  fun testFractionInputInteractionView_withInputNegativeWholeNumberText_hasCorrectPendingAnswer() {
     val activityScenario = ActivityScenario.launch(
       InputInteractionViewTestActivity::class.java
     )
@@ -188,7 +188,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputtedNegativeWholeNumberValue_hasCorrectPendingAnswer() { // ktlint-disable max-line-length
+  fun testFractionInputInteractionView_withInputNegativeWholeNumberValue_hasCorrectPendingAnswer() {
     val activityScenario = ActivityScenario.launch(
       InputInteractionViewTestActivity::class.java
     )
@@ -213,7 +213,7 @@ class InputInteractionViewTestActivityTest {
 
   @Test
   @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
-  fun testFractionInputInteractionView_withInputtedText_onConfigurationChange_hasCorrectPendingAnswer() { // ktlint-disable max-line-length
+  fun testFractionInputInteractionView_withInputText_configChange_hasCorrectPendingAnswer() {
     val activityScenario = ActivityScenario.launch(
       InputInteractionViewTestActivity::class.java
     )
@@ -231,7 +231,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputtedNegativeSymbolOtherThanAt0_numberFormatErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testFractionInputInteractionView_withInputNegSymbolOtherThanAt0_numberFormatErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
@@ -250,7 +250,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputtedNegativeSymbolAt0AndMoreThanOnce_numberFormatErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testFractionInputInteractionView_withInputNegSymbolAt0MoreThanOnce_numFormatErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
@@ -269,7 +269,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputtedDividerMoreThanOnce_numberFormatErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testFractionInputInteractionView_withInputDividerMoreThanOnce_numberFormatErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
@@ -319,7 +319,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputtedPartialValue_clickSubmitButton_numberFormatErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testFractionInputInteractionView_withInputPartialValue_clickSubmit_numFormatErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
@@ -340,7 +340,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputtedValidValue_clickSubmitButton_noErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testFractionInputInteractionView_withInputValidValue_clickSubmit_noErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
@@ -366,7 +366,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputtedDivideByZero_clickSubmitButton_divideByZeroErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testFractionInputInteractionView_withInputDivByZero_clickSubmit_divideByZeroErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
@@ -387,7 +387,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputtedInvalidCharacter_invalidCharacterErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testFractionInputInteractionView_withInputInvalidCharacter_invalidCharacterErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_fraction_input_interaction_view))
         .perform(
@@ -407,7 +407,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testFractionInputInteractionView_withInputtedLongNumber_clickSubmitButton_numberTooLongErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testFractionInputInteractionView_withInputLongNumber_clickSubmit_numTooLongErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_fraction_input_interaction_view))
         .perform(
@@ -482,7 +482,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputtedNegativeDecimal_hasCorrectPendingAnswerWithDecimalValues() { // ktlint-disable max-line-length
+  fun testNumericInputInteractionView_withInputNegDecimal_hasCorrectPendingAnsWithDecimalValues() {
     val activityScenario = ActivityScenario.launch(
       InputInteractionViewTestActivity::class.java
     )
@@ -504,7 +504,7 @@ class InputInteractionViewTestActivityTest {
 
   @Test
   @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
-  fun testNumberInputInteractionView_withInputtedText_onConfigurationChange_hasCorrectPendingAnswer() { // ktlint-disable max-line-length
+  fun testNumberInputInteractionView_withInputText_configChange_hasCorrectPendingAnswer() {
     val activityScenario = ActivityScenario.launch(
       InputInteractionViewTestActivity::class.java
     )
@@ -517,7 +517,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputtedInvalidCharacter_invalidCharacterErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testNumericInputInteractionView_withInputInvalidCharacter_invalidCharacterErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
@@ -537,7 +537,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputtedLongNumber_clickSubmitButton_numberTooLongErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testNumericInputInteractionView_withInputLongNumber_clickSubmit_numTooLongErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
@@ -559,7 +559,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputtedLongNonDecimalNumber_clickSubmitButton_numberTooLongErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testNumericInputInteractionView_withInputLongNonDecNum_submit_numTooLongErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
@@ -581,7 +581,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputtedMinusSymbol_clickSubmitButton_numberFormatErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testNumericInputInteractionView_withInputMinusSymbol_clickSubmit_numFormatErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
@@ -602,7 +602,7 @@ class InputInteractionViewTestActivityTest {
     }
   }
 
-  fun testNumericInputInteractionView_withInputtedNegativeSymbolOtherThanAt0_numberFormatErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testNumericInputInteractionView_withInputNegSymbolOtherThanAt0_numFormatErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view)).perform(typeText("55-"))
     onView(withId(R.id.number_input_error))
@@ -616,7 +616,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputtedNegativeSymbolAt0AndMoreThanOnce_numberFormatErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testNumericInputInteractionView_withInputNegSymbolAt0MoreThanOnce_numFormatErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view))
       .perform(
@@ -635,7 +635,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputtedFloatingPointMoreThanOnce_numberFormatErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testNumericInputInteractionView_withInputFloatPointMoreThanOnce_numFormatErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view))
       .perform(
@@ -654,7 +654,7 @@ class InputInteractionViewTestActivityTest {
   }
 
   @Test
-  fun testNumericInputInteractionView_withInputtedFloatingPointAtStart_numberStartingWithFloatingPointErrorIsDisplayed() { // ktlint-disable max-line-length
+  fun testNumericInputInteractionView_withInputFloatPtAtStart_numStartsWithFloatPtErrorDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view)).perform(typeText(".5"))
     onView(withId(R.id.number_input_error))
@@ -702,7 +702,7 @@ class InputInteractionViewTestActivityTest {
 
   @Test
   @Ignore("Landscape not properly supported") // TODO(#56): Reenable once landscape is supported.
-  fun testTextInputInteractionView_withInputtedText_onConfigurationChange_hasCorrectPendingAnswer() { // ktlint-disable max-line-length
+  fun testTextInputInteractionView_withInputText_configChange_hasCorrectPendingAnswer() {
     val activityScenario = ActivityScenario.launch(
       InputInteractionViewTestActivity::class.java
     )

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/NavigationDrawerTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/NavigationDrawerTestActivityTest.kt
@@ -173,7 +173,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavDrawerTest_clickNavDrawerHamburger_defaultProfileNameAtIndex0_nameDisplaySuccess() {
+  fun testActivity_clickNavDrawerHamburger_defaultProfileNameAtIndex0_nameDisplayedSuccessfully() {
     launch<NavigationDrawerTestActivity>(
       createNavigationDrawerActivityIntent(
         internalProfileId
@@ -190,7 +190,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavDrawerTest_clickNavDrawerHamburger_configChange_defaultProfileNameAt0_nameDisplayed() {
+  fun testActivity_clickNavDrawerHamburger_configChange_defaultProfileNameAtIndex0_nameDisplayed() {
     launch<NavigationDrawerTestActivity>(
       createNavigationDrawerActivityIntent(
         internalProfileId
@@ -211,7 +211,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavDrawerTest_clickNavDrawerHamburger_checkProfileProgress_profileProgressDisplayed() {
+  fun testActivity_clickNavDrawerHamburger_checkProfileProgress_profileProgressIsDisplayed() {
     launch<NavigationDrawerTestActivity>(
       createNavigationDrawerActivityIntent(
         internalProfileId
@@ -238,7 +238,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavDrawerTest_clickNavDrawerHamburger_defaultProfileNameAtIndex1_profileNameDisplayed() {
+  fun testActivity_clickNavDrawerHamburger_defaultProfileNameAtIndex1_profileNameIsDisplayed() {
     launch<NavigationDrawerTestActivity>(
       createNavigationDrawerActivityIntent(
         internalProfileId1
@@ -258,7 +258,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavDrawerTest_clickNavDrawerHamburger_navDrawerIsOpenedSuccessfully() {
+  fun testNavDrawerTestActivity_clickNavDrawerHamburger_navDrawerIsOpenedSuccessfully() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withContentDescription(R.string.drawer_open_content_description))
         .check(
@@ -293,7 +293,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavDrawerTest_openNavDrawerAndRotate_navDrawerIsNotClosedAfterRotationVerified() {
+  fun testNavDrawerTest_openNavDrawerAndRotate_navDrawerIsNotClosedAfterRotationIsVerified() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withContentDescription(R.string.drawer_open_content_description)).perform(click())
       onView(isRoot()).perform(orientationLandscape())
@@ -315,7 +315,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavDrawerTest_withAdminProfile_openNavDrawer_checkAdminControlsDisplayed() {
+  fun testNavDrawerTest_withAdminProfile_openNavDrawer_adminControlsIsDisplayed() {
     launch<NavigationDrawerTestActivity>(createNavigationDrawerActivityIntent(0)).use {
       onView(withContentDescription(R.string.drawer_open_content_description)).perform(click())
       onView(withId(R.id.administrator_controls_linear_layout)).check(matches(isDisplayed()))
@@ -337,7 +337,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavDrawerTest_withAdminProfile_openNavDrawer_clickAdminCtrls_checkOpensAdminControls() {
+  fun testNavDrawerTest_withAdminProfile_openNavDrawer_clickAdminControls_opensAdminControls() {
     launch<NavigationDrawerTestActivity>(
       createNavigationDrawerActivityIntent(
         internalProfileId
@@ -354,7 +354,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavDrawerTest_withUserProfile_openNavDrawer_checkAdminControlsNotDisplayed() {
+  fun testNavDrawerTest_withUserProfile_openNavDrawer_adminControlsIsNotDisplayed() {
     launch<NavigationDrawerTestActivity>(
       createNavigationDrawerActivityIntent(
         internalProfileId1
@@ -413,7 +413,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavDrawerTest_openNavDrawer_selectSwitch_showsExitToProfileChooser_exit_opensChooser() {
+  fun testActivity_openNavDrawer_selectSwitchProfileMenu_clickExit_opensProfileChooserActivity() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withId(R.id.home_activity_drawer_layout)).perform(open())
       onView(withText(R.string.menu_switch_profile)).perform(click())
@@ -426,7 +426,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavDrawerTest_openNavDrawer_selectSwitch_showsExitToProfileChooser_cancel_drawerClosed() {
+  fun testActivity_openNavDrawer_selectSwitchProfileMenu_clickCancel_drawerIsClosed() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withId(R.id.home_activity_drawer_layout)).perform(open())
       onView(withText(R.string.menu_switch_profile)).perform(click())
@@ -459,7 +459,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavDrawerTest_openNavDrawer_selectHelp_clickNavDrawerHamburger_drawerOpenedAndVerified() {
+  fun testActivity_openNavDrawer_selectHelpMenu_clickNavDrawerHamburger_drawerOpensAndIsVerified() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withId(R.id.home_activity_drawer_layout)).perform(open())
       onView(withText(R.string.menu_help)).perform(click())

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/NavigationDrawerTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/NavigationDrawerTestActivityTest.kt
@@ -173,7 +173,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_clickNavigationDrawerHamburger_defaultProfileNameAtIndex0_displayProfileNameSuccessfully() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_clickNavDrawerHamburger_defaultProfileNameAtIndex0_nameDisplaySuccess() {
     launch<NavigationDrawerTestActivity>(
       createNavigationDrawerActivityIntent(
         internalProfileId
@@ -190,7 +190,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_clickNavigationDrawerHamburger_changeConfiguration_defaultProfileNameAtIndex0_displayProfileNameSuccessfully() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_clickNavDrawerHamburger_configChange_defaultProfileNameAt0_nameDisplayed() {
     launch<NavigationDrawerTestActivity>(
       createNavigationDrawerActivityIntent(
         internalProfileId
@@ -211,7 +211,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_clickNavigationDrawerHamburger_checkProfileProgress_displayProfileProgressSuccessfully() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_clickNavDrawerHamburger_checkProfileProgress_profileProgressDisplayed() {
     launch<NavigationDrawerTestActivity>(
       createNavigationDrawerActivityIntent(
         internalProfileId
@@ -238,7 +238,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_clickNavigationDrawerHamburger_defaultProfileNameAtIndex1_displayProfileNameSuccessfully() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_clickNavDrawerHamburger_defaultProfileNameAtIndex1_profileNameDisplayed() {
     launch<NavigationDrawerTestActivity>(
       createNavigationDrawerActivityIntent(
         internalProfileId1
@@ -258,7 +258,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_clickNavigationDrawerHamburger_navigationDrawerIsOpenedSuccessfully() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_clickNavDrawerHamburger_navDrawerIsOpenedSuccessfully() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withContentDescription(R.string.drawer_open_content_description))
         .check(
@@ -275,7 +275,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_clickNavigationDrawerHamburger_changeConfiguration_navigationDrawerIsOpenedSuccessfully() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_clickNavDrawerHamburger_configChanged_navDrawerIsOpenedSuccessfully() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withContentDescription(R.string.drawer_open_content_description))
         .check(
@@ -293,7 +293,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_openNavigationDrawerAndRotate_navigationDrawerIsNotClosedAfterRotationIsVerifiedSuccessfully() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_openNavDrawerAndRotate_navDrawerIsNotClosedAfterRotationVerified() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withContentDescription(R.string.drawer_open_content_description)).perform(click())
       onView(isRoot()).perform(orientationLandscape())
@@ -304,7 +304,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_openNavigationDrawerAndClose_closingOfNavigationDrawerIsVerifiedSuccessfully() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_openNavDrawerAndClose_closingOfNavigationDrawerIsVerifiedSuccessfully() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withContentDescription(R.string.drawer_open_content_description)).perform(click())
       onView(withId(R.id.home_activity_drawer_layout)).perform(close())
@@ -315,7 +315,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_withAdminProfile_openNavigationDrawer_checkAdministratorControlsDisplayed() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_withAdminProfile_openNavDrawer_checkAdminControlsDisplayed() {
     launch<NavigationDrawerTestActivity>(createNavigationDrawerActivityIntent(0)).use {
       onView(withContentDescription(R.string.drawer_open_content_description)).perform(click())
       onView(withId(R.id.administrator_controls_linear_layout)).check(matches(isDisplayed()))
@@ -325,7 +325,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_withAdminProfile_openNavigationDrawer_changeConfiguration_checkAdministratorControlsDisplayed() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_withAdminProfile_openNavDrawer_configChanged_checkAdminControlsDisplayed() {
     launch<NavigationDrawerTestActivity>(createNavigationDrawerActivityIntent(0)).use {
       onView(withContentDescription(R.string.drawer_open_content_description)).perform(click())
       onView(isRoot()).perform(orientationLandscape())
@@ -337,7 +337,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_withAdminProfile_openNavigationDrawer_clickAdministratorControls_checkOpensAdministratorControlsActivity() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_withAdminProfile_openNavDrawer_clickAdminCtrls_checkOpensAdminControls() {
     launch<NavigationDrawerTestActivity>(
       createNavigationDrawerActivityIntent(
         internalProfileId
@@ -354,7 +354,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_withUserProfile_openNavigationDrawer_checkAdministratorControlsNotDisplayed() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_withUserProfile_openNavDrawer_checkAdminControlsNotDisplayed() {
     launch<NavigationDrawerTestActivity>(
       createNavigationDrawerActivityIntent(
         internalProfileId1
@@ -375,7 +375,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_openNavigationDrawer_selectHelpMenuInNavigationDrawer_showsHelpFragmentSuccessfully() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_openNavDrawer_selectHelpMenuInNavDrawer_showsHelpFragmentSuccessfully() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withId(R.id.home_activity_drawer_layout)).perform(open())
       onView(withText(R.string.menu_help)).perform(click())
@@ -391,7 +391,7 @@ class NavigationDrawerTestActivityTest {
   // TODO(#1806): Enable this once lowfi implementation is done.
   @Test
   @Ignore("My Downloads is removed until we have full download support.")
-  fun testNavigationDrawerTestActivity_openNavigationDrawer_selectMyDownloadsMenuInNavigationDrawer_showsMyDownloadsFragmentSuccessfully() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_openNavDrawer_selectMyDownloadsMenuInNavDrawer_showsMyDownloadsFragment() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withId(R.id.home_activity_drawer_layout)).perform(open())
       onView(withText(R.string.menu_my_downloads)).perform(click())
@@ -402,7 +402,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_openNavigationDrawer_selectSwitchProfileMenu_showsExitToProfileChooserDialog() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_openNavDrawer_selectSwitchProfileMenu_showsExitToProfileChooserDialog() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withId(R.id.home_activity_drawer_layout)).perform(open())
       onView(withText(R.string.menu_switch_profile)).perform(click())
@@ -413,7 +413,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_openNavigationDrawer_selectSwitchProfileMenu_showsExitToProfileChooserDialog_clickExit_checkOpensProfileChooserActivity() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_openNavDrawer_selectSwitch_showsExitToProfileChooser_exit_opensChooser() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withId(R.id.home_activity_drawer_layout)).perform(open())
       onView(withText(R.string.menu_switch_profile)).perform(click())
@@ -426,7 +426,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_openNavigationDrawer_selectSwitchProfileMenu_showsExitToProfileChooserDialog_clickCancel_checkDrawerIsClosed() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_openNavDrawer_selectSwitch_showsExitToProfileChooser_cancel_drawerClosed() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withId(R.id.home_activity_drawer_layout)).perform(open())
       onView(withText(R.string.menu_switch_profile)).perform(click())
@@ -459,7 +459,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_openNavigationDrawer_selectHelpMenuInNavigationDrawer_clickNavigationDrawerHamburger_navigationDrawerIsOpenedAndVerifiedSuccessfully() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_openNavDrawer_selectHelp_clickNavDrawerHamburger_drawerOpenedAndVerified() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withId(R.id.home_activity_drawer_layout)).perform(open())
       onView(withText(R.string.menu_help)).perform(click())
@@ -480,7 +480,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_openNavigationDrawer_selectHelpMenuInNavigationDrawer_openingAndClosingOfDrawerIsVerifiedSuccessfully() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_openNavDrawer_selectHelpMenu_openingAndClosingOfDrawerIsVerified() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withId(R.id.home_activity_drawer_layout)).perform(open())
       onView(withText(R.string.menu_help)).perform(click())
@@ -501,7 +501,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_openNavigationDrawer_selectHelpMenuInNavigationDrawer_navigationDrawerClosingIsVerifiedSuccessfully() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_openNavDrawer_selectHelpMenu_drawerClosingIsVerifiedSuccessfully() {
     launch(NavigationDrawerTestActivity::class.java).use {
       onView(withId(R.id.home_activity_drawer_layout)).perform(open())
       onView(withText(R.string.menu_help)).perform(click())
@@ -520,7 +520,7 @@ class NavigationDrawerTestActivityTest {
   @Test
   // TODO(#973): Fix NavigationDrawerTestActivityTest
   @Ignore
-  fun testNavigationDrawerTestActivity_openNavigationDrawer_selectHelpMenuInNavigationDrawer_selectHomeMenuInNavigationDrawer_showsHomeFragmentSuccessfully() { // ktlint-disable max-line-length
+  fun testNavDrawerTest_openNavDrawer_selectHelpMenu_selectHomeMenu_showsHomeFragment() {
     getApplicationDependencies()
     oppiaClock.setCurrentTimeMs(MORNING_TIMESTAMP)
     launch(NavigationDrawerTestActivity::class.java).use {

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentTest.kt
@@ -139,7 +139,7 @@ class ConceptCardFragmentTest {
   @Test
   // TODO(#973): Fix ConceptCardFragmentTest
   @Ignore
-  fun testConceptCard_openDialogFragment0_checkSkillAndExplanationDisplayedWithoutRichText() {
+  fun testConceptCardFragment_openDialogFragment0_skillAndExplanationAreDisplayedWithoutRichText() {
     onView(withId(R.id.open_dialog_0)).perform(click())
     onView(withId(R.id.concept_card_heading_text))
       .check(
@@ -163,7 +163,7 @@ class ConceptCardFragmentTest {
   @Test
   // TODO(#973): Fix ConceptCardFragmentTest
   @Ignore
-  fun testConceptCard_openDialogFragment1_checkSkillAndExplanationDisplayedWithRichText() {
+  fun testConceptCardFragment_openDialogFragment1_skillAndExplanationAreDisplayedWithRichText() {
     onView(withId(R.id.open_dialog_1)).perform(click())
     onView(withId(R.id.concept_card_heading_text))
       .check(

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentTest.kt
@@ -139,7 +139,7 @@ class ConceptCardFragmentTest {
   @Test
   // TODO(#973): Fix ConceptCardFragmentTest
   @Ignore
-  fun testConceptCardFragment_openDialogFragment0_checkSkillAndExplanationAreDisplayedWithoutRichText() { // ktlint-disable max-line-length
+  fun testConceptCard_openDialogFragment0_checkSkillAndExplanationDisplayedWithoutRichText() {
     onView(withId(R.id.open_dialog_0)).perform(click())
     onView(withId(R.id.concept_card_heading_text))
       .check(
@@ -163,7 +163,7 @@ class ConceptCardFragmentTest {
   @Test
   // TODO(#973): Fix ConceptCardFragmentTest
   @Ignore
-  fun testConceptCardFragment_openDialogFragment1_checkSkillAndExplanationAreDisplayedWithRichText() { // ktlint-disable max-line-length
+  fun testConceptCard_openDialogFragment1_checkSkillAndExplanationDisplayedWithRichText() {
     onView(withId(R.id.open_dialog_1)).perform(click())
     onView(withId(R.id.concept_card_heading_text))
       .check(
@@ -187,7 +187,7 @@ class ConceptCardFragmentTest {
   @Test
   // TODO(#973): Fix ConceptCardFragmentTest
   @Ignore
-  fun testConceptCardFragment_openDialogFragmentWithSkill2_afterConfigurationChange_workedExamplesAreDisplayed() { // ktlint-disable max-line-length
+  fun testConceptCard_openDialogFragmentWithSkill2_configChange_workedExamplesAreDisplayed() {
     onView(withId(R.id.open_dialog_1)).perform(click())
     onView(isRoot()).perform(orientationLandscape())
     onView(withId(R.id.concept_card_heading_text))

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
@@ -413,7 +413,7 @@ class TopicLessonsFragmentTest {
   @Test
   // TODO(@973): Fix TopicLessonsFragmentTest
   @Ignore
-  fun testLessonsPlayFragment_loadRatiosTopic_clickExpandListIconIndex1_clickExpandListIconIndex2_chapterListForIndex1IsNotDisplayed() { // ktlint-disable max-line-length
+  fun testLessonsPlay_loadRatios_clickExpandListIconIndex1and2_chapterListForIndex1NotDisplayed() {
     launch<TopicActivity>(createTopicActivityIntent(internalProfileId, RATIOS_TOPIC_ID)).use {
       onView(
         allOf(
@@ -463,7 +463,7 @@ class TopicLessonsFragmentTest {
   @Test
   // TODO(@973): Fix TopicLessonsFragmentTest
   @Ignore
-  fun testLessonsPlayFragment_loadRatiosTopic_clickExpandListIconIndex1_clickExpandListIconIndex0_chapterListForIndex0IsNotDisplayed() { // ktlint-disable max-line-length
+  fun testLessonsPlay_loadRatios_clickExpandListIconIndex1and0_chapterListForIndex0NotDisplayed() {
     launch<TopicActivity>(createTopicActivityIntent(internalProfileId, RATIOS_TOPIC_ID)).use {
       onView(
         allOf(
@@ -513,7 +513,7 @@ class TopicLessonsFragmentTest {
   @Test
   // TODO(@973): Fix TopicLessonsFragmentTest
   @Ignore
-  fun testLessonsPlayFragment_loadRatiosTopic_clickExpandListIconIndex1_configurationChange_chapterListIsVisible() { // ktlint-disable max-line-length
+  fun testLessonsPlay_loadRatios_clickExpandListIconIndex1_configChange_chapterListIsVisible() {
     launch<TopicActivity>(createTopicActivityIntent(internalProfileId, RATIOS_TOPIC_ID)).use {
       onView(
         allOf(

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
@@ -413,7 +413,7 @@ class TopicLessonsFragmentTest {
   @Test
   // TODO(@973): Fix TopicLessonsFragmentTest
   @Ignore
-  fun testLessonsPlay_loadRatios_clickExpandListIconIndex1and2_chapterListForIndex1NotDisplayed() {
+  fun testFragment_loadRatios_clickExpandListIconIndex1And2_chapterListForIndex1IsNotDisplayed() {
     launch<TopicActivity>(createTopicActivityIntent(internalProfileId, RATIOS_TOPIC_ID)).use {
       onView(
         allOf(
@@ -463,7 +463,7 @@ class TopicLessonsFragmentTest {
   @Test
   // TODO(@973): Fix TopicLessonsFragmentTest
   @Ignore
-  fun testLessonsPlay_loadRatios_clickExpandListIconIndex1and0_chapterListForIndex0NotDisplayed() {
+  fun testFragment_loadRatios_clickExpandListIconIndex1And0_chapterListForIndex0IsNotDisplayed() {
     launch<TopicActivity>(createTopicActivityIntent(internalProfileId, RATIOS_TOPIC_ID)).use {
       onView(
         allOf(

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
@@ -265,7 +265,7 @@ class TopicPracticeFragmentTest {
   @Test
   // TODO(#973): Fix TopicPracticeFragmentTest
   @Ignore
-  fun testTopicPracticeFragment_selectSubtopics_clickStart_skillListTransferSuccessfully() {
+  fun testTopicPracticeFragment_selectSubtopics_clickStartButton_skillListTransferIsSuccessful() {
     launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID)
     onView(
       allOf(

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
@@ -229,7 +229,7 @@ class TopicPracticeFragmentTest {
   @Test
   // TODO(#973): Fix TopicPracticeFragmentTest
   @Ignore
-  fun testTopicPracticeFragment_loadFragment_selectSubtopics_deselectsubtopics_startButtonIsInactive() { // ktlint-disable max-line-length
+  fun testTopicPracticeFragment_selectSubtopics_deselectsubtopics_startButtonIsInactive() {
     launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
       onView(
         allOf(
@@ -265,7 +265,7 @@ class TopicPracticeFragmentTest {
   @Test
   // TODO(#973): Fix TopicPracticeFragmentTest
   @Ignore
-  fun testTopicPracticeFragment_loadFragment_selectSubtopics_clickStartButton_skillListTransferSuccessfully() { // ktlint-disable max-line-length
+  fun testTopicPracticeFragment_selectSubtopics_clickStart_skillListTransferSuccessfully() {
     launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID)
     onView(
       allOf(
@@ -352,7 +352,7 @@ class TopicPracticeFragmentTest {
   @Test
   // TODO(#973): Fix TopicPracticeFragmentTest
   @Ignore
-  fun testTopicPracticeFragment_loadFragment_selectSkills_configurationChange_startButtonRemainsActive() { // ktlint-disable max-line-length
+  fun testTopicPracticeFragment_selectSkills_configChange_startButtonRemainsActive() {
     launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
       onView(
         allOf(

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentTest.kt
@@ -137,7 +137,7 @@ class TopicRevisionFragmentTest {
   @Test
   // TODO(#973): Fix TopicRevisionFragmentTest
   @Ignore
-  fun testTopicRevisionFragment_loadFragment_selectReviewTopics_reviewCardDisplaysCorrectExplanation() { // ktlint-disable max-line-length
+  fun testTopicRevisionFragment_selectReviewTopics_reviewCardDisplaysCorrectExplanation() {
     launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
       onView(
         allOf(

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentTest.kt
@@ -203,7 +203,7 @@ class RevisionCardFragmentTest {
   }
 
   @Test
-  fun testRevisionCardTestActivity_fractionSubtopicId1_checkReturnToTopicButtonIsDisplayedSuccessfully() { // ktlint-disable max-line-length
+  fun testRevisionCardTest_fractionSubtopicId1_checkReturnToTopicButtonIsDisplayedSuccessfully() {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         ApplicationProvider.getApplicationContext(),
@@ -224,7 +224,7 @@ class RevisionCardFragmentTest {
   }
 
   @Test
-  fun testRevisionCardTestActivity_configurationChange_toolbarTitle_fractionSubtopicId1_isDisplayedCorrectly() { // ktlint-disable max-line-length
+  fun testRevisionCardTest_configChange_toolbarTitle_fractionSubtopicId1_displayedCorrectly() {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         ApplicationProvider.getApplicationContext(),
@@ -240,7 +240,7 @@ class RevisionCardFragmentTest {
   }
 
   @Test
-  fun testRevisionCardTestActivity_configurationChange_fractionSubtopicId2_checkExplanationAreDisplayedSuccessfully() { // ktlint-disable max-line-length
+  fun testRevisionCardTest_configChange_fractionSubtopicId2_explanationDisplayedSuccessfully() {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         ApplicationProvider.getApplicationContext(),
@@ -270,7 +270,7 @@ class RevisionCardFragmentTest {
   }
 
   @Test
-  fun testRevisionCardTestActivity_configurationChange_fractionSubtopicId1_checkReturnToTopicButtonIsDisplayedSuccessfully() { // ktlint-disable max-line-length
+  fun testRevisionCardTest_configChange_fractionSubtopicId1_returnToTopicDisplayedSuccessfully() {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         ApplicationProvider.getApplicationContext(),

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentTest.kt
@@ -203,7 +203,7 @@ class RevisionCardFragmentTest {
   }
 
   @Test
-  fun testRevisionCardTest_fractionSubtopicId1_checkReturnToTopicButtonIsDisplayedSuccessfully() {
+  fun testRevisionCardTest_fractionSubtopicId1_returnToTopicButtonIsDisplayedSuccessfully() {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         ApplicationProvider.getApplicationContext(),
@@ -224,7 +224,7 @@ class RevisionCardFragmentTest {
   }
 
   @Test
-  fun testRevisionCardTest_configChange_toolbarTitle_fractionSubtopicId1_displayedCorrectly() {
+  fun testRevisionCardTest_configChange_toolbarTitle_fractionSubtopicId1_IsDisplayedCorrectly() {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         ApplicationProvider.getApplicationContext(),
@@ -240,7 +240,7 @@ class RevisionCardFragmentTest {
   }
 
   @Test
-  fun testRevisionCardTest_configChange_fractionSubtopicId2_explanationDisplayedSuccessfully() {
+  fun testRevisionCardTest_configChange_fractionSubtopicId2_explanationIsDisplayedSuccessfully() {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         ApplicationProvider.getApplicationContext(),
@@ -270,7 +270,7 @@ class RevisionCardFragmentTest {
   }
 
   @Test
-  fun testRevisionCardTest_configChange_fractionSubtopicId1_returnToTopicDisplayedSuccessfully() {
+  fun testRevisionCardTest_configChange_fractionSubtopicId1_returnToTopicIsDisplayedSuccessfully() {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         ApplicationProvider.getApplicationContext(),

--- a/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughActivityTest.kt
@@ -119,7 +119,7 @@ class WalkthroughActivityTest {
   }
 
   @Test
-  fun testWalkthroughFragment_increaseProgress_onBackPressed_decreaseProgress_progressWorksCorrectly() { // ktlint-disable max-line-length
+  fun testWalkthrough_increaseProgress_onBackPressed_decreaseProgress_progressWorksCorrectly() {
     launch(WalkthroughActivity::class.java).use {
       onView(withId(R.id.walkthrough_welcome_next_button)).perform(scrollTo(), click())
       onView(withId(R.id.walkthrough_progress_bar)).check(matches(withProgress(2)))

--- a/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughFinalFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughFinalFragmentTest.kt
@@ -145,7 +145,7 @@ class WalkthroughFinalFragmentTest {
   @Test
   // TODO(#973): Fix WalkthroughFinalFragmentTest
   @Ignore
-  fun testWalkthroughWelcomeFragment_recyclerViewIndex2_topicSelected_configurationChanged_topicTitleIsCorrect() { // ktlint-disable max-line-length
+  fun testWalkthroughWelcome_recyclerViewIndex2_topicSelected_configChanged_topicTitleIsCorrect() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
       onView(withId(R.id.walkthrough_welcome_next_button))
         .perform(scrollTo(), click())
@@ -173,7 +173,7 @@ class WalkthroughFinalFragmentTest {
   }
 
   @Test
-  fun testWalkthroughWelcomeFragment_recyclerViewIndex1_topicSelected_yesNoButton_isDisplayedCorrectly() { // ktlint-disable max-line-length
+  fun testWalkthroughWelcome_recyclerViewIndex1_topicSelected_yesNoButton_isDisplayedCorrectly() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
       onView(withId(R.id.walkthrough_welcome_next_button))
         .perform(scrollTo(), click())
@@ -194,7 +194,7 @@ class WalkthroughFinalFragmentTest {
   }
 
   @Test
-  fun testWalkthroughWelcomeFragment_recyclerViewIndex1_topicSelected_clickNoButton_worksCorrectly() { // ktlint-disable max-line-length
+  fun testWalkthroughWelcome_recyclerViewIndex1_topicSelected_clickNoButton_worksCorrectly() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
       onView(withId(R.id.walkthrough_welcome_next_button))
         .perform(scrollTo(), click())

--- a/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughTopicListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughTopicListFragmentTest.kt
@@ -138,7 +138,7 @@ class WalkthroughTopicListFragmentTest {
   @Test
   // TODO(#973): Fix WalkthroughTopicListFragmentTest
   @Ignore
-  fun testWalkthroughWelcomeFragment_recyclerViewIndex1_topicCard_configurationChanged_topicNameIsCorrect() { // ktlint-disable max-line-length
+  fun testWalkthroughWelcome_recyclerViewIndex1_topicCard_configChanged_topicNameIsCorrect() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
       onView(withId(R.id.walkthrough_welcome_next_button)).perform(scrollTo(), click())
       onView(withId(R.id.walkthrough_topic_recycler_view)).perform(


### PR DESCRIPTION
## Explanation
Fixes #1855 : In this Pull Request, we are re-enabling the ktlint max-line-length check in the test files in app module by shortening the names of certain functions.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
