### PR TITLE
Fix #2040: Reformating files under TextInput Package

### DIFF
--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputCaseSensitiveEqualsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputCaseSensitiveEqualsRuleClassifierProviderTest.kt
@@ -106,7 +106,6 @@ class TextInputCaseSensitiveEqualsRuleClassifierProviderTest {
       .inject(this)
   }
 
-
   // TODO(#89): Move to a common test library.
   private fun <T : Throwable> assertThrows(type: KClass<T>, operation: () -> Unit): T {
     try {

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputCaseSensitiveEqualsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputCaseSensitiveEqualsRuleClassifierProviderTest.kt
@@ -28,7 +28,7 @@ class TextInputCaseSensitiveEqualsRuleClassifierProviderTest {
     InteractionObjectTestBuilder.createString(value = "TEST")
   private val STRING_VALUE_TEST_LOWERCASE =
     InteractionObjectTestBuilder.createString(value = "test")
-  private val STRING_VALUE_RANDOM =
+  private val STRING_VALUE_TEST_RANDOM =
     InteractionObjectTestBuilder.createString(value = "random")
 
   @Inject
@@ -72,7 +72,7 @@ class TextInputCaseSensitiveEqualsRuleClassifierProviderTest {
 
   @Test
   fun testUppercaseStringAnswer_stringRandomInput_differentString_bothValuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_VALUE_RANDOM)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_RANDOM)
 
     val matches =
       inputCaseSensitiveEqualsRuleClassifier.matches(

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputCaseSensitiveEqualsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputCaseSensitiveEqualsRuleClassifierProviderTest.kt
@@ -9,7 +9,7 @@ import dagger.Component
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.oppia.android.app.model.InteractionObject
+import org.oppia.android.domain.classify.InteractionObjectTestBuilder
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -23,9 +23,13 @@ import kotlin.test.fail
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(manifest = Config.NONE)
 class TextInputCaseSensitiveEqualsRuleClassifierProviderTest {
-  private val STRING_VALUE_TEST_UPPERCASE = createString(value = "TEST")
-  private val STRING_VALUE_TEST_LOWERCASE = createString(value = "test")
-  private val STRING_VALUE_RANDOM = createString(value = "random")
+
+  private val STRING_VALUE_TEST_UPPERCASE =
+    InteractionObjectTestBuilder.createString(value = "TEST")
+  private val STRING_VALUE_TEST_LOWERCASE =
+    InteractionObjectTestBuilder.createString(value = "test")
+  private val STRING_VALUE_RANDOM =
+    InteractionObjectTestBuilder.createString(value = "random")
 
   @Inject
   internal lateinit var textInputCaseSensitiveEqualsRuleClassifierProvider:
@@ -102,9 +106,6 @@ class TextInputCaseSensitiveEqualsRuleClassifierProviderTest {
       .inject(this)
   }
 
-  private fun createString(value: String): InteractionObject {
-    return InteractionObject.newBuilder().setNormalizedString(value).build()
-  }
 
   // TODO(#89): Move to a common test library.
   private fun <T : Throwable> assertThrows(type: KClass<T>, operation: () -> Unit): T {

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputContainsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputContainsRuleClassifierProviderTest.kt
@@ -24,17 +24,19 @@ import kotlin.test.fail
 @Config(manifest = Config.NONE)
 class TextInputContainsRuleClassifierProviderTest {
 
-  private val STRING_VALUE_CONTAINS_ANSWER_TEXT =
+  private val STRING_INPUT_CONTAINS_ANSWER =
     InteractionObjectTestBuilder.createString(value = "this is a test i will break")
-  private val STRING_VALUE_AN_ANSWER =
+  private val STRING_INPUT_AN_ANSWER =
     InteractionObjectTestBuilder.createString(value = "an answer")
-  private val STRING_VALUE_A_TEST =
+  private val STRING_INPUT_A_TEST =
     InteractionObjectTestBuilder.createString(value = "a test")
-  private val STRING_VALUE_IS_A =
+  private val STRING_INPUT_IS_A =
     InteractionObjectTestBuilder.createString(value = "is a")
-  private val STRING_VALUE_THIS_IS =
+  private val STRING_INPUT_THIS_IS =
     InteractionObjectTestBuilder.createString(value = "this is")
-  private val STRING_VALUE_NULL =
+  private val STRING_INPUT_NULL =
+    InteractionObjectTestBuilder.createString(value = "")
+  private val STRING_ANSWER_NULL =
     InteractionObjectTestBuilder.createString(value = "")
   private val STRING_ANSWER =
     InteractionObjectTestBuilder.createString(value = "this is a test")
@@ -72,17 +74,17 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testEmptyStringAnswer_emptyStringInput_answerContainsInput_bothValuesMatch() {
-    val inputs = mapOf("x" to STRING_VALUE_NULL)
+    val inputs = mapOf("x" to STRING_INPUT_NULL)
 
     val matches =
-      inputContainsRuleClassifier.matches(answer = STRING_VALUE_NULL, inputs = inputs)
+      inputContainsRuleClassifier.matches(answer = STRING_ANSWER_NULL, inputs = inputs)
 
     assertThat(matches).isTrue()
   }
 
   @Test
   fun testNonEmptyStringAnswer_emptyStringInput_answerContainsInput_bothValuesMatch() {
-    val inputs = mapOf("x" to STRING_VALUE_NULL)
+    val inputs = mapOf("x" to STRING_INPUT_NULL)
 
     val matches = inputContainsRuleClassifier.matches(
       answer = STRING_ANSWER,
@@ -94,7 +96,7 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_answerContainsInputAtBeginning_bothValuesMatch() {
-    val inputs = mapOf("x" to STRING_VALUE_THIS_IS)
+    val inputs = mapOf("x" to STRING_INPUT_THIS_IS)
 
     val matches = inputContainsRuleClassifier.matches(
       answer = STRING_ANSWER,
@@ -106,7 +108,7 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_answerContainsInputInMiddle_bothValuesMatch() {
-    val inputs = mapOf("x" to STRING_VALUE_IS_A)
+    val inputs = mapOf("x" to STRING_INPUT_IS_A)
 
     val matches = inputContainsRuleClassifier.matches(
       answer = STRING_ANSWER,
@@ -118,7 +120,7 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_answerContainsInputAtEnd_bothValuesMatch() {
-    val inputs = mapOf("x" to STRING_VALUE_A_TEST)
+    val inputs = mapOf("x" to STRING_INPUT_A_TEST)
 
     val matches = inputContainsRuleClassifier.matches(
       answer = STRING_ANSWER,
@@ -142,7 +144,7 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_inputNotInAnswer_valuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_VALUE_AN_ANSWER)
+    val inputs = mapOf("x" to STRING_INPUT_AN_ANSWER)
 
     val matches = inputContainsRuleClassifier.matches(
       answer = STRING_ANSWER,
@@ -157,14 +159,14 @@ class TextInputContainsRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_ANSWER)
 
     val matches =
-      inputContainsRuleClassifier.matches(answer = STRING_VALUE_NULL, inputs = inputs)
+      inputContainsRuleClassifier.matches(answer = STRING_ANSWER_NULL, inputs = inputs)
 
     assertThat(matches).isFalse()
   }
 
   @Test
   fun testStringAnswer_stringInput_answerPartiallyContainsInput_valuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_VALUE_CONTAINS_ANSWER_TEXT)
+    val inputs = mapOf("x" to STRING_INPUT_CONTAINS_ANSWER)
 
     val matches = inputContainsRuleClassifier.matches(
       answer = STRING_ANSWER,

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputContainsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputContainsRuleClassifierProviderTest.kt
@@ -77,7 +77,7 @@ class TextInputContainsRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TEST_NULL)
 
     val matches =
-      inputContainsRuleClassifier.matches(answer =STRING_VALUE_TEST_ANSWER_NULL, inputs = inputs)
+      inputContainsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_NULL, inputs = inputs)
 
     assertThat(matches).isTrue()
   }
@@ -159,7 +159,7 @@ class TextInputContainsRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TEST_ANSWER)
 
     val matches =
-      inputContainsRuleClassifier.matches(answer =STRING_VALUE_TEST_ANSWER_NULL, inputs = inputs)
+      inputContainsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_NULL, inputs = inputs)
 
     assertThat(matches).isFalse()
   }

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputContainsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputContainsRuleClassifierProviderTest.kt
@@ -24,25 +24,25 @@ import kotlin.test.fail
 @Config(manifest = Config.NONE)
 class TextInputContainsRuleClassifierProviderTest {
 
-  private val STRING_INPUT_CONTAINS_ANSWER =
+  private val STRING_VALUE_TEST_CONTAINS_ANSWER =
     InteractionObjectTestBuilder.createString(value = "this is a test i will break")
-  private val STRING_INPUT_AN_ANSWER =
+  private val STRING_VALUE_TEST_AN_ANSWER =
     InteractionObjectTestBuilder.createString(value = "an answer")
-  private val STRING_INPUT_A_TEST =
+  private val STRING_VALUE_TEST_A_TEST =
     InteractionObjectTestBuilder.createString(value = "a test")
-  private val STRING_INPUT_IS_A =
+  private val STRING_VALUE_TEST_IS_A =
     InteractionObjectTestBuilder.createString(value = "is a")
-  private val STRING_INPUT_THIS_IS =
+  private val STRING_VALUE_TEST_THIS_IS =
     InteractionObjectTestBuilder.createString(value = "this is")
-  private val STRING_INPUT_NULL =
+  private val STRING_VALUE_TEST_NULL =
     InteractionObjectTestBuilder.createString(value = "")
-  private val STRING_ANSWER_NULL =
+  private val STRING_VALUE_TEST_ANSWER_NULL =
     InteractionObjectTestBuilder.createString(value = "")
-  private val STRING_ANSWER =
+  private val STRING_VALUE_TEST_ANSWER =
     InteractionObjectTestBuilder.createString(value = "this is a test")
-  private val STRING_ANSWER_EXTRA_SPACE =
+  private val STRING_VALUE_TEST_EXTRA_SPACE =
     InteractionObjectTestBuilder.createString(value = " this   is  a  test ")
-  private val STRING_ANSWER_NO_SPACE =
+  private val STRING_VALUE_TEST_NO_SPACE =
     InteractionObjectTestBuilder.createString(value = "thisisatest")
   private val NON_NEGATIVE_VALUE_TEST_1 =
     InteractionObjectTestBuilder.createNonNegativeInt(value = 1)
@@ -62,10 +62,10 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_sameString_bothValuesMatch() {
-    val inputs = mapOf("x" to STRING_ANSWER)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_ANSWER)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = STRING_ANSWER,
+      answer = STRING_VALUE_TEST_ANSWER,
       inputs = inputs
     )
 
@@ -74,20 +74,20 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testEmptyStringAnswer_emptyStringInput_answerContainsInput_bothValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_NULL)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_NULL)
 
     val matches =
-      inputContainsRuleClassifier.matches(answer = STRING_ANSWER_NULL, inputs = inputs)
+      inputContainsRuleClassifier.matches(answer =STRING_VALUE_TEST_ANSWER_NULL, inputs = inputs)
 
     assertThat(matches).isTrue()
   }
 
   @Test
   fun testNonEmptyStringAnswer_emptyStringInput_answerContainsInput_bothValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_NULL)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_NULL)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = STRING_ANSWER,
+      answer = STRING_VALUE_TEST_ANSWER,
       inputs = inputs
     )
 
