### PR TITLE
Fix #2175: RTL support for Onboarding flow footer

### DIFF
--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenter.kt
@@ -49,6 +49,7 @@ class OnboardingFragmentPresenter @Inject constructor(
     onboardingPagerAdapter =
       OnboardingPagerAdapter(fragment.requireContext(), getOnboardingSlideFinalViewModel())
     binding.onboardingSlideViewPager.adapter = onboardingPagerAdapter
+    binding.onboardingSlideViewPager.rotationY = 180f
     binding.onboardingSlideViewPager.addOnPageChangeListener(
       object :
         ViewPager.OnPageChangeListener {

--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenter.kt
@@ -15,7 +15,7 @@ import org.oppia.android.app.fragment.FragmentScope
 import org.oppia.android.app.viewmodel.ViewModelProvider
 import org.oppia.android.databinding.OnboardingFragmentBinding
 import org.oppia.android.util.statusbar.StatusBarColor
-import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 import kotlin.collections.ArrayList
 

--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenter.kt
@@ -53,6 +53,7 @@ class OnboardingFragmentPresenter @Inject constructor(
     onboardingPagerAdapter =
       OnboardingPagerAdapter(fragment.requireContext(), getOnboardingSlideFinalViewModel())
     binding.onboardingSlideViewPager.adapter = onboardingPagerAdapter
+    // TODO (#2194 ): Remove this once the implementation is updated to ViewPager2
     val isRTL = TextUtilsCompat
       .getLayoutDirectionFromLocale(Locale.getDefault()) == ViewCompat.LAYOUT_DIRECTION_RTL
     if (isRTL) {

--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenter.kt
@@ -6,6 +6,8 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.LinearLayout
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.text.TextUtilsCompat
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.viewpager.widget.ViewPager
 import org.oppia.android.R
@@ -13,7 +15,9 @@ import org.oppia.android.app.fragment.FragmentScope
 import org.oppia.android.app.viewmodel.ViewModelProvider
 import org.oppia.android.databinding.OnboardingFragmentBinding
 import org.oppia.android.util.statusbar.StatusBarColor
+import java.util.*
 import javax.inject.Inject
+import kotlin.collections.ArrayList
 
 /** The presenter for [OnboardingFragment]. */
 @FragmentScope
@@ -49,7 +53,10 @@ class OnboardingFragmentPresenter @Inject constructor(
     onboardingPagerAdapter =
       OnboardingPagerAdapter(fragment.requireContext(), getOnboardingSlideFinalViewModel())
     binding.onboardingSlideViewPager.adapter = onboardingPagerAdapter
-    binding.onboardingSlideViewPager.rotationY = 180f
+    val isRTL = TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault()) == ViewCompat.LAYOUT_DIRECTION_RTL
+    if(isRTL) {
+      binding.onboardingSlideViewPager.rotationY = 180f
+    }
     binding.onboardingSlideViewPager.addOnPageChangeListener(
       object :
         ViewPager.OnPageChangeListener {

--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenter.kt
@@ -54,7 +54,7 @@ class OnboardingFragmentPresenter @Inject constructor(
       OnboardingPagerAdapter(fragment.requireContext(), getOnboardingSlideFinalViewModel())
     binding.onboardingSlideViewPager.adapter = onboardingPagerAdapter
     val isRTL = TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault()) == ViewCompat.LAYOUT_DIRECTION_RTL
-    if(isRTL) {
+    if (isRTL) {
       binding.onboardingSlideViewPager.rotationY = 180f
     }
     binding.onboardingSlideViewPager.addOnPageChangeListener(

--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenter.kt
@@ -53,7 +53,8 @@ class OnboardingFragmentPresenter @Inject constructor(
     onboardingPagerAdapter =
       OnboardingPagerAdapter(fragment.requireContext(), getOnboardingSlideFinalViewModel())
     binding.onboardingSlideViewPager.adapter = onboardingPagerAdapter
-    val isRTL = TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault()) == ViewCompat.LAYOUT_DIRECTION_RTL
+    val isRTL = TextUtilsCompat
+      .getLayoutDirectionFromLocale(Locale.getDefault()) == ViewCompat.LAYOUT_DIRECTION_RTL
     if (isRTL) {
       binding.onboardingSlideViewPager.rotationY = 180f
     }

--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingPagerAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingPagerAdapter.kt
@@ -17,6 +17,7 @@ class OnboardingPagerAdapter(
   val context: Context,
   val onboardingSlideFinalViewModel: OnboardingSlideFinalViewModel
 ) : PagerAdapter() {
+  // TODO (#2194 ): Remove this once the implementation is updated to ViewPager2
   val isRTL = TextUtilsCompat
     .getLayoutDirectionFromLocale(Locale.getDefault()) == ViewCompat.LAYOUT_DIRECTION_RTL
   override fun instantiateItem(container: ViewGroup, position: Int): Any {

--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingPagerAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingPagerAdapter.kt
@@ -28,7 +28,7 @@ class OnboardingPagerAdapter(
           false
         )
       binding.viewModel = onboardingSlideFinalViewModel
-      if(isRTL) {
+      if (isRTL) {
         binding.finalLayout!!.rotationY = 180f
       }
 

--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingPagerAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingPagerAdapter.kt
@@ -5,15 +5,19 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
+import androidx.core.text.TextUtilsCompat
+import androidx.core.view.ViewCompat
 import androidx.viewpager.widget.PagerAdapter
 import org.oppia.android.databinding.OnboardingSlideBinding
 import org.oppia.android.databinding.OnboardingSlideFinalBinding
+import java.util.*
 
 /** Adapter to control the slide details in onboarding flow. */
 class OnboardingPagerAdapter(
   val context: Context,
   val onboardingSlideFinalViewModel: OnboardingSlideFinalViewModel
 ) : PagerAdapter() {
+  val isRTL = TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault()) == ViewCompat.LAYOUT_DIRECTION_RTL
   override fun instantiateItem(container: ViewGroup, position: Int): Any {
     if (position == TOTAL_NUMBER_OF_SLIDES - 1) {
       val binding =
@@ -23,7 +27,9 @@ class OnboardingPagerAdapter(
           false
         )
       binding.viewModel = onboardingSlideFinalViewModel
-      binding.finalLayout!!.rotationY = 180f
+      if(isRTL) {
+        binding.finalLayout!!.rotationY = 180f
+      }
 
       container.addView(binding.root)
       return binding.root
@@ -34,7 +40,9 @@ class OnboardingPagerAdapter(
       container,
       false
     )
-    binding.root.rotationY = 180f
+    if(isRTL) {
+      binding.root.rotationY = 180f
+    }
     val onboardingSlideViewModel =
       OnboardingSlideViewModel(context, ViewPagerSlide.getSlideForPosition(position))
     binding.viewModel = onboardingSlideViewModel

--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingPagerAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingPagerAdapter.kt
@@ -23,6 +23,8 @@ class OnboardingPagerAdapter(
           false
         )
       binding.viewModel = onboardingSlideFinalViewModel
+      binding.finalLayout!!.rotationY = 180f
+
       container.addView(binding.root)
       return binding.root
     }
@@ -32,6 +34,7 @@ class OnboardingPagerAdapter(
       container,
       false
     )
+    binding.root.rotationY = 180f
     val onboardingSlideViewModel =
       OnboardingSlideViewModel(context, ViewPagerSlide.getSlideForPosition(position))
     binding.viewModel = onboardingSlideViewModel

--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingPagerAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingPagerAdapter.kt
@@ -10,7 +10,7 @@ import androidx.core.view.ViewCompat
 import androidx.viewpager.widget.PagerAdapter
 import org.oppia.android.databinding.OnboardingSlideBinding
 import org.oppia.android.databinding.OnboardingSlideFinalBinding
-import java.util.*
+import java.util.Locale
 
 /** Adapter to control the slide details in onboarding flow. */
 class OnboardingPagerAdapter(

--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingPagerAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingPagerAdapter.kt
@@ -17,7 +17,8 @@ class OnboardingPagerAdapter(
   val context: Context,
   val onboardingSlideFinalViewModel: OnboardingSlideFinalViewModel
 ) : PagerAdapter() {
-  val isRTL = TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault()) == ViewCompat.LAYOUT_DIRECTION_RTL
+  val isRTL = TextUtilsCompat
+    .getLayoutDirectionFromLocale(Locale.getDefault()) == ViewCompat.LAYOUT_DIRECTION_RTL
   override fun instantiateItem(container: ViewGroup, position: Int): Any {
     if (position == TOTAL_NUMBER_OF_SLIDES - 1) {
       val binding =
@@ -40,7 +41,7 @@ class OnboardingPagerAdapter(
       container,
       false
     )
-    if(isRTL) {
+    if (isRTL) {
       binding.root.rotationY = 180f
     }
     val onboardingSlideViewModel =

--- a/app/src/main/res/layout-land/onboarding_fragment.xml
+++ b/app/src/main/res/layout-land/onboarding_fragment.xml
@@ -45,7 +45,7 @@
       android:text="@string/skip"
       android:textAllCaps="true"
       android:visibility="@{viewModel.slideNumber != 3 ? View.VISIBLE: View.GONE, default=visible}"
-      app:layout_constraintRight_toRightOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintTop_toTopOf="parent" />
 
     <LinearLayout

--- a/app/src/main/res/layout-land/onboarding_slide_final.xml
+++ b/app/src/main/res/layout-land/onboarding_slide_final.xml
@@ -18,6 +18,7 @@
     android:scrollbars="none">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/final_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:orientation="horizontal">

--- a/app/src/main/res/layout-sw600dp-land/onboarding_slide_final.xml
+++ b/app/src/main/res/layout-sw600dp-land/onboarding_slide_final.xml
@@ -18,6 +18,7 @@
     android:scrollbars="none">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/final_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:orientation="horizontal">

--- a/app/src/main/res/layout-sw600dp-port/onboarding_slide_final.xml
+++ b/app/src/main/res/layout-sw600dp-port/onboarding_slide_final.xml
@@ -18,6 +18,7 @@
     android:scrollbars="none">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/final_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:orientation="vertical">

--- a/app/src/main/res/layout/onboarding_slide_final.xml
+++ b/app/src/main/res/layout/onboarding_slide_final.xml
@@ -18,6 +18,7 @@
     android:scrollbars="none">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/final_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:orientation="vertical"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #2175 
Fixes viewpager swiping direction according to RTL (when forced to rtl)

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.

Mobile Portrait | Mobile Landscape 
--- | --- 
<img src="https://user-images.githubusercontent.com/54740946/100379504-0b8e2200-303b-11eb-8417-106952b8e6ea.png" align="center" width="100%"/> | <img src="https://user-images.githubusercontent.com/54740946/100379522-1052d600-303b-11eb-9a2f-439d0b9cf330.png" align="center" width="60%"/>

Tablet Portrait | Tablet Landscape 
--- | --- 
<img src="https://user-images.githubusercontent.com/54740946/100379757-70e21300-303b-11eb-8571-1690f17412f4.png" align="center" width="60%"/> | <img src="https://user-images.githubusercontent.com/54740946/100379765-73446d00-303b-11eb-91ad-e2667fedd3a4.png" align="center" width="200%"/>

