### PR TITLE
Fix #2090: avoid bang bang operator in networkinterceptor

### DIFF
--- a/data/src/main/java/org/oppia/android/data/backends/gae/NetworkInterceptor.kt
+++ b/data/src/main/java/org/oppia/android/data/backends/gae/NetworkInterceptor.kt
@@ -22,10 +22,10 @@ class NetworkInterceptor @Inject constructor() : Interceptor {
     val response = chain.proceed(request)
 
     if (response.code() == Constants.HTTP_OK) {
-      response.body()?.let {
-        var rawJson = it.string()
+      response.body()?.let { responseBody ->
+        var rawJson = responseBody.string()
         rawJson = removeXSSIPrefix(rawJson)
-        val contentType = it.contentType()
+        val contentType = responseBody.contentType()
         val body = ResponseBody.create(contentType, rawJson)
         return response.newBuilder().body(body).build()
       }

--- a/data/src/main/java/org/oppia/android/data/backends/gae/NetworkInterceptor.kt
+++ b/data/src/main/java/org/oppia/android/data/backends/gae/NetworkInterceptor.kt
@@ -22,10 +22,10 @@ class NetworkInterceptor @Inject constructor() : Interceptor {
     val response = chain.proceed(request)
 
     if (response.code() == Constants.HTTP_OK) {
-      if (response.body() != null) {
-        var rawJson = response.body()!!.string()
+      response.body()?.let {
+        var rawJson = it.string()
         rawJson = removeXSSIPrefix(rawJson)
-        val contentType = response.body()!!.contentType()
+        val contentType = it.contentType()
         val body = ResponseBody.create(contentType, rawJson)
         return response.newBuilder().body(body).build()
       }


### PR DESCRIPTION
## Explanation
removed bang bang operator which may null pointer exception though current code got null check but this is just a better way of coding and making use of kotlin higher order function . fixes #2090

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