@@ -96,10 +96,10 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_answerContainsInputAtBeginning_bothValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_THIS_IS)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_THIS_IS)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = STRING_ANSWER,
+      answer = STRING_VALUE_TEST_ANSWER,
       inputs = inputs
     )
 
@@ -108,10 +108,10 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_answerContainsInputInMiddle_bothValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_IS_A)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_IS_A)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = STRING_ANSWER,
+      answer = STRING_VALUE_TEST_ANSWER,
       inputs = inputs
     )
 
@@ -120,10 +120,10 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_answerContainsInputAtEnd_bothValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_A_TEST)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_A_TEST)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = STRING_ANSWER,
+      answer = STRING_VALUE_TEST_ANSWER,
       inputs = inputs
     )
 
@@ -132,10 +132,10 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringExtraSpacesInput_answerContainsInput_bothValuesMatch() {
-    val inputs = mapOf("x" to STRING_ANSWER_EXTRA_SPACE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_EXTRA_SPACE)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = STRING_ANSWER,
+      answer = STRING_VALUE_TEST_ANSWER,
       inputs = inputs
     )
 
@@ -144,10 +144,10 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_inputNotInAnswer_valuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_AN_ANSWER)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_AN_ANSWER)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = STRING_ANSWER,
+      answer = STRING_VALUE_TEST_ANSWER,
       inputs = inputs
     )
 
