### PR TITLE
Fix #2223: Introduce codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,8 +19,174 @@
 # be superseded by the relevant codeowners mentioned elsewhere in this file.
 # (Reference: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners)
 
-/WORKSPACE @BenHenning
-*.bazel @BenHenning
+#####################################################################################
+#                                 Blanket ownership                                 #
+#####################################################################################
 
-# TODO(#2223): Remove this and replace with segmented ownership.
+# Global ownership (only for cases when new files are added & no other matches occur).
 * @BenHenning
+
+# Codeowners ownership (for adding/changing/removing code owners).
+.github/CODEOWNERS @oppia/owners
+
+# Bazel build files.
+/WORKSPACE @BenHenning
+*.bzl @BenHenning
+*.bazel @BenHenning
+BUILD @BenHenning
+.bazelrc @BenHenning
+/tools/android/ @BenHenning
+
+# Gradle build files.
+*.gradle @BenHenning
+gradle.properties @BenHenning
+gradlew @BenHenning
+gradlew.bat @BenHenning
+/gradle/ @BenHenning
+
+# GitHub configuration files.
+.gitignore @BenHenning
+/.github/*.md @BenHenning
+/.github/ISSUE_TEMPLATE @BenHenning
+
+# CI configuration.
+/.github/workflows/ @BenHenning
+
+# All tests.
+*Test.kt @anandwana001
+
+# All layout files.
+layout*/*.xml @rt4914
+
+# Proguard configurations.
+*.pro @BenHenning
+
+# Lesson assets.
+/domain/src/main/assets/ @BenHenning @rt4914
+
+# Android manifests.
+*Manifest.xml @BenHenning
+
+# Linter configurations.
+buf.yaml @anandwana001
+
+# IDEA IDE configuration.
+.editorconfig @BenHenning
+/.idea/ @BenHenning
+
+# Important codebase files.
+LICENSE @BenHenning
+
+#####################################################################################
+#                                    app module                                     #
+#####################################################################################
+
+# Global app module code ownership.
+/app/**/*.kt @rt4914
+/app/**/*.java @rt4914
+
+# State players.
+/app/src/*/java/org/oppia/android/app/player/ @BenHenning
+
+# Bindable adapter utilities.
+/app/src/main/java/org/oppia/android/app/recyclerview/BindableAdapter.java @BenHenning
+/app/src/main/java/org/oppia/android/app/recyclerview/RecyclerViewBindingAdapter.java @BenHenning
+/app/src/sharedTest/java/org/oppia/android/app/recyclerview/BindableAdapterTest.kt @BenHenning
+
+# Dagger configuration.
+/app/src/main/java/org/oppia/android/app/activity/ @BenHenning
+/app/src/main/java/org/oppia/android/app/application/ @BenHenning
+/app/src/main/java/org/oppia/android/app/fragment/ @BenHenning
+/app/src/main/java/org/oppia/android/app/view/ @BenHenning
+
+# Databinding adapters.
+/app/src/main/java/org/oppia/android/app/databinding/ @BenHenning
+
+# App deprecation functionality.
+/app/src/*/java/org/oppia/android/app/deprecation/ @BenHenning
+
+# Parsing functionality needed for interactions.
+/app/src/*/java/org/oppia/android/app/parser/ @BenHenning
+
+# Bazel/data-binding shims.
+/app/src/*/java/org/oppia/android/app/shim/ @BenHenning
+
+# Splash screen.
+/app/src/*/java/org/oppia/android/app/splash/ @BenHenning
+
+# View model infrastructure.
+/app/src/*/java/org/oppia/android/app/viewmodel/ @BenHenning
+
+# App testing infrastructure.
+/app/src/*/java/org/oppia/android/app/testing/ @anandwana001
+
+#####################################################################################
+#                                  domain module                                    #
+#####################################################################################
+
+# Global domain module code ownership.
+/domain/**/*.kt @BenHenning
+/domain/**/*.java @BenHenning
+
+# Questions support.
+/domain/src/*/java/org/oppia/android/domain/question/ @vinitamurthi
+
+# Oppia logging support.
+/domain/src/main/java/org/oppia/android/domain/oppialogger/ @vinitamurthi
+
+#####################################################################################
+#                                  testing module                                   #
+#####################################################################################
+
+# Global testing module code ownership (secondary).
+/testing/**/*.kt @anandwana001
+/testing/**/*.java @anandwana001
+
+# Global testing module code ownership (primary).
+/testing/**/*.kt @BenHenning
+/testing/**/*.java @BenHenning
+
+#####################################################################################
+#                                    data module                                    #
+#####################################################################################
+
+# Global data module code ownership.
+/data/**/*.kt @BenHenning
+/data/**/*.java @BenHenning
+
+#####################################################################################
+#                                  utility module                                   #
+#####################################################################################
+
+# Global utility module code ownership.
+/utility/**/*.kt @BenHenning
+/utility/**/*.java @BenHenning
+
+# Accessibility utilities.
+/utility/src/*/java/org/oppia/android/util/accessibility/ @rt4914
+
+# Core logging infrastructure.
+/utility/src/*/java/org/oppia/android/util/logging/ @vinitamurthi
+
+# Miscellaneous statusbar UI utilities.
+/utility/src/*/java/org/oppia/android/util/statusbar/ @rt4914
+
+#####################################################################################
+#                                     scripts                                       #
+#####################################################################################
+
+# Global scripts code ownership.
+/scripts/ @anandwana001 @BenHenning
+
+#####################################################################################
+#                                      model                                        #
+#####################################################################################
+
+# Global proto file ownership (for protos outside the model directory since all protos should belong in models).
+*.proto @BenHenning @vinitamurthi
+
+# Global model ownership (secondary).
+/model/ @vinitamurthi
+
+# Global model ownership (primary).
+/model/ @BenHenning


### PR DESCRIPTION
Fix #2223.

Introduce codeowners per the approved document: https://docs.google.com/document/d/1OtGIwG-VMZkE8F5uGU0OMlmT20BjW0sQllWsQryAkiA/edit#.
