### PR TITLE
Fix #2237: Remove orientation attribute from ConstraintLayout and FrameLayout.

### DIFF
--- a/app/src/main/res/layout-land/home_fragment.xml
+++ b/app/src/main/res/layout-land/home_fragment.xml
@@ -11,8 +11,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white"
-    android:gravity="center"
-    android:orientation="vertical">
+    android:gravity="center">
 
     <androidx.recyclerview.widget.RecyclerView
       android:id="@+id/home_recycler_view"

--- a/app/src/main/res/layout-land/onboarding_slide.xml
+++ b/app/src/main/res/layout-land/onboarding_slide.xml
@@ -19,8 +19,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal">
+      android:layout_height="wrap_content">
 
       <ImageView
         android:id="@+id/slide_image_view"

--- a/app/src/main/res/layout-land/onboarding_slide_final.xml
+++ b/app/src/main/res/layout-land/onboarding_slide_final.xml
@@ -20,8 +20,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
       android:id="@+id/final_layout"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal">
+      android:layout_height="wrap_content">
 
       <ImageView
         android:id="@+id/slide_image_view"

--- a/app/src/main/res/layout-land/profile_progress_header.xml
+++ b/app/src/main/res/layout-land/profile_progress_header.xml
@@ -14,7 +14,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clipToPadding="false"
-    android:orientation="vertical"
     android:paddingStart="16dp"
     android:paddingTop="32dp"
     android:paddingEnd="16dp">

--- a/app/src/main/res/layout-land/reading_text_size_fragment.xml
+++ b/app/src/main/res/layout-land/reading_text_size_fragment.xml
@@ -70,8 +70,7 @@
           <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="84dp"
-            android:background="@color/white"
-            android:orientation="horizontal">
+            android:background="@color/white">
 
             <TextView
               android:id="@+id/reading_text_size_small_textview"

--- a/app/src/main/res/layout-land/solution_summary.xml
+++ b/app/src/main/res/layout-land/solution_summary.xml
@@ -27,8 +27,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="72dp"
         android:layout_marginEnd="72dp"
-        android:layout_marginBottom="20dp"
-        android:orientation="horizontal">
+        android:layout_marginBottom="20dp">
 
         <TextView
           android:id="@+id/solution_title"

--- a/app/src/main/res/layout-land/state_fragment.xml
+++ b/app/src/main/res/layout-land/state_fragment.xml
@@ -22,8 +22,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:orientation="horizontal">
+      android:layout_height="match_parent">
 
       <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/state_recycler_view"

--- a/app/src/main/res/layout-land/story_chapter_view.xml
+++ b/app/src/main/res/layout-land/story_chapter_view.xml
@@ -44,7 +44,6 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:minHeight="116dp"
-          android:orientation="vertical"
           android:padding="8dp"
           app:layout_constraintBottom_toBottomOf="parent"
           app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout-land/text_input_interaction_item.xml
+++ b/app/src/main/res/layout-land/text_input_interaction_item.xml
@@ -16,7 +16,6 @@
     android:layout_marginBottom="0dp"
     android:descendantFocusability="beforeDescendants"
     android:focusableInTouchMode="true"
-    android:orientation="vertical"
     android:padding="0dp"
     app:layoutMarginEnd="@{viewModel.hasConversationView ? @dimen/text_input_interaction_item_conversation_view_margin_end : @dimen/text_input_interaction_item_non_conversation_view_margin_end}"
     app:layoutMarginStart="@{viewModel.hasConversationView ? @dimen/text_input_interaction_item_margin_start : @dimen/text_input_interaction_item_non_conversation_view_margin_start}">

--- a/app/src/main/res/layout-sw600dp-land/hints_summary.xml
+++ b/app/src/main/res/layout-sw600dp-land/hints_summary.xml
@@ -26,8 +26,7 @@
       android:layout_height="wrap_content"
       android:layout_marginStart="176dp"
       android:layout_marginEnd="176dp"
-      android:paddingBottom="4dp"
-      android:orientation="horizontal">
+      android:paddingBottom="4dp">
 
       <TextView
         android:id="@+id/hint_title"

--- a/app/src/main/res/layout-sw600dp-land/home_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-land/home_fragment.xml
@@ -11,8 +11,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white"
-    android:gravity="center"
-    android:orientation="vertical">
+    android:gravity="center">
 
     <androidx.recyclerview.widget.RecyclerView
       android:id="@+id/home_recycler_view"