@@ -156,20 +156,20 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testEmptyStringAnswer_nonEmptyStringInput_answerDoesNotContainInput_valuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_ANSWER)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_ANSWER)
 
     val matches =
-      inputContainsRuleClassifier.matches(answer = STRING_ANSWER_NULL, inputs = inputs)
+      inputContainsRuleClassifier.matches(answer =STRING_VALUE_TEST_ANSWER_NULL, inputs = inputs)
 
     assertThat(matches).isFalse()
   }
 
   @Test
   fun testStringAnswer_stringInput_answerPartiallyContainsInput_valuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_CONTAINS_ANSWER)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_CONTAINS_ANSWER)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = STRING_ANSWER,
+      answer = STRING_VALUE_TEST_ANSWER,
       inputs = inputs
     )
 
@@ -178,10 +178,10 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringNoSpacesInput_answerPartiallyContainsInput_valuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_ANSWER_NO_SPACE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_NO_SPACE)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = STRING_ANSWER,
+      answer = STRING_VALUE_TEST_ANSWER,
       inputs = inputs
     )
 
@@ -190,11 +190,11 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_missingInput_throwsException() {
-    val inputs = mapOf("y" to STRING_ANSWER)
+    val inputs = mapOf("y" to STRING_VALUE_TEST_ANSWER)
 
     val exception = assertThrows(IllegalStateException::class) {
       inputContainsRuleClassifier.matches(
-        answer = STRING_ANSWER,
+        answer = STRING_VALUE_TEST_ANSWER,
         inputs = inputs
       )
     }
@@ -210,7 +210,7 @@ class TextInputContainsRuleClassifierProviderTest {
 
     val exception = assertThrows(IllegalStateException::class) {
       inputContainsRuleClassifier.matches(
-        answer = STRING_ANSWER,
+        answer = STRING_VALUE_TEST_ANSWER,
         inputs = inputs
       )
     }

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputContainsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputContainsRuleClassifierProviderTest.kt
@@ -9,7 +9,7 @@ import dagger.Component
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.oppia.android.app.model.InteractionObject
+import org.oppia.android.domain.classify.InteractionObjectTestBuilder
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -23,6 +23,27 @@ import kotlin.test.fail
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(manifest = Config.NONE)
 class TextInputContainsRuleClassifierProviderTest {
+
+  private val STRING_VALUE_WILL_BREAK =
+    InteractionObjectTestBuilder.createString(value = "this is a test i will break")
+  private val STRING_VALUE_AN_ANSWER =
+    InteractionObjectTestBuilder.createString(value = "an answer")
+  private val STRING_VALUE_A_TEST =
+    InteractionObjectTestBuilder.createString(value = "a test")
+  private val STRING_VALUE_IS_A =
+    InteractionObjectTestBuilder.createString(value = "is a")
+  private val STRING_VALUE_THIS_IS =
+    InteractionObjectTestBuilder.createString(value = "this is")
+  private val STRING_VALUE_NULL =
+    InteractionObjectTestBuilder.createString(value = "")
+  private val STRING_ANSWER =
+    InteractionObjectTestBuilder.createString(value = "this is a test")
+  private val STRING_ANSWER_EXTRA_SPACE =
+    InteractionObjectTestBuilder.createString(value = " this   is  a  test ")
+  private val STRING_ANSWER_NO_SPACE =
+    InteractionObjectTestBuilder.createString(value = "thisisatest")
+  private val NON_NEGATIVE_VALUE_TEST_1 =
+    InteractionObjectTestBuilder.createNonNegativeInt(value = 1)
 
   @Inject
   internal lateinit var textInputContainsRuleClassifierProvider:
@@ -39,10 +60,10 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_sameString_bothValuesMatch() {
-    val inputs = mapOf("x" to createString(value = "this is a test"))
+    val inputs = mapOf("x" to STRING_ANSWER)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = createString(value = "this is a test"),
+      answer = STRING_ANSWER,
       inputs = inputs
     )
 
@@ -51,20 +72,20 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testEmptyStringAnswer_emptyStringInput_answerContainsInput_bothValuesMatch() {
-    val inputs = mapOf("x" to createString(value = ""))
+    val inputs = mapOf("x" to STRING_VALUE_NULL)
 
     val matches =
-      inputContainsRuleClassifier.matches(answer = createString(value = ""), inputs = inputs)
+      inputContainsRuleClassifier.matches(answer = STRING_VALUE_NULL, inputs = inputs)
 
     assertThat(matches).isTrue()
   }
 
   @Test
   fun testNonEmptyStringAnswer_emptyStringInput_answerContainsInput_bothValuesMatch() {
-    val inputs = mapOf("x" to createString(value = ""))
+    val inputs = mapOf("x" to STRING_VALUE_NULL)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = createString(value = "this is a test"),
+      answer = STRING_ANSWER,
       inputs = inputs
     )
 
@@ -73,10 +94,10 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_answerContainsInputAtBeginning_bothValuesMatch() {
-    val inputs = mapOf("x" to createString(value = "this is"))
+    val inputs = mapOf("x" to STRING_VALUE_THIS_IS)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = createString(value = "this is a test"),
+      answer = STRING_ANSWER,
       inputs = inputs
     )
 
@@ -85,10 +106,10 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_answerContainsInputInMiddle_bothValuesMatch() {
-    val inputs = mapOf("x" to createString(value = "is a"))
+    val inputs = mapOf("x" to STRING_VALUE_IS_A)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = createString(value = "this is a test"),
+      answer = STRING_ANSWER,
       inputs = inputs
     )
 
@@ -97,10 +118,10 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_answerContainsInputAtEnd_bothValuesMatch() {
-    val inputs = mapOf("x" to createString(value = "a test"))
+    val inputs = mapOf("x" to STRING_VALUE_A_TEST)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = createString(value = "this is a test"),
+      answer = STRING_ANSWER,
       inputs = inputs
     )
 
@@ -109,10 +130,10 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringExtraSpacesInput_answerContainsInput_bothValuesMatch() {
-    val inputs = mapOf("x" to createString(value = " this   is  a  test "))
+    val inputs = mapOf("x" to STRING_ANSWER_EXTRA_SPACE)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = createString(value = "this is a test"),
+      answer = STRING_ANSWER,
       inputs = inputs
     )
 
@@ -121,10 +142,10 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_inputNotInAnswer_valuesDoNotMatch() {
-    val inputs = mapOf("x" to createString(value = "an answer"))
+    val inputs = mapOf("x" to STRING_VALUE_AN_ANSWER)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = createString(value = "this is a test"),
+      answer = STRING_ANSWER,
       inputs = inputs
     )
 
@@ -133,24 +154,20 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testEmptyStringAnswer_nonEmptyStringInput_answerDoesNotContainInput_valuesDoNotMatch() {
-    val inputs = mapOf("x" to createString(value = "this is a test"))
+    val inputs = mapOf("x" to STRING_ANSWER)
 
     val matches =
-      inputContainsRuleClassifier.matches(answer = createString(value = ""), inputs = inputs)
+      inputContainsRuleClassifier.matches(answer = STRING_VALUE_NULL, inputs = inputs)
 
     assertThat(matches).isFalse()
   }
 
   @Test
   fun testStringAnswer_stringInput_answerPartiallyContainsInput_valuesDoNotMatch() {
-    val inputs = mapOf(
-      "x" to createString(
-        value = "this is a test i will break"
-      )
-    )
+    val inputs = mapOf("x" to STRING_VALUE_WILL_BREAK)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = createString(value = "this is a test"),
+      answer = STRING_ANSWER,
       inputs = inputs
     )
 
@@ -159,10 +176,10 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringNoSpacesInput_answerPartiallyContainsInput_valuesDoNotMatch() {
-    val inputs = mapOf("x" to createString(value = "thisisatest"))
+    val inputs = mapOf("x" to STRING_ANSWER_NO_SPACE)
 
     val matches = inputContainsRuleClassifier.matches(
-      answer = createString(value = "this is a test"),
+      answer = STRING_ANSWER,
       inputs = inputs
     )
 
@@ -171,11 +188,11 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_missingInput_throwsException() {
-    val inputs = mapOf("y" to createString(value = "this is a test"))
+    val inputs = mapOf("y" to STRING_ANSWER)
 
     val exception = assertThrows(IllegalStateException::class) {
       inputContainsRuleClassifier.matches(
-        answer = createString(value = "this is a test"),
+        answer = STRING_ANSWER,
         inputs = inputs
       )
     }
@@ -187,11 +204,11 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_nonNegativeIntInput_throwsException() {
-    val inputs = mapOf("x" to createNonNegativeInt(value = 1))
+    val inputs = mapOf("x" to NON_NEGATIVE_VALUE_TEST_1)
 
     val exception = assertThrows(IllegalStateException::class) {
       inputContainsRuleClassifier.matches(
-        answer = createString(value = "this is a test"),
+        answer = STRING_ANSWER,
         inputs = inputs
       )
     }
@@ -199,14 +216,6 @@ class TextInputContainsRuleClassifierProviderTest {
     assertThat(exception)
       .hasMessageThat()
       .contains("Expected input value to be of type NORMALIZED_STRING")
-  }
-
-  private fun createNonNegativeInt(value: Int): InteractionObject {
-    return InteractionObject.newBuilder().setNonNegativeInt(value).build()
-  }
-
-  private fun createString(value: String): InteractionObject {
-    return InteractionObject.newBuilder().setNormalizedString(value).build()
   }
 
   private fun setUpTestApplicationComponent() {

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputContainsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputContainsRuleClassifierProviderTest.kt
@@ -24,7 +24,7 @@ import kotlin.test.fail
 @Config(manifest = Config.NONE)
 class TextInputContainsRuleClassifierProviderTest {
 
-  private val STRING_VALUE_WILL_BREAK =
+  private val STRING_VALUE_CONTAINS_ANSWER_TEXT =
     InteractionObjectTestBuilder.createString(value = "this is a test i will break")
   private val STRING_VALUE_AN_ANSWER =
     InteractionObjectTestBuilder.createString(value = "an answer")
@@ -164,7 +164,7 @@ class TextInputContainsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringInput_answerPartiallyContainsInput_valuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_VALUE_WILL_BREAK)
+    val inputs = mapOf("x" to STRING_VALUE_CONTAINS_ANSWER_TEXT)
 
     val matches = inputContainsRuleClassifier.matches(
       answer = STRING_ANSWER,

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputFuzzyEqualsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputFuzzyEqualsRuleClassifierProviderTest.kt
@@ -9,7 +9,7 @@ import dagger.Component
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.oppia.android.app.model.InteractionObject
+import org.oppia.android.domain.classify.InteractionObjectTestBuilder
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -22,6 +22,30 @@ import kotlin.test.fail
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(manifest = Config.NONE)
 class TextInputFuzzyEqualsRuleClassifierProviderTest {
+
+  private val STRING_ANSWER_UPPERCASE =
+    InteractionObjectTestBuilder.createString(value = "TEST")
+  private val STRING_INPUT_UPPERCASE =
+    InteractionObjectTestBuilder.createString(value = "TEST")
+  private val STRING_INPUT_LOWERCASE =
+    InteractionObjectTestBuilder.createString(value = "test")
+  private val STRING_ANSWER_LOWERCASE =
+    InteractionObjectTestBuilder.createString(value = "test")
+  private val STRING_ANSWER_DIFF_LOWERCASE =
+    InteractionObjectTestBuilder.createString(value = "diff")
+  private val STRING_INPUT_DIFF_LOWERCASE =
+    InteractionObjectTestBuilder.createString(value = "diff")
+  private val STRING_INPUT_DIFF_UPPERCASE =
+    InteractionObjectTestBuilder.createString(value = "DIFF")
+  private val STRING_FUZZY_INPUT =
+    InteractionObjectTestBuilder.createString(value = "This Is a TesT")
+  private val STRING_ANSWER =
+    InteractionObjectTestBuilder.createString(value = "this is a test")
+  private val STRING_WITH_WHITESPACE =
+    InteractionObjectTestBuilder.createString(value = "  test   ")
+  private val NON_NEGATIVE_VALUE =
+    InteractionObjectTestBuilder.createNonNegativeInt(value = 1)
+
   @Inject
   internal lateinit var textInputFuzzyEqualsRuleClassifierProvider:
     TextInputFuzzyEqualsRuleClassifierProvider
@@ -29,18 +53,6 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
   private val inputFuzzyEqualsRuleClassifier by lazy {
     textInputFuzzyEqualsRuleClassifierProvider.createRuleClassifier()
   }
-
-  private val STRING_ANSWER_UPPERCASE = createString(value = "TEST")
-  private val STRING_INPUT_UPPERCASE = createString(value = "TEST")
-  private val STRING_INPUT_LOWERCASE = createString(value = "test")
-  private val STRING_ANSWER_LOWERCASE = createString(value = "test")
-  private val STRING_ANSWER_DIFF_LOWERCASE = createString(value = "diff")
-  private val STRING_INPUT_DIFF_LOWERCASE = createString(value = "diff")
-  private val STRING_INPUT_DIFF_UPPERCASE = createString(value = "DIFF")
-  private val STRING_FUZZY_INPUT = createString(value = "This Is a TesT")
-  private val STRING_ANSWER = createString(value = "this is a test")
-  private val STRING_WITH_WHITESPACE = createString(value = "  test   ")
-  private val NON_NEGATIVE_VALUE = createNonNegativeInt(value = 1)
 
   @Before
   fun setUp() {
@@ -169,14 +181,6 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
       .setApplication(ApplicationProvider.getApplicationContext())
       .build()
       .inject(this)
-  }
-
-  private fun createString(value: String): InteractionObject {
-    return InteractionObject.newBuilder().setNormalizedString(value).build()
-  }
-
-  private fun createNonNegativeInt(value: Int): InteractionObject {
-    return InteractionObject.newBuilder().setNonNegativeInt(value).build()
   }
 
   private fun <T : Throwable> assertThrows(type: KClass<T>, operation: () -> Unit): T {

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputFuzzyEqualsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputFuzzyEqualsRuleClassifierProviderTest.kt
@@ -23,13 +23,13 @@ import kotlin.test.fail
 @Config(manifest = Config.NONE)
 class TextInputFuzzyEqualsRuleClassifierProviderTest {
 
-  private val STRING_ANSWER_UPPERCASE =
+  private val STRING_ANSWER_TEST_UPPERCASE =
     InteractionObjectTestBuilder.createString(value = "TEST")
-  private val STRING_INPUT_UPPERCASE =
+  private val STRING_INPUT_TEST_UPPERCASE =
     InteractionObjectTestBuilder.createString(value = "TEST")
-  private val STRING_INPUT_LOWERCASE =
+  private val STRING_INPUT_TEST_LOWERCASE =
     InteractionObjectTestBuilder.createString(value = "test")
-  private val STRING_ANSWER_LOWERCASE =
+  private val STRING_ANSWER_TEST_LOWERCASE =
     InteractionObjectTestBuilder.createString(value = "test")
   private val STRING_ANSWER_DIFF_LOWERCASE =
     InteractionObjectTestBuilder.createString(value = "diff")
@@ -43,7 +43,7 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
     InteractionObjectTestBuilder.createString(value = "this is a test")
   private val STRING_WITH_WHITESPACE =
     InteractionObjectTestBuilder.createString(value = "  test   ")
-  private val NON_NEGATIVE_VALUE =
+  private val NON_NEGATIVE_TEST_VALUE_1 =
     InteractionObjectTestBuilder.createNonNegativeInt(value = 1)
 
   @Inject
@@ -61,20 +61,20 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
 
   @Test
   fun testUpperCaseAnswer_testUpperCaseInput_sameString_verifyBothValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_UPPERCASE)
+    val inputs = mapOf("x" to STRING_INPUT_TEST_UPPERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_UPPERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_TEST_UPPERCASE, inputs = inputs)
 
     assertThat(matches).isTrue()
   }
 
   @Test
   fun testUpperCaseAnswer_testLowerCaseInput_sameString_verifyBothValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_LOWERCASE)
+    val inputs = mapOf("x" to STRING_INPUT_TEST_LOWERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_UPPERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_TEST_UPPERCASE, inputs = inputs)
 
     assertThat(matches).isTrue()
   }
@@ -84,14 +84,14 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_INPUT_DIFF_LOWERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_UPPERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_TEST_UPPERCASE, inputs = inputs)
 
     assertThat(matches).isFalse()
   }
 
   @Test
   fun testUpperCaseAnswer_testUpperCaseInput_differentString_verifyBothValuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_UPPERCASE)
+    val inputs = mapOf("x" to STRING_INPUT_TEST_UPPERCASE)
 
     val matches =
       inputFuzzyEqualsRuleClassifier.matches(answer = STRING_INPUT_DIFF_UPPERCASE, inputs = inputs)
@@ -101,27 +101,27 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
 
   @Test
   fun testLowerCaseAnswer_testUpperCaseInput_sameString_verifyBothValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_UPPERCASE)
+    val inputs = mapOf("x" to STRING_INPUT_TEST_UPPERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_LOWERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_TEST_LOWERCASE, inputs = inputs)
 
     assertThat(matches).isTrue()
   }
 
   @Test
   fun testLowerCaseAnswer_testLowerCaseInput_sameString_verifyBothValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_LOWERCASE)
+    val inputs = mapOf("x" to STRING_INPUT_TEST_LOWERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_LOWERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_TEST_LOWERCASE, inputs = inputs)
 
     assertThat(matches).isTrue()
   }
 
   @Test
   fun testLowerCaseAnswer_testLowerCaseInput_differentString_verifyBothValuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_LOWERCASE)
