### PR TITLE
Fix #2092: dialog orientation change issue

### DIFF
--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivityPresenter.kt
@@ -15,6 +15,7 @@ import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.logging.ConsoleLogger
 import javax.inject.Inject
+import kotlin.properties.Delegates
 
 /** The presenter for [ProfileEditActivity]. */
 @ActivityScope
@@ -28,6 +29,8 @@ class ProfileEditActivityPresenter @Inject constructor(
     getProfileEditViewModel()
   }
 
+  var profileId by Delegates.notNull<Int>()
+
   fun handleOnCreate() {
     activity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
     activity.supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_arrow_back_white_24dp)
@@ -36,7 +39,7 @@ class ProfileEditActivityPresenter @Inject constructor(
       activity,
       R.layout.profile_edit_activity
     )
-    val profileId = activity.intent.getIntExtra(KEY_PROFILE_EDIT_PROFILE_ID, 0)
+    profileId = activity.intent.getIntExtra(KEY_PROFILE_EDIT_PROFILE_ID, 0)
     editViewModel.setProfileId(
       profileId,
       activity.findViewById<Switch>(R.id.profile_edit_allow_download_switch)
@@ -61,6 +64,7 @@ class ProfileEditActivityPresenter @Inject constructor(
     }
 
     binding.profileDeleteButton.setOnClickListener {
+      editViewModel.isDeleteDialogShown = true
       showDeletionDialog(profileId)
     }
 
@@ -87,6 +91,9 @@ class ProfileEditActivityPresenter @Inject constructor(
 
   fun handleOnRestoreSavedInstanceState() {
     activity.title = editViewModel.profileName
+    if (editViewModel.isDeleteDialogShown) {
+      showDeletionDialog(profileId)
+    }
   }
 
   private fun showDeletionDialog(profileId: Int) {
@@ -109,6 +116,8 @@ class ProfileEditActivityPresenter @Inject constructor(
               }
             }
           )
+      }.setOnDismissListener {
+        editViewModel.isDeleteDialogShown = false
       }.create().show()
   }
 

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditViewModel.kt
@@ -35,6 +35,7 @@ class ProfileEditViewModel @Inject constructor(
   }
 
   var isAdmin = false
+  var isDeleteDialogShown = false
 
   fun setProfileId(id: Int, switch: Switch) {
     profileId = ProfileId.newBuilder().setInternalId(id).build()

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -388,7 +389,7 @@ class ProfileEditActivityTest {
   }
 
   @Test
-  fun testProfileEditActivity_configurationChange_startActivityWithUserProfile_clickProfileDeletionButton() { // ktlint-disable max-line-length
+  fun testProfileEditActivity_clickProfileDeletionButton_configurationChange_dialogPersists() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,
@@ -397,7 +398,7 @@ class ProfileEditActivityTest {
     ).use {
       onView(withId(R.id.profile_delete_button)).perform(click())
       onView(isRoot()).perform(orientationLandscape())
-      onView(withText(R.string.profile_edit_delete_dialog_positive)).check(matches(isDisplayed()))
+      onView(withText(R.string.profile_edit_delete_dialog_positive)).inRoot(isDialog())
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -388,7 +388,7 @@ class ProfileEditActivityTest {
   }
 
   @Test
-  fun testProfileEditActivity_configurationChange_startActivityWithUserProfile_clickProfileDeletionButton() {
+  fun testProfileEditActivity_configurationChange_startActivityWithUserProfile_clickProfileDeletionButton() { // ktlint-disable max-line-length
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
         context,

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -387,6 +387,20 @@ class ProfileEditActivityTest {
     }
   }
 
+  @Test
+  fun testProfileEditActivity_configurationChange_startActivityWithUserProfile_clickProfileDeletionButton() {
+    ActivityScenario.launch<ProfileEditActivity>(
+      ProfileEditActivity.createProfileEditActivity(
+        context,
+        1
+      )
+    ).use {
+      onView(withId(R.id.profile_delete_button)).perform(click())
+      onView(isRoot()).perform(orientationLandscape())
+      onView(withText(R.string.profile_edit_delete_dialog_positive)).check(matches(isDisplayed()))
+    }
+  }
+
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.
   // TODO(#1675): Add NetworkModule once data module is migrated off of Moshi.
   @Singleton

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -392,13 +392,15 @@ class ProfileEditActivityTest {
   fun testProfileEditActivity_clickProfileDeletionButton_configurationChange_dialogPersists() {
     ActivityScenario.launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(
-        context,
-        1
+        context = context,
+        profileId = 1
       )
     ).use {
       onView(withId(R.id.profile_delete_button)).perform(click())
       onView(isRoot()).perform(orientationLandscape())
-      onView(withText(R.string.profile_edit_delete_dialog_positive)).inRoot(isDialog())
+      onView(withText(R.string.profile_edit_delete_dialog_positive)).inRoot(isDialog()).check(
+        matches(isDisplayed())
+      )
     }
   }
 


### PR DESCRIPTION
## Explanation

  - Fixes #2092 

storing the dialog visibility variable and adding dialog back when restoring state.


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
