### PR TITLE
Fix #2333: Prevent crash on Administrator Controls when it is selected again in navigation drawer

### DIFF
--- a/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
@@ -100,6 +100,11 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
         getHeaderViewModel().profile.set(it)
         getFooterViewModel().isAdmin.set(it.isAdmin)
         binding.administratorControlsLinearLayout.setOnClickListener {
+          if (getFooterViewModel().isAdministratorControlsSelected.get()!!) {
+            drawerLayout.closeDrawers()
+            return@setOnClickListener
+          }
+
           binding.fragmentDrawerNavView.menu.forEach { menuItem ->
             menuItem.isCheckable = false
           }

--- a/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
@@ -100,7 +100,7 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
         getHeaderViewModel().profile.set(it)
         getFooterViewModel().isAdmin.set(it.isAdmin)
         binding.administratorControlsLinearLayout.setOnClickListener {
-          if (getFooterViewModel().isAdministratorControlsSelected.get()!!) {
+          if (getFooterViewModel().isAdministratorControlsSelected.get() == true) {
             drawerLayout.closeDrawers()
             return@setOnClickListener
           }


### PR DESCRIPTION
## Explanation
Fixes #2333 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