--- a/app/src/main/res/layout-sw600dp-land/onboarding_slide.xml
+++ b/app/src/main/res/layout-sw600dp-land/onboarding_slide.xml
@@ -19,8 +19,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal">
+      android:layout_height="wrap_content">
 
       <ImageView
         android:id="@+id/slide_image_view"

--- a/app/src/main/res/layout-sw600dp-land/onboarding_slide_final.xml
+++ b/app/src/main/res/layout-sw600dp-land/onboarding_slide_final.xml
@@ -20,8 +20,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
       android:id="@+id/final_layout"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal">
+      android:layout_height="wrap_content">
 
       <ImageView
         android:id="@+id/slide_image_view"

--- a/app/src/main/res/layout-sw600dp-land/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-sw600dp-land/profile_chooser_profile_view.xml
@@ -23,7 +23,6 @@
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
     android:layout_margin="@dimen/profile_chooser_profile_view_margin"
     android:padding="@dimen/profile_chooser_profile_view_parent_padding"
     app:layoutMarginBottom="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/space_0dp}"

--- a/app/src/main/res/layout-sw600dp-land/profile_progress_header.xml
+++ b/app/src/main/res/layout-sw600dp-land/profile_progress_header.xml
@@ -14,7 +14,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clipToPadding="false"
-    android:orientation="vertical"
     android:paddingTop="92dp">
 
     <com.jackandphantom.circularimageview.CircleImage

--- a/app/src/main/res/layout-sw600dp-land/solution_summary.xml
+++ b/app/src/main/res/layout-sw600dp-land/solution_summary.xml
@@ -26,8 +26,7 @@
       android:layout_height="wrap_content"
       android:layout_marginStart="176dp"
       android:layout_marginEnd="176dp"
-      android:paddingBottom="4dp"
-      android:orientation="horizontal">
+      android:paddingBottom="4dp">
 
       <TextView
         android:id="@+id/solution_title"

--- a/app/src/main/res/layout-sw600dp-land/state_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-land/state_fragment.xml
@@ -22,8 +22,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:orientation="horizontal">
+      android:layout_height="match_parent">
 
       <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/state_recycler_view"

--- a/app/src/main/res/layout-sw600dp-land/text_input_interaction_item.xml
+++ b/app/src/main/res/layout-sw600dp-land/text_input_interaction_item.xml
@@ -16,7 +16,6 @@
     android:layout_marginBottom="0dp"
     android:descendantFocusability="beforeDescendants"
     android:focusableInTouchMode="true"
-    android:orientation="vertical"
     android:padding="0dp"
     app:layoutMarginEnd="@{viewModel.hasConversationView ? @dimen/text_input_interaction_item_conversation_view_margin_end : @dimen/text_input_interaction_item_non_conversation_view_margin_end}"
     app:layoutMarginStart="@{viewModel.hasConversationView ? @dimen/text_input_interaction_item_conversation_view_margin_start : @dimen/text_input_interaction_item_non_conversation_view_margin_start}">

--- a/app/src/main/res/layout-sw600dp-port/hints_summary.xml
+++ b/app/src/main/res/layout-sw600dp-port/hints_summary.xml
@@ -26,8 +26,7 @@
       android:layout_height="wrap_content"
       android:layout_marginStart="128dp"
       android:layout_marginEnd="128dp"
-      android:paddingBottom="4dp"
-      android:orientation="horizontal">
+      android:paddingBottom="4dp">
 
       <TextView
         android:id="@+id/hint_title"

--- a/app/src/main/res/layout-sw600dp-port/home_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-port/home_fragment.xml
@@ -11,8 +11,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white"
-    android:gravity="center"
-    android:orientation="vertical">
+    android:gravity="center">
 
     <androidx.recyclerview.widget.RecyclerView
       android:id="@+id/home_recycler_view"

--- a/app/src/main/res/layout-sw600dp-port/onboarding_slide.xml
+++ b/app/src/main/res/layout-sw600dp-port/onboarding_slide.xml
@@ -19,8 +19,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="vertical">
+      android:layout_height="wrap_content">
 
       <ImageView
         android:id="@+id/slide_image_view"

--- a/app/src/main/res/layout-sw600dp-port/onboarding_slide_final.xml
+++ b/app/src/main/res/layout-sw600dp-port/onboarding_slide_final.xml
@@ -20,8 +20,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
       android:id="@+id/final_layout"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="vertical">
