### PR TITLE
Fix #1897: Add tests for ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProvider

### DIFF
--- a/domain/BUILD.bazel
+++ b/domain/BUILD.bazel
@@ -130,6 +130,15 @@ domain_test(
 )
 
 domain_test(
+    name = "ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProviderTest",
+    srcs = [
+        "src/test/java/org/oppia/android/domain/classify/rules/textinput/ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProviderTest.kt",
+    ],
+    test_class = "org.oppia.android.domain.classify.rules.textinput.ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProviderTest",
+    deps = TEST_DEPS,
+)
+
+domain_test(
     name = "TextInputEqualsRuleClassifierProviderTest",
     srcs = [
         "src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputEqualsRuleClassifierProviderTest.kt",

--- a/domain/src/main/java/org/oppia/android/domain/classify/rules/itemselectioninput/ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProvider.kt
+++ b/domain/src/main/java/org/oppia/android/domain/classify/rules/itemselectioninput/ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProvider.kt
@@ -26,7 +26,6 @@ internal class ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProvide
     )
   }
 
-  // TODO(#210): Add tests for this classifier.
   override fun matches(answer: StringList, input: StringList): Boolean {
     return answer.htmlList.toSet().intersect(input.htmlList).isEmpty()
   }

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/itemselectioninput/ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/itemselectioninput/ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProviderTest.kt
@@ -1,0 +1,172 @@
+package org.oppia.android.domain.classify.rules.itemselectioninput
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import dagger.BindsInstance
+import dagger.Component
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.oppia.android.domain.classify.InteractionObjectTestBuilder
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Tests for [ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProvider]. */
+@RunWith(AndroidJUnit4::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+@Config(manifest = Config.NONE)
+class ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProviderTest {
+
+  private val ITEM_SELECTION_SET_5 =
+    InteractionObjectTestBuilder.createHtmlStringListInteractionObject(
+      InteractionObjectTestBuilder
+        .createHtmlStringList("test1", "test2", "test3", "test4", "test5")
+    )
+
+  private val ITEM_SELECTION_SET_SUBSET =
+    InteractionObjectTestBuilder.createHtmlStringListInteractionObject(
+      InteractionObjectTestBuilder
+        .createHtmlStringList("test1")
+    )
+
+  private val ITEM_SELECTION_SET_ONE_ELEMENT_PRESENT =
+    InteractionObjectTestBuilder.createHtmlStringListInteractionObject(
+      InteractionObjectTestBuilder
+        .createHtmlStringList("test1", "test6")
+    )
+
+  private val ITEM_SELECTION_SET_TWO_ELEMENTS_PRESENT_NO_EXTRA_ELEMENT =
+    InteractionObjectTestBuilder.createHtmlStringListInteractionObject(
+      InteractionObjectTestBuilder
+        .createHtmlStringList("test1", "test2")
+    )
+
+  private val ITEM_SELECTION_SET_TWO_ELEMENTS_PRESENT_WITH_EXTRA_ELEMENT =
+    InteractionObjectTestBuilder.createHtmlStringListInteractionObject(
+      InteractionObjectTestBuilder
+        .createHtmlStringList("test1", "test2", "test6")
+    )
+
+  private val ITEM_SELECTION_SET_EMPTY =
+    InteractionObjectTestBuilder.createHtmlStringListInteractionObject(
+      InteractionObjectTestBuilder
+        .createHtmlStringList()
+    )
+
+  private val ITEM_SELECTION_SET_EXCLUSIVE =
+    InteractionObjectTestBuilder.createHtmlStringListInteractionObject(
+      InteractionObjectTestBuilder
+        .createHtmlStringList("test6")
+    )
+
+  @Inject
+  internal lateinit var itemSelectionInputDesNotContainAtLeastOneOfRuleClassifierProvider:
+    ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProvider
+
+  private val inputDoesNotContainAtLeastOneOfRuleClassifier by lazy {
+    itemSelectionInputDesNotContainAtLeastOneOfRuleClassifierProvider.createRuleClassifier()
+  }
+
+  @Before
+  fun setUp() {
+    setUpTestApplicationComponent()
+  }
+
+  @Test
+  fun testItemSet_setAnswer_inputIsASubset_answerContainsInput() {
+    val inputs = mapOf("x" to ITEM_SELECTION_SET_SUBSET)
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = ITEM_SELECTION_SET_5,
+      inputs = inputs
+    )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testItemSet_setAnswer_inputHasOneElementInSet_answerContainsInput() {
+    val inputs = mapOf("x" to ITEM_SELECTION_SET_ONE_ELEMENT_PRESENT)
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = ITEM_SELECTION_SET_5,
+      inputs = inputs
+    )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testItemSet_setAnswer_inputHasTwoElementsInSetNoneExtra_answerContainsInput() {
+    val inputs = mapOf("x" to ITEM_SELECTION_SET_TWO_ELEMENTS_PRESENT_NO_EXTRA_ELEMENT)
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = ITEM_SELECTION_SET_5,
+      inputs = inputs
+    )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testItemSet_setAnswer_inputHasTwoElementsInSetOneExtra_answerContainsInput() {
+    val inputs = mapOf("x" to ITEM_SELECTION_SET_TWO_ELEMENTS_PRESENT_WITH_EXTRA_ELEMENT)
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = ITEM_SELECTION_SET_5,
+      inputs = inputs
+    )
+
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testItemSet_setAnswer_inputIsEmptySet_answerDoesNotContainInput() {
+    val inputs = mapOf("x" to ITEM_SELECTION_SET_EMPTY)
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = ITEM_SELECTION_SET_5,
+      inputs = inputs
+    )
+
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testItemSet_setAnswer_inputIsExclusiveOfSet_answerDoesNotContainInput() {
+    val inputs = mapOf("x" to ITEM_SELECTION_SET_EXCLUSIVE)
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = ITEM_SELECTION_SET_5,
+      inputs = inputs
+    )
+
+    assertThat(matches).isTrue()
+  }
+
+  private fun setUpTestApplicationComponent() {
+    DaggerItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProviderTest_TestApplicationComponent // ktlint-disable max-line-length
+      .builder()
+      .setApplication(ApplicationProvider.getApplicationContext())
+      .build()
+      .inject(this)
+  }
+
+  @Singleton
+  @Component(modules = [])
+  interface TestApplicationComponent {
+    @Component.Builder
+    interface Builder {
+      @BindsInstance
+      fun setApplication(application: Application): Builder
+
+      fun build(): TestApplicationComponent
+    }
+
+    fun inject(test: ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProviderTest)
+  }
+}


### PR DESCRIPTION
## Explanation
Fixes  #1897. This PR adds the missing test file for `ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProvider`. I copied the `ItemSelectionInputContainsAtLeastOneOfRuleClassifierProvider` by changing the assertions since it provides the negation of the same functionality.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
