### PR TITLE
Fix #2098: Updated package names in the kdocs for RuleQualifiers class

### DIFF
--- a/domain/src/main/java/org/oppia/android/domain/classify/rules/RuleQualifiers.kt
+++ b/domain/src/main/java/org/oppia/android/domain/classify/rules/RuleQualifiers.kt
@@ -2,42 +2,42 @@ package org.oppia.android.domain.classify.rules
 
 import javax.inject.Qualifier
 
-/** Corresponds to [org.oppia.domain.classify.RuleClassifier]s that can be used by the continue interaction. */
+/** Corresponds to [org.oppia.android.domain.classify.RuleClassifier]s that can be used by the continue interaction. */
 @Qualifier
 annotation class ContinueRules
 
-/** Corresponds to [org.oppia.domain.classify.RuleClassifier]s that can be used by the fraction input interaction. */
+/** Corresponds to [org.oppia.android.domain.classify.RuleClassifier]s that can be used by the fraction input interaction. */
 @Qualifier
 annotation class FractionInputRules
 
-/** Corresponds to [org.oppia.domain.classify.RuleClassifier]s that can be used by the item selection interaction. */
+/** Corresponds to [org.oppia.android.domain.classify.RuleClassifier]s that can be used by the item selection interaction. */
 @Qualifier
 annotation class ItemSelectionInputRules
 
-/** Corresponds to [org.oppia.domain.classify.RuleClassifier]s that can be used by the multiple choice interaction. */
+/** Corresponds to [org.oppia.android.domain.classify.RuleClassifier]s that can be used by the multiple choice interaction. */
 @Qualifier
 annotation class MultipleChoiceInputRules
 
-/** Corresponds to [org.oppia.domain.classify.RuleClassifier]s that can be used by the number with units interaction. */
+/** Corresponds to [org.oppia.android.domain.classify.RuleClassifier]s that can be used by the number with units interaction. */
 @Qualifier
 annotation class NumberWithUnitsRules
 
-/** Corresponds to [org.oppia.domain.classify.RuleClassifier]s that can be used by the text input interaction. */
+/** Corresponds to [org.oppia.android.domain.classify.RuleClassifier]s that can be used by the text input interaction. */
 @Qualifier
 annotation class TextInputRules
 
-/** Corresponds to [org.oppia.domain.classify.RuleClassifier]s that can be used by the numeric input interaction. */
+/** Corresponds to [org.oppia.android.domain.classify.RuleClassifier]s that can be used by the numeric input interaction. */
 @Qualifier
 annotation class NumericInputRules
 
-/** Corresponds to [org.oppia.domain.classify.RuleClassifier]s that can be used by the drag drop sort input interaction. */
+/** Corresponds to [org.oppia.android.domain.classify.RuleClassifier]s that can be used by the drag drop sort input interaction. */
 @Qualifier
 annotation class DragDropSortInputRules
 
-/** Corresponds to [org.oppia.domain.classify.RuleClassifier]s that can be used by the image click input interaction. */
+/** Corresponds to [org.oppia.android.domain.classify.RuleClassifier]s that can be used by the image click input interaction. */
 @Qualifier
 annotation class ImageClickInputRules
 
-/** Corresponds to [org.oppia.domain.classify.RuleClassifier]s that can be used by the ratio input interaction. */
+/** Corresponds to [org.oppia.android.domain.classify.RuleClassifier]s that can be used by the ratio input interaction. */
 @Qualifier
 annotation class RatioExpressionInputRules


### PR DESCRIPTION
## Explanation
Fixes #2098 : 
Added the ".android" portion of the package name to the kdocs to accurately reflect the updated package name.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [X] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [X] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [X] The PR is made from a branch that's **not** called "develop".
- [X] The PR is made from a branch that is up-to-date with "develop".
- [X] The PR's branch is based on "develop" and not on any other branch.
- [X] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
