### PR TITLE
Fix #2227 : Profile name going out of bounds are moved to the next line

### DIFF
--- a/app/src/main/res/layout/profile_edit_activity.xml
+++ b/app/src/main/res/layout/profile_edit_activity.xml
@@ -209,12 +209,14 @@
             android:id="@+id/profile_edit_name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="150dp"
             android:fontFamily="sans-serif-medium"
             android:text="@{viewModel.profile.name}"
             android:textColor="@color/oppiaPrimaryText"
             android:textSize="20sp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            profile:ignore="TextViewEdits" />
 
           <TextView
             android:id="@+id/profile_edit_created"

--- a/app/src/main/res/layout/profile_edit_activity.xml
+++ b/app/src/main/res/layout/profile_edit_activity.xml
@@ -215,7 +215,7 @@
             android:textColor="@color/oppiaPrimaryText"
             android:textSize="20sp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            app:layout_constraintTop_toTopOf="parent" />
 
           <TextView
             android:id="@+id/profile_edit_created"

--- a/app/src/main/res/layout/profile_edit_activity.xml
+++ b/app/src/main/res/layout/profile_edit_activity.xml
@@ -215,8 +215,7 @@
             android:textColor="@color/oppiaPrimaryText"
             android:textSize="20sp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            profile:ignore="TextViewEdits" />
+            app:layout_constraintTop_toTopOf="parent"/>
 
           <TextView
             android:id="@+id/profile_edit_created"


### PR DESCRIPTION
## Explanation

Fixes #2227 

This PR shifts the profile name to the next line instead of taking the name out of the screen.

## Before
![image](https://user-images.githubusercontent.com/49037005/102976702-f916e380-4527-11eb-8999-c4bdcd0d15c5.png)
## After
![Screenshot_1608711984](https://user-images.githubusercontent.com/49037005/102976858-324f5380-4528-11eb-9003-68a463543f09.png)

## Tablet Landscape Mode
![Screenshot_1608624393](https://user-images.githubusercontent.com/49037005/102977591-392a9600-4529-11eb-9bad-79903ef5eaf6.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