+    val inputs = mapOf("x" to STRING_INPUT_TEST_LOWERCASE)
 
     val matches =
       inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_DIFF_LOWERCASE, inputs = inputs)
@@ -131,7 +131,7 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
 
   @Test
   fun testLowerCaseAnswer_testUpperCaseInput_differentString_verifyBothValuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_UPPERCASE)
+    val inputs = mapOf("x" to STRING_INPUT_TEST_UPPERCASE)
 
     val matches =
       inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_DIFF_LOWERCASE, inputs = inputs)
@@ -153,7 +153,7 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringWithWhitespacesInput_answerEqualsInput_verifyValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_LOWERCASE)
+    val inputs = mapOf("x" to STRING_INPUT_TEST_LOWERCASE)
 
     val matches = inputFuzzyEqualsRuleClassifier.matches(
       answer = STRING_WITH_WHITESPACE,
@@ -165,10 +165,10 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_nonNegativeIntInput_verifyThrowsException() {
-    val inputs = mapOf("x" to NON_NEGATIVE_VALUE)
+    val inputs = mapOf("x" to NON_NEGATIVE_TEST_VALUE_1)
 
     val exception = assertThrows(IllegalStateException::class) {
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_UPPERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_TEST_UPPERCASE, inputs = inputs)
     }
 
     assertThat(exception)

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputFuzzyEqualsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputFuzzyEqualsRuleClassifierProviderTest.kt
@@ -64,7 +64,10 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TEST_UPPERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_UPPERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(
+        answer = STRING_VALUE_TEST_ANSWER_UPPERCASE,
+        inputs = inputs
+      )
 
     assertThat(matches).isTrue()
   }
