### PR TITLE
Migrate getTopicList() to DataProvider

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,9 @@
+# Configurations for arguments that should automatically be added to Bazel commands.
+build --android_databinding_use_v3_4_args \
+    --experimental_android_databinding_v2 \
+    --java_header_compilation=false \
+    --noincremental_dexing \
+    --define=android_standalone_dexing_tool=d8_compat_dx
+
+# Show all test output by default (for better debugging).
+test --test_output=all

--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -1048,9 +1048,9 @@ app_test(
 
 # TODO(#973): Fix app module tests for Robolectric.
 app_test(
-    name = "NavigationDrawerTestActivityTest",
-    srcs = [test_with_resources("src/sharedTest/java/org/oppia/android/app/testing/NavigationDrawerTestActivityTest.kt")],
-    test_class = "org.oppia.android.app.testing.NavigationDrawerTestActivityTest",
+    name = "NavigationDrawerActivityTest",
+    srcs = [test_with_resources("src/sharedTest/java/org/oppia/android/app/testing/NavigationDrawerActivityTest.kt")],
+    test_class = "org.oppia.android.app.testing.NavigationDrawerActivityTest",
     deps = TEST_DEPS,
 )
 

--- a/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
@@ -143,7 +143,7 @@ class HomeFragmentPresenter @Inject constructor(
   }
 
   private val topicListSummaryResultLiveData: LiveData<AsyncResult<TopicList>> by lazy {
-    topicListController.getTopicList()
+    topicListController.getTopicList().toLiveData()
   }
 
   private fun subscribeToTopicList() {

--- a/app/src/main/java/org/oppia/android/app/walkthrough/topiclist/WalkthroughTopicViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/walkthrough/topiclist/WalkthroughTopicViewModel.kt
@@ -10,6 +10,7 @@ import org.oppia.android.app.walkthrough.topiclist.topiclistviewmodel.Walkthroug
 import org.oppia.android.app.walkthrough.topiclist.topiclistviewmodel.WalkthroughTopicSummaryViewModel
 import org.oppia.android.domain.topic.TopicListController
 import org.oppia.android.util.data.AsyncResult
+import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.logging.ConsoleLogger
 import javax.inject.Inject
 
@@ -24,7 +25,7 @@ class WalkthroughTopicViewModel @Inject constructor(
   }
 
   private val topicListSummaryResultLiveData: LiveData<AsyncResult<TopicList>> by lazy {
-    topicListController.getTopicList()
+    topicListController.getTopicList().toLiveData()
   }
 
   private val topicListSummaryLiveData: LiveData<TopicList> by lazy {

--- a/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
@@ -240,6 +240,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_recyclerViewIndex1_displaysRecentlyPlayedStoriesText() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.home_recycler_view)).perform(
         scrollToPosition<RecyclerView.ViewHolder>(1)
       )
@@ -260,6 +261,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_recyclerViewIndex1_displaysViewAllText() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.home_recycler_view)).perform(
         scrollToPosition<RecyclerView.ViewHolder>(1)
       )
@@ -274,6 +276,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_recyclerViewIndex1_clickViewAll_opensRecentlyPlayedActivity() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.home_recycler_view)).perform(
         scrollToPosition<RecyclerView.ViewHolder>(1)
       )
@@ -372,6 +375,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_recyclerViewIndex3_topicSummary_topicNameIsCorrect() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.home_recycler_view)).perform(
         scrollToPosition<RecyclerView.ViewHolder>(3)
       )
@@ -386,6 +390,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_recyclerViewIndex3_topicSummary_lessonCountIsCorrect() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.home_recycler_view)).perform(
         scrollToPosition<RecyclerView.ViewHolder>(3)
       )
@@ -405,6 +410,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_recyclerViewIndex4_topicSummary_topicNameIsCorrect() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.home_recycler_view)).perform(
         scrollToPosition<RecyclerView.ViewHolder>(4)
       )
