### PR TITLE
Fix #2263: Fixes App crashes in Lessons Tab and Espresso tests in TopicLessonFragmentTest

### DIFF
--- a/app/src/main/res/layout-land/topic_lessons_story_summary.xml
+++ b/app/src/main/res/layout-land/topic_lessons_story_summary.xml
@@ -164,7 +164,7 @@
           android:layout_marginTop="8dp"
           android:layout_marginBottom="8dp"
           app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-          app:list="@{viewModel.storySummary.chapterList}" />
+          app:list="@{viewModel.chapterSummaryItemList}" />
       </LinearLayout>
     </LinearLayout>
   </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout-sw600dp-land/topic_lessons_story_summary.xml
+++ b/app/src/main/res/layout-sw600dp-land/topic_lessons_story_summary.xml
@@ -167,7 +167,7 @@
             android:layout_marginTop="8dp"
             android:layout_marginBottom="8dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:list="@{viewModel.storySummary.chapterList}" />
+            app:list="@{viewModel.chapterSummaryItemList}" />
         </LinearLayout>
       </LinearLayout>
     </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout-sw600dp-port/topic_lessons_story_summary.xml
+++ b/app/src/main/res/layout-sw600dp-port/topic_lessons_story_summary.xml
@@ -167,7 +167,7 @@
             android:layout_marginTop="8dp"
             android:layout_marginBottom="8dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:list="@{viewModel.storySummary.chapterList}" />
+            app:list="@{viewModel.chapterSummaryItemList}" />
         </LinearLayout>
       </LinearLayout>
     </com.google.android.material.card.MaterialCardView>

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
@@ -166,11 +166,19 @@ class TopicLessonsFragmentTest {
   }
 
   @Test