+      android:layout_height="wrap_content">
 
       <ImageView
         android:id="@+id/slide_image_view"

--- a/app/src/main/res/layout-sw600dp-port/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-sw600dp-port/profile_chooser_profile_view.xml
@@ -23,7 +23,6 @@
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
     android:layout_margin="@dimen/profile_chooser_profile_view_margin"
     android:padding="@dimen/profile_chooser_profile_view_parent_padding"
     app:layoutMarginBottom="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/space_0dp}"

--- a/app/src/main/res/layout-sw600dp-port/profile_progress_header.xml
+++ b/app/src/main/res/layout-sw600dp-port/profile_progress_header.xml
@@ -14,7 +14,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clipToPadding="false"
-    android:orientation="vertical"
     android:paddingTop="92dp">
 
     <com.jackandphantom.circularimageview.CircleImage

--- a/app/src/main/res/layout-sw600dp-port/solution_summary.xml
+++ b/app/src/main/res/layout-sw600dp-port/solution_summary.xml
@@ -26,8 +26,7 @@
       android:layout_height="wrap_content"
       android:layout_marginStart="128dp"
       android:layout_marginEnd="128dp"
-      android:paddingBottom="4dp"
-      android:orientation="horizontal">
+      android:paddingBottom="4dp">
 
       <TextView
         android:id="@+id/solution_title"

--- a/app/src/main/res/layout-sw600dp-port/state_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-port/state_fragment.xml
@@ -22,8 +22,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:orientation="horizontal">
+      android:layout_height="match_parent">
 
       <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/state_recycler_view"

--- a/app/src/main/res/layout-sw600dp-port/text_input_interaction_item.xml
+++ b/app/src/main/res/layout-sw600dp-port/text_input_interaction_item.xml
@@ -16,7 +16,6 @@
     android:layout_marginBottom="0dp"
     android:descendantFocusability="beforeDescendants"
     android:focusableInTouchMode="true"
-    android:orientation="vertical"
     android:padding="0dp"
     app:layoutMarginEnd="@{viewModel.hasConversationView ? @dimen/text_input_interaction_item_conversation_view_margin_end : @dimen/text_input_interaction_item_non_conversation_view_margin_end}"
     app:layoutMarginStart="@{viewModel.hasConversationView ? @dimen/text_input_interaction_item_conversation_view_margin_start : @dimen/text_input_interaction_item_non_conversation_view_margin_start}">

--- a/app/src/main/res/layout-sw600dp/administrator_controls_activity.xml
+++ b/app/src/main/res/layout-sw600dp/administrator_controls_activity.xml
@@ -10,8 +10,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:background="@color/oppiaGreyBackground"
-      android:orientation="vertical">
+      android:background="@color/oppiaGreyBackground">
 
       <include
         android:id="@+id/administrator_controls_activity_toolbar"

--- a/app/src/main/res/layout-sw600dp/reading_text_size_fragment.xml
+++ b/app/src/main/res/layout-sw600dp/reading_text_size_fragment.xml
@@ -39,8 +39,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
           android:layout_width="match_parent"
           android:layout_height="132dp"
-          android:background="@color/white"
-          android:orientation="horizontal">
+          android:background="@color/white">
 
           <TextView
             android:id="@+id/story_text_size_small_textview"

--- a/app/src/main/res/layout-sw600dp/story_chapter_view.xml
+++ b/app/src/main/res/layout-sw600dp/story_chapter_view.xml
@@ -57,7 +57,6 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:minHeight="140dp"
-          android:orientation="vertical"
           android:padding="8dp"
           app:layout_constraintBottom_toBottomOf="parent"
           app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/audio_fragment.xml
+++ b/app/src/main/res/layout/audio_fragment.xml
@@ -22,7 +22,6 @@
     android:elevation="8dp"
     android:gravity="center_vertical"
     android:minHeight="48dp"
-    android:orientation="horizontal"
     android:padding="4dp">
 
     <ImageView

--- a/app/src/main/res/layout/drag_drop_interaction_items.xml
+++ b/app/src/main/res/layout/drag_drop_interaction_items.xml
@@ -17,8 +17,7 @@
     android:id="@+id/drag_drop_item_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="4dp"
-    android:orientation="horizontal">
+    android:layout_margin="4dp">
 
     <LinearLayout
       android:layout_width="0dp"

--- a/app/src/main/res/layout/hints_summary.xml
+++ b/app/src/main/res/layout/hints_summary.xml
@@ -27,8 +27,7 @@
       android:layout_height="wrap_content"
       android:layout_marginStart="28dp"
       android:layout_marginEnd="28dp"
