### PR TITLE
Fix #2283 [RTL] High-fi Topic Tabs Icons

### DIFF
--- a/app/src/main/res/drawable/ic_revision_icon_24dp.xml
+++ b/app/src/main/res/drawable/ic_revision_icon_24dp.xml
@@ -1,7 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-  android:autoMirrored="true"
   android:width="24dp"
   android:height="24dp"
+  android:autoMirrored="true"
   android:viewportWidth="24"
   android:viewportHeight="24">
   <path

--- a/app/src/main/res/drawable/ic_revision_icon_24dp.xml
+++ b/app/src/main/res/drawable/ic_revision_icon_24dp.xml
@@ -1,4 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:autoMirrored="true"
   android:width="24dp"
   android:height="24dp"
   android:viewportWidth="24"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #2283 **[RTL] High-fi Topic Tabs Icons**. Revision Icon needs to be mirrored in RTL layout.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