-  @Config(qualifiers = "land-xxhdpi")
   fun testLessonsPlayFragment_loadRatiosTopic_configurationChange_storyName_isCorrect() {
     launch<TopicActivity>(createTopicActivityIntent(internalProfileId, RATIOS_TOPIC_ID)).use {
       clickLessonTab()
       onView(isRoot()).perform(orientationLandscape())
+      verifyTextOnStorySummaryListItemAtPosition(itemPosition = 1, stringToMatch = "Ratios: Part 1")
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "land-xxhdpi")
+  fun testLessonsPlayFragment_loadRatiosTopic_configurationLandscape_storyName_isCorrect() {
+    launch<TopicActivity>(createTopicActivityIntent(internalProfileId, RATIOS_TOPIC_ID)).use {
+      clickLessonTab()
       verifyTextOnStorySummaryListItemAtPosition(itemPosition = 1, stringToMatch = "Ratios: Part 1")
     }
   }
@@ -307,11 +315,27 @@ class TopicLessonsFragmentTest {
   }
 
   @Test
-  @Config(qualifiers = "land-xxhdpi")
   fun testLessonsPlayFragment_loadRatiosTopic_clickExpandListIconIndex1_configurationChange_chapterListIsVisible() { // ktlint-disable max-line-length
     launch<TopicActivity>(createTopicActivityIntent(internalProfileId, RATIOS_TOPIC_ID)).use {
       clickLessonTab()
       onView(isRoot()).perform(orientationLandscape())
+      clickStoryItem(position = 1, targetViewId = R.id.chapter_list_drop_down_icon)
+      scrollToPosition(position = 1)
+      onView(
+        atPositionOnView(
+          R.id.story_summary_recycler_view,
+          1,
+          R.id.chapter_recycler_view
+        )
+      ).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "land-xxhdpi")
+  fun testLessonsPlayFragment_loadRatiosTopic_clickExpandListIconIndex1_configurationLandscape_chapterListIsVisible() { // ktlint-disable max-line-length
+    launch<TopicActivity>(createTopicActivityIntent(internalProfileId, RATIOS_TOPIC_ID)).use {
+      clickLessonTab()
       clickStoryItem(position = 1, targetViewId = R.id.chapter_list_drop_down_icon)
       scrollToPosition(position = 1)
       onView(

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
@@ -166,10 +166,10 @@ class TopicLessonsFragmentTest {
   }
 
   @Test
+  @Config(qualifiers = "land-xxhdpi")
   fun testLessonsPlayFragment_loadRatiosTopic_configurationChange_storyName_isCorrect() {
     launch<TopicActivity>(createTopicActivityIntent(internalProfileId, RATIOS_TOPIC_ID)).use {
       clickLessonTab()
-      onView(isRoot()).perform(orientationLandscape())
       verifyTextOnStorySummaryListItemAtPosition(itemPosition = 1, stringToMatch = "Ratios: Part 1")
     }
   }
@@ -306,12 +306,12 @@ class TopicLessonsFragmentTest {
   }
 
   @Test
+  @Config(qualifiers = "land-xxhdpi")
   fun testLessonsPlayFragment_loadRatiosTopic_clickExpandListIconIndex1_configurationChange_chapterListIsVisible() { // ktlint-disable max-line-length
     launch<TopicActivity>(createTopicActivityIntent(internalProfileId, RATIOS_TOPIC_ID)).use {
       clickLessonTab()
       clickStoryItem(position = 1, targetViewId = R.id.chapter_list_drop_down_icon)
       scrollToPosition(position = 1)
-      onView(isRoot()).perform(orientationLandscape())
       onView(
         atPositionOnView(
           R.id.story_summary_recycler_view,

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
@@ -20,6 +20,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -49,6 +50,7 @@ import org.oppia.android.app.story.StoryActivity
 import org.oppia.android.app.topic.TopicActivity
 import org.oppia.android.app.topic.TopicTab
 import org.oppia.android.app.utility.EspressoTestsMatchers.withDrawable
+import org.oppia.android.app.utility.OrientationChangeAction.Companion.orientationLandscape
 import org.oppia.android.domain.classify.InteractionsModule
 import org.oppia.android.domain.classify.rules.continueinteraction.ContinueModule
 import org.oppia.android.domain.classify.rules.dragAndDropSortInput.DragDropSortInputModule
@@ -168,6 +170,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_configurationChange_storyName_isCorrect() {
     launch<TopicActivity>(createTopicActivityIntent(internalProfileId, RATIOS_TOPIC_ID)).use {
       clickLessonTab()
+      onView(isRoot()).perform(orientationLandscape())
       verifyTextOnStorySummaryListItemAtPosition(itemPosition = 1, stringToMatch = "Ratios: Part 1")
     }
   }
@@ -308,6 +311,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_clickExpandListIconIndex1_configurationChange_chapterListIsVisible() { // ktlint-disable max-line-length
     launch<TopicActivity>(createTopicActivityIntent(internalProfileId, RATIOS_TOPIC_ID)).use {
       clickLessonTab()
+      onView(isRoot()).perform(orientationLandscape())
       clickStoryItem(position = 1, targetViewId = R.id.chapter_list_drop_down_icon)
       scrollToPosition(position = 1)
       onView(

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
@@ -20,7 +20,6 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -50,7 +49,6 @@ import org.oppia.android.app.story.StoryActivity
 import org.oppia.android.app.topic.TopicActivity
 import org.oppia.android.app.topic.TopicTab
 import org.oppia.android.app.utility.EspressoTestsMatchers.withDrawable
-import org.oppia.android.app.utility.OrientationChangeAction.Companion.orientationLandscape
 import org.oppia.android.domain.classify.InteractionsModule
 import org.oppia.android.domain.classify.rules.continueinteraction.ContinueModule
 import org.oppia.android.domain.classify.rules.dragAndDropSortInput.DragDropSortInputModule


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #2263 

 - Fixes app crash in lessons Tab (landscape)
 - Fixes Espresso lagging test case in TopicLessonFragmentTest (testLessonsPlayFragment_loadRatiosTopic_configurationChange_storyName_isCorrect)
- Fixes app crash in lesson Tab (Tablet portrait and Tablet landscape)
 - Fixes 12 failed test in TopicLessonFragmentTest when run in TopicLessonFragmentTest (run in tablet)

**NOTE**:  above mentioned tests passes in robolectric

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.


##ScreenShots
testLessonsPlayFragment_loadRatiosTopic_configurationChange_storyName_isCorrect before changes 
![image](https://user-images.githubusercontent.com/54740946/102191168-0d7f2e80-3edf-11eb-87f8-0234f8e5f05b.png)
Espresso test failing in tablet
![image](https://user-images.githubusercontent.com/54740946/102192083-48ce2d00-3ee0-11eb-81bb-d13e7d548a18.png)