### PR TITLE
Fix #1930: "Tick icon" disappears on configuration change in QuestionPlayer

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
@@ -118,6 +118,7 @@ const val CONCEPT_CARD_DIALOG_FRAGMENT_TAG = "CONCEPT_CARD_FRAGMENT"
 class StatePlayerRecyclerViewAssembler private constructor(
   val adapter: BindableAdapter<StateItemViewModel>,
   val rhsAdapter: BindableAdapter<StateItemViewModel>,
+  val isCorrectAnswer: ObservableField<Boolean>,
   private val playerFeatureSet: PlayerFeatureSet,
   private val fragment: Fragment,
   private val congratulationsTextView: TextView?,
@@ -147,8 +148,6 @@ class StatePlayerRecyclerViewAssembler private constructor(
    * not retained upon configuration changes since the user can just re-expand the list.
    */
   private var hasPreviousResponsesExpanded: Boolean = false
-
-  val isCorrectAnswer = ObservableField<Boolean>(false)
 
   private val lifecycleSafeTimerFactory = LifecycleSafeTimerFactory(backgroundCoroutineDispatcher)
 
@@ -775,6 +774,14 @@ class StatePlayerRecyclerViewAssembler private constructor(
       }
     }
 
+    private val isCorrectAnswer: ObservableField<Boolean> = ObservableField(false)
+
+    /** @param isCorrectAnswer is restored to its updated value on configuration change */
+    fun isAnswerCorrect(isCorrectAnswer: Boolean): Builder {
+      this.isCorrectAnswer.set(isCorrectAnswer)
+      return this
+    }
+
     /** Adds support for displaying state content to the learner. */
     fun addContentSupport(): Builder {
       adapterBuilder.registerViewBinder(
@@ -1170,6 +1177,7 @@ class StatePlayerRecyclerViewAssembler private constructor(
       val assembler = StatePlayerRecyclerViewAssembler(
         /* adapter= */ adapterBuilder.build(),
         /* rhsAdapter= */ adapterBuilder.build(),
+        isCorrectAnswer,
         playerFeatureSet,
         fragment,
         congratulationsTextView,

--- a/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerFragmentPresenter.kt
@@ -286,6 +286,7 @@ class QuestionPlayerFragmentPresenter @Inject constructor(
       fragment,
       Observer<AnsweredQuestionOutcome> { result ->
         recyclerViewAssembler.isCorrectAnswer.set(result.isCorrectAnswer)
+        questionViewModel.isAnswerCorrect = result.isCorrectAnswer
         if (result.isCorrectAnswer) {
           recyclerViewAssembler.stopHintsFromShowing()
           questionViewModel.setHintBulbVisibility(false)
@@ -415,6 +416,7 @@ class QuestionPlayerFragmentPresenter @Inject constructor(
       .addHintsAndSolutionsSupport()
       .addCongratulationsForCorrectAnswers(congratulationsTextView)
       .addConceptCardSupport()
+      .isAnswerCorrect(questionViewModel.isAnswerCorrect)
       .build()
   }
 

--- a/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerFragmentPresenter.kt
@@ -286,7 +286,7 @@ class QuestionPlayerFragmentPresenter @Inject constructor(
       fragment,
       Observer<AnsweredQuestionOutcome> { result ->
         recyclerViewAssembler.isCorrectAnswer.set(result.isCorrectAnswer)
-        questionViewModel.isAnswerCorrect = result.isCorrectAnswer
+        questionViewModel.isAnswerCorrect.set(result.isCorrectAnswer)
         if (result.isCorrectAnswer) {
           recyclerViewAssembler.stopHintsFromShowing()
           questionViewModel.setHintBulbVisibility(false)
@@ -416,7 +416,7 @@ class QuestionPlayerFragmentPresenter @Inject constructor(
       .addHintsAndSolutionsSupport()
       .addCongratulationsForCorrectAnswers(congratulationsTextView)
       .addConceptCardSupport()
-      .isAnswerCorrect(questionViewModel.isAnswerCorrect)
+      .isAnswerCorrect(questionViewModel.getIsAnswerCorrect())
       .build()
   }
 

--- a/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerViewModel.kt
@@ -24,13 +24,13 @@ class QuestionPlayerViewModel @Inject constructor() : ObservableViewModel() {
   val progressPercentage = ObservableField(0)
   val isAtEndOfSession = ObservableBoolean(false)
   private val canSubmitAnswer = ObservableField(false)
+  var isAnswerCorrect = false
 
   var newAvailableHintIndex = -1
   var allHintsExhausted = false
   val isHintBulbVisible = ObservableField(false)
   val isHintOpenedAndUnRevealed = ObservableField(false)
 
-  var isAnswerCorrect = false
 
   fun setHintBulbVisibility(hintBulbVisible: Boolean) {
     isHintBulbVisible.set(hintBulbVisible)

--- a/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerViewModel.kt
@@ -30,6 +30,8 @@ class QuestionPlayerViewModel @Inject constructor() : ObservableViewModel() {
   val isHintBulbVisible = ObservableField(false)
   val isHintOpenedAndUnRevealed = ObservableField(false)
 
+  var isAnswerCorrect = false
+
   fun setHintBulbVisibility(hintBulbVisible: Boolean) {
     isHintBulbVisible.set(hintBulbVisible)
   }

--- a/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerViewModel.kt
@@ -31,7 +31,6 @@ class QuestionPlayerViewModel @Inject constructor() : ObservableViewModel() {
   val isHintBulbVisible = ObservableField(false)
   val isHintOpenedAndUnRevealed = ObservableField(false)
 
-
   fun setHintBulbVisibility(hintBulbVisible: Boolean) {
     isHintBulbVisible.set(hintBulbVisible)
   }

--- a/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerViewModel.kt
@@ -24,7 +24,7 @@ class QuestionPlayerViewModel @Inject constructor() : ObservableViewModel() {
   val progressPercentage = ObservableField(0)
   val isAtEndOfSession = ObservableBoolean(false)
   private val canSubmitAnswer = ObservableField(false)
-  var isAnswerCorrect = false
+  val isAnswerCorrect = ObservableField(false)
 
   var newAvailableHintIndex = -1
   var allHintsExhausted = false
@@ -38,6 +38,8 @@ class QuestionPlayerViewModel @Inject constructor() : ObservableViewModel() {
   fun setHintOpenedAndUnRevealedVisibility(hintOpenedAndUnRevealedVisible: Boolean) {
     isHintOpenedAndUnRevealed.set(hintOpenedAndUnRevealedVisible)
   }
+
+  fun getIsAnswerCorrect(): Boolean = isAnswerCorrect.get() == true
 
   fun setCanSubmitAnswer(canSubmitAnswer: Boolean) = this.canSubmitAnswer.set(canSubmitAnswer)
 

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -233,6 +233,22 @@ class QuestionPlayerActivityTest {
   // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
   @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Test
+  fun testQuestionPlayer_chooseCorrectAnswer_configurationChange_tickIsCompletelyVisible() {
+    launchForSkillList(SKILL_ID_LIST).use {
+      // Option 2 is the right answer and tick icon should be visible completely
+      selectMultipleChoiceOption(optionPosition = 2)
+      rotateToLandscape()
+      onView(withId(R.id.answer_tick)).check(
+        matches(
+          isCompletelyDisplayed()
+        )
+      )
+    }
+  }
+
+  // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
+  @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
+  @Test
   fun testChooseCorrectAnswer_answerLongerThanScreen_phoneLand_tickIsCompletelyVisible() {
     launchForSkillList(SKILL_ID_LIST).use {
       rotateToLandscape()

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -78,10 +78,12 @@ import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.testing.CoroutineExecutorService
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.RobolectricModule
+import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestAccessibilityModule
 import org.oppia.android.testing.TestCoroutineDispatchers
 import org.oppia.android.testing.TestDispatcherModule
 import org.oppia.android.testing.TestLogReportingModule
+import org.oppia.android.testing.TestPlatform
 import org.oppia.android.testing.profile.ProfileTestHelper
 import org.oppia.android.util.caching.testing.CachingTestModule
 import org.oppia.android.util.gcsresource.GcsResourceModule
@@ -213,6 +215,8 @@ class QuestionPlayerActivityTest {
     }
   }
 
+  // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
+  @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Test
   fun testChooseCorrectAnswer_answerLongerThanScreen_phonePort_tickIsCompletelyVisible() {
     launchForSkillList(SKILL_ID_LIST).use {
@@ -226,6 +230,8 @@ class QuestionPlayerActivityTest {
     }
   }
 
+  // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
+  @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Test
   fun testQuestionPlayer_chooseCorrectAnswer_configurationChange_tickIsCompletelyVisible() {
     launchForSkillList(SKILL_ID_LIST).use {
@@ -240,6 +246,8 @@ class QuestionPlayerActivityTest {
     }
   }
 
+  // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
+  @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Test
   fun testChooseCorrectAnswer_answerLongerThanScreen_phoneLand_tickIsCompletelyVisible() {
     launchForSkillList(SKILL_ID_LIST).use {
@@ -254,6 +262,8 @@ class QuestionPlayerActivityTest {
     }
   }
 
+  // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
+  @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Config(qualifiers = "sw600dp")
   @Test
   fun testChooseCorrectAnswer_answerLongerThanScreen_tabletPort_tickIsCompletelyVisible() {
@@ -268,6 +278,8 @@ class QuestionPlayerActivityTest {
     }
   }
 
+  // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
+  @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Config(qualifiers = "sw600dp")
   @Test
   fun testChooseCorrectAnswer_answerLongerThanScreen_tabletLand_tickIsCompletelyVisible() {

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -215,8 +215,6 @@ class QuestionPlayerActivityTest {
     }
   }
 
-  // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
-  @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Test
   fun testChooseCorrectAnswer_answerLongerThanScreen_phonePort_tickIsCompletelyVisible() {
     launchForSkillList(SKILL_ID_LIST).use {
@@ -230,8 +228,6 @@ class QuestionPlayerActivityTest {
     }
   }
 
-  // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
-  @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Test
   fun testQuestionPlayer_chooseCorrectAnswer_configurationChange_tickIsCompletelyVisible() {
     launchForSkillList(SKILL_ID_LIST).use {
@@ -246,8 +242,6 @@ class QuestionPlayerActivityTest {
     }
   }
 
-  // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
-  @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Test
   fun testChooseCorrectAnswer_answerLongerThanScreen_phoneLand_tickIsCompletelyVisible() {
     launchForSkillList(SKILL_ID_LIST).use {
@@ -262,8 +256,6 @@ class QuestionPlayerActivityTest {
     }
   }
 
-  // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
-  @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Config(qualifiers = "sw600dp")
   @Test
   fun testChooseCorrectAnswer_answerLongerThanScreen_tabletPort_tickIsCompletelyVisible() {
@@ -278,8 +270,6 @@ class QuestionPlayerActivityTest {
     }
   }
 
-  // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
-  @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Config(qualifiers = "sw600dp")
   @Test
   fun testChooseCorrectAnswer_answerLongerThanScreen_tabletLand_tickIsCompletelyVisible() {

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -78,12 +78,10 @@ import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.testing.CoroutineExecutorService
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.RobolectricModule
-import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestAccessibilityModule
 import org.oppia.android.testing.TestCoroutineDispatchers
 import org.oppia.android.testing.TestDispatcherModule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.TestPlatform
 import org.oppia.android.testing.profile.ProfileTestHelper
 import org.oppia.android.util.caching.testing.CachingTestModule
 import org.oppia.android.util.gcsresource.GcsResourceModule

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -218,7 +218,7 @@ class QuestionPlayerActivityTest {
   // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
   @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Test
-  fun testChooseCorrectAnswer_answerLongerThanScreen_phonePort_tickIsCompletelyVisible() {
+  fun testQuestionPlayer_chooseCorrectAnswer_tickIsCompletelyVisible() {
     launchForSkillList(SKILL_ID_LIST).use {
       // Option 2 is the right answer and tick icon should be visible completely
       selectMultipleChoiceOption(optionPosition = 2)
@@ -249,7 +249,7 @@ class QuestionPlayerActivityTest {
   // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
   @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Test
-  fun testChooseCorrectAnswer_answerLongerThanScreen_phoneLand_tickIsCompletelyVisible() {
+  fun testQuestionPlayer_configChange_chooseCorrectAnswer_tickIsCompletelyVisible() {
     launchForSkillList(SKILL_ID_LIST).use {
       rotateToLandscape()
       // Option 2 is the right answer and tick icon should be visible completely
@@ -266,7 +266,7 @@ class QuestionPlayerActivityTest {
   @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Config(qualifiers = "sw600dp")
   @Test
-  fun testChooseCorrectAnswer_answerLongerThanScreen_tabletPort_tickIsCompletelyVisible() {
+  fun testQuestionPlayer_onTablet_chooseCorrectAnswer_tickIsCompletelyVisible() {
     launchForSkillList(SKILL_ID_LIST).use {
       // Option 2 is the right answer and tick icon should be visible completely
       selectMultipleChoiceOption(optionPosition = 2)
@@ -282,7 +282,7 @@ class QuestionPlayerActivityTest {
   @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
   @Config(qualifiers = "sw600dp")
   @Test
-  fun testChooseCorrectAnswer_answerLongerThanScreen_tabletLand_tickIsCompletelyVisible() {
+  fun testQuestionPlayer_onTablet_configChange_chooseCorrectAnswer_tickIsCompletelyVisible() {
     launchForSkillList(SKILL_ID_LIST).use {
       rotateToLandscape()
       // Option 2 is the right answer and tick icon should be visible completely


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #1930 
## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.


https://user-images.githubusercontent.com/53645584/103134815-f3f99600-46d9-11eb-9ba4-a0d2701f4cd8.mp4


## Tests
Roboelectric | Espresso
-- | --
![robo](https://user-images.githubusercontent.com/53645584/103479992-89420c00-4df7-11eb-9aad-aca80483fff3.png) | ![espresso](https://user-images.githubusercontent.com/53645584/103480001-9232dd80-4df7-11eb-91c2-675e89cf3311.png)


