### PR TITLE
Add self as global codeowners while Rajat is out

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,3 +21,6 @@
 
 /WORKSPACE @BenHenning
 *.bazel @BenHenning
+
+# TODO(#2223): Remove this and replace with segmented ownership.
+* @BenHenning


### PR DESCRIPTION
This is a temporary measure to ensure that I can at least glance at all PRs while @rt4914 is out next week. PRs will still be distributed between me and @anandwana001, but this is a stop-gap to make sure that nothing falls between the cracks.

It's also a forcing function to establish proper codeowners when @rt4914 returns so that I don't keep getting all code reviews. :)

**NOTE**: Please do not submit this until the beginning of next week.