@@ -419,6 +425,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_recyclerViewIndex4_topicSummary_lessonCountIsCorrect() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.home_recycler_view)).perform(
         scrollToPosition<RecyclerView.ViewHolder>(4)
       )
@@ -438,6 +445,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_recyclerViewIndex4_topicSummary_configurationChange_lessonCountIsCorrect() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.home_recycler_view)).perform(
         scrollToPosition<RecyclerView.ViewHolder>(4)
@@ -458,6 +466,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_recyclerViewIndex3_clickTopicSummary_opensTopicActivity() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.home_recycler_view)).perform(
         scrollToPosition<RecyclerView.ViewHolder>(3)
       )
@@ -470,6 +479,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_onBackPressed_showsExitToProfileChooserDialog() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       pressBack()
       onView(withText(R.string.home_activity_back_dialog_message))
         .inRoot(isDialog())
@@ -480,6 +490,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_onBackPressed_orientationChange_showsExitToProfileChooserDialog() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       pressBack()
       onView(isRoot()).perform(orientationLandscape())
       onView(withText(R.string.home_activity_back_dialog_message))
@@ -491,6 +502,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_onBackPressed_clickExit_checkOpensProfileActivity() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       pressBack()
       onView(withText(R.string.home_activity_back_dialog_exit))
         .inRoot(isDialog())
@@ -502,6 +514,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_checkSpanForItem0_spanSizeIsTwoOrThree() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       if (context.resources.getBoolean(R.bool.isTablet)) {
         onView(withId(R.id.home_recycler_view)).check(hasGridItemCount(3, 0))
       } else {
@@ -513,6 +526,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_checkSpanForItem4_spanSizeIsOne() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.home_recycler_view)).check(hasGridItemCount(1, 4))
     }
   }
@@ -520,6 +534,7 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_configurationChange_checkSpanForItem4_spanSizeIsOne() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.home_recycler_view)).check(hasGridItemCount(1, 4))
     }

--- a/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughFinalFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughFinalFragmentTest.kt
@@ -108,8 +108,10 @@ class WalkthroughFinalFragmentTest {
   @Test
   fun testWalkthroughWelcomeFragment_recyclerViewIndex1_topicSelected_topicTitleIsCorrect() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_welcome_next_button))
         .perform(scrollTo(), click())
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_topic_recycler_view))
         .perform(scrollToPosition<RecyclerView.ViewHolder>(1))
       onView(
@@ -131,8 +133,10 @@ class WalkthroughFinalFragmentTest {
   @Test
   fun testWalkthroughWelcomeFragment_recyclerViewIndex2_topicSelected_topicTitleIsCorrect() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_welcome_next_button))
         .perform(scrollTo(), click())
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_topic_recycler_view))
         .perform(scrollToPosition<RecyclerView.ViewHolder>(1))
       onView(
@@ -154,8 +158,10 @@ class WalkthroughFinalFragmentTest {
   @Test
   fun testWalkthroughWelcomeFragment_recyclerViewIndex2_topicSelected_configurationChanged_topicTitleIsCorrect() { // ktlint-disable max-line-length
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_welcome_next_button))
         .perform(scrollTo(), click())
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_topic_recycler_view))
         .perform(scrollToPosition<RecyclerView.ViewHolder>(1))
       onView(
@@ -184,8 +190,10 @@ class WalkthroughFinalFragmentTest {
   @Test
   fun testWalkthroughWelcomeFragment_recyclerViewIndex1_topicSelected_yesNoButton_isDisplayedCorrectly() { // ktlint-disable max-line-length
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_welcome_next_button))
         .perform(scrollTo(), click())
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_topic_recycler_view))
         .perform(scrollToPosition<RecyclerView.ViewHolder>(1))
       onView(
@@ -205,8 +213,10 @@ class WalkthroughFinalFragmentTest {
   @Test
   fun testWalkthroughWelcomeFragment_recyclerViewIndex1_topicSelected_clickNoButton_worksCorrectly() { // ktlint-disable max-line-length
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_welcome_next_button))
         .perform(scrollTo(), click())
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_topic_recycler_view))
         .perform(scrollToPosition<RecyclerView.ViewHolder>(1))
       onView(

--- a/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughTopicListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughTopicListFragmentTest.kt
@@ -106,7 +106,9 @@ class WalkthroughTopicListFragmentTest {
   @Test
   fun testWalkthroughWelcomeFragment_recyclerViewIndex0_topicHeader_topicHeaderIsCorrect() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_welcome_next_button)).perform(scrollTo(), click())
