### PR TITLE
[skip ci] Simplify html binding [DO NOT MERGE]

### DIFF
--- a/app/src/main/java/org/oppia/android/app/fragment/InjectableDialogFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/fragment/InjectableDialogFragment.kt
@@ -1,14 +1,17 @@
 package org.oppia.android.app.fragment
 
 import android.content.Context
+import android.view.View
 import androidx.fragment.app.DialogFragment
 import org.oppia.android.app.activity.InjectableAppCompatActivity
+import org.oppia.android.app.shim.ViewComponentFactory
+import org.oppia.android.app.view.ViewComponent
 
 /**
  * A fragment that facilitates field injection to children. This fragment can only be used with
  * [InjectableAppCompatActivity] contexts.
  */
-abstract class InjectableDialogFragment : DialogFragment() {
+abstract class InjectableDialogFragment : DialogFragment(), ViewComponentFactory {
   /**
    * The [FragmentComponent] corresponding to this fragment. This cannot be used before [onAttach] is called, and can be
    * used to inject lateinit fields in child fragments during fragment attachment (which is recommended to be done in an
@@ -20,5 +23,9 @@ abstract class InjectableDialogFragment : DialogFragment() {
     super.onAttach(context)
     fragmentComponent =
       (requireActivity() as InjectableAppCompatActivity).createFragmentComponent(this)
+  }
+
+  override fun createViewComponent(view: View): ViewComponent {
+    return fragmentComponent.getViewComponentBuilderProvider().get().setView(view).build()
   }
 }

--- a/app/src/main/java/org/oppia/android/app/help/faq/faqsingle/FAQSingleActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/help/faq/faqsingle/FAQSingleActivityPresenter.kt
@@ -1,6 +1,5 @@
 package org.oppia.android.app.help.faq.faqsingle
 
-import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.databinding.DataBindingUtil
@@ -8,14 +7,12 @@ import org.oppia.android.R
 import org.oppia.android.app.activity.ActivityScope
 import org.oppia.android.databinding.FaqSingleActivityBinding
 import org.oppia.android.util.gcsresource.DefaultResourceBucketName
-import org.oppia.android.util.parser.HtmlParser
 import javax.inject.Inject
 
 /** The presenter for [FAQSingleActivity]. */
 @ActivityScope
 class FAQSingleActivityPresenter @Inject constructor(
   private val activity: AppCompatActivity,
-  private val htmlParserFactory: HtmlParser.Factory,
   @DefaultResourceBucketName private val resourceBucketName: String
 ) {
 
@@ -39,20 +36,8 @@ class FAQSingleActivityPresenter @Inject constructor(
     binding.faqSingleActivityToolbar.setNavigationOnClickListener {
       (activity as FAQSingleActivity).finish()
     }
-    activity.findViewById<TextView>(R.id.faq_question_text_view).text = question
-
-    // NOTE: Here entityType and entityId can be anything as it will actually not get used.
-    // They are needed only for cases where rich-text contains images from server and in faq
-    // we do not have images.
-    val answerTextView = activity.findViewById<TextView>(R.id.faq_answer_text_view)
-    answerTextView.text = htmlParserFactory.create(
-      resourceBucketName,
-      entityType = "faq",
-      entityId = "oppia",
-      imageCenterAlign = false
-    ).parseOppiaHtml(
-      answer,
-      answerTextView
-    )
+    binding.questionText = question
+    binding.answerText = answer
+    binding.gcsResourceName = resourceBucketName
   }
 }

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsAndSolutionAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsAndSolutionAdapter.kt
@@ -23,10 +23,6 @@ class HintsAndSolutionAdapter(
   private val itemList: List<HintsAndSolutionItemViewModel>,
   private val expandedHintListIndexListener: ExpandedHintListIndexListener,
   private var currentExpandedHintListIndex: Int?,
-  private val explorationId: String?,
-  private val htmlParserFactory: HtmlParser.Factory,
-  private val resourceBucketName: String,
-  private val entityType: String,
   private val hintIndex: Int?,
   private val isHintRevealed: Boolean?,
   private val solutionIndex: Int?,
@@ -126,14 +122,7 @@ class HintsAndSolutionAdapter(
       }
 
       binding.viewModel = hintsViewModel
-
       binding.hintTitle.text = hintsViewModel.title.get()!!.replace("_", " ").capitalize()
-      binding.hintsAndSolutionSummary.text =
-        htmlParserFactory.create(
-          resourceBucketName, entityType, explorationId!!, /* imageCenterAlign= */ true
-        ).parseOppiaHtml(
-          hintsViewModel.hintsAndSolutionSummary.get()!!, binding.hintsAndSolutionSummary
-        )
 
       if (hintsViewModel.hintCanBeRevealed.get()!!) {
         binding.root.visibility = View.VISIBLE
@@ -212,11 +201,6 @@ class HintsAndSolutionAdapter(
       } else {
         binding.solutionCorrectAnswer.text = solutionViewModel.correctAnswer.get()
       }
-      binding.solutionSummary.text = htmlParserFactory.create(
-        resourceBucketName, entityType, explorationId!!, /* imageCenterAlign= */ true
-      ).parseOppiaHtml(
-        solutionViewModel.solutionSummary.get()!!, binding.solutionSummary
-      )
 
       if (solutionViewModel.solutionCanBeRevealed.get()!!) {
         binding.root.visibility = View.VISIBLE

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsAndSolutionDialogFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsAndSolutionDialogFragment.kt
@@ -96,7 +96,7 @@ class HintsAndSolutionDialogFragment :
       checkNotNull(
         arguments
       ) { "Expected arguments to be passed to HintsAndSolutionDialogFragment" }
-    val id =
+    val entityId =
       checkNotNull(
         args.getString(ID_ARGUMENT_KEY)
       ) { "Expected id to be passed to HintsAndSolutionDialogFragment" }
@@ -113,7 +113,7 @@ class HintsAndSolutionDialogFragment :
       inflater,
       container,
       state,
-      id,
+      entityId,
       currentExpandedHintListIndex,
       newAvailableHintIndex,
       allHintsExhausted,

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsAndSolutionDialogFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsAndSolutionDialogFragmentPresenter.kt
@@ -18,10 +18,7 @@ import javax.inject.Inject
 @FragmentScope
 class HintsAndSolutionDialogFragmentPresenter @Inject constructor(
   private val fragment: Fragment,
-  private val viewModelProvider: ViewModelProvider<HintsViewModel>,
-  private val htmlParserFactory: HtmlParser.Factory,
-  @DefaultResourceBucketName private val resourceBucketName: String,
-  @ExplorationHtmlParserEntityType private val entityType: String
+  private val viewModelProvider: ViewModelProvider<HintsViewModel>
 ) {
 
   private var currentExpandedHintListIndex: Int? = null
@@ -46,7 +43,7 @@ class HintsAndSolutionDialogFragmentPresenter @Inject constructor(
     inflater: LayoutInflater,
     container: ViewGroup?,
     state: State,
-    id: String?,
+    entityId: String?,
     currentExpandedHintListIndex: Int?,
     newAvailableHintIndex: Int,
     allHintsExhausted: Boolean,
@@ -80,7 +77,7 @@ class HintsAndSolutionDialogFragmentPresenter @Inject constructor(
     // Therefore multiplying the original index by 2.
     viewModel.newAvailableHintIndex.set(newAvailableHintIndex * 2)
     viewModel.allHintsExhausted.set(allHintsExhausted)
-    viewModel.explorationId.set(id)
+    viewModel.entityId.set(entityId)
 
     loadHintsAndSolution(state)
 
@@ -99,10 +96,6 @@ class HintsAndSolutionDialogFragmentPresenter @Inject constructor(
           viewModel.processHintList(),
           expandedHintListIndexListener,
           currentExpandedHintListIndex,
-          viewModel.explorationId.get(),
-          htmlParserFactory,
-          resourceBucketName,
-          entityType,
           index,
           isHintRevealed,
           solutionIndex,

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsViewModel.kt
@@ -5,15 +5,20 @@ import androidx.lifecycle.ViewModel
 import org.oppia.android.app.fragment.FragmentScope
 import org.oppia.android.app.model.Hint
 import org.oppia.android.app.model.Solution
+import org.oppia.android.util.gcsresource.DefaultResourceBucketName
+import org.oppia.android.util.parser.ExplorationHtmlParserEntityType
 import javax.inject.Inject
 
 /** [ViewModel] for Hints in [HintsAndSolutionDialogFragment]. */
 @FragmentScope
-class HintsViewModel @Inject constructor() : HintsAndSolutionItemViewModel() {
+class HintsViewModel @Inject constructor(
+  @DefaultResourceBucketName val gcsResourceName: String,
+  @ExplorationHtmlParserEntityType val gcsEntityType: String // TODO: fix for questions.
+) : HintsAndSolutionItemViewModel() {
 
   val newAvailableHintIndex = ObservableField<Int>(-1)
   val allHintsExhausted = ObservableField<Boolean>(false)
-  val explorationId = ObservableField<String>("")
+  val entityId = ObservableField<String>("")
 
   val title = ObservableField<String>("")
   val hintsAndSolutionSummary = ObservableField<String>("")
@@ -64,7 +69,9 @@ class HintsViewModel @Inject constructor() : HintsAndSolutionItemViewModel() {
   }
 
   private fun addHintToList(hint: Hint) {
-    val hintsViewModel = HintsViewModel()
+    // TODO: fix this. Should not be creating instances of itself, plus this class should be
+    //  injected.
+    val hintsViewModel = HintsViewModel(gcsResourceName, gcsEntityType)
     hintsViewModel.title.set(hint.hintContent.contentId)
     hintsViewModel.hintsAndSolutionSummary.set(hint.hintContent.html)
     hintsViewModel.isHintRevealed.set(hint.hintIsRevealed)
@@ -73,7 +80,7 @@ class HintsViewModel @Inject constructor() : HintsAndSolutionItemViewModel() {
   }
 
   private fun addSolutionToList(solution: Solution) {
-    val solutionViewModel = SolutionViewModel()
+    val solutionViewModel = SolutionViewModel(gcsResourceName, gcsEntityType, entityId)
     solutionViewModel.title.set(solution.explanation.contentId)
     solutionViewModel.correctAnswer.set(solution.correctAnswer.correctAnswer)
     solutionViewModel.numerator.set(solution.correctAnswer.numerator)

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
@@ -4,7 +4,11 @@ import androidx.databinding.ObservableField
 import androidx.lifecycle.ViewModel
 
 /** [ViewModel] for Solution in [HintsAndSolutionDialogFragment]. */
-class SolutionViewModel : HintsAndSolutionItemViewModel() {
+class SolutionViewModel(
+  val gcsResourceName: String,
+  val gcsEntityType: String,
+  val gcsEntityId: ObservableField<String>
+): HintsAndSolutionItemViewModel() {
   val solutionSummary = ObservableField<String>("")
   val correctAnswer = ObservableField<String>("")
   val numerator = ObservableField<Int>()

--- a/app/src/main/java/org/oppia/android/app/player/state/DragDropSortInteractionView.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/DragDropSortInteractionView.kt
@@ -10,12 +10,14 @@ import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
 import org.oppia.android.app.player.state.itemviewmodel.DragDropInteractionContentViewModel
+import org.oppia.android.app.player.state.itemviewmodel.DragDropSingleItemViewModel
 import org.oppia.android.app.recyclerview.BindableAdapter
 import org.oppia.android.app.recyclerview.DragAndDropItemFacilitator
 import org.oppia.android.app.recyclerview.OnDragEndedListener
 import org.oppia.android.app.recyclerview.OnItemDragListener
 import org.oppia.android.app.shim.ViewBindingShim
 import org.oppia.android.app.shim.ViewComponentFactory
+import org.oppia.android.databinding.DragDropSingleItemBinding
 import org.oppia.android.util.accessibility.CustomAccessibilityManager
 import org.oppia.android.util.gcsresource.DefaultResourceBucketName
 import org.oppia.android.util.parser.ExplorationHtmlParserEntityType
@@ -91,8 +93,6 @@ class DragDropSortInteractionView @JvmOverloads constructor(
         },
         bindView = { view, viewModel ->
           viewBindingShim.setDragDropInteractionItemsBinding(view)
-          viewBindingShim.getDragDropInteractionItemsBindingRecyclerView().adapter =
-            createNestedAdapter()
           adapter?.let { viewBindingShim.setDragDropInteractionItemsBindingAdapter(it) }
           viewBindingShim.getDragDropInteractionItemsBindingGroupItem().isVisible =
             isMultipleItemsInSamePositionAllowed
@@ -101,31 +101,6 @@ class DragDropSortInteractionView @JvmOverloads constructor(
           viewBindingShim.getDragDropInteractionItemsBindingAccessibleContainer().isVisible =
             isAccessibilityEnabled
           viewBindingShim.setDragDropInteractionItemsBindingViewModel(viewModel)
-        }
-      )
-      .build()
-  }
-
-  private fun createNestedAdapter(): BindableAdapter<String> {
-    return BindableAdapter.SingleTypeBuilder
-      .newBuilder<String>()
-      .registerViewBinder(
-        inflateView = { parent ->
-          viewBindingShim.provideDragDropSingleItemInflatedView(
-            LayoutInflater.from(parent.context),
-            parent,
-            /* attachToParent= */ false
-          )
-        },
-        bindView = { view, viewModel ->
-          viewBindingShim.setDragDropSingleItemBinding(view)
-          viewBindingShim.setDragDropSingleItemBindingHtmlContent(
-            htmlParserFactory,
-            resourceBucketName,
-            entityType,
-            entityId,
-            viewModel
-          )
         }
       )
       .build()

--- a/app/src/main/java/org/oppia/android/app/player/state/DragDropSortNestedItemRecyclerView.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/DragDropSortNestedItemRecyclerView.kt
@@ -1,0 +1,26 @@
+package org.oppia.android.app.player.state
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.recyclerview.widget.RecyclerView
+import org.oppia.android.app.player.state.itemviewmodel.DragDropSingleItemViewModel
+import org.oppia.android.app.recyclerview.BindableAdapter
+import org.oppia.android.databinding.DragDropSingleItemBinding
+
+// TODO: doc
+class DragDropSortNestedItemRecyclerView @JvmOverloads constructor(
+  context: Context,
+  attrs: AttributeSet? = null,
+  defStyleAttr: Int = 0
+) : RecyclerView(context, attrs, defStyleAttr) {
+  init {
+    adapter =
+      BindableAdapter.SingleTypeBuilder
+        .newBuilder<DragDropSingleItemViewModel>()
+        .registerViewDataBinderWithSameModelType(
+          inflateDataBinding = DragDropSingleItemBinding::inflate,
+          setViewModel = DragDropSingleItemBinding::setViewModel
+        )
+        .build()
+  }
+}

--- a/app/src/main/java/org/oppia/android/app/player/state/ImageRegionSelectionInteractionView.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/ImageRegionSelectionInteractionView.kt
@@ -46,6 +46,7 @@ class ImageRegionSelectionInteractionView @JvmOverloads constructor(
   @Inject
   lateinit var imageLoader: ImageLoader
 
+  // TODO: Make this work for questions.
   @Inject
   @field:ExplorationHtmlParserEntityType
   lateinit var entityType: String

--- a/app/src/main/java/org/oppia/android/app/player/state/SelectionInteractionView.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/SelectionInteractionView.kt
@@ -12,6 +12,8 @@ import org.oppia.android.app.player.state.itemviewmodel.SelectionItemInputType
 import org.oppia.android.app.recyclerview.BindableAdapter
 import org.oppia.android.app.shim.ViewBindingShim
 import org.oppia.android.app.shim.ViewComponentFactory
+import org.oppia.android.databinding.ItemSelectionInteractionItemsBinding
+import org.oppia.android.databinding.MultipleChoiceInteractionItemsBinding
 import org.oppia.android.util.gcsresource.DefaultResourceBucketName
 import org.oppia.android.util.parser.ExplorationHtmlParserEntityType
 import org.oppia.android.util.parser.HtmlParser
@@ -32,6 +34,7 @@ class SelectionInteractionView @JvmOverloads constructor(
   @Inject
   lateinit var htmlParserFactory: HtmlParser.Factory
 
+  // TODO: make this work for questions.
   @Inject
   @field:ExplorationHtmlParserEntityType
   lateinit var entityType: String
@@ -71,47 +74,17 @@ class SelectionInteractionView @JvmOverloads constructor(
       SelectionItemInputType.CHECKBOXES ->
         BindableAdapter.SingleTypeBuilder
           .newBuilder<SelectionInteractionContentViewModel>()
-          .registerViewBinder(
-            inflateView = { parent ->
-              bindingInterface.provideSelectionInteractionViewInflatedView(
-                LayoutInflater.from(parent.context),
-                parent,
-                /* attachToParent= */ false
-              )
-            },
-            bindView = { view, viewModel ->
-              bindingInterface.provideSelectionInteractionViewModel(
-                view,
-                viewModel,
-                htmlParserFactory,
-                resourceBucketName,
-                entityType,
-                entityId
-              )
-            }
+          .registerViewDataBinderWithSameModelType(
+            inflateDataBinding = ItemSelectionInteractionItemsBinding::inflate,
+            setViewModel = ItemSelectionInteractionItemsBinding::setViewModel
           )
           .build()
       SelectionItemInputType.RADIO_BUTTONS ->
         BindableAdapter.SingleTypeBuilder
           .newBuilder<SelectionInteractionContentViewModel>()
-          .registerViewBinder(
-            inflateView = { parent ->
-              bindingInterface.provideMultipleChoiceInteractionItemsInflatedView(
-                LayoutInflater.from(parent.context),
-                parent,
-                /* attachToParent= */ false
-              )
-            },
-            bindView = { view, viewModel ->
-              bindingInterface.provideMultipleChoiceInteractionItemsViewModel(
-                view,
-                viewModel,
-                htmlParserFactory,
-                resourceBucketName,
-                entityType,
-                entityId
-              )
-            }
+          .registerViewDataBinderWithSameModelType(
+            inflateDataBinding = MultipleChoiceInteractionItemsBinding::inflate,
+            setViewModel = MultipleChoiceInteractionItemsBinding::setViewModel
           )
           .build()
     }

--- a/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
@@ -130,6 +130,8 @@ class StatePlayerRecyclerViewAssembler private constructor(
     String, @JvmSuppressWildcards InteractionViewModelFactory>,
   backgroundCoroutineDispatcher: CoroutineDispatcher,
   private val hasConversationView: Boolean,
+  private val gcsResourceName: String,
+  private val gcsEntityType: String,
   delayShowInitialHintMs: Long,
   delayShowAdditionalHintsMs: Long,
   delayShowAdditionalHintsFromWrongAnswerMs: Long
@@ -302,12 +304,16 @@ class StatePlayerRecyclerViewAssembler private constructor(
     gcsEntityId: String
   ) {
     val contentSubtitledHtml: SubtitledHtml = ephemeralState.state.content
+
     pendingItemList += ContentViewModel(
       contentSubtitledHtml.html,
+      gcsResourceName,
+      gcsEntityType,
       gcsEntityId,
       hasConversationView,
       isSplitView.get()!!,
-      playerFeatureSet.conceptCardSupport
+      playerFeatureSet.conceptCardSupport,
+      this as HtmlParser.CustomOppiaTagActionListener
     )
   }
 
@@ -790,19 +796,19 @@ class StatePlayerRecyclerViewAssembler private constructor(
           val binding = DataBindingUtil.findBinding<ContentItemBinding>(view)!!
           val contentViewModel = viewModel as ContentViewModel
           binding.viewModel = contentViewModel
-          binding.htmlContent =
-            htmlParserFactory.create(
-              resourceBucketName,
-              entityType,
-              contentViewModel.gcsEntityId,
-              imageCenterAlign = true,
-              customOppiaTagActionListener = customTagListener
-            ).parseOppiaHtml(
-              contentViewModel.htmlContent.toString(),
-              binding.contentTextView,
-              supportsLinks = true,
-              supportsConceptCards = contentViewModel.supportsConceptCards
-            )
+//          binding.htmlContent =
+//            htmlParserFactory.create(
+//              resourceBucketName,
+//              entityType,
+//              contentViewModel.gcsEntityId,
+//              imageCenterAlign = true,
+//              customOppiaTagActionListener = customTagListener
+//            ).parseOppiaHtml(
+//              contentViewModel.htmlContent.toString(),
+//              binding.contentTextView,
+//              supportsLinks = true,
+//              supportsConceptCards = contentViewModel.supportsConceptCards
+//            )
         }
       )
       featureSets += PlayerFeatureSet(contentSupport = true)
@@ -1181,6 +1187,8 @@ class StatePlayerRecyclerViewAssembler private constructor(
         interactionViewModelFactoryMap,
         backgroundCoroutineDispatcher,
         hasConversationView,
+        resourceBucketName,
+        entityType,
         delayShowInitialHintMs,
         delayShowAdditionalHintsMs,
         delayShowAdditionalHintsFromWrongAnswerMs

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/ContentViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/ContentViewModel.kt
@@ -1,10 +1,15 @@
 package org.oppia.android.app.player.state.itemviewmodel
 
+import org.oppia.android.util.parser.HtmlParser
+
 /** [StateItemViewModel] for content-card state. */
 class ContentViewModel(
   val htmlContent: CharSequence,
+  val gcsResourceName: String,
+  val gcsEntityType: String,
   val gcsEntityId: String,
   val hasConversationView: Boolean,
   val isSplitView: Boolean,
-  val supportsConceptCards: Boolean
+  val supportsConceptCards: Boolean,
+  val customOppiaTagActionListener: HtmlParser.CustomOppiaTagActionListener
 ) : StateItemViewModel(ViewType.CONTENT)

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/DragAndDropSortInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/DragAndDropSortInteractionViewModel.kt
@@ -16,6 +16,8 @@ import org.oppia.android.app.recyclerview.OnItemDragListener
 
 /** [StateItemViewModel] for drag drop & sort choice list. */
 class DragAndDropSortInteractionViewModel(
+  private val gcsResourceName: String,
+  private val gcsEntityType: String,
   val entityId: String,
   val hasConversationView: Boolean,
   interaction: Interaction,
@@ -37,7 +39,7 @@ class DragAndDropSortInteractionViewModel(
   }
 
   val choiceItems: ArrayList<DragDropInteractionContentViewModel> =
-    computeChoiceItems(choiceStrings, this)
+    computeChoiceItems(choiceStrings, this, gcsResourceName, gcsEntityType, entityId)
 
   var isAnswerAvailable = ObservableField<Boolean>(false)
 
@@ -149,6 +151,9 @@ class DragAndDropSortInteractionViewModel(
           StringList.newBuilder()
             .addHtml(it)
             .build(),
+          gcsResourceName,
+          gcsEntityType,
+          entityId,
           /* itemIndex= */ 0,
           /* listSize= */ 0,
           /* dragAndDropSortInteractionViewModel= */this
@@ -167,12 +172,18 @@ class DragAndDropSortInteractionViewModel(
   companion object {
     private fun computeChoiceItems(
       choiceStrings: List<String>,
-      dragAndDropSortInteractionViewModel: DragAndDropSortInteractionViewModel
+      dragAndDropSortInteractionViewModel: DragAndDropSortInteractionViewModel,
+      gcsResourceName: String,
+      gcsEntityType: String,
+      gcsEntityId: String
     ): ArrayList<DragDropInteractionContentViewModel> {
       val itemList = ArrayList<DragDropInteractionContentViewModel>()
       itemList += choiceStrings.mapIndexed { index, choiceString ->
         DragDropInteractionContentViewModel(
           htmlContent = StringList.newBuilder().addHtml(choiceString).build(),
+          gcsResourceName = gcsResourceName,
+          gcsEntityType = gcsEntityType,
+          gcsEntityId = gcsEntityId,
           itemIndex = index,
           listSize = choiceStrings.size,
           dragAndDropSortInteractionViewModel = dragAndDropSortInteractionViewModel

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/DragDropInteractionContentViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/DragDropInteractionContentViewModel.kt
@@ -7,10 +7,20 @@ import org.oppia.android.app.viewmodel.ObservableViewModel
 /** [ObservableViewModel] for DragDropSortInput values. */
 class DragDropInteractionContentViewModel(
   var htmlContent: StringList,
+  val gcsResourceName: String,
+  val gcsEntityType: String,
+  val gcsEntityId: String,
   var itemIndex: Int,
   var listSize: Int,
   var dragAndDropSortInteractionViewModel: DragAndDropSortInteractionViewModel
 ) : ObservableViewModel() {
+
+  // TODO: doc
+  val nestedItemViewModelList: List<DragDropSingleItemViewModel> by lazy {
+    htmlContent.htmlList.map { string ->
+      DragDropSingleItemViewModel(string, gcsResourceName, gcsEntityType, gcsEntityId)
+    }
+  }
 
   fun handleGrouping(adapter: RecyclerView.Adapter<RecyclerView.ViewHolder>) {
     dragAndDropSortInteractionViewModel.updateList(itemIndex, adapter)

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/DragDropSingleItemViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/DragDropSingleItemViewModel.kt
@@ -1,0 +1,11 @@
+package org.oppia.android.app.player.state.itemviewmodel
+
+import org.oppia.android.app.viewmodel.ObservableViewModel
+
+// TODO: doc
+class DragDropSingleItemViewModel(
+  val htmlContent: String,
+  val gcsResourceName: String,
+  val gcsEntityType: String,
+  val gcsEntityId: String
+) : ObservableViewModel()

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/InteractionViewModelFactory.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/InteractionViewModelFactory.kt
@@ -10,6 +10,8 @@ import org.oppia.android.app.player.state.answerhandling.InteractionAnswerReceiv
  * there's a previous button enabled (only relevant for navigation-based interactions).
  */
 typealias InteractionViewModelFactory = (
+  gcsResourceName: String,
+  gcsEntityType: String,
   entityId: String,
   hasConversationView: Boolean,
   interaction: Interaction,

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/InteractionViewModelModule.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/InteractionViewModelModule.kt
@@ -14,6 +14,7 @@ import org.oppia.android.app.player.state.listener.PreviousNavigationButtonListe
  */
 @Module
 class InteractionViewModelModule {
+  // TODO: move to Dagger graph rather than directly referencing modules.
   companion object {
     val splitScreenInteractionIdsPool = listOf("DragAndDropSortInput", "ImageClickInput")
   }
@@ -24,7 +25,7 @@ class InteractionViewModelModule {
   @IntoMap
   @StringKey("Continue")
   fun provideContinueInteractionViewModelFactory(fragment: Fragment): InteractionViewModelFactory {
-    return { _, hasConversationView, _, interactionAnswerReceiver, _, hasPreviousButton, isSplitView -> // ktlint-disable max-line-length
+    return { _, _, _, hasConversationView, _, interactionAnswerReceiver, _, hasPreviousButton, isSplitView -> // ktlint-disable max-line-length
       ContinueInteractionViewModel(
         interactionAnswerReceiver,
         hasConversationView,
@@ -39,8 +40,10 @@ class InteractionViewModelModule {
   @IntoMap
   @StringKey("MultipleChoiceInput")
   fun provideMultipleChoiceInputViewModelFactory(): InteractionViewModelFactory {
-    return { entityId, hasConversationView, interaction, interactionAnswerReceiver, interactionAnswerErrorReceiver, _, isSplitView -> // ktlint-disable max-line-length
+    return { gcsResourceName, gcsEntityType, entityId, hasConversationView, interaction, interactionAnswerReceiver, interactionAnswerErrorReceiver, _, isSplitView -> // ktlint-disable max-line-length
       SelectionInteractionViewModel(
+        gcsResourceName,
+        gcsEntityType,
         entityId,
         hasConversationView,
         interaction,
@@ -55,8 +58,10 @@ class InteractionViewModelModule {
   @IntoMap
   @StringKey("ItemSelectionInput")
   fun provideItemSelectionInputViewModelFactory(): InteractionViewModelFactory {
-    return { entityId, hasConversationView, interaction, interactionAnswerReceiver, interactionAnswerErrorReceiver, _, isSplitView -> // ktlint-disable max-line-length
+    return { gcsResourceName, gcsEntityType, entityId, hasConversationView, interaction, interactionAnswerReceiver, interactionAnswerErrorReceiver, _, isSplitView -> // ktlint-disable max-line-length
       SelectionInteractionViewModel(
+        gcsResourceName,
+        gcsEntityType,
         entityId,
         hasConversationView,
         interaction,
@@ -71,7 +76,7 @@ class InteractionViewModelModule {
   @IntoMap
   @StringKey("FractionInput")
   fun provideFractionInputViewModelFactory(context: Context): InteractionViewModelFactory {
-    return { _, hasConversationView, interaction, _, interactionAnswerErrorReceiver, _, isSplitView -> // ktlint-disable max-line-length
+    return { _, _, _, hasConversationView, interaction, _, interactionAnswerErrorReceiver, _, isSplitView -> // ktlint-disable max-line-length
       FractionInteractionViewModel(
         interaction,
         context,
@@ -86,7 +91,7 @@ class InteractionViewModelModule {
   @IntoMap
   @StringKey("NumericInput")
   fun provideNumericInputViewModelFactory(context: Context): InteractionViewModelFactory {
-    return { _, hasConversationView, _, _, interactionAnswerErrorReceiver, _, isSplitView ->
+    return { _, _, _, hasConversationView, _, _, interactionAnswerErrorReceiver, _, isSplitView ->
       NumericInputViewModel(
         context,
         hasConversationView,
@@ -100,7 +105,7 @@ class InteractionViewModelModule {
   @IntoMap
   @StringKey("TextInput")
   fun provideTextInputViewModelFactory(): InteractionViewModelFactory {
-    return { _, hasConversationView, interaction, _, interactionAnswerErrorReceiver, _, isSplitView -> // ktlint-disable max-line-length
+    return { _, _, _, hasConversationView, interaction, _, interactionAnswerErrorReceiver, _, isSplitView -> // ktlint-disable max-line-length
       TextInputViewModel(
         interaction, hasConversationView, interactionAnswerErrorReceiver, isSplitView
       )
@@ -111,9 +116,9 @@ class InteractionViewModelModule {
   @IntoMap
   @StringKey("DragAndDropSortInput")
   fun provideDragAndDropSortInputViewModelFactory(): InteractionViewModelFactory {
-    return { entityId, hasConversationView, interaction, _, interactionAnswerErrorReceiver, _, isSplitView -> // ktlint-disable max-line-length
+    return { gcsResourceName, gcsEntityType, entityId, hasConversationView, interaction, _, interactionAnswerErrorReceiver, _, isSplitView -> // ktlint-disable max-line-length
       DragAndDropSortInteractionViewModel(
-        entityId, hasConversationView, interaction, interactionAnswerErrorReceiver, isSplitView
+        gcsResourceName, gcsEntityType, entityId, hasConversationView, interaction, interactionAnswerErrorReceiver, isSplitView
       )
     }
   }
@@ -122,7 +127,7 @@ class InteractionViewModelModule {
   @IntoMap
   @StringKey("ImageClickInput")
   fun provideImageClickInputViewModelFactory(context: Context): InteractionViewModelFactory {
-    return { entityId, _, interaction, _, interactionAnswerErrorReceiver, _, _ ->
+    return { _, _, entityId, _, interaction, _, interactionAnswerErrorReceiver, _, _ ->
       ImageRegionSelectionInteractionViewModel(
         entityId,
         interaction,
@@ -136,7 +141,7 @@ class InteractionViewModelModule {
   @IntoMap
   @StringKey("RatioExpressionInput")
   fun provideRatioExpressionInputViewModelFactory(context: Context): InteractionViewModelFactory {
-    return { _, hasConversationView, interaction, _, answerErrorReceiver, _, isSplitView ->
+    return { _, _, _, hasConversationView, interaction, _, answerErrorReceiver, _, isSplitView ->
       RatioExpressionInputInteractionViewModel(
         interaction,
         context,

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionContentViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionContentViewModel.kt
@@ -6,6 +6,9 @@ import org.oppia.android.app.viewmodel.ObservableViewModel
 /** [ObservableViewModel] for MultipleChoiceInput values or ItemSelectionInput values. */
 class SelectionInteractionContentViewModel(
   val htmlContent: String,
+  val gcsResourceName: String,
+  val gcsEntityType: String,
+  val gcsEntityId: String,
   val hasConversationView: Boolean,
   private val itemIndex: Int,
   private val selectionInteractionViewModel: SelectionInteractionViewModel

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
@@ -20,6 +20,8 @@ enum class SelectionItemInputType {
 
 /** [StateItemViewModel] for multiple or item-selection input choice list. */
 class SelectionInteractionViewModel(
+  val gcsResourceName: String,
+  val gcsEntityType: String,
   val entityId: String,
   val hasConversationView: Boolean,
   interaction: Interaction,
@@ -47,7 +49,7 @@ class SelectionInteractionViewModel(
   }
   private val selectedItems: MutableList<Int> = mutableListOf()
   val choiceItems: ObservableList<SelectionInteractionContentViewModel> =
-    computeChoiceItems(choiceStrings, hasConversationView, this)
+    computeChoiceItems(choiceStrings, hasConversationView, this, gcsResourceName, gcsEntityType, entityId)
 
   private val isAnswerAvailable = ObservableField<Boolean>(false)
 
@@ -150,12 +152,18 @@ class SelectionInteractionViewModel(
     private fun computeChoiceItems(
       choiceStrings: List<String>,
       hasConversationView: Boolean,
-      selectionInteractionViewModel: SelectionInteractionViewModel
+      selectionInteractionViewModel: SelectionInteractionViewModel,
+      gcsResourceName: String,
+      gcsEntityType: String,
+      gcsEntityId: String
     ): ObservableArrayList<SelectionInteractionContentViewModel> {
       val observableList = ObservableArrayList<SelectionInteractionContentViewModel>()
       observableList += choiceStrings.mapIndexed { index, choiceString ->
         SelectionInteractionContentViewModel(
           htmlContent = choiceString,
+          gcsResourceName = gcsResourceName,
+          gcsEntityType = gcsEntityType,
+          gcsEntityId = gcsEntityId,
           hasConversationView = hasConversationView,
           itemIndex = index,
           selectionInteractionViewModel = selectionInteractionViewModel

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SubmittedAnswerViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SubmittedAnswerViewModel.kt
@@ -2,15 +2,55 @@ package org.oppia.android.app.player.state.itemviewmodel
 
 import androidx.databinding.ObservableField
 import org.oppia.android.app.model.UserAnswer
+import org.oppia.android.app.player.state.itemviewmodel.submittedanswers.SubmittedHtmlAnswerItemViewModel
+import org.oppia.android.app.player.state.itemviewmodel.submittedanswers.SubmittedHtmlAnswerListViewModel
+import org.oppia.android.util.parser.HtmlParser
 
 /** [StateItemViewModel] for previously submitted answers. */
 class SubmittedAnswerViewModel(
   val submittedUserAnswer: UserAnswer,
+  val gcsResourceName: String,
+  val gcsEntityType: String,
   val gcsEntityId: String,
   val hasConversationView: Boolean,
   val isSplitView: Boolean,
-  val supportsConceptCards: Boolean
+  val supportsConceptCards: Boolean,
+  val customOppiaTagActionListener: HtmlParser.CustomOppiaTagActionListener
 ) : StateItemViewModel(ViewType.SUBMITTED_ANSWER) {
   val isCorrectAnswer = ObservableField<Boolean>(false)
   val isExtraInteractionAnswerCorrect = ObservableField<Boolean>(false)
+
+  // TODO: doc
+  val singleAnswerString: CharSequence by lazy {
+    when (submittedUserAnswer.textualAnswerCase) {
+      UserAnswer.TextualAnswerCase.PLAIN_ANSWER -> submittedUserAnswer.plainAnswer
+      else -> submittedUserAnswer.htmlAnswer
+    }
+  }
+
+  // TODO: doc
+  val accessibleAnswerString: CharSequence by lazy {
+    when (submittedUserAnswer.textualAnswerCase) {
+      UserAnswer.TextualAnswerCase.PLAIN_ANSWER -> submittedUserAnswer.contentDescription
+      else -> singleAnswerString
+    }
+  }
+
+  // TODO: doc. This is a list of lists.
+  val answerRecyclerViewListItemViewModelList: List<SubmittedHtmlAnswerListViewModel> by lazy {
+    submittedUserAnswer.listOfHtmlAnswers.setOfHtmlStringsList.map { stringList ->
+      SubmittedHtmlAnswerListViewModel(
+        stringList.htmlList.map { answerString ->
+          SubmittedHtmlAnswerItemViewModel(
+            answerString,
+            gcsResourceName,
+            gcsEntityType,
+            gcsEntityId,
+            supportsConceptCards,
+            customOppiaTagActionListener
+          )
+        }
+      )
+    }
+  }
 }

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/submittedanswers/SubmittedAnswerRecyclerView.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/submittedanswers/SubmittedAnswerRecyclerView.kt
@@ -1,0 +1,26 @@
+package org.oppia.android.app.player.state.itemviewmodel.submittedanswers
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.recyclerview.widget.RecyclerView
+import org.oppia.android.app.recyclerview.BindableAdapter
+import org.oppia.android.databinding.SubmittedAnswerListItemBinding
+import org.oppia.android.databinding.SubmittedHtmlAnswerItemBinding
+
+// TODO: doc
+class SubmittedAnswerRecyclerView @JvmOverloads constructor(
+  context: Context,
+  attrs: AttributeSet? = null,
+  defStyleAttr: Int = 0
+) : RecyclerView(context, attrs, defStyleAttr) {
+  init {
+    adapter =
+      BindableAdapter.SingleTypeBuilder
+        .newBuilder<SubmittedHtmlAnswerListViewModel>()
+        .registerViewDataBinderWithSameModelType(
+          inflateDataBinding = SubmittedAnswerListItemBinding::inflate,
+          setViewModel = SubmittedAnswerListItemBinding::setViewModel
+        )
+        .build()
+  }
+}

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/submittedanswers/SubmittedHtmlAnswerItemViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/submittedanswers/SubmittedHtmlAnswerItemViewModel.kt
@@ -1,15 +1,14 @@
-package org.oppia.android.app.player.state.itemviewmodel
+package org.oppia.android.app.player.state.itemviewmodel.submittedanswers
 
+import org.oppia.android.app.viewmodel.ObservableViewModel
 import org.oppia.android.util.parser.HtmlParser
 
-/** [StateItemViewModel] for feedback blurbs. */
-class FeedbackViewModel(
+// TODO: doc
+class SubmittedHtmlAnswerItemViewModel(
   val htmlContent: CharSequence,
   val gcsResourceName: String,
   val gcsEntityType: String,
   val gcsEntityId: String,
-  val hasConversationView: Boolean,
-  val isSplitView: Boolean,
   val supportsConceptCards: Boolean,
   val customOppiaTagActionListener: HtmlParser.CustomOppiaTagActionListener
-) : StateItemViewModel(ViewType.FEEDBACK)
+): ObservableViewModel()

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/submittedanswers/SubmittedHtmlAnswerListViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/submittedanswers/SubmittedHtmlAnswerListViewModel.kt
@@ -1,0 +1,9 @@
+package org.oppia.android.app.player.state.itemviewmodel.submittedanswers
+
+import org.oppia.android.app.viewmodel.ObservableViewModel
+import org.oppia.android.util.parser.HtmlParser
+
+// TODO: doc
+class SubmittedHtmlAnswerListViewModel(
+  val itemViewModelList: List<SubmittedHtmlAnswerItemViewModel>
+): ObservableViewModel()

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/submittedanswers/SubmittedHtmlAnswerRecyclerView.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/submittedanswers/SubmittedHtmlAnswerRecyclerView.kt
@@ -1,0 +1,25 @@
+package org.oppia.android.app.player.state.itemviewmodel.submittedanswers
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.recyclerview.widget.RecyclerView
+import org.oppia.android.app.recyclerview.BindableAdapter
+import org.oppia.android.databinding.SubmittedHtmlAnswerItemBinding
+
+// TODO: doc
+class SubmittedHtmlAnswerRecyclerView @JvmOverloads constructor(
+  context: Context,
+  attrs: AttributeSet? = null,
+  defStyleAttr: Int = 0
+) : RecyclerView(context, attrs, defStyleAttr) {
+  init {
+    adapter =
+      BindableAdapter.SingleTypeBuilder
+        .newBuilder<SubmittedHtmlAnswerItemViewModel>()
+        .registerViewDataBinderWithSameModelType(
+          inflateDataBinding = SubmittedHtmlAnswerItemBinding::inflate,
+          setViewModel = SubmittedHtmlAnswerItemBinding::setViewModel
+        )
+        .build()
+  }
+}

--- a/app/src/main/java/org/oppia/android/app/richtext/RteTextView.kt
+++ b/app/src/main/java/org/oppia/android/app/richtext/RteTextView.kt
@@ -1,0 +1,405 @@
+package org.oppia.android.app.richtext
+
+import android.content.Context
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import android.text.Spanned
+import android.text.method.LinkMovementMethod
+import android.text.style.ImageSpan
+import android.util.AttributeSet
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import org.oppia.android.app.shim.ViewComponentFactory
+import org.oppia.android.util.R
+import org.oppia.android.util.parser.DeferredImageDrawable
+import org.oppia.android.util.parser.HtmlParser
+import javax.inject.Inject
+import kotlin.math.max
+
+/**
+ * A custom TextView that supports Oppia rich-text components. This should be used for all text
+ * views in the app that need to support Oppia's custom rich-text elements (including concept card
+ * links, embedded images, and others).
+ *
+ * It's also advisable to use this for any HTML-supporting text views that have embedded images
+ * since it will automatically size the images to fit, and supports image binding in a way that does
+ * not interfere with data-binding (that is, binding this view's text property will properly handle
+ * HTML and embedded image binding).
+ */
+class RteTextView @JvmOverloads constructor(
+  context: Context,
+  attrs: AttributeSet? = null,
+  defStyle: Int = android.R.attr.textViewStyle
+) : AppCompatTextView(context, attrs, defStyle) {
+  @Inject
+  lateinit var htmlParserFactory: HtmlParser.Factory
+
+  private val viewLifecycleOwner = ViewLifecycleOwner()
+  private val minimumImageSize by lazy {
+    context.resources.getDimensionPixelSize(R.dimen.minimum_image_size)
+  }
+  private val maxContentItemPadding by lazy {
+    context.resources.getDimensionPixelSize(R.dimen.maximum_content_item_padding)
+  }
+
+  private var supportsConceptCards: Boolean = false
+  private var centerAlignImages: Boolean = false
+  private var boundRawHtml: CharSequence? = null
+  private var drawablesRequireLayOut: Boolean = false
+  private var lastViewWidthUsedForDrawables: Int = -1
+  private var htmlParser: HtmlParser? = null
+  private var customOppiaTagActionListener: HtmlParser.CustomOppiaTagActionListener? = null
+  private lateinit var gcsResourceName: String
+  private lateinit var entityType: String
+  private lateinit var entityId: String
+
+  /**
+   * Sets whether this view supports clickable links. Passing true to this will result in links
+   * automatically linkifying for bound HTML, including for custom links like concept cards. The
+   * default behavior is that links are not linkified.
+   */
+  fun setSupportsLinks(supportsLinks: Boolean) {
+    // Reference: https://stackoverflow.com/a/8662457.
+    movementMethod = if (supportsLinks) LinkMovementMethod.getInstance() else null
+  }
+
+  /**
+   * Sets whether this view supports clickable links. Passing true to this will result in links
+   * automatically linkifying for bound HTML, including for custom links like concept cards. The
+   * default behavior is false (concept cards are not linkified).
+   *
+   * Note that [setSupportsLinks] also needs to be set to true, otherwise the concept card tags will
+   * be handled by the resulting spans will not actually be clickable by the user.
+   */
+  fun setSupportsConceptCards(supportsConceptCards: Boolean) {
+    this.supportsConceptCards = supportsConceptCards
+    reBindHtml()
+  }
+
+  /**
+   * Sets whether images embedded within this text view should automatically be centered, or else
+   * left aligned. The default behavior is false which leads to images, by default, being
+   * left-aligned.
+   */
+  fun setCenterAlignImages(centerAlignImages: Boolean) {
+    this.centerAlignImages = centerAlignImages
+    reBindHtml()
+  }
+
+  // TODO: doc
+  fun setCustomOppiaTagActionListener(
+    customOppiaTagActionListener: HtmlParser.CustomOppiaTagActionListener
+  ) {
+    this.customOppiaTagActionListener = customOppiaTagActionListener
+    maybeReinitializeHtmlParser()
+    rebindHtmlIfGcsIsSetup()
+  }
+
+  // TODO: doc
+  fun setGcsResourceName(gcsResourceName: String) {
+    this.gcsResourceName = gcsResourceName
+    maybeReinitializeHtmlParser()
+    rebindHtmlIfGcsIsSetup()
+  }
+
+  // TODO: doc
+  fun setEntityType(entityType: String) {
+    this.entityType = entityType
+    maybeReinitializeHtmlParser()
+    rebindHtmlIfGcsIsSetup()
+  }
+
+  // TODO: doc
+  fun setEntityId(entityId: String) {
+    this.entityId = entityId
+    maybeReinitializeHtmlParser()
+    rebindHtmlIfGcsIsSetup()
+  }
+
+  private fun rebindHtmlIfGcsIsSetup() {
+    if (isReadyForHtmlParsing()) {
+      reBindHtml()
+    }
+  }
+
+  private fun maybeReinitializeHtmlParser() {
+    if (isReadyForHtmlParsing()) {
+      reinitializeHtmlParser()
+    }
+  }
+
+  // TODO: doc
+  private fun isReadyForHtmlParsing(): Boolean {
+    return this::gcsResourceName.isInitialized
+      && this::entityType.isInitialized
+      && this::entityId.isInitialized
+  }
+
+  // TODO: simplify
+  private fun reinitializeHtmlParser() {
+    // TODO: remove imageCenterAlign here since it's unused.
+    check(this::gcsResourceName.isInitialized) { "Expected GCS resource name to be set." }
+    check(this::entityType.isInitialized) { "Expected GCS entity type to be set." }
+    check(this::entityId.isInitialized) { "Expected GCS entity ID to be set." }
+    htmlParser = htmlParserFactory.create(gcsResourceName, entityType, entityId, imageCenterAlign = false, customOppiaTagActionListener = customOppiaTagActionListener)
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    (FragmentManager.findFragment<Fragment>(this) as ViewComponentFactory)
+      .createViewComponent(this)
+      .inject(this)
+    viewLifecycleOwner.setAttachedToWindow()
+  }
+
+  override fun onDetachedFromWindow() {
+    viewLifecycleOwner.setDetachedFromWindow()
+    super.onDetachedFromWindow()
+  }
+
+  override fun setText(text: CharSequence?, type: BufferType?) {
+    val currentText = getText()
+    // Guard against 'text = text' scenarios stripping away rich-text by ensuring that text isn't
+    // rebound if the text isn't actually different (otherwise the parsed text can override
+    // boundRawHtml resulting in the actual markup being lost). Also, ensure that the HTML isn't
+    // re-parsed since it will trigger new spans to be created which will result in many extra and
+    // unnecessary image drawables to be bound below.
+    if (currentText != text) {
+      // Null strings are treated as empty string since TextView expects that null is never bound.
+      // Note that HTML strings are not parsed until all of the GCS properties are properly set up.
+      val styledHtmlText = htmlParser?.parseOppiaRichText(
+        context, text?.toString() ?: "", supportsConceptCards
+      ) ?: ""
+      super.setText(styledHtmlText, type)
+      boundRawHtml = text // Save for later rebinds.
+
+      // After the text is set & before re-layout, make sure all deferred drawables are observed so
+      // that, when they're loaded, the text view is re-laid out to fit the newly loaded image. Note
+      // that this operation has some room for performance improvements: it triggers a full
+      // re-layout of the TextView for quickly subsequent loads. It may be preferable in the future
+      // to batch load all assets when they're guaranteed to be stored locally and do a single
+      // layout to avoid flickering or perceived latency.
+      val needsToLayOut = getImageDrawables().fold(initial = false) { needsToReLayOut, drawable ->
+        if (drawable is DeferredImageDrawable<*>) {
+          // Only listen for the drawable if it isn't already loaded.
+          val loadedDrawable = drawable.getLoadedDrawable()
+          if (loadedDrawable.value == null) {
+            viewLifecycleOwner.observeOnce(loadedDrawable) {
+              // This drawable needs to be re-laid out.
+              drawablesRequireLayOut = true
+
+              // The drawable being finished loading requires another re-layout since the layout
+              // step is responsible for fitting images within the text view.
+              requestLayout()
+            }
+          } else {
+            return@fold true // The image is already available. Ensure it's measured immediately.
+          }
+        }
+        return@fold needsToReLayOut
+      }
+      if (needsToLayOut) {
+        // There are drawables that are immediately available for laying out the view.
+        drawablesRequireLayOut = true
+        requestLayout()
+      }
+    }  else {
+      // Trigger internal updates by setting the same text again. This may happen during layout and
+      // is not guaranteed to trigger a re-layout or re-draw.
+      super.setText(currentText, type)
+    }
+  }
+
+  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+    super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+
+    val viewWidth = width
+    if (drawablesRequireLayOut || viewWidth != lastViewWidthUsedForDrawables) {
+      layOutImageDrawables(getImageDrawables(), viewWidth)
+      drawablesRequireLayOut = false
+      lastViewWidthUsedForDrawables = viewWidth
+
+      // Re-measure the text view in case the drawables lead to the text view taking up more/less
+      // space than before. Note that only height is expected to ever change since the drawables are
+      // constrained based on the view's computed width.
+      super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+    }
+  }
+
+  private fun layOutImageDrawables(drawables: List<Drawable>, viewWidth: Int) {
+    val layoutParams = layoutParams
+    val maxAvailableWidth = if (layoutParams.width == ViewGroup.LayoutParams.WRAP_CONTENT) {
+      // Assume that wrap_content cases means that the view cannot exceed its parent's width minus
+      // margins.
+      val parent = parent
+      if (parent is View && layoutParams is ViewGroup.MarginLayoutParams) {
+        // Only pick the computed space if it allows the view to expand to accommodate larger
+        // images.
+        max(viewWidth, parent.width - (layoutParams.leftMargin + layoutParams.rightMargin))
+      } else viewWidth
+    } else viewWidth
+
+    val atLeastOneUpdate = drawables.fold(initial = false) { prevDrawableUpdated, drawable ->
+      // Note 'or' is used to make sure each drawable is evaluated and there's no short-circuiting.
+      prevDrawableUpdated or layOutImageDrawable(drawable, maxAvailableWidth)
+    }
+    if (atLeastOneUpdate) {
+      // Ensure the view is redrawn if at least one drawable has new bounds. Note that the
+      // 'text = text' bit is needed to properly account for bounds changes happening during layout.
+      text = text
+      invalidate()
+    }
+  }
+
+  // TODO: doc. Mention returns whether the drawable has had its bounds updated.
+  private fun layOutImageDrawable(drawable: Drawable, maxAvailableWidth: Int): Boolean {
+    var drawableHeight = drawable.intrinsicHeight
+    var drawableWidth = drawable.intrinsicWidth
+    if (drawableWidth == 0 || drawableHeight == 0) {
+      // Either the drawable is invalid, or it hasn't finished loading yet.
+      return false
+    }
+    if (drawableHeight <= minimumImageSize || drawableWidth <= minimumImageSize) {
+      // The multipleFactor value is used to make sure that the aspect ratio of the image remains the same.
+      // Example: Height is 90, width is 60 and minimumImageSize is 120.
+      // Then multipleFactor will be 2 (120/60).
+      // The new height will be 180 and new width will be 120.
+      val multipleFactor = if (drawableHeight <= drawableWidth) {
+        // If height is less then the width, multipleFactor value is determined by height.
+        (minimumImageSize.toDouble() / drawableHeight.toDouble())
+      } else {
+        // If height is less then the width, multipleFactor value is determined by width.
+        (minimumImageSize.toDouble() / drawableWidth.toDouble())
+      }
+      drawableHeight = (drawableHeight.toDouble() * multipleFactor).toInt()
+      drawableWidth = (drawableWidth.toDouble() * multipleFactor).toInt()
+    }
+    val maximumImageSize = maxAvailableWidth - maxContentItemPadding
+    if (drawableWidth >= maximumImageSize) {
+      // The multipleFactor value is used to make sure that the aspect ratio of the image remains the same.
+      // Example: Height is 420, width is 440 and maximumImageSize is 200.
+      // Then multipleFactor will be (200/440).
+      // The new height will be 191 and new width will be 200.
+      val multipleFactor = if (drawableHeight >= drawableWidth) {
+        // If height is greater then the width, multipleFactor value is determined by height.
+        (maximumImageSize.toDouble() / drawableHeight.toDouble())
+      } else {
+        // If height is greater then the width, multipleFactor value is determined by width.
+        (maximumImageSize.toDouble() / drawableWidth.toDouble())
+      }
+      drawableHeight = (drawableHeight.toDouble() * multipleFactor).toInt()
+      drawableWidth = (drawableWidth.toDouble() * multipleFactor).toInt()
+    }
+    val initialDrawableMargin = if (centerAlignImages) {
+      ((maxAvailableWidth - drawableWidth) / 2).coerceAtLeast(0)
+    } else {
+      0
+    }
+
+    val newDrawableBounds = Rect(
+      /* left= */ initialDrawableMargin,
+      /* top= */ 0,
+      /* right= */ drawableWidth + initialDrawableMargin,
+      /* bottom= */ drawableHeight
+    )
+    if (newDrawableBounds != drawable.bounds) {
+      drawable.bounds = newDrawableBounds
+      return true // New bounds have been computed.
+    }
+    // The drawable doesn't need to be redrawn since it's the same. Note that this could result in a
+    // new drawable not being drawn, but that's not expected since the default bounds is
+    // (0, 0 - 0, 0) which, if computed here, won't lead to anything being drawn, anyway.
+    return false
+  }
+
+  private fun getImageDrawables(): List<Drawable> {
+    val imageSpans = (text as? Spanned)?.getSpans(0, text.length, ImageSpan::class.java)
+    return imageSpans?.map(ImageSpan::getDrawable) ?: listOf()
+  }
+
+  /**
+   * If raw HTML was previously bound, rebinds it. This should be used in situations when settings
+   * have changed that may lead to the HTML being interpreted differently.
+   *
+   * Calling this method should guarantee all image drawable bounds are recomputed.
+   */
+  private fun reBindHtml() {
+    boundRawHtml?.let { text = it }
+  }
+
+  /**
+   * A custom [LifecycleOwner] that hackily superimposes a view's lifecycle into the buckets of an
+   * activity's lifecycle. This is done privately since it should only ever be used for LiveData
+   * observers whose results can be processed within the window this owner classifies as "resumed"
+   * in activity terminology (view is attached).
+   *
+   * One limitation is that this class treats view detachment as a destruction. Views can be
+   * detached/reattached in legitimate view hierarchy organizations. This class works around this
+   * limitation by returning a new lifecycle after detachment that's again in the initialized state.
+   * If the view gets attached again, new observers should correctly be processed. Observers must
+   * not be long-lived, and will need to reset themselves to work against this situation. To
+   * simplify management, callers should just use [observeOnce].
+   *
+   * Note: the internal lifecycle events processed by this class SHOULD NOT BE CONSTRUED to mean
+   * their corresponding value (e.g. a state of RESUMED does NOT mean that the fragment/activity to
+   * which this view is bound to, if any, is in a RESUMED state--that is not guaranteed nor can it
+   * be).
+   *
+   * Reference for this implementation:
+   * https://developer.android.com/topic/libraries/architecture/lifecycle#implementing-lco.
+   */
+  private class ViewLifecycleOwner: LifecycleOwner {
+    /**
+     * Tracks the lifecycle state. Note that this is not a proper lifecycle since Views do not
+     * follow the same lifecycle patterns as activities. However, this is emulating a
+     * fragment/activity's lifecycle for the sake of allowing the view to safely observe LiveDatas.
+     */
+    private var lifecycleRegistry = LifecycleRegistry(this)
+
+    override fun getLifecycle(): Lifecycle = lifecycleRegistry
+
+    internal fun setAttachedToWindow() {
+      // Treat attached to window as "ready" by combining created, started, and resumed.
+      lifecycleRegistry.currentState = Lifecycle.State.CREATED
+      lifecycleRegistry.currentState = Lifecycle.State.STARTED
+      lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+    }
+
+    internal fun setDetachedFromWindow() {
+      // Treat detachment from the window as destroyed. Note that this means moving the view around
+      // in the hierarchy will effectively look like configuration changes to observers relying on
+      // the lifecycle maintained by this class.
+      lifecycleRegistry.currentState = Lifecycle.State.STARTED
+      lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
+
+      // Recreate the lifecycle registry so that new observers can be added in the event the view is
+      // reattached. Note that no memory should ever be leaked since moving the lifecycle to a
+      // destroyed state automatically unregisters downstream observers, even for long-lived
+      // LiveData objects.
+      lifecycleRegistry = LifecycleRegistry(this)
+    }
+
+    /**
+     * Observes that exactly one value is received from the [LiveData], only if the view is
+     * currently attached, or when the view is next attached. If the view is detached before the
+     * observed value is observed, it will never be observed even after the view is attached.
+     * Callers should call this function again after re-attachment if no result is observed.
+     */
+    internal fun <T> observeOnce(liveData: LiveData<T>, callback: (T) -> Unit) {
+      return liveData.observe(this, object: Observer<T> {
+        override fun onChanged(result: T) {
+          callback(result)
+          liveData.removeObserver(this)
+        }
+      })
+    }
+  }
+}

--- a/app/src/main/java/org/oppia/android/app/shim/ViewBindingShim.kt
+++ b/app/src/main/java/org/oppia/android/app/shim/ViewBindingShim.kt
@@ -47,52 +47,6 @@ interface ViewBindingShim {
   ): TextView
 
   /**
-   * Handles binding inflation for [SelectionInteractionView]'s ItemSelectionInteraction and
-   * returns the binding's root.
-   */
-  fun provideSelectionInteractionViewInflatedView(
-    inflater: LayoutInflater,
-    parent: ViewGroup,
-    attachToParent: Boolean
-  ): View
-
-  /**
-   * Handles binding inflation for [SelectionInteractionView]'s ItemSelectionInteraction and
-   * returns the binding's view model.
-   */
-  fun provideSelectionInteractionViewModel(
-    view: View,
-    viewModel: SelectionInteractionContentViewModel,
-    htmlParserFactory: HtmlParser.Factory,
-    resourceBucketName: String,
-    entityType: String,
-    entityId: String
-  )
-
-  /**
-   * Handles binding inflation for [SelectionInteractionView]'s MultipleChoiceInteraction and
-   * returns the binding's view.
-   */
-  fun provideMultipleChoiceInteractionItemsInflatedView(
-    inflater: LayoutInflater,
-    parent: ViewGroup,
-    attachToParent: Boolean
-  ): View
-
-  /**
-   * Handles binding inflation for [SelectionInteractionView]'s MultipleChoiceInteraction and
-   * returns the binding's view model.
-   */
-  fun provideMultipleChoiceInteractionItemsViewModel(
-    view: View,
-    viewModel: SelectionInteractionContentViewModel,
-    htmlParserFactory: HtmlParser.Factory,
-    resourceBucketName: String,
-    entityType: String,
-    entityId: String
-  )
-
-  /**
    * Handles binding inflation for [DragDropSortInteractionView]'s SortInteraction and returns the
    * binding's view.
    */
@@ -111,9 +65,6 @@ interface ViewBindingShim {
   fun setDragDropInteractionItemsBindingAdapter(
     adapter: RecyclerView.Adapter<RecyclerView.ViewHolder>
   )
-
-  /** Returns [DragDropInteractionItemsBinding]'s RecyclerView. */
-  fun getDragDropInteractionItemsBindingRecyclerView(): RecyclerView
 
   /** Returns [DragDropInteractionItemsBinding]'s dragDropContentGroupItem. */
   fun getDragDropInteractionItemsBindingGroupItem(): ImageButton
@@ -138,20 +89,6 @@ interface ViewBindingShim {
     parent: ViewGroup,
     attachToParent: Boolean
   ): View
-
-  /** Handles setting [DragDropSingleItemBinding]. */
-  fun setDragDropSingleItemBinding(
-    view: View
-  )
-
-  /** Handles setting [DragDropSingleItemBinding]'s html content. */
-  fun setDragDropSingleItemBindingHtmlContent(
-    htmlParserFactory: HtmlParser.Factory,
-    resourceBucketName: String,
-    entityType: String,
-    entityId: String,
-    viewModel: String
-  )
 
   /** Returns [ClickableAreasImage]'s default region. */
   fun getDefaultRegion(parentView: FrameLayout): View

--- a/app/src/main/java/org/oppia/android/app/shim/ViewBindingShimImpl.kt
+++ b/app/src/main/java/org/oppia/android/app/shim/ViewBindingShimImpl.kt
@@ -63,72 +63,6 @@ class ViewBindingShimImpl @Inject constructor() : ViewBindingShim {
     return DataBindingUtil.findBinding<ProfileInputViewBinding>(profileInputView)!!.errorText
   }
 
-  override fun provideSelectionInteractionViewInflatedView(
-    inflater: LayoutInflater,
-    parent: ViewGroup,
-    attachToParent: Boolean
-  ): View {
-    return ItemSelectionInteractionItemsBinding.inflate(
-      LayoutInflater.from(parent.context),
-      parent,
-      /* attachToParent= */ false
-    ).root
-  }
-
-  override fun provideSelectionInteractionViewModel(
-    view: View,
-    viewModel: SelectionInteractionContentViewModel,
-    htmlParserFactory: HtmlParser.Factory,
-    resourceBucketName: String,
-    entityType: String,
-    entityId: String
-  ) {
-    val binding =
-      DataBindingUtil.findBinding<ItemSelectionInteractionItemsBinding>(view)!!
-    binding.htmlContent =
-      htmlParserFactory.create(
-        resourceBucketName,
-        entityType,
-        entityId,
-        false
-      ).parseOppiaHtml(
-        viewModel.htmlContent,
-        binding.itemSelectionContentsTextView
-      )
-    binding.viewModel = viewModel
-  }
-
-  override fun provideMultipleChoiceInteractionItemsInflatedView(
-    inflater: LayoutInflater,
-    parent: ViewGroup,
-    attachToParent: Boolean
-  ): View {
-    return MultipleChoiceInteractionItemsBinding.inflate(
-      LayoutInflater.from(parent.context),
-      parent,
-      false
-    ).root
-  }
-
-  override fun provideMultipleChoiceInteractionItemsViewModel(
-    view: View,
-    viewModel: SelectionInteractionContentViewModel,
-    htmlParserFactory: HtmlParser.Factory,
-    resourceBucketName: String,
-    entityType: String,
-    entityId: String
-  ) {
-    val binding =
-      DataBindingUtil.findBinding<MultipleChoiceInteractionItemsBinding>(view)!!
-    binding.htmlContent =
-      htmlParserFactory.create(
-        resourceBucketName, entityType, entityId, /* imageCenterAlign= */ false
-      ).parseOppiaHtml(
-        viewModel.htmlContent, binding.multipleChoiceContentTextView
-      )
-    binding.viewModel = viewModel
-  }
-
   override fun provideDragDropSortInteractionInflatedView(
     inflater: LayoutInflater,
     parent: ViewGroup,
@@ -152,10 +86,6 @@ class ViewBindingShimImpl @Inject constructor() : ViewBindingShim {
     adapter: RecyclerView.Adapter<RecyclerView.ViewHolder>
   ) {
     dragDropInteractionItemsBinding.adapter = adapter
-  }
-
-  override fun getDragDropInteractionItemsBindingRecyclerView(): RecyclerView {
-    return dragDropInteractionItemsBinding.dragDropItemRecyclerview
   }
 
   override fun getDragDropInteractionItemsBindingGroupItem(): ImageButton {
@@ -184,33 +114,6 @@ class ViewBindingShimImpl @Inject constructor() : ViewBindingShim {
     return DragDropSingleItemBinding.inflate(
       LayoutInflater.from(parent.context), parent, /* attachToParent= */ false
     ).root
-  }
-
-  // TODO(#1692): Fix implementation to not use cache binding.
-  private lateinit var dragDropSingleItemBinding: DragDropSingleItemBinding
-
-  override fun setDragDropSingleItemBinding(
-    view: View
-  ) {
-    dragDropSingleItemBinding =
-      DataBindingUtil.findBinding<DragDropSingleItemBinding>(view)!!
-  }
-
-  override fun setDragDropSingleItemBindingHtmlContent(
-    htmlParserFactory: HtmlParser.Factory,
-    resourceBucketName: String,
-    entityType: String,
-    entityId: String,
-    viewModel: String
-  ) {
-    dragDropSingleItemBinding.htmlContent = htmlParserFactory.create(
-      resourceBucketName,
-      entityType,
-      entityId,
-      /* imageCenterAlign= */ false
-    ).parseOppiaHtml(
-      viewModel, dragDropSingleItemBinding.dragDropContentTextView
-    )
   }
 
   override fun getDefaultRegion(parentView: FrameLayout): View {

--- a/app/src/main/java/org/oppia/android/app/story/StoryFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/story/StoryFragmentPresenter.kt
@@ -33,10 +33,7 @@ class StoryFragmentPresenter @Inject constructor(
   private val activity: AppCompatActivity,
   private val fragment: Fragment,
   private val oppiaLogger: OppiaLogger,
-  private val oppiaClock: OppiaClock,
-  private val htmlParserFactory: HtmlParser.Factory,
-  @DefaultResourceBucketName private val resourceBucketName: String,
-  @TopicHtmlParserEntityType private val entityType: String
+  private val oppiaClock: OppiaClock
 ) {
   private val routeToExplorationListener = activity as RouteToExplorationListener
 
@@ -120,29 +117,11 @@ class StoryFragmentPresenter @Inject constructor(
         setViewModel = StoryHeaderViewBinding::setViewModel,
         transformViewModel = { it as StoryHeaderViewModel }
       )
-      .registerViewBinder(
+      .registerViewDataBinder(
         viewType = ViewType.VIEW_TYPE_CHAPTER,
-        inflateView = { parent ->
-          StoryChapterViewBinding.inflate(
-            LayoutInflater.from(parent.context),
-            parent,
-            /* attachToParent= */ false
-          ).root
-        },
-        bindView = { view, viewModel ->
-          val binding = DataBindingUtil.findBinding<StoryChapterViewBinding>(view)!!
-          val storyItemViewModel = viewModel as StoryChapterSummaryViewModel
-          binding.viewModel = storyItemViewModel
-          binding.htmlContent =
-            htmlParserFactory.create(
-              resourceBucketName,
-              entityType,
-              storyItemViewModel.storyId,
-              imageCenterAlign = true
-            ).parseOppiaHtml(
-              storyItemViewModel.summary, binding.chapterSummary
-            )
-        }
+        inflateDataBinding = StoryChapterViewBinding::inflate,
+        setViewModel = StoryChapterViewBinding::setViewModel,
+        transformViewModel = { it as StoryChapterSummaryViewModel }
       )
       .build()
   }

--- a/app/src/main/java/org/oppia/android/app/story/StoryViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/story/StoryViewModel.kt
@@ -15,8 +15,10 @@ import org.oppia.android.domain.exploration.ExplorationDataController
 import org.oppia.android.domain.topic.TopicController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.gcsresource.DefaultResourceBucketName
 import org.oppia.android.util.logging.ConsoleLogger
 import org.oppia.android.util.parser.StoryHtmlParserEntityType
+import org.oppia.android.util.parser.TopicHtmlParserEntityType
 import javax.inject.Inject
 
 /** The ViewModel for StoryFragment. */
@@ -26,7 +28,9 @@ class StoryViewModel @Inject constructor(
   private val topicController: TopicController,
   private val explorationDataController: ExplorationDataController,
   private val logger: ConsoleLogger,
-  @StoryHtmlParserEntityType val entityType: String
+  @DefaultResourceBucketName private val gcsResourceName: String,
+  @TopicHtmlParserEntityType private val gcsTopicEntityType: String,
+  @StoryHtmlParserEntityType val gcsStoryEntityType: String
 ) {
   private var internalProfileId: Int = -1
   private lateinit var topicId: String
@@ -109,7 +113,9 @@ class StoryViewModel @Inject constructor(
           topicId,
           storyId,
           chapter,
-          entityType
+          gcsResourceName,
+          gcsTopicEntityType,
+          gcsStoryEntityType
         )
       }
     )

--- a/app/src/main/java/org/oppia/android/app/story/storyitemviewmodel/StoryChapterSummaryViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/story/storyitemviewmodel/StoryChapterSummaryViewModel.kt
@@ -22,7 +22,9 @@ class StoryChapterSummaryViewModel(
   val topicId: String,
   val storyId: String,
   val chapterSummary: ChapterSummary,
-  val entityType: String
+  val gcsResourceName: String,
+  val gcsTopicEntityType: String,
+  val gcsStoryEntityType: String
 ) : StoryItemViewModel() {
   val explorationId: String = chapterSummary.explorationId
   val name: String = chapterSummary.name

--- a/app/src/main/java/org/oppia/android/app/testing/HtmlParserTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/HtmlParserTestActivity.kt
@@ -26,16 +26,16 @@ class HtmlParserTestActivity : InjectableAppCompatActivity() {
     val testHtmlContentTextView: TextView = findViewById(R.id.test_html_content_text_view)
     val rawDummyString =
       "\u003cp\u003e\"Let's try one last question,\" said Mr. Baker. \"Here's a pineapple cake cut into pieces.\"\u003c/p\u003e\u003coppia-noninteractive-image alt-with-value=\"\u0026amp;quot;Pineapple cake with 7/9 having cherries.\u0026amp;quot;\" caption-with-value=\"\u0026amp;quot;\u0026amp;quot;\" filepath-with-value=\"\u0026amp;quot;pineapple_cake_height_479_width_480.png\u0026amp;quot;\"\u003e\u003c/oppia-noninteractive-image\u003e\u003cp\u003e\u00a0\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eQuestion 6\u003c/strong\u003e: What fraction of the cake has big red cherries in the pineapple slices?\u003c/p\u003e" // ktlint-disable max-line-length
-    val htmlResult: Spannable =
-      htmlParserFactory.create(
-        resourceBucketName,
-        /* entityType= */ "exploration",
-        /* entityId= */ "oppia",
-        /* imageCenterAlign= */ false
-      ).parseOppiaHtml(
-        rawDummyString,
-        testHtmlContentTextView
-      )
-    testHtmlContentTextView.text = htmlResult
+//    val htmlResult: Spannable =
+//      htmlParserFactory.create(
+//        resourceBucketName,
+//        /* entityType= */ "exploration",
+//        /* entityId= */ "oppia",
+//        /* imageCenterAlign= */ false
+//      ).parseOppiaHtml(
+//        rawDummyString,
+//        testHtmlContentTextView
+//      )
+//    testHtmlContentTextView.text = htmlResult
   }
 }

--- a/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentPresenter.kt
@@ -33,11 +33,10 @@ class ConceptCardFragmentPresenter @Inject constructor(
       container,
       /* attachToRoot= */ false
     )
-    val view = binding.conceptCardExplanationText
     val viewModel = getConceptCardViewModel()
 
     skillId = id
-    viewModel.setSkillIdAndBinding(skillId, view)
+    viewModel.setSkillIdAndBinding(skillId)
     logConceptCardEvent(skillId)
 
     binding.conceptCardToolbar.setNavigationIcon(R.drawable.ic_close_white_24dp)

--- a/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardViewModel.kt
@@ -20,12 +20,10 @@ import javax.inject.Inject
 class ConceptCardViewModel @Inject constructor(
   private val topicController: TopicController,
   private val logger: ConsoleLogger,
-  private val htmlParserFactory: HtmlParser.Factory,
-  @ConceptCardHtmlParserEntityType private val entityType: String,
-  @DefaultResourceBucketName private val resourceBucketName: String
+  @DefaultResourceBucketName val gcsResourceName: String,
+  @ConceptCardHtmlParserEntityType val gcsEntityType: String
 ) : ObservableViewModel() {
   private lateinit var skillId: String
-  private lateinit var view: TextView
 
   val conceptCardLiveData: LiveData<ConceptCard> by lazy {
     processConceptCardLiveData()
@@ -36,10 +34,11 @@ class ConceptCardViewModel @Inject constructor(
   }
 
   /** Sets the value of skillId and binding. Must be called before setting ViewModel to binding */
-  fun setSkillIdAndBinding(id: String, view: TextView) {
+  fun setSkillIdAndBinding(id: String) {
     skillId = id
-    this.view = view
   }
+
+  fun getSkillId(): String = skillId
 
   private val conceptCardResultLiveData: LiveData<AsyncResult<ConceptCard>> by lazy {
     topicController.getConceptCard(skillId)
@@ -73,8 +72,6 @@ class ConceptCardViewModel @Inject constructor(
       )
     }
     val conceptCard = conceptCardResult.getOrDefault(ConceptCard.getDefaultInstance())
-    return htmlParserFactory
-      .create(resourceBucketName, entityType, skillId, /* imageCenterAlign= */true)
-      .parseOppiaHtml(conceptCard.explanation.html, view)
+    return conceptCard.explanation.html
   }
 }

--- a/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentPresenter.kt
@@ -33,10 +33,9 @@ class RevisionCardFragmentPresenter @Inject constructor(
         container,
         /* attachToRoot= */ false
       )
-    val view = binding.revisionCardExplanationText
     val viewModel = getReviewCardViewModel()
 
-    viewModel.setSubtopicIdAndBinding(topicId, subtopicId, view)
+    viewModel.setSubtopicIdAndBinding(topicId, subtopicId)
     logRevisionCardEvent(topicId, subtopicId)
 
     binding.let {

--- a/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardViewModel.kt
@@ -23,13 +23,11 @@ class RevisionCardViewModel @Inject constructor(
   activity: AppCompatActivity,
   private val topicController: TopicController,
   private val logger: ConsoleLogger,
-  private val htmlParserFactory: HtmlParser.Factory,
-  @DefaultResourceBucketName private val resourceBucketName: String,
-  @TopicHtmlParserEntityType private val entityType: String
+  @DefaultResourceBucketName val gcsResourceName: String,
+  @TopicHtmlParserEntityType val gcsEntityType: String
 ) : ObservableViewModel() {
   private lateinit var topicId: String
   private var subtopicId: Int = 0
-  private lateinit var view: TextView
 
   private val returnToTopicClickListener: ReturnToTopicClickListener =
     activity as ReturnToTopicClickListener
@@ -45,13 +43,13 @@ class RevisionCardViewModel @Inject constructor(
   /** Sets the value of topicId, subtopicId and binding before anything else. */
   fun setSubtopicIdAndBinding(
     topicId: String,
-    subtopicId: Int,
-    view: TextView
+    subtopicId: Int
   ) {
     this.topicId = topicId
     this.subtopicId = subtopicId
-    this.view = view
   }
+
+  fun getTopicId(): String = topicId
 
   private val revisionCardResultLiveData: LiveData<AsyncResult<RevisionCard>> by lazy {
     topicController.getRevisionCard(topicId, subtopicId)
@@ -74,9 +72,6 @@ class RevisionCardViewModel @Inject constructor(
     val revisionCard = revisionCardResult.getOrDefault(
       RevisionCard.getDefaultInstance()
     )
-    return htmlParserFactory.create(
-
-      resourceBucketName, entityType, topicId, /* imageCenterAlign= */ true
-    ).parseOppiaHtml(revisionCard.pageContents.html, view)
+    return revisionCard.pageContents.html
   }
 }

--- a/app/src/main/java/org/oppia/android/app/view/ViewComponent.kt
+++ b/app/src/main/java/org/oppia/android/app/view/ViewComponent.kt
@@ -7,6 +7,7 @@ import org.oppia.android.app.customview.LessonThumbnailImageView
 import org.oppia.android.app.player.state.DragDropSortInteractionView
 import org.oppia.android.app.player.state.ImageRegionSelectionInteractionView
 import org.oppia.android.app.player.state.SelectionInteractionView
+import org.oppia.android.app.richtext.RteTextView
 
 /** Root subcomponent for custom views. */
 @Subcomponent
@@ -24,4 +25,5 @@ interface ViewComponent {
   fun inject(dragDropSortInteractionView: DragDropSortInteractionView)
   fun inject(imageRegionSelectionInteractionView: ImageRegionSelectionInteractionView)
   fun inject(lessonThumbnailImageView: LessonThumbnailImageView)
+  fun inject(rteTextView: RteTextView)
 }

--- a/app/src/main/res/layout-land/concept_card_fragment.xml
+++ b/app/src/main/res/layout-land/concept_card_fragment.xml
@@ -59,7 +59,7 @@
             android:textColor="@color/oppiaPrimaryText"
             android:textSize="20sp" />
 
-          <TextView
+          <org.oppia.android.app.richtext.RteTextView
             android:id="@+id/concept_card_explanation_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -69,7 +69,11 @@
             android:fontFamily="sans-serif"
             android:text="@{viewModel.explanationLiveData}"
             android:textColor="@color/oppiaPrimaryText"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            app:centerAlignImages="@{true}"
+            app:gcsResourceName="@{viewModel.gcsResourceName}"
+            app:entityType="@{viewModel.gcsEntityType}"
+            app:entityId="@{viewModel.getSkillId()}" />
         </LinearLayout>
         <!--TODO(#352): Show worked examples in Concept Card.-->
       </ScrollView>

--- a/app/src/main/res/layout-land/content_item.xml
+++ b/app/src/main/res/layout-land/content_item.xml
@@ -6,10 +6,6 @@
     <import type="android.view.View" />
 
     <variable
-      name="htmlContent"
-      type="CharSequence" />
-
-    <variable
       name="viewModel"
       type="org.oppia.android.app.player.state.itemviewmodel.ContentViewModel" />
   </data>
@@ -59,15 +55,22 @@
     app:questionViewPaddingStart="@{@dimen/space_0dp}"
     app:questionViewPaddingTop="@{@dimen/space_0dp}">
 
-    <TextView
+    <org.oppia.android.app.richtext.RteTextView
       android:id="@+id/content_text_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:breakStrategy="simple"
       android:fontFamily="sans-serif"
-      android:text="@{htmlContent}"
+      android:text="@{viewModel.htmlContent}"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="16sp"
-      android:visibility="@{htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}" />
+      android:visibility="@{viewModel.htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}"
+      app:centerAlignImages="@{true}"
+      app:supportsLinks="@{true}"
+      app:supportsConceptCards="@{viewModel.supportsConceptCards}"
+      app:customOppiaTagActionListener="@{viewModel.customOppiaTagActionListener}"
+      app:gcsResourceName="@{viewModel.gcsResourceName}"
+      app:entityType="@{viewModel.gcsEntityType}"
+      app:entityId="@{viewModel.gcsEntityId}" />
   </FrameLayout>
 </layout>

--- a/app/src/main/res/layout-land/faq_single_activity.xml
+++ b/app/src/main/res/layout-land/faq_single_activity.xml
@@ -2,6 +2,21 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
+  <data>
+
+    <variable
+      name="questionText"
+      type="CharSequence" />
+
+    <variable
+      name="answerText"
+      type="CharSequence" />
+
+    <variable
+      name="gcsResourceName"
+      type="String" />
+  </data>
+
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -63,16 +78,25 @@
             android:layout_height="wrap_content"
             android:fontFamily="sans-serif-medium"
             android:textColor="@color/oppiaPrimaryText"
-            android:textSize="18sp" />
+            android:textSize="18sp"
+            android:text="@{questionText}" />
 
-          <TextView
+          <!-- NOTE: Here entityType and entityId can be anything as it will actually not get used.
+          They are needed only for cases where rich-text contains images from server and in faq
+          we do not have images. -->
+          <!-- TODO: move to fragment since injectable views must be hosted by an Oppia fragment. -->
+          <org.oppia.android.app.richtext.RteTextView
             android:id="@+id/faq_answer_text_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
             android:fontFamily="sans-serif"
             android:textColor="@color/oppiaPrimaryText"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:text="@{answerText}"
+            app:gcsResourceName="@{gcsResourceName}"
+            app:entityType="@{&quot;faq&quot;}"
+            app:entityId="@{&quot;oppia&quot;}" />
         </LinearLayout>
       </ScrollView>
 

--- a/app/src/main/res/layout-land/feedback_item.xml
+++ b/app/src/main/res/layout-land/feedback_item.xml
@@ -6,10 +6,6 @@
     <import type="android.view.View" />
 
     <variable
-      name="htmlContent"
-      type="CharSequence" />
-
-    <variable
       name="viewModel"
       type="org.oppia.android.app.player.state.itemviewmodel.FeedbackViewModel" />
   </data>
@@ -59,15 +55,22 @@
     app:questionViewPaddingStart="@{@dimen/space_0dp}"
     app:questionViewPaddingTop="@{@dimen/space_0dp}">
 
-    <TextView
+    <org.oppia.android.app.richtext.RteTextView
       android:id="@+id/feedback_text_view"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:breakStrategy="simple"
       android:fontFamily="sans-serif"
-      android:text="@{htmlContent}"
+      android:text="@{viewModel.htmlContent}"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="16sp"
-      android:visibility="@{htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}" />
+      android:visibility="@{viewModel.htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}"
+      app:centerAlignImages="@{true}"
+      app:supportsLinks="@{true}"
+      app:supportsConceptCards="@{viewModel.supportsConceptCards}"
+      app:customOppiaTagActionListener="@{viewModel.customOppiaTagActionListener}"
+      app:gcsResourceName="@{viewModel.gcsResourceName}"
+      app:entityType="@{viewModel.gcsEntityType}"
+      app:entityId="@{viewModel.gcsEntityId}" />
   </FrameLayout>
 </layout>

--- a/app/src/main/res/layout-land/hints_summary.xml
+++ b/app/src/main/res/layout-land/hints_summary.xml
@@ -102,14 +102,19 @@
         android:orientation="vertical"
         android:visibility="@{isListExpanded? View.VISIBLE : View.GONE}">
 
-        <TextView
+        <org.oppia.android.app.richtext.RteTextView
           android:id="@+id/hints_and_solution_summary"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_gravity="start"
           android:fontFamily="sans-serif"
           android:textColor="@color/oppiaPrimaryText"
-          android:textSize="16sp" />
+          android:textSize="16sp"
+          android:text="@{viewModel.hintsAndSolutionSummary}"
+          app:centerAlignImages="@{true}"
+          app:gcsResourceName="@{viewModel.gcsResourceName}"
+          app:entityType="@{viewModel.gcsEntityType}"
+          app:entityId="@{viewModel.entityId}" />
       </LinearLayout>
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout-land/revision_card_fragment.xml
+++ b/app/src/main/res/layout-land/revision_card_fragment.xml
@@ -1,4 +1,5 @@
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <data>
 
@@ -22,17 +23,21 @@
       android:orientation="vertical"
       android:paddingBottom="145dp">
 
-      <TextView
+      <org.oppia.android.app.richtext.RteTextView
         android:id="@+id/revision_card_explanation_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="52dp"
-        android:layout_marginTop="24dp"
-        android:layout_marginEnd="52dp"
+        android:layout_marginStart="28dp"
+        android:layout_marginTop="36dp"
+        android:layout_marginEnd="28dp"
         android:fontFamily="sans-serif"
         android:text="@{viewModel.explanationLiveData}"
         android:textColor="@color/oppiaPrimaryText"
-        android:textSize="16sp" />
+        android:textSize="16sp"
+        app:centerAlignImages="@{true}"
+        app:gcsResourceName="@{viewModel.gcsResourceName}"
+        app:entityType="@{viewModel.gcsEntityType}"
+        app:entityId="@{viewModel.getTopicId()}" />
 
       <Button
         android:id="@+id/revision_card_return_button"

--- a/app/src/main/res/layout-land/solution_summary.xml
+++ b/app/src/main/res/layout-land/solution_summary.xml
@@ -146,14 +146,19 @@
             android:textColor="@color/oppiaPrimaryText"
             android:textSize="16sp" />
 
-          <TextView
+          <org.oppia.android.app.richtext.RteTextView
             android:id="@+id/solution_summary"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start"
             android:fontFamily="sans-serif"
             android:textColor="@color/oppiaPrimaryText"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:text="@{viewModel.solutionSummary}"
+            app:centerAlignImages="@{true}"
+            app:gcsResourceName="@{viewModel.gcsResourceName}"
+            app:entityType="@{viewModel.gcsEntityType}"
+            app:entityId="@{viewModel.gcsEntityId}" />
         </LinearLayout>
       </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout-land/story_chapter_view.xml
+++ b/app/src/main/res/layout-land/story_chapter_view.xml
@@ -9,10 +9,6 @@
     <import type="org.oppia.android.app.model.ChapterPlayState" />
 
     <variable
-      name="htmlContent"
-      type="CharSequence" />
-
-    <variable
       name="viewModel"
       type="org.oppia.android.app.story.storyitemviewmodel.StoryChapterSummaryViewModel" />
   </data>
@@ -68,7 +64,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-          <TextView
+          <org.oppia.android.app.richtext.RteTextView
             android:id="@+id/chapter_summary"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -79,14 +75,18 @@
             android:ellipsize="end"
             android:fontFamily="sans-serif"
             android:maxLines="3"
-            android:text="@{htmlContent}"
+            android:text="@{viewModel.summary}"
             android:textColor="@color/oppiaPrimaryText"
             android:textSize="16sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/chapter_title"
-            app:layout_constraintVertical_bias="0.0" />
+            app:layout_constraintVertical_bias="0.0"
+            app:centerAlignImages="@{true}"
+            app:gcsResourceName="@{viewModel.gcsResourceName}"
+            app:entityType="@{viewModel.gcsTopicEntityType}"
+            app:entityId="@{viewModel.storyId}" />
 
           <ImageView
             android:id="@+id/chapter_completed_tick"

--- a/app/src/main/res/layout-land/submitted_answer_item.xml
+++ b/app/src/main/res/layout-land/submitted_answer_item.xml
@@ -5,16 +5,8 @@
   <data>
 
     <import type="android.view.Gravity" />
-
     <import type="android.view.View" />
-
-    <variable
-      name="submittedAnswer"
-      type="CharSequence" />
-
-    <variable
-      name="submittedListAnswer"
-      type="org.oppia.android.app.model.ListOfSetsOfHtmlStrings" />
+    <import type="org.oppia.android.app.model.UserAnswer" />
 
     <variable
       name="viewModel"
@@ -47,33 +39,39 @@
     app:questionViewMarginStart="@{@dimen/space_64dp}"
     app:questionViewMarginTop="@{@dimen/space_24dp}">
 
-    <TextView
+    <org.oppia.android.app.richtext.RteTextView
       android:id="@+id/submitted_answer_text_view"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:background="@drawable/submitted_answer_background"
+      android:contentDescription="@{viewModel.accessibleAnswerString}"
       android:paddingStart="12dp"
-      android:paddingTop="@{viewModel.hasConversationView ? @dimen/space_16dp : @dimen/space_8dp}"
+      android:paddingTop="8dp"
       android:paddingEnd="12dp"
-      android:paddingBottom="@{viewModel.hasConversationView ? @dimen/space_16dp : @dimen/space_8dp}"
-      android:text="@{submittedAnswer}"
+      android:visibility="@{viewModel.submittedUserAnswer.textualAnswerCase != UserAnswer.TextualAnswerCase.LIST_OF_HTML_ANSWERS ? View.VISIBLE : View.GONE}"
+      android:paddingBottom="8dp"
+      android:text="@{viewModel.singleAnswerString}"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="16sp"
-      android:visibility="gone" />
+      app:supportsConceptCards="@{viewModel.supportsConceptCards}"
+      app:customOppiaTagActionListener="@{viewModel.customOppiaTagActionListener}"
+      app:gcsResourceName="@{viewModel.gcsResourceName}"
+      app:entityType="@{viewModel.gcsEntityType}"
+      app:entityId="@{viewModel.gcsEntityId}" />
 
-    <androidx.recyclerview.widget.RecyclerView
+    <org.oppia.android.app.player.state.itemviewmodel.submittedanswers.SubmittedAnswerRecyclerView
       android:id="@+id/submitted_answer_recycler_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:background="@drawable/submitted_answer_background"
       android:paddingStart="8dp"
       android:paddingEnd="8dp"
-      android:visibility="gone"
+      android:visibility="@{viewModel.submittedUserAnswer.textualAnswerCase == UserAnswer.TextualAnswerCase.LIST_OF_HTML_ANSWERS ? View.VISIBLE : View.GONE}"
       app:itemDecorator="@{@drawable/divider}"
       app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
-      app:list="@{submittedListAnswer.setOfHtmlStringsList}" />
+      app:list="@{viewModel.answerRecyclerViewListItemViewModelList}" />
 
     <ImageView
       android:id="@+id/answer_tick"

--- a/app/src/main/res/layout-sw600dp-land/concept_card_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-land/concept_card_fragment.xml
@@ -59,7 +59,7 @@
             android:textColor="@color/oppiaPrimaryText"
             android:textSize="20sp" />
 
-          <TextView
+          <org.oppia.android.app.richtext.RteTextView
             android:id="@+id/concept_card_explanation_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -69,7 +69,11 @@
             android:fontFamily="sans-serif"
             android:text="@{viewModel.explanationLiveData}"
             android:textColor="@color/oppiaPrimaryText"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            app:centerAlignImages="@{true}"
+            app:gcsResourceName="@{viewModel.gcsResourceName}"
+            app:entityType="@{viewModel.gcsEntityType}"
+            app:entityId="@{viewModel.getSkillId()}" />
         </LinearLayout>
         <!--TODO(#352): Show worked examples in Concept Card.-->
       </ScrollView>

--- a/app/src/main/res/layout-sw600dp-land/content_item.xml
+++ b/app/src/main/res/layout-sw600dp-land/content_item.xml
@@ -6,10 +6,6 @@
     <import type="android.view.View" />
 
     <variable
-      name="htmlContent"
-      type="CharSequence" />
-
-    <variable
       name="viewModel"
       type="org.oppia.android.app.player.state.itemviewmodel.ContentViewModel" />
   </data>
@@ -59,15 +55,22 @@
     app:questionViewPaddingStart="@{@dimen/space_0dp}"
     app:questionViewPaddingTop="@{@dimen/space_0dp}">
 
-    <TextView
+    <org.oppia.android.app.richtext.RteTextView
       android:id="@+id/content_text_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:breakStrategy="simple"
       android:fontFamily="sans-serif"
-      android:text="@{htmlContent}"
+      android:text="@{viewModel.htmlContent}"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="16sp"
-      android:visibility="@{htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}" />
+      android:visibility="@{viewModel.htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}"
+      app:centerAlignImages="@{true}"
+      app:supportsLinks="@{true}"
+      app:supportsConceptCards="@{viewModel.supportsConceptCards}"
+      app:customOppiaTagActionListener="@{viewModel.customOppiaTagActionListener}"
+      app:gcsResourceName="@{viewModel.gcsResourceName}"
+      app:entityType="@{viewModel.gcsEntityType}"
+      app:entityId="@{viewModel.gcsEntityId}" />
   </FrameLayout>
 </layout>

--- a/app/src/main/res/layout-sw600dp-land/feedback_item.xml
+++ b/app/src/main/res/layout-sw600dp-land/feedback_item.xml
@@ -4,10 +4,6 @@
   <data>
 
     <variable
-      name="htmlContent"
-      type="CharSequence" />
-
-    <variable
       name="viewModel"
       type="org.oppia.android.app.player.state.itemviewmodel.FeedbackViewModel" />
   </data>
@@ -57,14 +53,22 @@
     app:questionViewPaddingStart="@{@dimen/space_0dp}"
     app:questionViewPaddingTop="@{@dimen/space_0dp}">
 
-    <TextView
+    <org.oppia.android.app.richtext.RteTextView
       android:id="@+id/feedback_text_view"
-      android:layout_width="match_parent"
+      android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:breakStrategy="simple"
       android:fontFamily="sans-serif"
-      android:text="@{htmlContent}"
+      android:text="@{viewModel.htmlContent}"
       android:textColor="@color/oppiaPrimaryText"
-      android:textSize="16sp" />
+      android:textSize="16sp"
+      android:visibility="@{viewModel.htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}"
+      app:centerAlignImages="@{true}"
+      app:supportsLinks="@{true}"
+      app:supportsConceptCards="@{viewModel.supportsConceptCards}"
+      app:customOppiaTagActionListener="@{viewModel.customOppiaTagActionListener}"
+      app:gcsResourceName="@{viewModel.gcsResourceName}"
+      app:entityType="@{viewModel.gcsEntityType}"
+      app:entityId="@{viewModel.gcsEntityId}" />
   </FrameLayout>
 </layout>

--- a/app/src/main/res/layout-sw600dp-land/hints_summary.xml
+++ b/app/src/main/res/layout-sw600dp-land/hints_summary.xml
@@ -95,14 +95,19 @@
       android:orientation="vertical"
       android:visibility="@{isListExpanded? View.VISIBLE : View.GONE}">
 
-      <TextView
+      <org.oppia.android.app.richtext.RteTextView
         android:id="@+id/hints_and_solution_summary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="start"
         android:fontFamily="sans-serif"
         android:textColor="@color/oppiaPrimaryText"
-        android:textSize="16sp" />
+        android:textSize="16sp"
+        android:text="@{viewModel.hintsAndSolutionSummary}"
+        app:centerAlignImages="@{true}"
+        app:gcsResourceName="@{viewModel.gcsResourceName}"
+        app:entityType="@{viewModel.gcsEntityType}"
+        app:entityId="@{viewModel.entityId}" />
     </LinearLayout>
   </LinearLayout>
 </layout>

--- a/app/src/main/res/layout-sw600dp-land/solution_summary.xml
+++ b/app/src/main/res/layout-sw600dp-land/solution_summary.xml
@@ -138,14 +138,19 @@
           android:textColor="@color/oppiaPrimaryText"
           android:textSize="16sp" />
 
-        <TextView
+        <org.oppia.android.app.richtext.RteTextView
           android:id="@+id/solution_summary"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_gravity="start"
           android:fontFamily="sans-serif"
           android:textColor="@color/oppiaPrimaryText"
-          android:textSize="16sp" />
+          android:textSize="16sp"
+          android:text="@{viewModel.solutionSummary}"
+          app:centerAlignImages="@{true}"
+          app:gcsResourceName="@{viewModel.gcsResourceName}"
+          app:entityType="@{viewModel.gcsEntityType}"
+          app:entityId="@{viewModel.gcsEntityId}" />
       </LinearLayout>
     </LinearLayout>
   </LinearLayout>

--- a/app/src/main/res/layout-sw600dp-land/submitted_answer_item.xml
+++ b/app/src/main/res/layout-sw600dp-land/submitted_answer_item.xml
@@ -6,14 +6,7 @@
 
     <import type="android.view.View" />
     <import type="android.view.Gravity" />
-
-    <variable
-      name="submittedAnswer"
-      type="CharSequence" />
-
-    <variable
-      name="submittedListAnswer"
-      type="org.oppia.android.app.model.ListOfSetsOfHtmlStrings" />
+    <import type="org.oppia.android.app.model.UserAnswer" />
 
     <variable
       name="viewModel"
@@ -79,33 +72,39 @@
         android:gravity="@{viewModel.hasConversationView ? Gravity.END : Gravity.START}"
         android:layout_height="wrap_content">
 
-        <TextView
+        <org.oppia.android.app.richtext.RteTextView
           android:id="@+id/submitted_answer_text_view"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:background="@drawable/submitted_answer_background"
+          android:contentDescription="@{viewModel.accessibleAnswerString}"
           android:paddingStart="12dp"
           android:paddingTop="8dp"
           android:paddingEnd="12dp"
-          android:visibility="gone"
+          android:visibility="@{viewModel.submittedUserAnswer.textualAnswerCase != UserAnswer.TextualAnswerCase.LIST_OF_HTML_ANSWERS ? View.VISIBLE : View.GONE}"
           android:paddingBottom="8dp"
-          android:text="@{submittedAnswer}"
+          android:text="@{viewModel.singleAnswerString}"
           android:textColor="@color/oppiaPrimaryText"
-          android:textSize="16sp" />
+          android:textSize="16sp"
+          app:supportsConceptCards="@{viewModel.supportsConceptCards}"
+          app:customOppiaTagActionListener="@{viewModel.customOppiaTagActionListener}"
+          app:gcsResourceName="@{viewModel.gcsResourceName}"
+          app:entityType="@{viewModel.gcsEntityType}"
+          app:entityId="@{viewModel.gcsEntityId}" />
 
-        <androidx.recyclerview.widget.RecyclerView
+        <org.oppia.android.app.player.state.itemviewmodel.submittedanswers.SubmittedAnswerRecyclerView
           android:id="@+id/submitted_answer_recycler_view"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:background="@drawable/submitted_answer_background"
           android:paddingStart="8dp"
           android:paddingEnd="8dp"
-          android:visibility="gone"
+          android:visibility="@{viewModel.submittedUserAnswer.textualAnswerCase == UserAnswer.TextualAnswerCase.LIST_OF_HTML_ANSWERS ? View.VISIBLE : View.GONE}"
           app:itemDecorator="@{@drawable/divider}"
           app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toTopOf="parent"
-          app:list="@{submittedListAnswer.setOfHtmlStringsList}" />
+          app:list="@{viewModel.answerRecyclerViewListItemViewModelList}" />
 
         <ImageView
           android:id="@+id/answer_tick"

--- a/app/src/main/res/layout-sw600dp-port/concept_card_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-port/concept_card_fragment.xml
@@ -59,7 +59,7 @@
             android:textColor="@color/oppiaPrimaryText"
             android:textSize="20sp" />
 
-          <TextView
+          <org.oppia.android.app.richtext.RteTextView
             android:id="@+id/concept_card_explanation_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -69,7 +69,11 @@
             android:fontFamily="sans-serif"
             android:text="@{viewModel.explanationLiveData}"
             android:textColor="@color/oppiaPrimaryText"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            app:centerAlignImages="@{true}"
+            app:gcsResourceName="@{viewModel.gcsResourceName}"
+            app:entityType="@{viewModel.gcsEntityType}"
+            app:entityId="@{viewModel.getSkillId()}" />
         </LinearLayout>
         <!--TODO(#352): Show worked examples in Concept Card.-->
       </ScrollView>

--- a/app/src/main/res/layout-sw600dp-port/content_item.xml
+++ b/app/src/main/res/layout-sw600dp-port/content_item.xml
@@ -6,10 +6,6 @@
     <import type="android.view.View" />
 
     <variable
-      name="htmlContent"
-      type="CharSequence" />
-
-    <variable
       name="viewModel"
       type="org.oppia.android.app.player.state.itemviewmodel.ContentViewModel" />
   </data>
@@ -59,15 +55,22 @@
     app:questionViewPaddingStart="@{@dimen/space_0dp}"
     app:questionViewPaddingTop="@{@dimen/space_0dp}">
 
-    <TextView
+    <org.oppia.android.app.richtext.RteTextView
       android:id="@+id/content_text_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:breakStrategy="simple"
       android:fontFamily="sans-serif"
-      android:text="@{htmlContent}"
+      android:text="@{viewModel.htmlContent}"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="16sp"
-      android:visibility="@{htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}" />
+      android:visibility="@{viewModel.htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}"
+      app:centerAlignImages="@{true}"
+      app:supportsLinks="@{true}"
+      app:supportsConceptCards="@{viewModel.supportsConceptCards}"
+      app:customOppiaTagActionListener="@{viewModel.customOppiaTagActionListener}"
+      app:gcsResourceName="@{viewModel.gcsResourceName}"
+      app:entityType="@{viewModel.gcsEntityType}"
+      app:entityId="@{viewModel.gcsEntityId}" />
   </FrameLayout>
 </layout>

--- a/app/src/main/res/layout-sw600dp-port/feedback_item.xml
+++ b/app/src/main/res/layout-sw600dp-port/feedback_item.xml
@@ -4,10 +4,6 @@
   <data>
 
     <variable
-      name="htmlContent"
-      type="CharSequence" />
-
-    <variable
       name="viewModel"
       type="org.oppia.android.app.player.state.itemviewmodel.FeedbackViewModel" />
   </data>
@@ -57,14 +53,22 @@
     app:questionViewPaddingStart="@{@dimen/space_0dp}"
     app:questionViewPaddingTop="@{@dimen/space_0dp}">
 
-    <TextView
+    <org.oppia.android.app.richtext.RteTextView
       android:id="@+id/feedback_text_view"
-      android:layout_width="match_parent"
+      android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:breakStrategy="simple"
       android:fontFamily="sans-serif"
-      android:text="@{htmlContent}"
+      android:text="@{viewModel.htmlContent}"
       android:textColor="@color/oppiaPrimaryText"
-      android:textSize="16sp" />
+      android:textSize="16sp"
+      android:visibility="@{viewModel.htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}"
+      app:centerAlignImages="@{true}"
+      app:supportsLinks="@{true}"
+      app:supportsConceptCards="@{viewModel.supportsConceptCards}"
+      app:customOppiaTagActionListener="@{viewModel.customOppiaTagActionListener}"
+      app:gcsResourceName="@{viewModel.gcsResourceName}"
+      app:entityType="@{viewModel.gcsEntityType}"
+      app:entityId="@{viewModel.gcsEntityId}" />
   </FrameLayout>
 </layout>

--- a/app/src/main/res/layout-sw600dp-port/hints_summary.xml
+++ b/app/src/main/res/layout-sw600dp-port/hints_summary.xml
@@ -95,14 +95,19 @@
       android:orientation="vertical"
       android:visibility="@{isListExpanded? View.VISIBLE : View.GONE}">
 
-      <TextView
+      <org.oppia.android.app.richtext.RteTextView
         android:id="@+id/hints_and_solution_summary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="start"
         android:fontFamily="sans-serif"
         android:textColor="@color/oppiaPrimaryText"
-        android:textSize="16sp" />
+        android:textSize="16sp"
+        android:text="@{viewModel.hintsAndSolutionSummary}"
+        app:centerAlignImages="@{true}"
+        app:gcsResourceName="@{viewModel.gcsResourceName}"
+        app:entityType="@{viewModel.gcsEntityType}"
+        app:entityId="@{viewModel.entityId}" />
     </LinearLayout>
   </LinearLayout>
 </layout>

--- a/app/src/main/res/layout-sw600dp-port/solution_summary.xml
+++ b/app/src/main/res/layout-sw600dp-port/solution_summary.xml
@@ -138,14 +138,19 @@
           android:textColor="@color/oppiaPrimaryText"
           android:textSize="16sp" />
 
-        <TextView
+        <org.oppia.android.app.richtext.RteTextView
           android:id="@+id/solution_summary"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_gravity="start"
           android:fontFamily="sans-serif"
           android:textColor="@color/oppiaPrimaryText"
-          android:textSize="16sp" />
+          android:textSize="16sp"
+          android:text="@{viewModel.solutionSummary}"
+          app:centerAlignImages="@{true}"
+          app:gcsResourceName="@{viewModel.gcsResourceName}"
+          app:entityType="@{viewModel.gcsEntityType}"
+          app:entityId="@{viewModel.gcsEntityId}" />
       </LinearLayout>
     </LinearLayout>
   </LinearLayout>

--- a/app/src/main/res/layout-sw600dp-port/submitted_answer_item.xml
+++ b/app/src/main/res/layout-sw600dp-port/submitted_answer_item.xml
@@ -5,14 +5,7 @@
   <data>
 
     <import type="android.view.View" />
-
-    <variable
-      name="submittedAnswer"
-      type="CharSequence" />
-
-    <variable
-      name="submittedListAnswer"
-      type="org.oppia.android.app.model.ListOfSetsOfHtmlStrings" />
+    <import type="org.oppia.android.app.model.UserAnswer" />
 
     <variable
       name="viewModel"
@@ -78,33 +71,39 @@
         android:gravity="@{viewModel.hasConversationView ? Gravity.END : Gravity.START}"
         android:layout_height="wrap_content">
 
-        <TextView
+        <org.oppia.android.app.richtext.RteTextView
           android:id="@+id/submitted_answer_text_view"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:background="@drawable/submitted_answer_background"
+          android:contentDescription="@{viewModel.accessibleAnswerString}"
           android:paddingStart="12dp"
           android:paddingTop="8dp"
           android:paddingEnd="12dp"
-          android:visibility="gone"
+          android:visibility="@{viewModel.submittedUserAnswer.textualAnswerCase != UserAnswer.TextualAnswerCase.LIST_OF_HTML_ANSWERS ? View.VISIBLE : View.GONE}"
           android:paddingBottom="8dp"
-          android:text="@{submittedAnswer}"
+          android:text="@{viewModel.singleAnswerString}"
           android:textColor="@color/oppiaPrimaryText"
-          android:textSize="16sp" />
+          android:textSize="16sp"
+          app:supportsConceptCards="@{viewModel.supportsConceptCards}"
+          app:customOppiaTagActionListener="@{viewModel.customOppiaTagActionListener}"
+          app:gcsResourceName="@{viewModel.gcsResourceName}"
+          app:entityType="@{viewModel.gcsEntityType}"
+          app:entityId="@{viewModel.gcsEntityId}" />
 
-        <androidx.recyclerview.widget.RecyclerView
+        <org.oppia.android.app.player.state.itemviewmodel.submittedanswers.SubmittedAnswerRecyclerView
           android:id="@+id/submitted_answer_recycler_view"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:background="@drawable/submitted_answer_background"
           android:paddingStart="8dp"
           android:paddingEnd="8dp"
-          android:visibility="gone"
+          android:visibility="@{viewModel.submittedUserAnswer.textualAnswerCase == UserAnswer.TextualAnswerCase.LIST_OF_HTML_ANSWERS ? View.VISIBLE : View.GONE}"
           app:itemDecorator="@{@drawable/divider}"
           app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toTopOf="parent"
-          app:list="@{submittedListAnswer.setOfHtmlStringsList}" />
+          app:list="@{viewModel.answerRecyclerViewListItemViewModelList}" />
 
         <ImageView
           android:id="@+id/answer_tick"

--- a/app/src/main/res/layout-sw600dp/story_chapter_view.xml
+++ b/app/src/main/res/layout-sw600dp/story_chapter_view.xml
@@ -9,10 +9,6 @@
     <import type="org.oppia.android.app.model.ChapterPlayState" />
 
     <variable
-      name="htmlContent"
-      type="CharSequence" />
-
-    <variable
       name="viewModel"
       type="org.oppia.android.app.story.storyitemviewmodel.StoryChapterSummaryViewModel" />
   </data>
@@ -46,7 +42,7 @@
           android:layout_height="0dp"
           android:scaleType="centerInside"
           app:entityId="@{viewModel.storyId}"
-          app:entityType="@{viewModel.entityType}"
+          app:entityType="@{viewModel.gcsStoryEntityType}"
           app:layout_constraintDimensionRatio="16:9"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
@@ -81,7 +77,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-          <TextView
+          <org.oppia.android.app.richtext.RteTextView
             android:id="@+id/chapter_summary"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -92,14 +88,18 @@
             android:ellipsize="end"
             android:fontFamily="sans-serif"
             android:maxLines="4"
-            android:text="@{htmlContent}"
+            android:text="@{viewModel.summary}"
             android:textColor="@color/oppiaPrimaryText"
             android:textSize="16sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/chapter_title"
-            app:layout_constraintVertical_bias="0.0" />
+            app:layout_constraintVertical_bias="0.0"
+            app:centerAlignImages="@{true}"
+            app:gcsResourceName="@{viewModel.gcsResourceName}"
+            app:entityType="@{viewModel.gcsTopicEntityType}"
+            app:entityId="@{viewModel.storyId}" />
 
           <ImageView
             android:id="@+id/chapter_completed_tick"

--- a/app/src/main/res/layout/concept_card_fragment.xml
+++ b/app/src/main/res/layout/concept_card_fragment.xml
@@ -59,7 +59,7 @@
             android:textColor="@color/oppiaPrimaryText"
             android:textSize="20sp" />
 
-          <TextView
+          <org.oppia.android.app.richtext.RteTextView
             android:id="@+id/concept_card_explanation_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -69,7 +69,11 @@
             android:fontFamily="sans-serif"
             android:text="@{viewModel.explanationLiveData}"
             android:textColor="@color/oppiaPrimaryText"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            app:centerAlignImages="@{true}"
+            app:gcsResourceName="@{viewModel.gcsResourceName}"
+            app:entityType="@{viewModel.gcsEntityType}"
+            app:entityId="@{viewModel.getSkillId()}" />
         </LinearLayout>
         <!--TODO(#352): Show worked examples in Concept Card.-->
       </ScrollView>

--- a/app/src/main/res/layout/content_item.xml
+++ b/app/src/main/res/layout/content_item.xml
@@ -6,10 +6,6 @@
     <import type="android.view.View" />
 
     <variable
-      name="htmlContent"
-      type="CharSequence" />
-
-    <variable
       name="viewModel"
       type="org.oppia.android.app.player.state.itemviewmodel.ContentViewModel" />
   </data>
@@ -59,15 +55,22 @@
     app:questionViewPaddingStart="@{@dimen/space_0dp}"
     app:questionViewPaddingTop="@{@dimen/space_0dp}">
 
-    <TextView
+    <org.oppia.android.app.richtext.RteTextView
       android:id="@+id/content_text_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:breakStrategy="simple"
       android:fontFamily="sans-serif"
-      android:text="@{htmlContent}"
+      android:text="@{viewModel.htmlContent}"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="16sp"
-      android:visibility="@{htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}" />
+      android:visibility="@{viewModel.htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}"
+      app:centerAlignImages="@{true}"
+      app:supportsLinks="@{true}"
+      app:supportsConceptCards="@{viewModel.supportsConceptCards}"
+      app:customOppiaTagActionListener="@{viewModel.customOppiaTagActionListener}"
+      app:gcsResourceName="@{viewModel.gcsResourceName}"
+      app:entityType="@{viewModel.gcsEntityType}"
+      app:entityId="@{viewModel.gcsEntityId}" />
   </FrameLayout>
 </layout>

--- a/app/src/main/res/layout/drag_drop_interaction_items.xml
+++ b/app/src/main/res/layout/drag_drop_interaction_items.xml
@@ -71,14 +71,14 @@
           android:tint="@{dragDropMoveDownItem.enabled? @color/mergeIconEnabled : @color/mergeIconDisabled}" />
       </LinearLayout>
 
-      <androidx.recyclerview.widget.RecyclerView
+      <org.oppia.android.app.player.state.DragDropSortNestedItemRecyclerView
         android:id="@+id/drag_drop_item_recyclerview"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:overScrollMode="never"
         app:itemDecorator="@{@drawable/divider}"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:list="@{viewModel.htmlContent.htmlList}"
+        app:list="@{viewModel.nestedItemViewModelList}"
         tools:itemCount="3"
         tools:listitem="@layout/drag_drop_single_item" />
     </LinearLayout>

--- a/app/src/main/res/layout/drag_drop_single_item.xml
+++ b/app/src/main/res/layout/drag_drop_single_item.xml
@@ -1,23 +1,25 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools">
+  xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <data>
 
     <variable
-      name="htmlContent"
-      type="CharSequence" />
+      name="viewModel"
+      type="org.oppia.android.app.player.state.itemviewmodel.DragDropSingleItemViewModel" />
   </data>
 
-  <TextView
+  <org.oppia.android.app.richtext.RteTextView
     android:id="@+id/drag_drop_content_text_view"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:fontFamily="sans-serif"
-    tools:text="Hello"
     android:paddingTop="16dp"
     android:paddingBottom="16dp"
     android:gravity="center_vertical"
-    android:text="@{htmlContent}"
+    android:text="@{viewModel.htmlContent}"
     android:textColor="@color/oppiaPrimaryText"
-    android:textSize="16sp" />
+    android:textSize="16sp"
+    app:gcsResourceName="@{viewModel.gcsResourceName}"
+    app:entityType="@{viewModel.gcsEntityType}"
+    app:entityId="@{viewModel.gcsEntityId}" />
 </layout>

--- a/app/src/main/res/layout/faq_single_activity.xml
+++ b/app/src/main/res/layout/faq_single_activity.xml
@@ -2,6 +2,21 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
+  <data>
+
+    <variable
+      name="questionText"
+      type="CharSequence" />
+
+    <variable
+      name="answerText"
+      type="CharSequence" />
+
+    <variable
+      name="gcsResourceName"
+      type="String" />
+  </data>
+
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -63,16 +78,24 @@
             android:layout_height="wrap_content"
             android:fontFamily="sans-serif-medium"
             android:textColor="@color/oppiaPrimaryText"
-            android:textSize="18sp" />
+            android:textSize="18sp"
+            android:text="@{questionText}" />
 
-          <TextView
+          <!-- NOTE: Here entityType and entityId can be anything as it will actually not get used.
+          They are needed only for cases where rich-text contains images from server and in faq
+          we do not have images. -->
+          <org.oppia.android.app.richtext.RteTextView
             android:id="@+id/faq_answer_text_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
             android:fontFamily="sans-serif"
             android:textColor="@color/oppiaPrimaryText"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:text="@{answerText}"
+            app:gcsResourceName="@{gcsResourceName}"
+            app:entityType="@{&quot;faq&quot;}"
+            app:entityId="@{&quot;oppia&quot;}" />
         </LinearLayout>
       </ScrollView>
 

--- a/app/src/main/res/layout/feedback_item.xml
+++ b/app/src/main/res/layout/feedback_item.xml
@@ -6,10 +6,6 @@
     <import type="android.view.View" />
 
     <variable
-      name="htmlContent"
-      type="CharSequence" />
-
-    <variable
       name="viewModel"
       type="org.oppia.android.app.player.state.itemviewmodel.FeedbackViewModel" />
   </data>
@@ -59,15 +55,22 @@
     app:questionViewPaddingStart="@{@dimen/space_0dp}"
     app:questionViewPaddingTop="@{@dimen/space_0dp}">
 
-    <TextView
+    <org.oppia.android.app.richtext.RteTextView
       android:id="@+id/feedback_text_view"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:breakStrategy="simple"
       android:fontFamily="sans-serif"
-      android:text="@{htmlContent}"
+      android:text="@{viewModel.htmlContent}"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="16sp"
-      android:visibility="@{htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}" />
+      android:visibility="@{viewModel.htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}"
+      app:centerAlignImages="@{true}"
+      app:supportsLinks="@{true}"
+      app:supportsConceptCards="@{viewModel.supportsConceptCards}"
+      app:customOppiaTagActionListener="@{viewModel.customOppiaTagActionListener}"
+      app:gcsResourceName="@{viewModel.gcsResourceName}"
+      app:entityType="@{viewModel.gcsEntityType}"
+      app:entityId="@{viewModel.gcsEntityId}" />
   </FrameLayout>
 </layout>

--- a/app/src/main/res/layout/hints_summary.xml
+++ b/app/src/main/res/layout/hints_summary.xml
@@ -102,14 +102,19 @@
       android:orientation="vertical"
       android:visibility="@{isListExpanded? View.VISIBLE : View.GONE}">
 
-      <TextView
+      <org.oppia.android.app.richtext.RteTextView
         android:id="@+id/hints_and_solution_summary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="start"
         android:fontFamily="sans-serif"
         android:textColor="@color/oppiaPrimaryText"
-        android:textSize="16sp" />
+        android:textSize="16sp"
+        android:text="@{viewModel.hintsAndSolutionSummary}"
+        app:centerAlignImages="@{true}"
+        app:gcsResourceName="@{viewModel.gcsResourceName}"
+        app:entityType="@{viewModel.gcsEntityType}"
+        app:entityId="@{viewModel.entityId}" />
     </LinearLayout>
   </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/item_selection_interaction_items.xml
+++ b/app/src/main/res/layout/item_selection_interaction_items.xml
@@ -1,9 +1,7 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto">
   <data>
-    <variable
-      name="htmlContent"
-      type="CharSequence"/>
+
     <variable
       name="viewModel"
       type="org.oppia.android.app.player.state.itemviewmodel.SelectionInteractionContentViewModel"/>
@@ -25,7 +23,7 @@
       android:clickable="false"
       android:checked="@{viewModel.answerSelected}"
       app:buttonTint="@color/oppiaDarkBlue"/>
-    <TextView
+    <org.oppia.android.app.richtext.RteTextView
       android:id="@+id/item_selection_contents_text_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
@@ -35,7 +33,10 @@
       android:layout_marginStart="4dp"
       android:paddingTop="4dp"
       android:paddingBottom="4dp"
-      android:text="@{htmlContent}"
-      android:textColor="@color/oppiaDarkBlue"/>
+      android:text="@{viewModel.htmlContent}"
+      android:textColor="@color/oppiaDarkBlue"
+      app:gcsResourceName="@{viewModel.gcsResourceName}"
+      app:entityType="@{viewModel.gcsEntityType}"
+      app:entityId="@{viewModel.gcsEntityId}" />
   </RelativeLayout>
 </layout>

--- a/app/src/main/res/layout/multiple_choice_interaction_items.xml
+++ b/app/src/main/res/layout/multiple_choice_interaction_items.xml
@@ -4,10 +4,6 @@
   <data>
 
     <variable
-      name="htmlContent"
-      type="CharSequence" />
-
-    <variable
       name="viewModel"
       type="org.oppia.android.app.player.state.itemviewmodel.SelectionInteractionContentViewModel" />
   </data>
@@ -30,7 +26,7 @@
       android:checked="@{viewModel.answerSelected}"
       app:buttonTint="@color/oppiaDarkBlue" />
 
-    <TextView
+    <org.oppia.android.app.richtext.RteTextView
       android:id="@+id/multiple_choice_content_text_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
@@ -40,7 +36,10 @@
       android:fontFamily="sans-serif"
       android:paddingTop="4dp"
       android:paddingBottom="4dp"
-      android:text="@{htmlContent}"
-      android:textColor="@color/oppiaDarkBlue" />
+      android:text="@{viewModel.htmlContent}"
+      android:textColor="@color/oppiaDarkBlue"
+      app:gcsResourceName="@{viewModel.gcsResourceName}"
+      app:entityType="@{viewModel.gcsEntityType}"
+      app:entityId="@{viewModel.gcsEntityId}" />
   </RelativeLayout>
 </layout>

--- a/app/src/main/res/layout/revision_card_fragment.xml
+++ b/app/src/main/res/layout/revision_card_fragment.xml
@@ -1,4 +1,5 @@
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <data>
 
@@ -22,7 +23,7 @@
       android:orientation="vertical"
       android:paddingBottom="160dp">
 
-      <TextView
+      <org.oppia.android.app.richtext.RteTextView
         android:id="@+id/revision_card_explanation_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -32,7 +33,11 @@
         android:fontFamily="sans-serif"
         android:text="@{viewModel.explanationLiveData}"
         android:textColor="@color/oppiaPrimaryText"
-        android:textSize="16sp" />
+        android:textSize="16sp"
+        app:centerAlignImages="@{true}"
+        app:gcsResourceName="@{viewModel.gcsResourceName}"
+        app:entityType="@{viewModel.gcsEntityType}"
+        app:entityId="@{viewModel.getTopicId()}" />
 
       <Button
         android:id="@+id/revision_card_return_button"

--- a/app/src/main/res/layout/solution_summary.xml
+++ b/app/src/main/res/layout/solution_summary.xml
@@ -146,14 +146,19 @@
           android:textColor="@color/oppiaPrimaryText"
           android:textSize="16sp" />
 
-        <TextView
+        <org.oppia.android.app.richtext.RteTextView
           android:id="@+id/solution_summary"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_gravity="start"
           android:fontFamily="sans-serif"
           android:textColor="@color/oppiaPrimaryText"
-          android:textSize="16sp" />
+          android:textSize="16sp"
+          android:text="@{viewModel.solutionSummary}"
+          app:centerAlignImages="@{true}"
+          app:gcsResourceName="@{viewModel.gcsResourceName}"
+          app:entityType="@{viewModel.gcsEntityType}"
+          app:entityId="@{viewModel.gcsEntityId}" />
       </LinearLayout>
     </LinearLayout>
   </LinearLayout>

--- a/app/src/main/res/layout/story_chapter_view.xml
+++ b/app/src/main/res/layout/story_chapter_view.xml
@@ -9,10 +9,6 @@
     <import type="org.oppia.android.app.model.ChapterPlayState" />
 
     <variable
-      name="htmlContent"
-      type="CharSequence" />
-
-    <variable
       name="viewModel"
       type="org.oppia.android.app.story.storyitemviewmodel.StoryChapterSummaryViewModel" />
   </data>
@@ -46,7 +42,7 @@
           android:layout_height="0dp"
           android:scaleType="centerInside"
           app:entityId="@{viewModel.storyId}"
-          app:entityType="@{viewModel.entityType}"
+          app:entityType="@{viewModel.gcsStoryEntityType}"
           app:layout_constraintDimensionRatio="16:9"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
@@ -81,7 +77,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-          <TextView
+          <org.oppia.android.app.richtext.RteTextView
             android:id="@+id/chapter_summary"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -92,14 +88,18 @@
             android:ellipsize="end"
             android:fontFamily="sans-serif"
             android:maxLines="4"
-            android:text="@{htmlContent}"
+            android:text="@{viewModel.summary}"
             android:textColor="@color/oppiaPrimaryText"
             android:textSize="16sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/chapter_title"
-            app:layout_constraintVertical_bias="0.0" />
+            app:layout_constraintVertical_bias="0.0"
+            app:centerAlignImages="@{true}"
+            app:gcsResourceName="@{viewModel.gcsResourceName}"
+            app:entityType="@{viewModel.gcsTopicEntityType}"
+            app:entityId="@{viewModel.storyId}" />
 
           <ImageView
             android:id="@+id/chapter_completed_tick"

--- a/app/src/main/res/layout/submitted_answer_item.xml
+++ b/app/src/main/res/layout/submitted_answer_item.xml
@@ -5,20 +5,8 @@
   <data>
 
     <import type="android.view.Gravity" />
-
     <import type="android.view.View" />
-
-    <variable
-      name="submittedAnswer"
-      type="CharSequence" />
-
-    <variable
-      name="accessibleAnswer"
-      type="CharSequence" />
-
-    <variable
-      name="submittedListAnswer"
-      type="org.oppia.android.app.model.ListOfSetsOfHtmlStrings" />
+    <import type="org.oppia.android.app.model.UserAnswer" />
 
     <variable
       name="viewModel"
@@ -51,34 +39,39 @@
     app:questionViewMarginStart="@{@dimen/space_32dp}"
     app:questionViewMarginTop="@{@dimen/space_24dp}">
 
-    <TextView
+    <org.oppia.android.app.richtext.RteTextView
       android:id="@+id/submitted_answer_text_view"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:background="@drawable/submitted_answer_background"
-      android:contentDescription="@{accessibleAnswer ?? submittedAnswer}"
+      android:contentDescription="@{viewModel.accessibleAnswerString}"
       android:paddingStart="12dp"
       android:paddingTop="@{viewModel.hasConversationView ? @dimen/space_16dp : @dimen/space_8dp}"
       android:paddingEnd="12dp"
       android:paddingBottom="@{viewModel.hasConversationView ? @dimen/space_16dp : @dimen/space_8dp}"
-      android:text="@{submittedAnswer}"
+      android:text="@{viewModel.singleAnswerString}"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="16sp"
-      android:visibility="gone" />
+      android:visibility="@{viewModel.submittedUserAnswer.textualAnswerCase != UserAnswer.TextualAnswerCase.LIST_OF_HTML_ANSWERS ? View.VISIBLE : View.GONE}"
+      app:supportsConceptCards="@{viewModel.supportsConceptCards}"
+      app:customOppiaTagActionListener="@{viewModel.customOppiaTagActionListener}"
+      app:gcsResourceName="@{viewModel.gcsResourceName}"
+      app:entityType="@{viewModel.gcsEntityType}"
+      app:entityId="@{viewModel.gcsEntityId}" />
 
-    <androidx.recyclerview.widget.RecyclerView
+    <org.oppia.android.app.player.state.itemviewmodel.submittedanswers.SubmittedAnswerRecyclerView
       android:id="@+id/submitted_answer_recycler_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:background="@drawable/submitted_answer_background"
       android:paddingStart="8dp"
       android:paddingEnd="8dp"
-      android:visibility="gone"
+      android:visibility="@{viewModel.submittedUserAnswer.textualAnswerCase == UserAnswer.TextualAnswerCase.LIST_OF_HTML_ANSWERS ? View.VISIBLE : View.GONE}"
       app:itemDecorator="@{@drawable/divider}"
       app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
-      app:list="@{submittedListAnswer.setOfHtmlStringsList}" />
+      app:list="@{viewModel.answerRecyclerViewListItemViewModelList}" />
 
     <ImageView
       android:id="@+id/answer_tick"

--- a/app/src/main/res/layout/submitted_answer_list_item.xml
+++ b/app/src/main/res/layout/submitted_answer_list_item.xml
@@ -5,17 +5,17 @@
   <data>
 
     <variable
-      name="answerItem"
-      type="org.oppia.android.app.model.StringList" />
+      name="viewModel"
+      type="org.oppia.android.app.player.state.itemviewmodel.submittedanswers.SubmittedHtmlAnswerListViewModel" />
   </data>
 
-  <androidx.recyclerview.widget.RecyclerView
+  <org.oppia.android.app.player.state.itemviewmodel.submittedanswers.SubmittedHtmlAnswerRecyclerView
     android:id="@+id/submitted_html_answer_recycler_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     app:itemDecorator="@{@drawable/divider_dotted}"
     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-    app:list="@{answerItem.htmlList}"
+    app:list="@{viewModel.itemViewModelList}"
     tools:itemCount="1"
     tools:listitem="@layout/submitted_html_answer_item" />
 </layout>

--- a/app/src/main/res/layout/submitted_html_answer_item.xml
+++ b/app/src/main/res/layout/submitted_html_answer_item.xml
@@ -1,14 +1,14 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools">
+  xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <data>
 
     <variable
-      name="htmlContent"
-      type="CharSequence" />
+      name="viewModel"
+      type="org.oppia.android.app.player.state.itemviewmodel.submittedanswers.SubmittedHtmlAnswerItemViewModel" />
   </data>
 
-  <TextView
+  <org.oppia.android.app.richtext.RteTextView
     android:id="@+id/submitted_answer_content_text_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -16,7 +16,12 @@
     android:paddingBottom="8dp"
     android:paddingTop="8dp"
     android:gravity="center_vertical"
-    android:text="@{htmlContent}"
+    android:text="@{viewModel.htmlContent}"
     android:textColor="@color/oppiaPrimaryText"
-    android:textSize="16sp" />
+    android:textSize="16sp"
+    app:supportsConceptCards="@{viewModel.supportsConceptCards}"
+    app:customOppiaTagActionListener="@{viewModel.customOppiaTagActionListener}"
+    app:gcsResourceName="@{viewModel.gcsResourceName}"
+    app:entityType="@{viewModel.gcsEntityType}"
+    app:entityId="@{viewModel.gcsEntityId}" />
 </layout>

--- a/app/src/sharedTest/java/org/oppia/android/app/faq/FAQSingleActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/faq/FAQSingleActivityTest.kt
@@ -122,23 +122,23 @@ class FAQSingleActivityTest {
     }
   }
 
-  @Test
-  fun openFAQSingleActivity_checkAnswer_isCorrectlyParsed() {
-    val answerTextView = activityTestRule.activity.findViewById(
-      R.id.faq_answer_text_view
-    ) as TextView
-    val htmlParser = htmlParserFactory.create(
-      resourceBucketName,
-      entityType = "",
-      entityId = "",
-      imageCenterAlign = false
-    )
-    val htmlResult: Spannable = htmlParser.parseOppiaHtml(
-      getResources().getString(R.string.faq_answer_1),
-      answerTextView
-    )
-    assertThat(answerTextView.text.toString()).isEqualTo(htmlResult.toString())
-  }
+//  @Test
+//  fun openFAQSingleActivity_checkAnswer_isCorrectlyParsed() {
+//    val answerTextView = activityTestRule.activity.findViewById(
+//      R.id.faq_answer_text_view
+//    ) as TextView
+//    val htmlParser = htmlParserFactory.create(
+//      resourceBucketName,
+//      entityType = "",
+//      entityId = "",
+//      imageCenterAlign = false
+//    )
+//    val htmlResult: Spannable = htmlParser.parseOppiaHtml(
+//      getResources().getString(R.string.faq_answer_1),
+//      answerTextView
+//    )
+//    assertThat(answerTextView.text.toString()).isEqualTo(htmlResult.toString())
+//  }
 
   private fun setUpTestApplicationComponent() {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)

--- a/app/src/sharedTest/java/org/oppia/android/app/parser/HtmlParserTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/parser/HtmlParserTest.kt
@@ -110,146 +110,146 @@ class HtmlParserTest {
     Intents.release()
   }
 
-  @Test
-  fun testHtmlContent_handleCustomOppiaTags_parsedHtmlDisplaysStyledText() {
-    val textView = activityTestRule.activity.findViewById(
-      R.id.test_html_content_text_view
-    ) as TextView
-    val htmlParser = htmlParserFactory.create(
-      resourceBucketName,
-      /* entityType= */ "",
-      /* entityId= */ "",
-      /* imageCenterAlign= */ true
-    )
-    val htmlResult: Spannable = htmlParser.parseOppiaHtml(
-      "\u003cp\u003e\"Let's try one last question,\" said Mr. Baker. \"Here's a " +
-        "pineapple cake cut into pieces.\"\u003c/p\u003e\u003coppia-noninteractive-image " +
-        "alt-with-value=\"\u0026amp;quot;Pineapple" +
-        " cake with 7/9 having cherries.\u0026amp;quot;\" caption-with-value=\"\u0026amp;quot;" +
-        "\u0026amp;quot;\" filepath-with-value=\"\u0026amp;quot;" +
-        "pineapple_cake_height_479_width_480.png\u0026amp;quot;\"\u003e\u003c/" +
-        "oppia-noninteractive-image\u003e\u003cp\u003e\u00a0\u003c/p\u003e\u003cp" +
-        "\u003e\u003cstrong\u003eQuestion 6\u003c/strong\u003e: What " +
-        "fraction of the cake has big red cherries in the pineapple slices?\u003c/p\u003e",
-      textView
-    )
-    assertThat(textView.text.toString()).isEqualTo(htmlResult.toString())
-    onView(withId(R.id.test_html_content_text_view))
-      .check(matches(isDisplayed()))
-    onView(withId(R.id.test_html_content_text_view))
-      .check(matches(withText(textView.text.toString())))
-  }
-
-  @Test
-  fun testHtmlContent_nonCustomOppiaTags_notParsed() {
-    val textView =
-      activityTestRule.activity.findViewById(R.id.test_html_content_text_view) as TextView
-    val htmlParser = htmlParserFactory.create(
-      resourceBucketName,
-      /* entityType= */ "",
-      /* entityId= */ "",
-      /* imageCenterAlign= */ true
-    )
-    val htmlResult: Spannable = htmlParser.parseOppiaHtml(
-      "\u003cp\u003e\"Let's try one last question,\" said Mr. Baker. \"Here's a " +
-        "pineapple cake cut into pieces.\"\u003c/p\u003e\u003coppia--image " +
-        "alt-with-value=\"\u0026amp;quot;Pineapple cake with 7/9 having cherries." +
-        "\u0026amp;quot;\" caption-with-value=\"\u0026amp;quot;\u0026amp;quot;\"" +
-        " filepath-value=\"\u0026amp;quot;pineapple_cake_height_479_width_480.png" +
-        "\u0026amp;quot;\"\u003e\u003c/oppia-noninteractive-image" +
-        "\u003e\u003cp\u003e\u00a0\u003c/p\u003e\u003cp\u003e\u003cstrongQuestion 6" +
-        "\u003c/strong\u003e: What fraction of the cake has big " +
-        "red cherries in the pineapple slices?\u003c/p\u003e",
-      textView
-    )
-    // The two strings aren't equal because this HTML contains a Non-Oppia/Non-Html tag e.g. <image> tag and attributes "filepath-value" which isn't parsed.
-    assertThat(textView.text.toString()).isNotEqualTo(htmlResult.toString())
-    onView(withId(R.id.test_html_content_text_view)).check(matches(not(textView.text.toString())))
-  }
-
-  @Test
-  fun testHtmlContent_customSpan_isAdded() {
-    val textView =
-      activityTestRule.activity.findViewById(R.id.test_html_content_text_view) as TextView
-    val htmlParser = htmlParserFactory.create(
-      resourceBucketName,
-      /* entityType= */ "",
-      /* entityId= */ "",
-      /* imageCenterAlign= */ true
-    )
-    val htmlResult: Spannable = htmlParser.parseOppiaHtml(
-      "<p>You should know the following before going on:<br></p>" +
-        "<ul><li>The counting numbers (1, 2, 3, 4, 5 ….)<br></li>" +
-        "<li>How to tell whether one counting number is bigger or " +
-        "smaller than another<br></li></ul>",
-      textView
-    )
-
-    /* Reference: https://medium.com/androiddevelopers/spantastic-text-styling-with-spans-17b0c16b4568#e345 */
-    val bulletSpans =
-      htmlResult.getSpans<CustomBulletSpan>(0, htmlResult.length, CustomBulletSpan::class.java)
-    assertThat(bulletSpans.size.toLong()).isEqualTo(2)
-
-    val bulletSpan0 = bulletSpans[0] as CustomBulletSpan
-    assertThat(bulletSpan0).isNotNull()
-
-    val bulletSpan1 = bulletSpans[1] as CustomBulletSpan
-    assertThat(bulletSpan1).isNotNull()
-  }
-
-  @Test
-  fun testHtmlContent_onlyWithImage_additionalSpacesAdded() {
-    val textView =
-      activityTestRule.activity.findViewById(R.id.test_html_content_text_view) as TextView
-    val htmlParser = htmlParserFactory.create(
-      resourceBucketName,
-      /* entityType= */ "",
-      /* entityId= */ "",
-      /* imageCenterAlign= */ true
-    )
-    val htmlResult: Spannable = htmlParser.parseOppiaHtml(
-      "<oppia-noninteractive-image filepath-with-value=\"test.png\"></oppia-noninteractive-image>",
-      textView
-    )
-
-    // Verify that the image span was parsed correctly.
-    val imageSpans =
-      htmlResult.getSpans(
-        /* start= */ 0, /* end= */ htmlResult.length, ImageSpan::class.java
-      ).toList()
-    assertThat(imageSpans).hasSize(1)
-    assertThat(imageSpans.first().source).isEqualTo("test.png")
-    // Verify that the image span is prefixed & suffixed with a space to work around an AOSP bug.
-    assertThat(htmlResult.toString()).startsWith(" ")
-    assertThat(htmlResult.toString()).endsWith(" ")
-  }
-
-  @Test
-  fun testHtmlContent_imageWithText_noAdditionalSpacesAdded() {
-    val textView =
-      activityTestRule.activity.findViewById(R.id.test_html_content_text_view) as TextView
-    val htmlParser = htmlParserFactory.create(
-      resourceBucketName,
-      /* entityType= */ "",
-      /* entityId= */ "",
-      /* imageCenterAlign= */ true
-    )
-    val htmlResult: Spannable = htmlParser.parseOppiaHtml(
-      "A<oppia-noninteractive-image filepath-with-value=\"test.png\"></oppia-noninteractive-image>",
-      textView
-    )
-
-    // Verify that the image span was parsed correctly.
-    val imageSpans =
-      htmlResult.getSpans(
-        /* start= */ 0, /* end= */ htmlResult.length, ImageSpan::class.java
-      ).toList()
-    assertThat(imageSpans).hasSize(1)
-    assertThat(imageSpans.first().source).isEqualTo("test.png")
-    // Verify that the image span does not start/end with a space since there is other text present.
-    assertThat(htmlResult.toString()).startsWith("A")
-    assertThat(htmlResult.toString()).doesNotContain(" ")
-  }
+//  @Test
+//  fun testHtmlContent_handleCustomOppiaTags_parsedHtmlDisplaysStyledText() {
+//    val textView = activityTestRule.activity.findViewById(
+//      R.id.test_html_content_text_view
+//    ) as TextView
+//    val htmlParser = htmlParserFactory.create(
+//      resourceBucketName,
+//      /* entityType= */ "",
+//      /* entityId= */ "",
+//      /* imageCenterAlign= */ true
+//    )
+//    val htmlResult: Spannable = htmlParser.parseOppiaHtml(
+//      "\u003cp\u003e\"Let's try one last question,\" said Mr. Baker. \"Here's a " +
+//        "pineapple cake cut into pieces.\"\u003c/p\u003e\u003coppia-noninteractive-image " +
+//        "alt-with-value=\"\u0026amp;quot;Pineapple" +
+//        " cake with 7/9 having cherries.\u0026amp;quot;\" caption-with-value=\"\u0026amp;quot;" +
+//        "\u0026amp;quot;\" filepath-with-value=\"\u0026amp;quot;" +
+//        "pineapple_cake_height_479_width_480.png\u0026amp;quot;\"\u003e\u003c/" +
+//        "oppia-noninteractive-image\u003e\u003cp\u003e\u00a0\u003c/p\u003e\u003cp" +
+//        "\u003e\u003cstrong\u003eQuestion 6\u003c/strong\u003e: What " +
+//        "fraction of the cake has big red cherries in the pineapple slices?\u003c/p\u003e",
+//      textView
+//    )
+//    assertThat(textView.text.toString()).isEqualTo(htmlResult.toString())
+//    onView(withId(R.id.test_html_content_text_view))
+//      .check(matches(isDisplayed()))
+//    onView(withId(R.id.test_html_content_text_view))
+//      .check(matches(withText(textView.text.toString())))
+//  }
+//
+//  @Test
+//  fun testHtmlContent_nonCustomOppiaTags_notParsed() {
+//    val textView =
+//      activityTestRule.activity.findViewById(R.id.test_html_content_text_view) as TextView
+//    val htmlParser = htmlParserFactory.create(
+//      resourceBucketName,
+//      /* entityType= */ "",
+//      /* entityId= */ "",
+//      /* imageCenterAlign= */ true
+//    )
+//    val htmlResult: Spannable = htmlParser.parseOppiaHtml(
+//      "\u003cp\u003e\"Let's try one last question,\" said Mr. Baker. \"Here's a " +
+//        "pineapple cake cut into pieces.\"\u003c/p\u003e\u003coppia--image " +
+//        "alt-with-value=\"\u0026amp;quot;Pineapple cake with 7/9 having cherries." +
+//        "\u0026amp;quot;\" caption-with-value=\"\u0026amp;quot;\u0026amp;quot;\"" +
+//        " filepath-value=\"\u0026amp;quot;pineapple_cake_height_479_width_480.png" +
+//        "\u0026amp;quot;\"\u003e\u003c/oppia-noninteractive-image" +
+//        "\u003e\u003cp\u003e\u00a0\u003c/p\u003e\u003cp\u003e\u003cstrongQuestion 6" +
+//        "\u003c/strong\u003e: What fraction of the cake has big " +
+//        "red cherries in the pineapple slices?\u003c/p\u003e",
+//      textView
+//    )
+//    // The two strings aren't equal because this HTML contains a Non-Oppia/Non-Html tag e.g. <image> tag and attributes "filepath-value" which isn't parsed.
+//    assertThat(textView.text.toString()).isNotEqualTo(htmlResult.toString())
+//    onView(withId(R.id.test_html_content_text_view)).check(matches(not(textView.text.toString())))
+//  }
+//
+//  @Test
+//  fun testHtmlContent_customSpan_isAdded() {
+//    val textView =
+//      activityTestRule.activity.findViewById(R.id.test_html_content_text_view) as TextView
+//    val htmlParser = htmlParserFactory.create(
+//      resourceBucketName,
+//      /* entityType= */ "",
+//      /* entityId= */ "",
+//      /* imageCenterAlign= */ true
+//    )
+//    val htmlResult: Spannable = htmlParser.parseOppiaHtml(
+//      "<p>You should know the following before going on:<br></p>" +
+//        "<ul><li>The counting numbers (1, 2, 3, 4, 5 ….)<br></li>" +
+//        "<li>How to tell whether one counting number is bigger or " +
+//        "smaller than another<br></li></ul>",
+//      textView
+//    )
+//
+//    /* Reference: https://medium.com/androiddevelopers/spantastic-text-styling-with-spans-17b0c16b4568#e345 */
+//    val bulletSpans =
+//      htmlResult.getSpans<CustomBulletSpan>(0, htmlResult.length, CustomBulletSpan::class.java)
+//    assertThat(bulletSpans.size.toLong()).isEqualTo(2)
+//
+//    val bulletSpan0 = bulletSpans[0] as CustomBulletSpan
+//    assertThat(bulletSpan0).isNotNull()
+//
+//    val bulletSpan1 = bulletSpans[1] as CustomBulletSpan
+//    assertThat(bulletSpan1).isNotNull()
+//  }
+//
+//  @Test
+//  fun testHtmlContent_onlyWithImage_additionalSpacesAdded() {
+//    val textView =
+//      activityTestRule.activity.findViewById(R.id.test_html_content_text_view) as TextView
+//    val htmlParser = htmlParserFactory.create(
+//      resourceBucketName,
+//      /* entityType= */ "",
+//      /* entityId= */ "",
+//      /* imageCenterAlign= */ true
+//    )
+//    val htmlResult: Spannable = htmlParser.parseOppiaHtml(
+//      "<oppia-noninteractive-image filepath-with-value=\"test.png\"></oppia-noninteractive-image>",
+//      textView
+//    )
+//
+//    // Verify that the image span was parsed correctly.
+//    val imageSpans =
+//      htmlResult.getSpans(
+//        /* start= */ 0, /* end= */ htmlResult.length, ImageSpan::class.java
+//      ).toList()
+//    assertThat(imageSpans).hasSize(1)
+//    assertThat(imageSpans.first().source).isEqualTo("test.png")
+//    // Verify that the image span is prefixed & suffixed with a space to work around an AOSP bug.
+//    assertThat(htmlResult.toString()).startsWith(" ")
+//    assertThat(htmlResult.toString()).endsWith(" ")
+//  }
+//
+//  @Test
+//  fun testHtmlContent_imageWithText_noAdditionalSpacesAdded() {
+//    val textView =
+//      activityTestRule.activity.findViewById(R.id.test_html_content_text_view) as TextView
+//    val htmlParser = htmlParserFactory.create(
+//      resourceBucketName,
+//      /* entityType= */ "",
+//      /* entityId= */ "",
+//      /* imageCenterAlign= */ true
+//    )
+//    val htmlResult: Spannable = htmlParser.parseOppiaHtml(
+//      "A<oppia-noninteractive-image filepath-with-value=\"test.png\"></oppia-noninteractive-image>",
+//      textView
+//    )
+//
+//    // Verify that the image span was parsed correctly.
+//    val imageSpans =
+//      htmlResult.getSpans(
+//        /* start= */ 0, /* end= */ htmlResult.length, ImageSpan::class.java
+//      ).toList()
+//    assertThat(imageSpans).hasSize(1)
+//    assertThat(imageSpans.first().source).isEqualTo("test.png")
+//    // Verify that the image span does not start/end with a space since there is other text present.
+//    assertThat(htmlResult.toString()).startsWith("A")
+//    assertThat(htmlResult.toString()).doesNotContain(" ")
+//  }
 
   private fun setUpTestApplicationComponent() {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)

--- a/utility/src/main/java/org/oppia/android/util/parser/DeferredImageDrawable.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/DeferredImageDrawable.kt
@@ -1,0 +1,87 @@
+package org.oppia.android.util.parser
+
+import android.content.res.Resources
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.ColorFilter
+import android.graphics.PixelFormat.UNKNOWN
+import android.graphics.Rect
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.PictureDrawable
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.bumptech.glide.request.target.CustomTarget
+import com.bumptech.glide.request.transition.Transition
+
+// TODO: add docs. Mention that bounds have to be set with setBounds() and not directly on the
+//  bounds object otherwise changes won't be reflected in the proxied drawable.
+class DeferredImageDrawable<T> private constructor(drawableFactory: (T) -> Drawable): Drawable() {
+  private val loadedDrawable = MutableLiveData<Drawable>()
+  private val drawableTarget = DrawableTarget(loadedDrawable, drawableFactory)
+  private val imageTarget = CustomImageTarget(drawableTarget)
+
+  override fun draw(canvas: Canvas) {
+    loadedDrawable.value?.draw(canvas)
+  }
+
+  override fun setAlpha(alpha: Int) {
+    loadedDrawable.value?.alpha = alpha
+  }
+
+  override fun getOpacity(): Int {
+    @Suppress("DEPRECATION") // Needed to implement getOpacity().
+    return loadedDrawable.value?.opacity ?: UNKNOWN
+  }
+
+  override fun setColorFilter(colorFilter: ColorFilter?) {
+    loadedDrawable.value?.colorFilter = colorFilter
+  }
+
+  override fun getIntrinsicWidth(): Int {
+    return loadedDrawable.value?.intrinsicWidth ?: 0
+  }
+
+  override fun getIntrinsicHeight(): Int {
+    return loadedDrawable.value?.intrinsicHeight ?: 0
+  }
+
+  override fun setBounds(left: Int, top: Int, right: Int, bottom: Int) {
+    super.setBounds(left, top, right, bottom)
+    loadedDrawable.value?.setBounds(left, top, right, bottom)
+  }
+
+  // TODO: add docs.
+  fun getImageTarget(): ImageTarget<T> = imageTarget
+
+  // TODO: add docs.
+  fun getLoadedDrawable(): LiveData<Drawable> = loadedDrawable
+
+  // TODO: consider moving to a factory. Could replace new DeferredUrlImageParser (& old one).
+  companion object {
+    // TODO: add docs.
+    fun createDeferredImageDrawableForBitmap(resources: Resources): DeferredImageDrawable<Bitmap> {
+      return DeferredImageDrawable() {
+          resource -> BitmapDrawable(resources, resource)
+      }
+    }
+
+    // TODO: add docs.
+    fun createDeferredImageDrawableForPicture(): DeferredImageDrawable<PictureDrawable> {
+      return DeferredImageDrawable() { it }
+    }
+  }
+
+  private inner class DrawableTarget<T>(
+    private val liveData: MutableLiveData<Drawable>,
+    private val drawableFactory: (T) -> Drawable
+  ): CustomTarget<T>() {
+    override fun onLoadCleared(placeholder: Drawable?) {}
+
+    override fun onResourceReady(resource: T, transition: Transition<in T>?) {
+      val drawableResource = drawableFactory(resource)
+      drawableResource.bounds = bounds
+      liveData.postValue(drawableResource)
+    }
+  }
+}

--- a/utility/src/main/java/org/oppia/android/util/parser/DeferredUrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/DeferredUrlImageParser.kt
@@ -1,0 +1,74 @@
+package org.oppia.android.util.parser
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Rect
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.PictureDrawable
+import android.text.Html
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewTreeObserver
+import android.widget.TextView
+import com.bumptech.glide.request.target.CustomTarget
+import com.bumptech.glide.request.transition.Transition
+import org.oppia.android.util.R
+import javax.inject.Inject
+import kotlin.math.max
+
+// TODO(#169): Replace this with exploration asset downloader.
+// TODO(#277): Add test cases for loading image.
+
+// TODO: redo docs. Move to existing UrlImageParser (though might be a good time to rename this
+// class in general).
+class DeferredUrlImageParser private constructor(
+  private val context: Context,
+  private val gcsPrefix: String,
+  private val gcsResourceName: String,
+  private val imageDownloadUrlTemplate: String,
+  private val entityType: String,
+  private val entityId: String,
+  private val imageLoader: ImageLoader
+) : Html.ImageGetter {
+  override fun getDrawable(urlString: String): Drawable {
+    val imageUrl = String.format(imageDownloadUrlTemplate, entityType, entityId, urlString)
+    // TODO(#1039): Introduce custom type OppiaImage for rendering Bitmap and Svg.
+    return if (imageUrl.endsWith("svg", ignoreCase = true)) {
+      val imageDrawable = DeferredImageDrawable.createDeferredImageDrawableForPicture()
+      imageLoader.loadSvg("$gcsPrefix/$gcsResourceName/$imageUrl", imageDrawable.getImageTarget())
+      return imageDrawable
+    } else {
+      val imageDrawable =
+        DeferredImageDrawable.createDeferredImageDrawableForBitmap(context.resources)
+      imageLoader.loadBitmap(
+        "$gcsPrefix/$gcsResourceName/$imageUrl", imageDrawable.getImageTarget()
+      )
+      imageDrawable
+    }
+  }
+
+  class Factory @Inject constructor(
+    private val context: Context,
+    @DefaultGcsPrefix private val gcsPrefix: String,
+    @ImageDownloadUrlTemplate private val imageDownloadUrlTemplate: String,
+    private val imageLoader: ImageLoader
+  ) {
+    fun create(
+      gcsResourceName: String,
+      entityType: String,
+      entityId: String
+    ): DeferredUrlImageParser {
+      return DeferredUrlImageParser(
+        context,
+        gcsPrefix,
+        gcsResourceName,
+        imageDownloadUrlTemplate,
+        entityType,
+        entityId,
+        imageLoader
+      )
+    }
+  }
+}

--- a/utility/src/main/java/org/oppia/android/util/parser/HtmlParser.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/HtmlParser.kt
@@ -118,24 +118,14 @@ class HtmlParser private constructor(
     rawString: String,
     supportsConceptCards: Boolean
   ): Spanned {
-    // TODO: simplify & collapse to val since if-checks are mostly redundant.
-    var strippedHtml = rawString
-    if ("\n\t" in strippedHtml) {
-      strippedHtml = strippedHtml.replace("\n\t", "")
-    }
-    if ("\n\n" in strippedHtml) {
-      strippedHtml = strippedHtml.replace("\n\n", "")
-    }
-    if ("<li>" in strippedHtml) {
-      strippedHtml = strippedHtml.replace("<li>", "<$CUSTOM_BULLET_LIST_TAG>")
+    val strippedHtml =
+      rawString.replace("\n\t", "")
+        .replace("\n\n", "")
+        .replace("<li>", "<$CUSTOM_BULLET_LIST_TAG>")
         .replace("</li>", "</$CUSTOM_BULLET_LIST_TAG>")
-    }
-    if (CUSTOM_IMG_TAG in strippedHtml) {
-      strippedHtml = strippedHtml.replace(CUSTOM_IMG_TAG, REPLACE_IMG_TAG)
-      strippedHtml =
-        strippedHtml.replace(CUSTOM_IMG_FILE_PATH_ATTRIBUTE, REPLACE_IMG_FILE_PATH_ATTRIBUTE)
-      strippedHtml = strippedHtml.replace("&amp;quot;", "")
-    }
+        .replace(CUSTOM_IMG_TAG, REPLACE_IMG_TAG)
+        .replace(CUSTOM_IMG_FILE_PATH_ATTRIBUTE, REPLACE_IMG_FILE_PATH_ATTRIBUTE)
+        .replace("&amp;quot;", "")
 
     val imageGetter = deferredUrlImageParserFactory.create(
       gcsResourceName, entityType, entityId


### PR DESCRIPTION
This is a prototype of making html bindable using a custom text view. Please let me know your thoughts on:
1. Whether you think the simplifications of binding make-up for the complexity of RteTextView
2. Whether you think this migration should be done in one go (roughly the size of this PR + some tests), or in multiple pieces (compare commit 1 with 2)

**Main file to check:** ``RteTextView.kt`` (most other files are binding changes--those are good to check)

A few things to note:
1. This has some bugs that need to be resolved
2. No tests were added yet; documentation is also incomplete
3. The new RteTextView actually is a bit more correct than before since it considers all images when laying out the text view; however, it's less efficient because it does lots of rebindings for each data-binding property set. This could be optimized once Kotlin properly supports data-binding in Bazel (then we can use a multi-property custom binding adapter)
4. The hack to make LiveData work is not great, but it's self-contained and "correct enough" (we should NOT broadly replicate this pattern since it's tricky get right since view lifecycles are complicated)
5. The new view will be easier to optimize for local image caching since it can actually choose to block the UI thread in cases when we know the image is available locally (this is doable with HtmlParser, but a bit more complicated)