@@ -74,7 +77,10 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TEST_LOWERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_UPPERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(
+        answer = STRING_VALUE_TEST_ANSWER_UPPERCASE,
+        inputs = inputs
+      )
 
     assertThat(matches).isTrue()
   }
@@ -84,7 +90,10 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TEST_DIFF_LOWERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_UPPERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(
+        answer = STRING_VALUE_TEST_ANSWER_UPPERCASE,
+        inputs = inputs
+      )
 
     assertThat(matches).isFalse()
   }
@@ -94,7 +103,10 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TEST_UPPERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_DIFF_UPPERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(
+        answer = STRING_VALUE_TEST_DIFF_UPPERCASE,
+        inputs = inputs
+      )
 
     assertThat(matches).isFalse()
   }
@@ -104,7 +116,10 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TEST_UPPERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_LOWERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(
+        answer = STRING_VALUE_TEST_ANSWER_LOWERCASE,
+        inputs = inputs
+      )
 
     assertThat(matches).isTrue()
   }
@@ -114,7 +129,10 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TEST_LOWERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_LOWERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(
+        answer = STRING_VALUE_TEST_ANSWER_LOWERCASE,
+        inputs = inputs
+      )
 
     assertThat(matches).isTrue()
   }
@@ -124,7 +142,10 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TEST_LOWERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_DIFF_LOWERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(
+        answer = STRING_VALUE_TEST_ANSWER_DIFF_LOWERCASE,
+        inputs = inputs
+      )
 
     assertThat(matches).isFalse()
   }