+      testCoroutineDispatchers.runCurrent()
       onView(
         atPositionOnView(
           R.id.walkthrough_topic_recycler_view,
@@ -124,7 +126,9 @@ class WalkthroughTopicListFragmentTest {
   @Test
   fun testWalkthroughWelcomeFragment_recyclerViewIndex1_topicCard_topicNameIsCorrect() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_welcome_next_button)).perform(scrollTo(), click())
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_topic_recycler_view)).perform(
         scrollToPosition<RecyclerView.ViewHolder>(
           1
@@ -148,7 +152,9 @@ class WalkthroughTopicListFragmentTest {
   @Test
   fun testWalkthroughWelcomeFragment_recyclerViewIndex1_topicCard_configurationChanged_topicNameIsCorrect() { // ktlint-disable max-line-length
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_welcome_next_button)).perform(scrollTo(), click())
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.walkthrough_topic_recycler_view)).perform(
         scrollToPosition<RecyclerView.ViewHolder>(
           1

--- a/domain/src/main/java/org/oppia/android/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/TopicListController.kt
@@ -1,8 +1,6 @@
 package org.oppia.android.domain.topic
 
 import android.graphics.Color
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import org.json.JSONObject
 import org.oppia.android.app.model.ChapterPlayState
 import org.oppia.android.app.model.ChapterProgress
@@ -19,6 +17,7 @@ import org.oppia.android.app.model.TopicSummary
 import org.oppia.android.domain.util.JsonAssetRetriever
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProvider
+import org.oppia.android.util.data.DataProviders
 import org.oppia.android.util.data.DataProviders.Companion.transformAsync
 import java.util.Date
 import java.util.concurrent.TimeUnit
@@ -67,6 +66,7 @@ val EXPLORATION_THUMBNAILS = mapOf(
   TEST_EXPLORATION_ID_6 to createChapterThumbnail0()
 )
 
+private const val GET_TOPIC_LIST_PROVIDER_ID = "get_topic_list_provider_id"
 private const val GET_ONGOING_STORY_LIST_PROVIDER_ID =
   "get_ongoing_story_list_provider_id"
 
@@ -77,14 +77,18 @@ private val EVICTION_TIME_MILLIS = TimeUnit.DAYS.toMillis(1)
 class TopicListController @Inject constructor(
   private val jsonAssetRetriever: JsonAssetRetriever,
   private val topicController: TopicController,
-  private val storyProgressController: StoryProgressController
+  private val storyProgressController: StoryProgressController,
+  private val dataProviders: DataProviders
 ) {
   /**
    * Returns the list of [TopicSummary]s currently tracked by the app, possibly up to
    * [EVICTION_TIME_MILLIS] old.
    */
-  fun getTopicList(): LiveData<AsyncResult<TopicList>> {
-    return MutableLiveData(AsyncResult.success(createTopicList()))
+  fun getTopicList(): DataProvider<TopicList> {
+    return dataProviders.createInMemoryDataProvider(
+      GET_TOPIC_LIST_PROVIDER_ID,
+      this::createTopicList
+    )
   }
 
   /**

--- a/domain/src/test/java/org/oppia/android/domain/topic/TopicListControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/topic/TopicListControllerTest.kt
@@ -26,6 +26,7 @@ import org.oppia.android.app.model.LessonThumbnailGraphic
 import org.oppia.android.app.model.OngoingStoryList
 import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.PromotedStory
+import org.oppia.android.app.model.TopicList
 import org.oppia.android.domain.oppialogger.LogStorageModule
 import org.oppia.android.testing.TestCoroutineDispatchers
 import org.oppia.android.testing.TestDispatcherModule
@@ -73,7 +74,13 @@ class TopicListControllerTest {
   lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
 
   @Mock
+  lateinit var mockTopicListObserver: Observer<AsyncResult<TopicList>>
+
+  @Mock
   lateinit var mockOngoingStoryListObserver: Observer<AsyncResult<OngoingStoryList>>
+
+  @Captor
+  lateinit var topicListResultCaptor: ArgumentCaptor<AsyncResult<TopicList>>
 
   @Captor
   lateinit var ongoingStoryListResultCaptor: ArgumentCaptor<AsyncResult<OngoingStoryList>>
@@ -96,26 +103,37 @@ class TopicListControllerTest {
 
   @Test
   fun testRetrieveTopicList_isSuccessful() {
-    val topicListLiveData = topicListController.getTopicList()
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
 
-    val topicListResult = topicListLiveData.value
-    assertThat(topicListResult).isNotNull()
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicListResult = topicListResultCaptor.value
     assertThat(topicListResult!!.isSuccess()).isTrue()
   }
 
   @Test
   fun testRetrieveTopicList_providesListOfMultipleTopics() {
-    val topicListLiveData = topicListController.getTopicList()
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicList = topicListResultCaptor.value.getOrThrow()
     assertThat(topicList.topicSummaryCount).isGreaterThan(1)
   }
 
   @Test
   fun testRetrieveTopicList_firstTopic_hasCorrectTopicInfo() {
-    val topicListLiveData = topicListController.getTopicList()
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicList = topicListResultCaptor.value.getOrThrow()
     val firstTopic = topicList.getTopicSummary(0)
     assertThat(firstTopic.topicId).isEqualTo(TEST_TOPIC_ID_0)
     assertThat(firstTopic.name).isEqualTo("First Test Topic")
@@ -123,9 +141,13 @@ class TopicListControllerTest {
 
   @Test
   fun testRetrieveTopicList_firstTopic_hasCorrectThumbnail() {
-    val topicListLiveData = topicListController.getTopicList()
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicList = topicListResultCaptor.value.getOrThrow()
     val firstTopic = topicList.getTopicSummary(0)
     assertThat(firstTopic.topicThumbnail.thumbnailGraphic)
       .isEqualTo(LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS)
@@ -133,18 +155,26 @@ class TopicListControllerTest {
 
   @Test
   fun testRetrieveTopicList_firstTopic_hasCorrectLessonCount() {
-    val topicListLiveData = topicListController.getTopicList()
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicList = topicListResultCaptor.value.getOrThrow()
     val firstTopic = topicList.getTopicSummary(0)
     assertThat(firstTopic.totalChapterCount).isEqualTo(5)
   }
 
   @Test
   fun testRetrieveTopicList_secondTopic_hasCorrectTopicInfo() {
-    val topicListLiveData = topicListController.getTopicList()
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicList = topicListResultCaptor.value.getOrThrow()
     val secondTopic = topicList.getTopicSummary(1)
     assertThat(secondTopic.topicId).isEqualTo(TEST_TOPIC_ID_1)
     assertThat(secondTopic.name).isEqualTo("Second Test Topic")
@@ -152,9 +182,13 @@ class TopicListControllerTest {
 
   @Test
   fun testRetrieveTopicList_secondTopic_hasCorrectThumbnail() {
-    val topicListLiveData = topicListController.getTopicList()
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicList = topicListResultCaptor.value.getOrThrow()
     val secondTopic = topicList.getTopicSummary(1)
     assertThat(secondTopic.topicThumbnail.thumbnailGraphic)
       .isEqualTo(LessonThumbnailGraphic.BAKER)
@@ -162,18 +196,26 @@ class TopicListControllerTest {
 
   @Test
   fun testRetrieveTopicList_secondTopic_hasCorrectLessonCount() {
-    val topicListLiveData = topicListController.getTopicList()
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicList = topicListResultCaptor.value.getOrThrow()
     val secondTopic = topicList.getTopicSummary(1)
     assertThat(secondTopic.totalChapterCount).isEqualTo(1)
   }
 
   @Test
   fun testRetrieveTopicList_fractionsTopic_hasCorrectTopicInfo() {
-    val topicListLiveData = topicListController.getTopicList()
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicList = topicListResultCaptor.value.getOrThrow()
     val fractionsTopic = topicList.getTopicSummary(2)
     assertThat(fractionsTopic.topicId).isEqualTo(FRACTIONS_TOPIC_ID)
     assertThat(fractionsTopic.name).isEqualTo("Fractions")
@@ -181,9 +223,13 @@ class TopicListControllerTest {
 
   @Test
   fun testRetrieveTopicList_fractionsTopic_hasCorrectThumbnail() {
-    val topicListLiveData = topicListController.getTopicList()
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicList = topicListResultCaptor.value.getOrThrow()
     val fractionsTopic = topicList.getTopicSummary(2)
     assertThat(fractionsTopic.topicThumbnail.thumbnailGraphic)
       .isEqualTo(LessonThumbnailGraphic.CHILD_WITH_FRACTIONS_HOMEWORK)
@@ -191,18 +237,26 @@ class TopicListControllerTest {
 
   @Test
   fun testRetrieveTopicList_fractionsTopic_hasCorrectLessonCount() {
-    val topicListLiveData = topicListController.getTopicList()
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicList = topicListResultCaptor.value.getOrThrow()
     val fractionsTopic = topicList.getTopicSummary(2)
     assertThat(fractionsTopic.totalChapterCount).isEqualTo(2)
   }
 
   @Test
   fun testRetrieveTopicList_ratiosTopic_hasCorrectTopicInfo() {
-    val topicListLiveData = topicListController.getTopicList()
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicList = topicListResultCaptor.value.getOrThrow()
     val ratiosTopic = topicList.getTopicSummary(3)
     assertThat(ratiosTopic.topicId).isEqualTo(RATIOS_TOPIC_ID)
     assertThat(ratiosTopic.name).isEqualTo("Ratios and Proportional Reasoning")
@@ -210,9 +264,13 @@ class TopicListControllerTest {
 
   @Test
   fun testRetrieveTopicList_ratiosTopic_hasCorrectThumbnail() {
-    val topicListLiveData = topicListController.getTopicList()
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicList = topicListResultCaptor.value.getOrThrow()
     val ratiosTopic = topicList.getTopicSummary(3)
     assertThat(ratiosTopic.topicThumbnail.thumbnailGraphic)
       .isEqualTo(LessonThumbnailGraphic.DUCK_AND_CHICKEN)
@@ -220,9 +278,13 @@ class TopicListControllerTest {
 
   @Test
   fun testRetrieveTopicList_ratiosTopic_hasCorrectLessonCount() {
-    val topicListLiveData = topicListController.getTopicList()
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
 
-    val topicList = topicListLiveData.value!!.getOrThrow()
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicList = topicListResultCaptor.value.getOrThrow()
     val ratiosTopic = topicList.getTopicSummary(3)
     assertThat(ratiosTopic.totalChapterCount).isEqualTo(4)
   }


### PR DESCRIPTION
``TopicListController.getTopicList()`` was just a ``LiveData`` before which prevents us from leveraging other ``DataProviders`` tools. This PR migrates it to a ``DataProvider`` to follow the general pattern to always provide data from controllers in ``DataProvider``s and to let us interop better with other ``DataProvider``s.