### PR TITLE
Fix #1589: Naming consistency for domain data provider id

### DIFF
--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
@@ -10,7 +10,6 @@ import org.oppia.android.util.data.DataProviders
 import org.oppia.android.util.system.OppiaClock
 import javax.inject.Inject
 
-//xplorationDataController
 private const val EXPLORATION_DATA_CONTROLLER_PROVIDER_ID = "exploration_data_controller_provider_id"
 
 /**

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
@@ -10,7 +10,8 @@ import org.oppia.android.util.data.DataProviders
 import org.oppia.android.util.system.OppiaClock
 import javax.inject.Inject
 
-private const val EXPLORATION_DATA_PROVIDER_ID = "ExplorationDataProvider"
+//xplorationDataController
+private const val EXPLORATION_DATA_CONTROLLER_PROVIDER_ID = "exploration_data_controller_provider_id"
 
 /**
  * Controller for loading explorations by ID, or beginning to play an exploration.
@@ -28,7 +29,7 @@ class ExplorationDataController @Inject constructor(
   /** Returns an [Exploration] given an ID. */
   fun getExplorationById(id: String): DataProvider<Exploration> {
     return dataProviders.createInMemoryDataProviderAsync(
-      EXPLORATION_DATA_PROVIDER_ID
+      EXPLORATION_DATA_CONTROLLER_PROVIDER_ID
     ) {
       retrieveExplorationById(id)
     }

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
@@ -10,7 +10,8 @@ import org.oppia.android.util.data.DataProviders
 import org.oppia.android.util.system.OppiaClock
 import javax.inject.Inject
 
-private const val EXPLORATION_DATA_CONTROLLER_PROVIDER_ID = "exploration_data_controller_provider_id"
+private const val EXPLORATION_DATA_CONTROLLER_PROVIDER_ID =
+  "exploration_data_controller_provider_id"
 
 /**
  * Controller for loading explorations by ID, or beginning to play an exploration.

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
@@ -10,8 +10,8 @@ import org.oppia.android.util.data.DataProviders
 import org.oppia.android.util.system.OppiaClock
 import javax.inject.Inject
 
-private const val EXPLORATION_DATA_CONTROLLER_PROVIDER_ID =
-  "exploration_data_controller_provider_id"
+private const val GET_EXPLORATION_BY_ID_PROVIDER_ID =
+  "get_exploration_by_id_provider_id"
 
 /**
  * Controller for loading explorations by ID, or beginning to play an exploration.
@@ -29,7 +29,7 @@ class ExplorationDataController @Inject constructor(
   /** Returns an [Exploration] given an ID. */
   fun getExplorationById(id: String): DataProvider<Exploration> {
     return dataProviders.createInMemoryDataProviderAsync(
-      EXPLORATION_DATA_CONTROLLER_PROVIDER_ID
+      GET_EXPLORATION_BY_ID_PROVIDER_ID
     ) {
       retrieveExplorationById(id)
     }

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
@@ -21,7 +21,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.concurrent.withLock
 
-//beginExplorationAsync
 private const val CURRENT_STATE_DATA_PROVIDER_ID = "current_state_data_provider_id"
 
 

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
@@ -21,7 +21,9 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.concurrent.withLock
 
-private const val CURRENT_STATE_DATA_PROVIDER_ID = "CurrentStateDataProvider"
+//beginExplorationAsync
+private const val CURRENT_STATE_DATA_PROVIDER_ID = "current_state_data_provider_id"
+
 
 /**
  * Controller that tracks and reports the learner's ephemeral/non-persisted progress through an

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
@@ -22,8 +22,6 @@ import javax.inject.Singleton
 import kotlin.concurrent.withLock
 
 private const val CURRENT_STATE_DATA_PROVIDER_ID = "current_state_data_provider_id"
-
-
 /**
  * Controller that tracks and reports the learner's ephemeral/non-persisted progress through an
  * exploration. Note that this controller only supports one active exploration at a time.

--- a/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
@@ -33,7 +33,6 @@ import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
-//getProfiles
 private const val GET_PROFILES_PROVIDER_ID = "get_profiles_provider_id"
 private const val GET_PROFILE_PROVIDER_ID = "xget_profile_provider_id"
 private const val GET_WAS_PROFILE_EVER_ADDED_PROVIDER_ID =

--- a/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
@@ -34,14 +34,14 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val GET_PROFILES_PROVIDER_ID = "get_profiles_provider_id"
-private const val GET_PROFILE_PROVIDER_ID = "xget_profile_provider_id"
+private const val GET_PROFILE_PROVIDER_ID = "get_profile_provider_id"
 private const val GET_WAS_PROFILE_EVER_ADDED_PROVIDER_ID =
-  "was_profile_ever_added_provider_id"
+  "get_was_profile_ever_added_provider_id"
 private const val GET_DEVICE_SETTINGS_PROVIDER_ID =
-  "device_settings_provider_id"
+  "get_device_settings_provider_id"
 private const val ADD_PROFILE_PROVIDER_ID = "add_profile_provided_id"
 private const val UPDATE_NAME_PROVIDER_ID = "update_name_provider_id"
-private const val UPDATE_PIN_TRANSFORMED_PROVIDER_ID = "update_pin_transformed_id"
+private const val UPDATE_PIN_PROVIDER_ID = "update_pin_provider_id"
 private const val UPDATE_PROFILE_AVATAR_PROVIDER_ID =
   "update_profile_avatar_provider_id"
 private const val UPDATE_WIFI_PERMISSION_DEVICE_SETTINGS_PROVIDER_ID =
@@ -52,7 +52,7 @@ private const val UPDATE_ALL_DOWNLOAD_ACCESS_PROVIDER_ID =
   "update_all_download_provider_id"
 private const val LOGIN_TO_PROFILE_PROVIDER_ID = "login_to_profile_provider_id"
 private const val DELETE_PROFILE_PROVIDER_ID = "delete_profile_provider_id"
-private const val SET_CURRENT_PROFILE_ID_PROVIDER_ID = "set_profile_id_provider_id"
+private const val SET_CURRENT_PROFILE_ID_PROVIDER_ID = "set_current_profile_id_provider_id"
 private const val UPDATE_READING_TEXT_SIZE_PROVIDER_ID =
   "update_reading_text_size_provider_id"
 private const val UPDATE_APP_LANGUAGE_PROVIDER_ID = "update_app_language_provider_id"
@@ -344,7 +344,7 @@ class ProfileManagementController @Inject constructor(
       )
       Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
     }
-    return dataProviders.createInMemoryDataProviderAsync(UPDATE_PIN_TRANSFORMED_PROVIDER_ID) {
+    return dataProviders.createInMemoryDataProviderAsync(UPDATE_PIN_PROVIDER_ID) {
       return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
     }
   }

--- a/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
@@ -33,29 +33,32 @@ import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
-private const val TRANSFORMED_GET_PROFILES_PROVIDER_ID = "transformed_get_profiles_provider_id"
-private const val TRANSFORMED_GET_PROFILE_PROVIDER_ID = "transformed_get_profile_provider_id"
-private const val TRANSFORMED_GET_WAS_PROFILE_EVER_ADDED_PROVIDER_ID =
-  "transformed_was_profile_ever_added_provider_id"
-private const val TRANSFORMED_GET_DEVICE_SETTINGS_PROVIDER_ID =
-  "transformed_device_settings_provider_id"
-private const val ADD_PROFILE_TRANSFORMED_PROVIDER_ID = "add_profile_transformed_id"
-private const val UPDATE_NAME_TRANSFORMED_PROVIDER_ID = "update_name_transformed_id"
+//getProfiles
+private const val GET_PROFILES_PROVIDER_ID = "get_profiles_provider_id"
+private const val GET_PROFILE_PROVIDER_ID = "xget_profile_provider_id"
+private const val GET_WAS_PROFILE_EVER_ADDED_PROVIDER_ID =
+  "was_profile_ever_added_provider_id"
+private const val GET_DEVICE_SETTINGS_PROVIDER_ID =
+  "device_settings_provider_id"
+private const val ADD_PROFILE_PROVIDER_ID = "add_profile_provided_id"
+private const val UPDATE_NAME_PROVIDER_ID = "update_name_provider_id"
 private const val UPDATE_PIN_TRANSFORMED_PROVIDER_ID = "update_pin_transformed_id"
-private const val UPDATE_PROFILE_AVATER_TRANSFORMED_PROVIDER_ID =
-  "update_profile_avater_transformed_id"
-private const val UPDATE_DEVICE_SETTINGS_TRANSFORMED_PROVIDER_ID =
-  "update_device_settings_transformed_id"
-private const val UPDATE_DOWNLOAD_ACCESS_TRANSFORMED_PROVIDER_ID =
-  "update_download_access_transformed_id"
-private const val LOGIN_PROFILE_TRANSFORMED_PROVIDER_ID = "login_profile_transformed_id"
-private const val DELETE_PROFILE_TRANSFORMED_PROVIDER_ID = "delete_profile_transformed_id"
-private const val SET_PROFILE_TRANSFORMED_PROVIDER_ID = "set_profile_transformed_id"
-private const val UPDATE_READING_TEXT_SIZE_TRANSFORMED_ID =
-  "update_reading_text_size_transformed_id"
-private const val UPDATE_APP_LANGUAGE_TRANSFORMED_PROVIDER_ID = "update_app_language_transformed_id"
-private const val UPDATE_AUDIO_LANGUAGE_TRANSFORMED_PROVIDER_ID =
-  "update_audio_language_transformed_id"
+private const val UPDATE_PROFILE_AVATAR_PROVIDER_ID =
+  "update_profile_avatar_provider_id"
+private const val UPDATE_WIFI_PERMISSION_DEVICE_SETTINGS_PROVIDER_ID =
+  "update_wifi_permission_device_settings_provider_id"
+private const val UPDATE_TOPIC_AUTOMATICALLY_PERMISSION_DEVICE_SETTINGS_PROVIDER_ID =
+  "update_topic_automatically_permission_device_settings_provider_id"
+private const val UPDATE_ALL_DOWNLOAD_ACCESS_PROVIDER_ID =
+  "update_all_download_provider_id"
+private const val LOGIN_TO_PROFILE_PROVIDER_ID = "login_to_profile_provider_id"
+private const val DELETE_PROFILE_PROVIDER_ID = "delete_profile_provider_id"
+private const val SET_CURRENT_PROFILE_ID_PROVIDER_ID = "set_profile_id_provider_id"
+private const val UPDATE_READING_TEXT_SIZE_PROVIDER_ID =
+  "update_reading_text_size_provider_id"
+private const val UPDATE_APP_LANGUAGE_PROVIDER_ID = "update_app_language_provider_id"
+private const val UPDATE_AUDIO_LANGUAGE_PROVIDER_ID =
+  "update_audio_language_provider_id"
 
 /** Controller for retrieving, adding, updating, and deleting profiles. */
 @Singleton
@@ -128,14 +131,14 @@ class ProfileManagementController @Inject constructor(
 
   /** Returns the list of created profiles. */
   fun getProfiles(): DataProvider<List<Profile>> {
-    return profileDataStore.transform(TRANSFORMED_GET_PROFILES_PROVIDER_ID) {
+    return profileDataStore.transform(GET_PROFILES_PROVIDER_ID) {
       it.profilesMap.values.toList()
     }
   }
 
   /** Returns a single profile, specified by profiledId. */
   fun getProfile(profileId: ProfileId): DataProvider<Profile> {
-    return profileDataStore.transformAsync(TRANSFORMED_GET_PROFILE_PROVIDER_ID) {
+    return profileDataStore.transformAsync(GET_PROFILE_PROVIDER_ID) {
       val profile = it.profilesMap[profileId.internalId]
       if (profile != null) {
         AsyncResult.success(profile)
@@ -152,7 +155,7 @@ class ProfileManagementController @Inject constructor(
 
   /** Returns a boolean determining whether the profile was ever added or not. */
   fun getWasProfileEverAdded(): DataProvider<Boolean> {
-    return profileDataStore.transformAsync(TRANSFORMED_GET_WAS_PROFILE_EVER_ADDED_PROVIDER_ID) {
+    return profileDataStore.transformAsync(GET_WAS_PROFILE_EVER_ADDED_PROVIDER_ID) {
       val wasProfileEverAdded = it.wasProfileEverAdded
       AsyncResult.success(wasProfileEverAdded)
     }
@@ -160,7 +163,7 @@ class ProfileManagementController @Inject constructor(
 
   /** Returns device settings for the app. */
   fun getDeviceSettings(): DataProvider<DeviceSettings> {
-    return profileDataStore.transformAsync(TRANSFORMED_GET_DEVICE_SETTINGS_PROVIDER_ID) {
+    return profileDataStore.transformAsync(GET_DEVICE_SETTINGS_PROVIDER_ID) {
       val deviceSettings = it.deviceSettings
       if (deviceSettings != null) {
         AsyncResult.success(deviceSettings)
@@ -232,7 +235,7 @@ class ProfileManagementController @Inject constructor(
           .setNextProfileId(nextProfileId + 1)
       Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
     }
-    return dataProviders.createInMemoryDataProviderAsync(ADD_PROFILE_TRANSFORMED_PROVIDER_ID) {
+    return dataProviders.createInMemoryDataProviderAsync(ADD_PROFILE_PROVIDER_ID) {
       return@createInMemoryDataProviderAsync getDeferredResult(null, name, deferred)
     }
   }
@@ -279,7 +282,7 @@ class ProfileManagementController @Inject constructor(
       Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
     }
     return dataProviders.createInMemoryDataProviderAsync(
-      UPDATE_PROFILE_AVATER_TRANSFORMED_PROVIDER_ID
+      UPDATE_PROFILE_AVATAR_PROVIDER_ID
     ) {
       return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
     }
@@ -314,7 +317,7 @@ class ProfileManagementController @Inject constructor(
       )
       Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
     }
-    return dataProviders.createInMemoryDataProviderAsync(UPDATE_NAME_TRANSFORMED_PROVIDER_ID) {
+    return dataProviders.createInMemoryDataProviderAsync(UPDATE_NAME_PROVIDER_ID) {
       return@createInMemoryDataProviderAsync getDeferredResult(profileId, newName, deferred)
     }
   }
@@ -377,7 +380,7 @@ class ProfileManagementController @Inject constructor(
       }
     }
     return dataProviders.createInMemoryDataProviderAsync(
-      UPDATE_DEVICE_SETTINGS_TRANSFORMED_PROVIDER_ID
+      UPDATE_WIFI_PERMISSION_DEVICE_SETTINGS_PROVIDER_ID
     ) {
       return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
     }
@@ -413,7 +416,7 @@ class ProfileManagementController @Inject constructor(
       }
     }
     return dataProviders.createInMemoryDataProviderAsync(
-      UPDATE_DEVICE_SETTINGS_TRANSFORMED_PROVIDER_ID
+      UPDATE_TOPIC_AUTOMATICALLY_PERMISSION_DEVICE_SETTINGS_PROVIDER_ID
     ) {
       return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
     }
@@ -447,7 +450,7 @@ class ProfileManagementController @Inject constructor(
       Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
     }
     return dataProviders.createInMemoryDataProviderAsync(
-      UPDATE_DOWNLOAD_ACCESS_TRANSFORMED_PROVIDER_ID
+      UPDATE_ALL_DOWNLOAD_ACCESS_PROVIDER_ID
     ) {
       return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
     }
@@ -479,7 +482,7 @@ class ProfileManagementController @Inject constructor(
       )
       Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
     }
-    return dataProviders.createInMemoryDataProviderAsync(UPDATE_READING_TEXT_SIZE_TRANSFORMED_ID) {
+    return dataProviders.createInMemoryDataProviderAsync(UPDATE_READING_TEXT_SIZE_PROVIDER_ID) {
       return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
     }
   }
@@ -508,7 +511,7 @@ class ProfileManagementController @Inject constructor(
       Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
     }
     return dataProviders.createInMemoryDataProviderAsync(
-      UPDATE_APP_LANGUAGE_TRANSFORMED_PROVIDER_ID
+      UPDATE_APP_LANGUAGE_PROVIDER_ID
     ) {
       return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
     }
@@ -538,7 +541,7 @@ class ProfileManagementController @Inject constructor(
       Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
     }
     return dataProviders.createInMemoryDataProviderAsync(
-      UPDATE_AUDIO_LANGUAGE_TRANSFORMED_PROVIDER_ID
+      UPDATE_AUDIO_LANGUAGE_PROVIDER_ID
     ) {
       return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
     }
@@ -551,7 +554,7 @@ class ProfileManagementController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this login operation.
    */
   fun loginToProfile(profileId: ProfileId): DataProvider<Any?> {
-    return setCurrentProfileId(profileId).transformAsync(LOGIN_PROFILE_TRANSFORMED_PROVIDER_ID) {
+    return setCurrentProfileId(profileId).transformAsync(LOGIN_TO_PROFILE_PROVIDER_ID) {
       return@transformAsync getDeferredResult(
         profileId,
         null,
@@ -561,7 +564,7 @@ class ProfileManagementController @Inject constructor(
   }
 
   private fun setCurrentProfileId(profileId: ProfileId): DataProvider<Any?> {
-    return dataProviders.createInMemoryDataProviderAsync(SET_PROFILE_TRANSFORMED_PROVIDER_ID) {
+    return dataProviders.createInMemoryDataProviderAsync(SET_CURRENT_PROFILE_ID_PROVIDER_ID) {
       val profileDatabase = profileDataStore.readDataAsync().await()
       if (profileDatabase.profilesMap.containsKey(profileId.internalId)) {
         currentProfileId = profileId.internalId
@@ -611,7 +614,7 @@ class ProfileManagementController @Inject constructor(
       )
       Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
     }
-    return dataProviders.createInMemoryDataProviderAsync(DELETE_PROFILE_TRANSFORMED_PROVIDER_ID) {
+    return dataProviders.createInMemoryDataProviderAsync(DELETE_PROFILE_PROVIDER_ID) {
       return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
     }
   }

--- a/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgressController.kt
@@ -24,8 +24,12 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.concurrent.withLock
 
-private const val CURRENT_QUESTION_DATA_PROVIDER_ID = "CurrentQuestionDataProvider"
+private const val CREATE_CURRENT_QUESTION_DATA_PROVIDER_ID =
+  "create_current_question_data_provider_id"
+private const val BEGIN_QUESTION_TRAINING_SESSION_PROVIDER_ID =
+  "begin_question_training_session_provider_id"
 private const val EMPTY_QUESTIONS_LIST_DATA_PROVIDER_ID = "EmptyQuestionsListDataProvider"
+private const val SUBMIT_ANSWER_PROVIDER_ID = "submit_answer_provider_id"
 
 /**
  * Controller that tracks and reports the learner's ephemeral/non-persisted progress through a
@@ -68,7 +72,7 @@ class QuestionAssessmentProgressController @Inject constructor(
         questionsListDataProvider,
         this::retrieveCurrentQuestionAsync
       )
-      asyncDataSubscriptionManager.notifyChangeAsync(CURRENT_QUESTION_DATA_PROVIDER_ID)
+      asyncDataSubscriptionManager.notifyChangeAsync(BEGIN_QUESTION_TRAINING_SESSION_PROVIDER_ID)
     }
   }
 
@@ -128,7 +132,7 @@ class QuestionAssessmentProgressController @Inject constructor(
 
         // Notify observers that the submitted answer is currently pending.
         progress.advancePlayStageTo(TrainStage.SUBMITTING_ANSWER)
-        asyncDataSubscriptionManager.notifyChangeAsync(CURRENT_QUESTION_DATA_PROVIDER_ID)
+        asyncDataSubscriptionManager.notifyChangeAsync(SUBMIT_ANSWER_PROVIDER_ID)
 
         lateinit var answeredQuestionOutcome: AnsweredQuestionOutcome
         try {
@@ -158,7 +162,7 @@ class QuestionAssessmentProgressController @Inject constructor(
           progress.advancePlayStageTo(TrainStage.VIEWING_STATE)
         }
 
-        asyncDataSubscriptionManager.notifyChangeAsync(CURRENT_QUESTION_DATA_PROVIDER_ID)
+        asyncDataSubscriptionManager.notifyChangeAsync(CREATE_CURRENT_QUESTION_DATA_PROVIDER_ID)
 
         return MutableLiveData(AsyncResult.success(answeredQuestionOutcome))
       }
@@ -199,7 +203,7 @@ class QuestionAssessmentProgressController @Inject constructor(
           // exception.
           progress.advancePlayStageTo(TrainStage.VIEWING_STATE)
         }
-        asyncDataSubscriptionManager.notifyChangeAsync(CURRENT_QUESTION_DATA_PROVIDER_ID)
+        asyncDataSubscriptionManager.notifyChangeAsync(CREATE_CURRENT_QUESTION_DATA_PROVIDER_ID)
         return MutableLiveData(AsyncResult.success(hint))
       }
     } catch (e: Exception) {
@@ -233,7 +237,7 @@ class QuestionAssessmentProgressController @Inject constructor(
           progress.advancePlayStageTo(TrainStage.VIEWING_STATE)
         }
 
-        asyncDataSubscriptionManager.notifyChangeAsync(CURRENT_QUESTION_DATA_PROVIDER_ID)
+        asyncDataSubscriptionManager.notifyChangeAsync(CREATE_CURRENT_QUESTION_DATA_PROVIDER_ID)
         return MutableLiveData(AsyncResult.success(solution))
       }
     } catch (e: Exception) {
@@ -270,7 +274,7 @@ class QuestionAssessmentProgressController @Inject constructor(
         if (progress.isViewingMostRecentQuestion()) {
           progress.processNavigationToNewQuestion()
         }
-        asyncDataSubscriptionManager.notifyChangeAsync(CURRENT_QUESTION_DATA_PROVIDER_ID)
+        asyncDataSubscriptionManager.notifyChangeAsync(CREATE_CURRENT_QUESTION_DATA_PROVIDER_ID)
       }
       return MutableLiveData(AsyncResult.success<Any?>(null))
     } catch (e: Exception) {
@@ -309,7 +313,7 @@ class QuestionAssessmentProgressController @Inject constructor(
     questionsListDataProvider: DataProvider<List<Question>>
   ): NestedTransformedDataProvider<EphemeralQuestion> {
     return questionsListDataProvider.transformNested(
-      CURRENT_QUESTION_DATA_PROVIDER_ID,
+      CREATE_CURRENT_QUESTION_DATA_PROVIDER_ID,
       this::retrieveCurrentQuestionAsync
     )
   }

--- a/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgressController.kt
@@ -28,7 +28,8 @@ private const val CREATE_CURRENT_QUESTION_DATA_PROVIDER_ID =
   "create_current_question_data_provider_id"
 private const val BEGIN_QUESTION_TRAINING_SESSION_PROVIDER_ID =
   "begin_question_training_session_provider_id"
-private const val EMPTY_QUESTIONS_LIST_DATA_PROVIDER_ID = "EmptyQuestionsListDataProvider"
+private const val CREATE_EMPTY_QUESTIONS_LIST_DATA_PROVIDER_ID =
+  "create_empty_questions_list_data_provider_id"
 private const val SUBMIT_ANSWER_PROVIDER_ID = "submit_answer_provider_id"
 
 /**
@@ -368,7 +369,7 @@ class QuestionAssessmentProgressController @Inject constructor(
 
   /** Returns a temporary [DataProvider] that always provides an empty list of [Question]s. */
   private fun createEmptyQuestionsListDataProvider(): DataProvider<List<Question>> {
-    return dataProviders.createInMemoryDataProvider(EMPTY_QUESTIONS_LIST_DATA_PROVIDER_ID) {
+    return dataProviders.createInMemoryDataProvider(CREATE_EMPTY_QUESTIONS_LIST_DATA_PROVIDER_ID) {
       listOf<Question>()
     }
   }

--- a/domain/src/main/java/org/oppia/android/domain/question/QuestionTrainingController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/question/QuestionTrainingController.kt
@@ -14,7 +14,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.random.Random
 
-//etrieveQuestionsForSkillIds
 private const val RETRIEVE_QUESTION_FOR_SKILLS_ID_PROVIDER_ID =
   "retrieve_question_for_skills_id_provider_id"
 private const val START_QUESTION_TRAINING_SESSION_PROVIDER_ID = "" +

--- a/domain/src/main/java/org/oppia/android/domain/question/QuestionTrainingController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/question/QuestionTrainingController.kt
@@ -14,8 +14,11 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.random.Random
 
-private const val TRAINING_QUESTIONS_PROVIDER = "TrainingQuestionsProvider"
-private const val RETRIEVE_QUESTIONS_RESULT_DATA_PROVIDER = "RetrieveQuestionsResultsProvider"
+//etrieveQuestionsForSkillIds
+private const val RETRIEVE_QUESTION_FOR_SKILLS_ID_PROVIDER_ID =
+  "retrieve_question_for_skills_id_provider_id"
+private const val START_QUESTION_TRAINING_SESSION_PROVIDER_ID = "" +
+  "start_question_training_session_provider_id"
 
 /** Controller for retrieving a set of questions. */
 @Singleton
@@ -51,7 +54,7 @@ class QuestionTrainingController @Inject constructor(
       )
       // Convert the data provider type to 'Any' via a transformation.
       val erasedDataProvider: DataProvider<Any> = retrieveQuestionsDataProvider
-        .transform(RETRIEVE_QUESTIONS_RESULT_DATA_PROVIDER) { it }
+        .transform(START_QUESTION_TRAINING_SESSION_PROVIDER_ID) { it }
       erasedDataProvider.toLiveData()
     } catch (e: Exception) {
       exceptionsController.logNonFatalException(e, oppiaClock.getCurrentCalendar().timeInMillis)
@@ -68,7 +71,7 @@ class QuestionTrainingController @Inject constructor(
     // regenerate the session (unless the questions themselves change). This is necessary since the
     // underlying structure may be notified multiple times during a single submit answer operation.
     val seed = seedRandom.nextLong()
-    return questionsDataProvider.transform(TRAINING_QUESTIONS_PROVIDER) {
+    return questionsDataProvider.transform(RETRIEVE_QUESTION_FOR_SKILLS_ID_PROVIDER_ID) {
       val questionsList = if (skillIdsList.isEmpty()) {
         listOf()
       } else {

--- a/domain/src/main/java/org/oppia/android/domain/topic/StoryProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/StoryProgressController.kt
@@ -44,8 +44,7 @@ private const val RETRIEVE_TOPIC_PROGRESS_DATA_PROVIDER_ID =
   "retrieve_topic_progress_data_provider_id"
 private const val RETRIEVE_STORY_PROGRESS_DATA_PROVIDER_ID =
   "retrieve_story_progress_data_provider_id"
-private const val RECORD_COMPLETED_CHAPTER_PROVIDER_ID =
-  "record_completed_chapter_provider_id"
+private const val RECORD_COMPLETED_CHAPTER_PROVIDER_ID = "record_completed_chapter_provider_id"
 private const val RECORD_RECENTLY_PLAYED_CHAPTER_PROVIDER_ID =
   "record_recently_played_chapter_provider_id"
 

--- a/domain/src/main/java/org/oppia/android/domain/topic/StoryProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/StoryProgressController.kt
@@ -37,9 +37,8 @@ const val RATIOS_EXPLORATION_ID_2 = "k2bQ7z5XHNbK"
 const val RATIOS_EXPLORATION_ID_3 = "tIoSb3HZFN6e"
 
 private const val CACHE_NAME = "topic_progress_database"
-
 private const val RETRIEVE_TOPIC_PROGRESS_LIST_DATA_PROVIDER_ID =
-  "retrieved_topic_progress_list_data_provider_id"
+  "retrieve_topic_progress_list_data_provider_id"
 private const val RETRIEVE_TOPIC_PROGRESS_DATA_PROVIDER_ID =
   "retrieve_topic_progress_data_provider_id"
 private const val RETRIEVE_STORY_PROGRESS_DATA_PROVIDER_ID =

--- a/domain/src/main/java/org/oppia/android/domain/topic/StoryProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/StoryProgressController.kt
@@ -38,15 +38,16 @@ const val RATIOS_EXPLORATION_ID_3 = "tIoSb3HZFN6e"
 
 private const val CACHE_NAME = "topic_progress_database"
 
-private const val TRANSFORMED_GET_STORY_PROGRESS_LIST_PROVIDER_ID =
-  "transformed_get_story_progress_list_provider_id"
-private const val TRANSFORMED_GET_TOPIC_PROGRESS_PROVIDER_ID =
-  "transformed_get_topic_progress_provider_id"
-private const val TRANSFORMED_GET_STORY_PROGRESS_PROVIDER_ID =
-  "transformed_get_story_progress_provider_id"
-private const val ADD_STORY_PROGRESS_TRANSFORMED_PROVIDER_ID = "add_story_progress_transformed_id"
-private const val RECENTLY_PLAYED_CHAPTER_TRANSFORMED_PROVIDER_ID =
-  "recently_played_chapter_transformed_id"
+private const val RETRIEVE_TOPIC_PROGRESS_LIST_DATA_PROVIDER_ID =
+  "retrieved_topic_progress_list_data_provider_id"
+private const val RETRIEVE_TOPIC_PROGRESS_DATA_PROVIDER_ID =
+  "retrieve_topic_progress_data_provider_id"
+private const val RETRIEVE_STORY_PROGRESS_DATA_PROVIDER_ID =
+  "retrieve_story_progress_data_provider_id"
+private const val RECORD_COMPLETED_CHAPTER_PROVIDER_ID =
+  "record_completed_chapter_provider_id"
+private const val RECORD_RECENTLY_PLAYED_CHAPTER_PROVIDER_ID =
+  "record_recently_played_chapter_provider_id"
 
 /**
  * Controller that records and provides completion statuses of chapters within the context of a
@@ -125,7 +126,7 @@ class StoryProgressController @Inject constructor(
       }
 
     return dataProviders.createInMemoryDataProviderAsync(
-      ADD_STORY_PROGRESS_TRANSFORMED_PROVIDER_ID
+      RECORD_COMPLETED_CHAPTER_PROVIDER_ID
     ) {
       return@createInMemoryDataProviderAsync getDeferredResult(deferred)
     }
@@ -206,7 +207,7 @@ class StoryProgressController @Inject constructor(
       }
 
     return dataProviders.createInMemoryDataProviderAsync(
-      RECENTLY_PLAYED_CHAPTER_TRANSFORMED_PROVIDER_ID
+      RECORD_RECENTLY_PLAYED_CHAPTER_PROVIDER_ID
     ) {
       return@createInMemoryDataProviderAsync getDeferredResult(deferred)
     }
@@ -217,7 +218,7 @@ class StoryProgressController @Inject constructor(
     profileId: ProfileId
   ): DataProvider<List<TopicProgress>> {
     return retrieveCacheStore(profileId)
-      .transformAsync(TRANSFORMED_GET_STORY_PROGRESS_LIST_PROVIDER_ID) { topicProgressDatabase ->
+      .transformAsync(RETRIEVE_TOPIC_PROGRESS_LIST_DATA_PROVIDER_ID) { topicProgressDatabase ->
         val topicProgressList = mutableListOf<TopicProgress>()
         topicProgressList.addAll(topicProgressDatabase.topicProgressMap.values)
         AsyncResult.success(topicProgressList.toList())
@@ -230,7 +231,7 @@ class StoryProgressController @Inject constructor(
     topicId: String
   ): DataProvider<TopicProgress> {
     return retrieveCacheStore(profileId)
-      .transformAsync(TRANSFORMED_GET_TOPIC_PROGRESS_PROVIDER_ID) {
+      .transformAsync(RETRIEVE_TOPIC_PROGRESS_DATA_PROVIDER_ID) {
         AsyncResult.success(it.topicProgressMap[topicId] ?: TopicProgress.getDefaultInstance())
       }
   }
@@ -242,7 +243,7 @@ class StoryProgressController @Inject constructor(
     storyId: String
   ): DataProvider<StoryProgress> {
     return retrieveTopicProgressDataProvider(profileId, topicId)
-      .transformAsync(TRANSFORMED_GET_STORY_PROGRESS_PROVIDER_ID) {
+      .transformAsync(RETRIEVE_STORY_PROGRESS_DATA_PROVIDER_ID) {
         AsyncResult.success(it.storyProgressMap[storyId] ?: StoryProgress.getDefaultInstance())
       }
   }

--- a/domain/src/main/java/org/oppia/android/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/TopicController.kt
@@ -66,13 +66,13 @@ private const val SUBTOPIC_BG_COLOR = "#FFFFFF"
 
 private const val RETRIEVED_QUESTIONS_FOR_SKILLS_ID_PROVIDER_ID =
   "retrieved_questions_for_skills_id_provider_id"
-private const val GET_COMPLETED_STORy_LIST_PROVIDER_ID =
+private const val GET_COMPLETED_STORY_LIST_PROVIDER_ID =
   "get_completed_story_list_provider_id"
 private const val GET_ONGOING_TOPIC_LIST_PROVIDER_ID =
   "get_ongoing_topic_list_provider_id"
 private const val GET_TOPIC_PROVIDER_ID = "get_topic_provider_id"
 private const val GET_STORY_PROVIDER_ID = "get_story_provider_id"
-private const val GE_TOPIC_COMBINED_PROVIDER_ID = "get_topic_combined_provider_id"
+private const val GET_TOPIC_COMBINED_PROVIDER_ID = "get_topic_combined_provider_id"
 private const val GET_STORY_COMBINED_PROVIDER_ID = "get_story_combined_provider_id"
 
 /** Controller for retrieving all aspects of a topic. */
@@ -105,7 +105,7 @@ class TopicController @Inject constructor(
 
     return topicDataProvider.combineWith(
       topicProgressDataProvider,
-      GE_TOPIC_COMBINED_PROVIDER_ID,
+      GET_TOPIC_COMBINED_PROVIDER_ID,
       ::combineTopicAndTopicProgress
     )
   }
@@ -174,7 +174,7 @@ class TopicController @Inject constructor(
   fun getCompletedStoryList(profileId: ProfileId): DataProvider<CompletedStoryList> {
     return storyProgressController.retrieveTopicProgressListDataProvider(
       profileId
-    ).transformAsync(GET_COMPLETED_STORy_LIST_PROVIDER_ID) {
+    ).transformAsync(GET_COMPLETED_STORY_LIST_PROVIDER_ID) {
       val completedStoryListBuilder = CompletedStoryList.newBuilder()
       it.forEach { topicProgress ->
         val topic = retrieveTopic(topicProgress.topicId)

--- a/domain/src/main/java/org/oppia/android/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/TopicController.kt
@@ -64,15 +64,17 @@ private const val FRACTIONS_SUBTOPIC_ID_3 = 3
 private const val FRACTIONS_SUBTOPIC_ID_4 = 4
 private const val SUBTOPIC_BG_COLOR = "#FFFFFF"
 
-private const val QUESTION_DATA_PROVIDER_ID = "QuestionDataProvider"
-private const val TRANSFORMED_GET_COMPLETED_STORIES_PROVIDER_ID =
-  "transformed_get_completed_stories_provider_id"
-private const val TRANSFORMED_GET_ONGOING_TOPICS_PROVIDER_ID =
-  "transformed_get_ongoing_topics_provider_id"
-private const val TRANSFORMED_GET_TOPIC_PROVIDER_ID = "transformed_get_topic_provider_id"
-private const val TRANSFORMED_GET_STORY_PROVIDER_ID = "transformed_get_story_provider_id"
-private const val COMBINED_TOPIC_PROVIDER_ID = "combined_topic_provider_id"
-private const val COMBINED_STORY_PROVIDER_ID = "combined_story_provider_id"
+private const val RETRIEVED_QUESTIONS_FOR_SKILLS_ID_PROVIDER_ID =
+  "retrieved_questions_for_skills_id_provider_id"
+
+private const val GET_COMPLETED_STORy_LIST_PROVIDER_ID =
+  "get_completed_story_list_provider_id"
+private const val GET_ONGOING_TOPIC_LIST_PROVIDER_ID =
+  "get_ongoing_topic_list_provider_id"
+private const val GET_TOPIC_PROVIDER_ID = "get_topic_provider_id"
+private const val GET_STORY_PROVIDER_ID = "get_story_provider_id"
+private const val GE_TOPIC_COMBINED_PROVIDER_ID = "get_topic_combined_provider_id"
+private const val GET_STORY_COMBINED_PROVIDER_ID = "get_story_combined_provider_id"
 
 /** Controller for retrieving all aspects of a topic. */
 @Singleton
@@ -96,7 +98,7 @@ class TopicController @Inject constructor(
    */
   fun getTopic(profileId: ProfileId, topicId: String): DataProvider<Topic> {
     val topicDataProvider =
-      dataProviders.createInMemoryDataProviderAsync(TRANSFORMED_GET_TOPIC_PROVIDER_ID) {
+      dataProviders.createInMemoryDataProviderAsync(GET_TOPIC_PROVIDER_ID) {
         return@createInMemoryDataProviderAsync AsyncResult.success(retrieveTopic(topicId))
       }
     val topicProgressDataProvider =
@@ -104,7 +106,7 @@ class TopicController @Inject constructor(
 
     return topicDataProvider.combineWith(
       topicProgressDataProvider,
-      COMBINED_TOPIC_PROVIDER_ID,
+      GE_TOPIC_COMBINED_PROVIDER_ID,
       ::combineTopicAndTopicProgress
     )
   }
@@ -123,7 +125,7 @@ class TopicController @Inject constructor(
     storyId: String
   ): DataProvider<StorySummary> {
     val storyDataProvider =
-      dataProviders.createInMemoryDataProviderAsync(TRANSFORMED_GET_STORY_PROVIDER_ID) {
+      dataProviders.createInMemoryDataProviderAsync(GET_STORY_PROVIDER_ID) {
         return@createInMemoryDataProviderAsync AsyncResult.success(retrieveStory(topicId, storyId))
       }
     val storyProgressDataProvider =
@@ -131,7 +133,7 @@ class TopicController @Inject constructor(
 
     return storyDataProvider.combineWith(
       storyProgressDataProvider,
-      COMBINED_STORY_PROVIDER_ID,
+      GET_STORY_COMBINED_PROVIDER_ID,
       ::combineStorySummaryAndStoryProgress
     )
   }
@@ -173,7 +175,7 @@ class TopicController @Inject constructor(
   fun getCompletedStoryList(profileId: ProfileId): DataProvider<CompletedStoryList> {
     return storyProgressController.retrieveTopicProgressListDataProvider(
       profileId
-    ).transformAsync(TRANSFORMED_GET_COMPLETED_STORIES_PROVIDER_ID) {
+    ).transformAsync(GET_COMPLETED_STORy_LIST_PROVIDER_ID) {
       val completedStoryListBuilder = CompletedStoryList.newBuilder()
       it.forEach { topicProgress ->
         val topic = retrieveTopic(topicProgress.topicId)
@@ -199,14 +201,14 @@ class TopicController @Inject constructor(
   fun getOngoingTopicList(profileId: ProfileId): DataProvider<OngoingTopicList> {
     return storyProgressController.retrieveTopicProgressListDataProvider(
       profileId
-    ).transformAsync(TRANSFORMED_GET_ONGOING_TOPICS_PROVIDER_ID) {
+    ).transformAsync(GET_ONGOING_TOPIC_LIST_PROVIDER_ID) {
       val ongoingTopicList = createOngoingTopicListFromProgress(it)
       AsyncResult.success(ongoingTopicList)
     }
   }
 
   fun retrieveQuestionsForSkillIds(skillIdsList: List<String>): DataProvider<List<Question>> {
-    return dataProviders.createInMemoryDataProvider(QUESTION_DATA_PROVIDER_ID) {
+    return dataProviders.createInMemoryDataProvider(RETRIEVED_QUESTIONS_FOR_SKILLS_ID_PROVIDER_ID) {
       loadQuestionsForSkillIds(skillIdsList)
     }
   }

--- a/domain/src/main/java/org/oppia/android/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/TopicController.kt
@@ -66,7 +66,6 @@ private const val SUBTOPIC_BG_COLOR = "#FFFFFF"
 
 private const val RETRIEVED_QUESTIONS_FOR_SKILLS_ID_PROVIDER_ID =
   "retrieved_questions_for_skills_id_provider_id"
-
 private const val GET_COMPLETED_STORy_LIST_PROVIDER_ID =
   "get_completed_story_list_provider_id"
 private const val GET_ONGOING_TOPIC_LIST_PROVIDER_ID =

--- a/domain/src/main/java/org/oppia/android/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/TopicListController.kt
@@ -67,7 +67,6 @@ val EXPLORATION_THUMBNAILS = mapOf(
   TEST_EXPLORATION_ID_6 to createChapterThumbnail0()
 )
 
-//getOngoingStoryList
 private const val GET_ONGOING_STORY_LIST_PROVIDER_ID =
   "get_ongoing_story_list_provider_id"
 

--- a/domain/src/main/java/org/oppia/android/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/TopicListController.kt
@@ -67,8 +67,9 @@ val EXPLORATION_THUMBNAILS = mapOf(
   TEST_EXPLORATION_ID_6 to createChapterThumbnail0()
 )
 
-private const val TRANSFORMED_GET_ONGOING_STORY_LIST_PROVIDER_ID =
-  "transformed_get_ongoing_story_list_provider_id"
+//getOngoingStoryList
+private const val GET_ONGOING_STORY_LIST_PROVIDER_ID =
+  "get_ongoing_story_list_provider_id"
 
 private val EVICTION_TIME_MILLIS = TimeUnit.DAYS.toMillis(1)
 
@@ -98,7 +99,7 @@ class TopicListController @Inject constructor(
    */
   fun getOngoingStoryList(profileId: ProfileId): DataProvider<OngoingStoryList> {
     return storyProgressController.retrieveTopicProgressListDataProvider(profileId)
-      .transformAsync(TRANSFORMED_GET_ONGOING_STORY_LIST_PROVIDER_ID) {
+      .transformAsync(GET_ONGOING_STORY_LIST_PROVIDER_ID) {
         val ongoingStoryList = createOngoingStoryListFromProgress(it)
         AsyncResult.success(ongoingStoryList)
       }


### PR DESCRIPTION

## Explanation
Fix #1589 Improves naming consistency for all data provider ids in the domain layer.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