@@ -134,7 +155,10 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TEST_UPPERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_DIFF_LOWERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(
+        answer = STRING_VALUE_TEST_ANSWER_DIFF_LOWERCASE,
+        inputs = inputs
+      )
 
     assertThat(matches).isFalse()
   }
@@ -168,7 +192,10 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
     val inputs = mapOf("x" to NON_NEGATIVE_TEST_VALUE_1)
 
     val exception = assertThrows(IllegalStateException::class) {
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_UPPERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(
+        answer = STRING_VALUE_TEST_ANSWER_UPPERCASE,
+        inputs = inputs
+      )
     }
 
     assertThat(exception)

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputFuzzyEqualsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputFuzzyEqualsRuleClassifierProviderTest.kt
@@ -23,25 +23,25 @@ import kotlin.test.fail
 @Config(manifest = Config.NONE)
 class TextInputFuzzyEqualsRuleClassifierProviderTest {
 
-  private val STRING_ANSWER_TEST_UPPERCASE =
+  private val STRING_VALUE_TEST_ANSWER_UPPERCASE =
     InteractionObjectTestBuilder.createString(value = "TEST")
-  private val STRING_INPUT_TEST_UPPERCASE =
+  private val STRING_VALUE_TEST_UPPERCASE =
     InteractionObjectTestBuilder.createString(value = "TEST")
-  private val STRING_INPUT_TEST_LOWERCASE =
+  private val STRING_VALUE_TEST_LOWERCASE =
     InteractionObjectTestBuilder.createString(value = "test")
-  private val STRING_ANSWER_TEST_LOWERCASE =
+  private val STRING_VALUE_TEST_ANSWER_LOWERCASE =
     InteractionObjectTestBuilder.createString(value = "test")
-  private val STRING_ANSWER_DIFF_LOWERCASE =
+  private val STRING_VALUE_TEST_ANSWER_DIFF_LOWERCASE =
     InteractionObjectTestBuilder.createString(value = "diff")
-  private val STRING_INPUT_DIFF_LOWERCASE =
+  private val STRING_VALUE_TEST_DIFF_LOWERCASE =
     InteractionObjectTestBuilder.createString(value = "diff")
-  private val STRING_INPUT_DIFF_UPPERCASE =
+  private val STRING_VALUE_TEST_DIFF_UPPERCASE =
     InteractionObjectTestBuilder.createString(value = "DIFF")
-  private val STRING_FUZZY_INPUT =
+  private val STRING_VALUE_TEST_FUZZY_INPUT =
     InteractionObjectTestBuilder.createString(value = "This Is a TesT")
-  private val STRING_ANSWER =
+  private val STRING_VALUE_TEST_ANSWER =
     InteractionObjectTestBuilder.createString(value = "this is a test")
-  private val STRING_WITH_WHITESPACE =
+  private val STRING_VALUE_TEST_WITH_WHITESPACE =
     InteractionObjectTestBuilder.createString(value = "  test   ")
   private val NON_NEGATIVE_TEST_VALUE_1 =
     InteractionObjectTestBuilder.createNonNegativeInt(value = 1)
@@ -61,90 +61,90 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
 
   @Test
   fun testUpperCaseAnswer_testUpperCaseInput_sameString_verifyBothValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_TEST_UPPERCASE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_UPPERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_TEST_UPPERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_UPPERCASE, inputs = inputs)
 
     assertThat(matches).isTrue()
   }
 
   @Test
   fun testUpperCaseAnswer_testLowerCaseInput_sameString_verifyBothValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_TEST_LOWERCASE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_LOWERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_TEST_UPPERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_UPPERCASE, inputs = inputs)
 
     assertThat(matches).isTrue()
   }
 
   @Test
   fun testUpperCaseAnswer_testLowercaseInput_differentString_verifyBothValuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_DIFF_LOWERCASE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_DIFF_LOWERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_TEST_UPPERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_UPPERCASE, inputs = inputs)
 
     assertThat(matches).isFalse()
   }
 
   @Test
   fun testUpperCaseAnswer_testUpperCaseInput_differentString_verifyBothValuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_TEST_UPPERCASE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_UPPERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_INPUT_DIFF_UPPERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_DIFF_UPPERCASE, inputs = inputs)
 
     assertThat(matches).isFalse()
   }
 
   @Test
   fun testLowerCaseAnswer_testUpperCaseInput_sameString_verifyBothValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_TEST_UPPERCASE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_UPPERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_TEST_LOWERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_LOWERCASE, inputs = inputs)
 
     assertThat(matches).isTrue()
   }
 
   @Test
   fun testLowerCaseAnswer_testLowerCaseInput_sameString_verifyBothValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_TEST_LOWERCASE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_LOWERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_TEST_LOWERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_LOWERCASE, inputs = inputs)
 
     assertThat(matches).isTrue()
   }
 
   @Test
   fun testLowerCaseAnswer_testLowerCaseInput_differentString_verifyBothValuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_TEST_LOWERCASE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_LOWERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_DIFF_LOWERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_DIFF_LOWERCASE, inputs = inputs)
 
     assertThat(matches).isFalse()
   }
 
   @Test
   fun testLowerCaseAnswer_testUpperCaseInput_differentString_verifyBothValuesDoNotMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_TEST_UPPERCASE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_UPPERCASE)
 
     val matches =
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_DIFF_LOWERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_DIFF_LOWERCASE, inputs = inputs)
 
     assertThat(matches).isFalse()
   }
 
   @Test
   fun testStringAnswer_stringFuzzyInput_answerFuzzyEqualsInput_verifyValuesMatch() {
-    val inputs = mapOf("x" to STRING_FUZZY_INPUT)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_FUZZY_INPUT)
 
     val matches = inputFuzzyEqualsRuleClassifier.matches(
-      answer = STRING_ANSWER,
+      answer = STRING_VALUE_TEST_ANSWER,
       inputs = inputs
     )
 
