### PR TITLE
Add support for unpublished topics

### DIFF
--- a/domain/src/main/assets/GJ2rLXRKD5hw.json
+++ b/domain/src/main/assets/GJ2rLXRKD5hw.json
@@ -19,6 +19,7 @@
   "topic_description": "You'll often need to talk about part of an object or group. For example, a jar of milk might be half-full, or some of the eggs in a box might have broken. In these lessons, you'll learn to use fractions to describe situations like these.",
   "topic_id": "GJ2rLXRKD5hw",
   "version": 1,
+  "published": true,
   "skill_descriptions": {
     "5RM9KPfQxobH": "Given a picture divided into unequal parts, write the fraction.",
     "UxTGIJqaHMLa": "Identify the numerator and denominator of a fraction.",

--- a/domain/src/main/assets/omzF4oqgeTXd.json
+++ b/domain/src/main/assets/omzF4oqgeTXd.json
@@ -31,6 +31,7 @@
   "topic_name": "Ratios and Proportional Reasoning",
   "topic_id": "omzF4oqgeTXd",
   "version": 1,
+  "published": true,
   "skill_descriptions": {
     "NGZ89uMw0IGV": "Ratios Skill 1"
   },

--- a/domain/src/main/assets/test_topic_id_0.json
+++ b/domain/src/main/assets/test_topic_id_0.json
@@ -32,6 +32,7 @@
   "topic_name": "First Test Topic",
   "topic_id": "test_topic_id_0",
   "version": 1,
+  "published": true,
   "skill_descriptions": {
     "test_skill_id_0": "An important skill",
     "test_skill_id_1": "Another important skill"

--- a/domain/src/main/assets/test_topic_id_1.json
+++ b/domain/src/main/assets/test_topic_id_1.json
@@ -18,6 +18,7 @@
   "topic_name": "Second Test Topic",
   "topic_id": "test_topic_id_1",
   "version": 3,
+  "published": true,
   "skill_descriptions": {
     "test_skill_id_2": "A different skill in a different topic Another important skill",
     "test_skill_id_3": "Another important skill 4"

--- a/domain/src/main/assets/test_topic_id_2.json
+++ b/domain/src/main/assets/test_topic_id_2.json
@@ -1,0 +1,12 @@
+{
+  "canonical_story_dicts": [],
+  "uncategorized_skill_ids": [],
+  "additional_story_dicts": [],
+  "topic_description": "A topic that's not yet ready to be played.",
+  "topic_name": "Third Test Topic",
+  "topic_id": "test_topic_id_2",
+  "version": 1,
+  "published": false,
+  "skill_descriptions": {},
+  "subtopics": []
+}

--- a/domain/src/main/assets/topics.json
+++ b/domain/src/main/assets/topics.json
@@ -2,6 +2,7 @@
   "topic_id_list": [
     "test_topic_id_0",
     "test_topic_id_1",
+    "test_topic_id_2",
     "GJ2rLXRKD5hw",
     "omzF4oqgeTXd"
   ]

--- a/domain/src/main/java/org/oppia/android/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/TopicController.kt
@@ -21,6 +21,7 @@ import org.oppia.android.app.model.StoryProgress
 import org.oppia.android.app.model.StorySummary
 import org.oppia.android.app.model.Subtopic
 import org.oppia.android.app.model.Topic
+import org.oppia.android.app.model.TopicPlayAvailability
 import org.oppia.android.app.model.TopicProgress
 import org.oppia.android.domain.oppialogger.exceptions.ExceptionsController
 import org.oppia.android.domain.question.QuestionRetriever
@@ -406,6 +407,11 @@ class TopicController @Inject constructor(
       createSubtopicListFromJsonArray(topicData.optJSONArray("subtopics"))
     val storySummaryList: List<StorySummary> =
       createStorySummaryListFromJsonArray(topicId, topicData.optJSONArray("canonical_story_dicts"))
+    val topicPlayAvailability = if (topicData.getBoolean("published")) {
+      TopicPlayAvailability.newBuilder().setAvailableToPlayNow(true).build()
+    } else {
+      TopicPlayAvailability.newBuilder().setAvailableToPlayInFuture(true).build()
+    }
     return Topic.newBuilder()
       .setTopicId(topicId)
       .setName(topicData.getString("topic_name"))
@@ -414,6 +420,7 @@ class TopicController @Inject constructor(
       .setTopicThumbnail(createTopicThumbnail(topicData))
       .setDiskSizeBytes(computeTopicSizeBytes(getAssetFileNameList(topicId)))
       .addAllSubtopic(subtopicList)
+      .setTopicPlayAvailability(topicPlayAvailability)
       .build()
   }
 

--- a/domain/src/test/java/org/oppia/android/domain/topic/TopicControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/topic/TopicControllerTest.kt
@@ -31,6 +31,8 @@ import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.Question
 import org.oppia.android.app.model.StorySummary
 import org.oppia.android.app.model.Topic
+import org.oppia.android.app.model.TopicPlayAvailability.AvailabilityCase.AVAILABLE_TO_PLAY_IN_FUTURE
+import org.oppia.android.app.model.TopicPlayAvailability.AvailabilityCase.AVAILABLE_TO_PLAY_NOW
 import org.oppia.android.domain.oppialogger.LogStorageModule
 import org.oppia.android.testing.FakeExceptionLogger
 import org.oppia.android.testing.TestCoroutineDispatchers
@@ -216,7 +218,30 @@ class TopicControllerTest {
     testCoroutineDispatchers.runCurrent()
 
     verifyGetTopicFailed()
-    assertThat(topicResultCaptor.value!!.isFailure()).isTrue()
+  }
+
+  @Test
+  fun testRetrieveTopic_testTopic_published_returnsAsAvailable() {
+    topicController.getTopic(
+      profileId1, TEST_TOPIC_ID_0
+    ).toLiveData().observeForever(mockTopicObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verifyGetTopicSucceeded()
+    val topic = topicResultCaptor.value.getOrThrow()
+    assertThat(topic.topicPlayAvailability.availabilityCase).isEqualTo(AVAILABLE_TO_PLAY_NOW)
+  }
+
+  @Test
+  fun testRetrieveTopic_testTopic_unpublished_returnsAsAvailableInFuture() {
+    topicController.getTopic(
+      profileId1, TEST_TOPIC_ID_2
+    ).toLiveData().observeForever(mockTopicObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    verifyGetTopicSucceeded()
+    val topic = topicResultCaptor.value.getOrThrow()
+    assertThat(topic.topicPlayAvailability.availabilityCase).isEqualTo(AVAILABLE_TO_PLAY_IN_FUTURE)
   }
 
   @Test

--- a/domain/src/test/java/org/oppia/android/domain/topic/TopicListControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/topic/TopicListControllerTest.kt
@@ -27,6 +27,7 @@ import org.oppia.android.app.model.OngoingStoryList
 import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.PromotedStory
 import org.oppia.android.app.model.TopicList
+import org.oppia.android.app.model.TopicSummary
 import org.oppia.android.domain.oppialogger.LogStorageModule
 import org.oppia.android.testing.TestCoroutineDispatchers
 import org.oppia.android.testing.TestDispatcherModule
@@ -287,6 +288,21 @@ class TopicListControllerTest {
     val topicList = topicListResultCaptor.value.getOrThrow()
     val ratiosTopic = topicList.getTopicSummary(3)
     assertThat(ratiosTopic.totalChapterCount).isEqualTo(4)
+  }
+
+  @Test
+  fun testRetrieveTopicList_doesNotContainUnavailableTopic() {
+    val topicListLiveData = topicListController.getTopicList().toLiveData()
+
+    topicListLiveData.observeForever(mockTopicListObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    // Verify that the topic list does not contain a not-yet published topic (since it can't be
+    // played by the user).
+    verify(mockTopicListObserver).onChanged(topicListResultCaptor.capture())
+    val topicList = topicListResultCaptor.value.getOrThrow()
+    val topicIds = topicList.topicSummaryList.map(TopicSummary::getTopicId)
+    assertThat(topicIds).doesNotContain(TEST_TOPIC_ID_2)
   }
 
   @Test

--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -42,10 +42,10 @@ message TopicPlayAvailability {
   // Corresponds to the availability of this topic (e.g. whether it can be played now).
   oneof availability {
     // Indicates this topic is available to be played.
-    bool available_to_play_now = 8;
+    bool available_to_play_now = 1;
 
     // Indicates this topic is not yet available to be played but is expected to be in the future.
-    bool available_to_play_in_future = 9;
+    bool available_to_play_in_future = 2;
   }
 }
 

--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -32,6 +32,21 @@ message Topic {
 
   // The number of on-disk bytes this topic consumes.
   int64 disk_size_bytes = 7;
+
+  // Specifics about whether this topic is playable.
+  TopicPlayAvailability topic_play_availability = 8;
+}
+
+// Corresponds to details around whether a particular topic is playable.
+message TopicPlayAvailability {
+  // Corresponds to the availability of this topic (e.g. whether it can be played now).
+  oneof availability {
+    // Indicates this topic is available to be played.
+    bool available_to_play_now = 8;
+
+    // Indicates this topic is not yet available to be played but is expected to be in the future.
+    bool available_to_play_in_future = 9;
+  }
 }
 
 // Corresponds to a concept card that can be displayed for a specific skill.
@@ -206,6 +221,9 @@ message TopicSummary {
 
   // The associated thumbnail that should be displayed with this topic summary.
   LessonThumbnail topic_thumbnail = 5;
+
+  // Specifics about whether this topic is playable.
+  TopicPlayAvailability topic_play_availability = 6;
 }
 
 // Represents the play state of a single chapter.


### PR DESCRIPTION
Marking a topic as unpublished is the key way to indicate that it may be coming in the future. The proto modeling for this is a oneof to be a bit more future-proof, but currently there are only two states: can be played, cannot be played. Conceivably, we may add future states to help display potential release dates (e.g. quarters, specific time, etc.).