### PR TITLE
Fix #2080: Remove injected TestCoroutineDispatchers if not in use

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/faq/FAQListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/faq/FAQListFragmentTest.kt
@@ -58,7 +58,6 @@ import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfiguration
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.testing.TestAccessibilityModule
-import org.oppia.android.testing.TestCoroutineDispatchers
 import org.oppia.android.testing.TestDispatcherModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.util.caching.testing.CachingTestModule
@@ -70,7 +69,6 @@ import org.oppia.android.util.parser.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.ImageParsingModule
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
 import javax.inject.Singleton
 
 /** Tests for [FAQListFragment]. */

--- a/app/src/sharedTest/java/org/oppia/android/app/faq/FAQListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/faq/FAQListFragmentTest.kt
@@ -78,19 +78,15 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = FAQListFragmentTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class FAQListFragmentTest {
-  @Inject
-  lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
 
   @Before
   fun setUp() {
     Intents.init()
     setUpTestApplicationComponent()
-    testCoroutineDispatchers.registerIdlingResource()
   }
 
   @After
   fun tearDown() {
-    testCoroutineDispatchers.unregisterIdlingResource()
     Intents.release()
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/faq/FAQSingleActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/faq/FAQSingleActivityTest.kt
@@ -53,7 +53,6 @@ import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfiguration
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.testing.TestAccessibilityModule
-import org.oppia.android.testing.TestCoroutineDispatchers
 import org.oppia.android.testing.TestDispatcherModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.util.caching.testing.CachingTestModule

--- a/app/src/sharedTest/java/org/oppia/android/app/faq/FAQSingleActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/faq/FAQSingleActivityTest.kt
@@ -79,9 +79,6 @@ class FAQSingleActivityTest {
   private lateinit var launchedActivity: Activity
 
   @Inject
-  lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-
-  @Inject
   lateinit var htmlParserFactory: HtmlParser.Factory
 
   @Inject
@@ -96,7 +93,6 @@ class FAQSingleActivityTest {
   @Before
   fun setUp() {
     setUpTestApplicationComponent()
-    testCoroutineDispatchers.registerIdlingResource()
     Intents.init()
     val intent = createFAQSingleActivity()
     launchedActivity = activityTestRule.launchActivity(intent)
@@ -104,7 +100,6 @@ class FAQSingleActivityTest {
 
   @After
   fun tearDown() {
-    testCoroutineDispatchers.unregisterIdlingResource()
     Intents.release()
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/help/HelpFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/help/HelpFragmentTest.kt
@@ -61,7 +61,6 @@ import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfiguration
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.testing.TestAccessibilityModule
-import org.oppia.android.testing.TestCoroutineDispatchers
 import org.oppia.android.testing.TestDispatcherModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.util.caching.testing.CachingTestModule
@@ -73,7 +72,6 @@ import org.oppia.android.util.parser.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.ImageParsingModule
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
 import javax.inject.Singleton
 
 @RunWith(AndroidJUnit4::class)

--- a/app/src/sharedTest/java/org/oppia/android/app/help/HelpFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/help/HelpFragmentTest.kt
@@ -80,20 +80,16 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = HelpFragmentTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class HelpFragmentTest {
-  @Inject
-  lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
 
   @Before
   fun setUp() {
     setUpTestApplicationComponent()
-    testCoroutineDispatchers.registerIdlingResource()
     Intents.init()
     FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
   }
 
   @After
   fun tearDown() {
-    testCoroutineDispatchers.unregisterIdlingResource()
     Intents.release()
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsFragmentTest.kt
@@ -18,7 +18,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Component
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.instanceOf
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsFragmentTest.kt
@@ -71,19 +71,13 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = MyDownloadsFragmentTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class MyDownloadsFragmentTest {
-  @Inject
-  lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-
   @Before
   fun setUp() {
     setUpTestApplicationComponent()
-    testCoroutineDispatchers.registerIdlingResource()
   }
 
   @After
-  fun tearDown() {
-    testCoroutineDispatchers.unregisterIdlingResource()
-  }
+  fun tearDown() {}
 
   @Test
   fun testMyDownloadsFragment_toolbarTitle_isDisplayedSuccessfully() {

--- a/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsFragmentTest.kt
@@ -51,7 +51,6 @@ import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfiguration
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.testing.TestAccessibilityModule
-import org.oppia.android.testing.TestCoroutineDispatchers
 import org.oppia.android.testing.TestDispatcherModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.util.caching.testing.CachingTestModule
@@ -63,7 +62,6 @@ import org.oppia.android.util.parser.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.ImageParsingModule
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
 import javax.inject.Singleton
 
 /** Tests for [MyDownloadsFragment]. */

--- a/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsFragmentTest.kt
@@ -69,13 +69,11 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = MyDownloadsFragmentTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class MyDownloadsFragmentTest {
+
   @Before
   fun setUp() {
     setUpTestApplicationComponent()
   }
-
-  @After
-  fun tearDown() {}
 
   @Test
   fun testMyDownloadsFragment_toolbarTitle_isDisplayedSuccessfully() {

--- a/app/src/sharedTest/java/org/oppia/android/app/parser/HtmlParserTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/parser/HtmlParserTest.kt
@@ -81,9 +81,6 @@ class HtmlParserTest {
   private lateinit var launchedActivity: Activity
 
   @Inject
-  lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-
-  @Inject
   lateinit var htmlParserFactory: HtmlParser.Factory
 
   @Inject
@@ -98,7 +95,6 @@ class HtmlParserTest {
   @Before
   fun setUp() {
     setUpTestApplicationComponent()
-    testCoroutineDispatchers.registerIdlingResource()
     Intents.init()
     val intent = Intent(Intent.ACTION_PICK)
     launchedActivity = activityTestRule.launchActivity(intent)
@@ -106,7 +102,6 @@ class HtmlParserTest {
 
   @After
   fun tearDown() {
-    testCoroutineDispatchers.unregisterIdlingResource()
     Intents.release()
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/parser/HtmlParserTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/parser/HtmlParserTest.kt
@@ -53,7 +53,6 @@ import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfiguration
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.testing.TestAccessibilityModule
-import org.oppia.android.testing.TestCoroutineDispatchers
 import org.oppia.android.testing.TestDispatcherModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.util.caching.testing.CachingTestModule


### PR DESCRIPTION
## Explanation
Fixes #2080 

Removed injected `TestCoroutineDispatchers` from the following test since it was not being used:
1. FAQListFragmentTest
2. FAQSingleActivityTest
3. HelpFragmentTest
4. HtmlParserTest
5. MyDownloadsFragmentTest

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.

## Screenshots

### Roboelectric:

![FAQListFragmentTest](https://user-images.githubusercontent.com/35566748/98201041-db2ff800-1f54-11eb-8900-812a6bc15adc.png)
![FAQSingleActivityTest](https://user-images.githubusercontent.com/35566748/98201056-dff4ac00-1f54-11eb-9708-361503a1417a.png)
![HelpFragmentTest](https://user-images.githubusercontent.com/35566748/98201063-e1be6f80-1f54-11eb-8b3b-dced8f74d588.png)
![HtmlParserTest](https://user-images.githubusercontent.com/35566748/98201068-e3883300-1f54-11eb-9a8d-3990941b8002.png)
![MyDownloadsFragmentTest](https://user-images.githubusercontent.com/35566748/98201073-e551f680-1f54-11eb-94f1-d0402039aae1.png)

### Espresso:

![FAQListFragmentTest](https://user-images.githubusercontent.com/35566748/98318796-57821400-2005-11eb-8dbf-e863143fe85f.png)
![FAQSingleActivityTest](https://user-images.githubusercontent.com/35566748/98318876-944e0b00-2005-11eb-8475-4f070e871740.png)
![HelpFragmentTest](https://user-images.githubusercontent.com/35566748/98318884-9748fb80-2005-11eb-8811-d1bdfd5bc2b9.png)
![HtmlParserTest](https://user-images.githubusercontent.com/35566748/98318889-9a43ec00-2005-11eb-9d33-80870582239b.png)
![MyDownloadsFragmentTest](https://user-images.githubusercontent.com/35566748/98318893-9ca64600-2005-11eb-9cdb-bb9f6a71793d.png)
