### PR TITLE
Fix #2333: Prevent crash on Administrator Controls when it is selected again in navigation drawer

### DIFF
--- a/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
@@ -100,6 +100,11 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
         getHeaderViewModel().profile.set(it)
         getFooterViewModel().isAdmin.set(it.isAdmin)
         binding.administratorControlsLinearLayout.setOnClickListener {
+          if (getFooterViewModel().isAdministratorControlsSelected.get() == true) {
+            drawerLayout.closeDrawers()
+            return@setOnClickListener
+          }
+
           binding.fragmentDrawerNavView.menu.forEach { menuItem ->
             menuItem.isCheckable = false
           }

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -24,8 +24,10 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
+import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.espresso.util.HumanReadables
@@ -531,6 +533,23 @@ class AdministratorControlsActivityTest {
       )
       onView(withId(R.id.app_version_text_view)).perform(click())
       intended(hasComponent(AppVersionActivity::class.java.name))
+    }
+  }
+
+  @Test
+  fun testAdministratorControls_selectAdminNavItem_displaysAdminControls() {
+    launch<AdministratorControlsActivity>(
+      createAdministratorControlsActivityIntent(
+        0
+      )
+    ).use {
+      onView(withContentDescription(R.string.drawer_open_content_description))
+        .check(matches(isCompletelyDisplayed()))
+        .perform(click())
+      onView(withId(R.id.administrator_controls_linear_layout)).perform(nestedScrollTo())
+        .perform(click())
+      onView(withText(context.getString(R.string.administrator_controls_edit_account)))
+        .check(matches(isDisplayed()))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -58,7 +58,6 @@ import org.oppia.android.app.profile.ProfileChooserActivity
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
 import org.oppia.android.app.settings.profile.ProfileListActivity
 import org.oppia.android.app.shim.ViewBindingShimModule
-import org.oppia.android.app.testing.NavigationDrawerTestActivity
 import org.oppia.android.app.utility.OrientationChangeAction.Companion.orientationLandscape
 import org.oppia.android.app.utility.OrientationChangeAction.Companion.orientationPortrait
 import org.oppia.android.domain.classify.InteractionsModule
@@ -583,13 +582,6 @@ class AdministratorControlsActivityTest {
   private fun createAdministratorControlsActivityIntent(profileId: Int): Intent {
     return AdministratorControlsActivity.createAdministratorControlsActivityIntent(
       context,
-      profileId
-    )
-  }
-
-  private fun createNavigationDrawerActivityIntent(profileId: Int): Intent {
-    return NavigationDrawerTestActivity.createNavigationDrawerTestActivity(
-      ApplicationProvider.getApplicationContext(),
       profileId
     )
   }


### PR DESCRIPTION
## Explanation
Fixes #2333 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.

## Screenshots
<img width="1387" alt="Screenshot 1" src="https://user-images.githubusercontent.com/35566748/103336464-43571200-4a9e-11eb-8ae0-ed8f0f19208b.png">
<img width="1487" alt="Screenshot 2" src="https://user-images.githubusercontent.com/35566748/103394913-68588d00-4b51-11eb-9ee3-88e698ea4755.png">