### PR TITLE
Add .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,9 @@
+# Configurations for arguments that should automatically be added to Bazel commands.
+build --android_databinding_use_v3_4_args \
+    --experimental_android_databinding_v2 \
+    --java_header_compilation=false \
+    --noincremental_dexing \
+    --define=android_standalone_dexing_tool=d8_compat_dx
+
+# Show all test output by default (for better debugging).
+test --test_output=all


### PR DESCRIPTION
This file comes from https://github.com/oppia/oppia-android/pull/1904. We need it to simplify Bazel build commands locally (bazelrc lets us automatically add arguments to certain commands like build to make it easier to type the commands in CLI locally). This file will also be used by Android Studio when using the Android Studio-with-Bazel plugin.