-      android:layout_marginBottom="20dp"
-      android:orientation="horizontal">
+      android:layout_marginBottom="20dp">
 
       <TextView
         android:id="@+id/hint_title"

--- a/app/src/main/res/layout/home_fragment.xml
+++ b/app/src/main/res/layout/home_fragment.xml
@@ -11,8 +11,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white"
-    android:gravity="center"
-    android:orientation="vertical">
+    android:gravity="center">
 
     <androidx.recyclerview.widget.RecyclerView
       android:id="@+id/home_recycler_view"

--- a/app/src/main/res/layout/image_region_selection_interaction_item.xml
+++ b/app/src/main/res/layout/image_region_selection_interaction_item.xml
@@ -22,7 +22,6 @@
     android:background="@drawable/drag_drop_white_background"
     android:descendantFocusability="beforeDescendants"
     android:focusableInTouchMode="true"
-    android:orientation="vertical"
     android:paddingStart="8dp"
     android:paddingTop="8dp"
     android:paddingEnd="8dp"

--- a/app/src/main/res/layout/onboarding_slide.xml
+++ b/app/src/main/res/layout/onboarding_slide.xml
@@ -19,8 +19,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="vertical">
+      android:layout_height="wrap_content">
 
       <ImageView
         android:id="@+id/slide_image_view"

--- a/app/src/main/res/layout/onboarding_slide_final.xml
+++ b/app/src/main/res/layout/onboarding_slide_final.xml
@@ -21,7 +21,6 @@
       android:id="@+id/final_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:orientation="vertical"
       android:overScrollMode="always">
 
       <ImageView

--- a/app/src/main/res/layout/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout/profile_chooser_profile_view.xml
@@ -22,7 +22,6 @@
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
     app:layoutMarginBottom="@{hasProfileEverBeenAddedValue ? @dimen/profile_view_already_added_margin : @dimen/space_0dp}">
 
     <LinearLayout

--- a/app/src/main/res/layout/reading_text_size_fragment.xml
+++ b/app/src/main/res/layout/reading_text_size_fragment.xml
@@ -63,8 +63,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
           android:layout_width="match_parent"
           android:layout_height="132dp"
-          android:background="@color/white"
-          android:orientation="horizontal">
+          android:background="@color/white">
 
           <TextView
             android:id="@+id/reading_text_size_small_textview"

--- a/app/src/main/res/layout/solution_summary.xml
+++ b/app/src/main/res/layout/solution_summary.xml
@@ -27,8 +27,7 @@
       android:layout_height="wrap_content"
       android:layout_marginStart="28dp"
       android:layout_marginEnd="28dp"
-      android:layout_marginBottom="20dp"
-      android:orientation="horizontal">
+      android:layout_marginBottom="20dp">
 
       <TextView
         android:id="@+id/solution_title"

--- a/app/src/main/res/layout/state_fragment.xml
+++ b/app/src/main/res/layout/state_fragment.xml
@@ -22,8 +22,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:orientation="horizontal">
+      android:layout_height="match_parent">
 
       <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/state_recycler_view"

--- a/app/src/main/res/layout/story_chapter_view.xml
+++ b/app/src/main/res/layout/story_chapter_view.xml
@@ -57,7 +57,6 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:minHeight="140dp"
-          android:orientation="vertical"
           android:padding="8dp"
           app:layout_constraintBottom_toBottomOf="parent"
           app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/text_input_interaction_item.xml
+++ b/app/src/main/res/layout/text_input_interaction_item.xml
@@ -16,7 +16,6 @@
     android:layout_marginBottom="0dp"
     android:descendantFocusability="beforeDescendants"
     android:focusableInTouchMode="true"
-    android:orientation="vertical"
     android:padding="0dp"
     app:layoutMarginEnd="@{viewModel.hasConversationView ? @dimen/text_input_interaction_item_conversation_view_margin_end : @dimen/text_input_interaction_item_non_conversation_view_margin_end}"
     app:layoutMarginStart="@{viewModel.hasConversationView ? @dimen/text_input_interaction_item_conversation_view_margin_start : @dimen/text_input_interaction_item_non_conversation_view_margin_start}">


### PR DESCRIPTION
## Explanation
Fixing #2237, remove the orientation attribute from ConstraintLayout and FrameLayout since the attribute is not neccesary for those layouts.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