@@ -153,10 +153,10 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
 
   @Test
   fun testStringAnswer_stringWithWhitespacesInput_answerEqualsInput_verifyValuesMatch() {
-    val inputs = mapOf("x" to STRING_INPUT_TEST_LOWERCASE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_LOWERCASE)
 
     val matches = inputFuzzyEqualsRuleClassifier.matches(
-      answer = STRING_WITH_WHITESPACE,
+      answer = STRING_VALUE_TEST_WITH_WHITESPACE,
       inputs = inputs
     )
 
@@ -168,7 +168,7 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
     val inputs = mapOf("x" to NON_NEGATIVE_TEST_VALUE_1)
 
     val exception = assertThrows(IllegalStateException::class) {
-      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_ANSWER_TEST_UPPERCASE, inputs = inputs)
+      inputFuzzyEqualsRuleClassifier.matches(answer = STRING_VALUE_TEST_ANSWER_UPPERCASE, inputs = inputs)
     }
 
     assertThat(exception)

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputStartsWithRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputStartsWithRuleClassifierProviderTest.kt
@@ -38,9 +38,9 @@ class TextInputStartsWithRuleClassifierProviderTest {
     InteractionObjectTestBuilder.createString("TESTSTRING")
   private val STRING_VALUE_TEST_UPPERCASE =
     InteractionObjectTestBuilder.createString("TEST")
-  private val EMPTY_STRING =
+  private val STRING_VALUE_TEST_NULL =
     InteractionObjectTestBuilder.createString(value = "")
-  private val NON_NEGATIVE_INT =
+  private val NON_NEGATIVE_TEST_VALUE_1 =
     InteractionObjectTestBuilder.createNonNegativeInt(value = 1)
 
   @Inject
@@ -130,7 +130,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
 
   @Test
   fun testLowercaseStringAns_emptyStringInput_differentStrings_verifyAnsStartsWith() {
-    val inputs = mapOf("x" to EMPTY_STRING)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_NULL)
 
     val matches = inputStartsWithRuleClassifier.matches(
       answer = STRING_VALUE_TESTSTRING_LOWERCASE,
@@ -166,7 +166,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
 
   @Test
   fun testUppercaseStringAns_emptyStringInput_differentStrings_verifyAnsStartWith() {
-    val inputs = mapOf("x" to EMPTY_STRING)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_NULL)
 
     val matches = inputStartsWithRuleClassifier.matches(
       answer = STRING_VALUE_TESTSTRING_UPPERCASE,
@@ -181,7 +181,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TESTSTRING_LOWERCASE)
 
     val matches = inputStartsWithRuleClassifier.matches(
-      answer = EMPTY_STRING,
+      answer = STRING_VALUE_TEST_NULL,
       inputs = inputs
     )
 
@@ -190,10 +190,10 @@ class TextInputStartsWithRuleClassifierProviderTest {
 
   @Test
   fun testEmptyStringAns_emptyStringInput_exactSameStrings_verifyAnsStartsWith() {
-    val inputs = mapOf("x" to EMPTY_STRING)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_NULL)
 
     val matches = inputStartsWithRuleClassifier.matches(
-      answer = EMPTY_STRING,
+      answer = STRING_VALUE_TEST_NULL,
       inputs = inputs
     )
 
@@ -218,7 +218,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
 
   @Test
   fun testStringAns_nonNegativeIntInput_throwsException() {
-    val inputs = mapOf("x" to NON_NEGATIVE_INT)
+    val inputs = mapOf("x" to NON_NEGATIVE_TEST_VALUE_1)
 
     val exception = assertThrows(IllegalStateException::class) {
       inputStartsWithRuleClassifier.matches(

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputStartsWithRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputStartsWithRuleClassifierProviderTest.kt
@@ -24,17 +24,17 @@ import kotlin.test.fail
 @Config(manifest = Config.NONE)
 class TextInputStartsWithRuleClassifierProviderTest {
 
-  private val STRING_VALUE_TESTSTRING_LOWERCASE =
+  private val STRING_VALUE_TEST_STRING_LOWERCASE =
     InteractionObjectTestBuilder.createString("test string")
-  private val STRING_VALUE_TESTSTRING_LOWERCASE_EXTRA_SPACES =
+  private val STRING_VALUE_TEST_STRING_LOWERCASE_EXTRA_SPACES =
     InteractionObjectTestBuilder.createString("test  string")
   private val STRING_VALUE_TEST_LOWERCASE =
     InteractionObjectTestBuilder.createString("test")
   private val STRING_VALUE_STRING_LOWERCASE =
     InteractionObjectTestBuilder.createString("string")
-  private val STRING_VALUE_TESTSTRING_UPPERCASE =
+  private val STRING_VALUE_TEST_STRING_UPPERCASE =
     InteractionObjectTestBuilder.createString("TEST STRING")
-  private val STRING_VALUE_TESTSTRING_UPPERCASE_NO_SPACES =
+  private val STRING_VALUE_TEST_STRING_UPPERCASE_NO_SPACES =
     InteractionObjectTestBuilder.createString("TESTSTRING")
   private val STRING_VALUE_TEST_UPPERCASE =
     InteractionObjectTestBuilder.createString("TEST")
@@ -61,7 +61,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TEST_LOWERCASE)
 
     val matches = inputStartsWithRuleClassifier.matches(
-      answer = STRING_VALUE_TESTSTRING_LOWERCASE,
+      answer = STRING_VALUE_TEST_STRING_LOWERCASE,
       inputs = inputs
     )
 
@@ -73,7 +73,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_STRING_LOWERCASE)
 
     val matches = inputStartsWithRuleClassifier.matches(
-      answer = STRING_VALUE_TESTSTRING_LOWERCASE,
+      answer = STRING_VALUE_TEST_STRING_LOWERCASE,
       inputs = inputs
     )
 
@@ -82,7 +82,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
 
   @Test
   fun testLowercaseStringAns_lowercaseStringInput_inputStartsWithAns_verifyAnsDoesNotStartsWith() {
-    val inputs = mapOf("x" to STRING_VALUE_TESTSTRING_LOWERCASE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_STRING_LOWERCASE)
 
     val matches = inputStartsWithRuleClassifier.matches(
       answer = STRING_VALUE_TEST_LOWERCASE,
@@ -94,10 +94,10 @@ class TextInputStartsWithRuleClassifierProviderTest {
 
   @Test
   fun testLowercaseStringAns_uppercaseStringInput_sameCaseInsensitive_verifyAnsDoesNotStartWith() {
-    val inputs = mapOf("x" to STRING_VALUE_TESTSTRING_UPPERCASE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_STRING_UPPERCASE)
 
     val matches = inputStartsWithRuleClassifier.matches(
-      answer = STRING_VALUE_TESTSTRING_LOWERCASE,
+      answer = STRING_VALUE_TEST_STRING_LOWERCASE,
       inputs = inputs
     )
 
@@ -106,10 +106,10 @@ class TextInputStartsWithRuleClassifierProviderTest {
 
   @Test
   fun testLowercaseStringAns_lowercaseStringInput_extraSpaces_verifyAnsStartWith() {
-    val inputs = mapOf("x" to STRING_VALUE_TESTSTRING_LOWERCASE_EXTRA_SPACES)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_STRING_LOWERCASE_EXTRA_SPACES)
 
     val matches = inputStartsWithRuleClassifier.matches(
-      answer = STRING_VALUE_TESTSTRING_LOWERCASE,
+      answer = STRING_VALUE_TEST_STRING_LOWERCASE,
       inputs = inputs
     )
 
@@ -121,7 +121,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TEST_UPPERCASE)
 
     val matches = inputStartsWithRuleClassifier.matches(
-      answer = STRING_VALUE_TESTSTRING_LOWERCASE,
+      answer = STRING_VALUE_TEST_STRING_LOWERCASE,
       inputs = inputs
     )
 
@@ -133,7 +133,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TEST_NULL)
 
     val matches = inputStartsWithRuleClassifier.matches(
-      answer = STRING_VALUE_TESTSTRING_LOWERCASE,
+      answer = STRING_VALUE_TEST_STRING_LOWERCASE,
       inputs = inputs
     )
 
@@ -142,7 +142,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
 
   @Test
   fun testUppercaseStringAns_uppercaseStringInput_inputStartWithAns_verifyAnsDoesNotStartsWith() {
-    val inputs = mapOf("x" to STRING_VALUE_TESTSTRING_UPPERCASE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_STRING_UPPERCASE)
 
     val matches = inputStartsWithRuleClassifier.matches(
       answer = STRING_VALUE_TEST_UPPERCASE,
@@ -154,7 +154,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
 
   @Test
   fun testUppercaseStringAns_uppercaseStringInput_noSpaces_verifyAnsDoesNotStartsWith() {
-    val inputs = mapOf("x" to STRING_VALUE_TESTSTRING_UPPERCASE_NO_SPACES)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_STRING_UPPERCASE_NO_SPACES)
 
     val matches = inputStartsWithRuleClassifier.matches(
       answer = STRING_VALUE_TEST_UPPERCASE,
@@ -169,7 +169,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
     val inputs = mapOf("x" to STRING_VALUE_TEST_NULL)
 
     val matches = inputStartsWithRuleClassifier.matches(
-      answer = STRING_VALUE_TESTSTRING_UPPERCASE,
+      answer = STRING_VALUE_TEST_STRING_UPPERCASE,
       inputs = inputs
     )
 
@@ -178,7 +178,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
 
   @Test
   fun testEmptyStringAns_lowercaseStringInput_differentStrings_verifyAnsDoesNotStartsWith() {
-    val inputs = mapOf("x" to STRING_VALUE_TESTSTRING_LOWERCASE)
+    val inputs = mapOf("x" to STRING_VALUE_TEST_STRING_LOWERCASE)
 
     val matches = inputStartsWithRuleClassifier.matches(
       answer = STRING_VALUE_TEST_NULL,
@@ -202,11 +202,11 @@ class TextInputStartsWithRuleClassifierProviderTest {
 
   @Test
   fun testStringAns_missingInput_throwsException() {
-    val inputs = mapOf("y" to STRING_VALUE_TESTSTRING_LOWERCASE)
+    val inputs = mapOf("y" to STRING_VALUE_TEST_STRING_LOWERCASE)
 
     val exception = assertThrows(IllegalStateException::class) {
       inputStartsWithRuleClassifier.matches(
-        answer = STRING_VALUE_TESTSTRING_LOWERCASE,
+        answer = STRING_VALUE_TEST_STRING_LOWERCASE,
         inputs = inputs
       )
     }
@@ -222,7 +222,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
 
     val exception = assertThrows(IllegalStateException::class) {
       inputStartsWithRuleClassifier.matches(
-        answer = STRING_VALUE_TESTSTRING_LOWERCASE,
+        answer = STRING_VALUE_TEST_STRING_LOWERCASE,
         inputs = inputs
       )
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #2040 : Reformated fies under TextInput Package according to this [file](https://github.com/oppia/oppia-android/blob/develop/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputEqualsRuleClassifierProviderTest.kt)
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
