### PR TITLE
Fix #2306: Revert "Temporarily remove vinitamurthi from codeowners"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -149,12 +149,10 @@ LICENSE @rt4914
 /domain/**/*.java @rt4914
 
 # Questions support.
-# TODO(#2306): Replace @rt4914 with @vinitamurthi after 2021-01-05
-/domain/src/*/java/org/oppia/android/domain/question/ @rt4914
+/domain/src/*/java/org/oppia/android/domain/question/ @vinitamurthi
 
 # Oppia logging support.
-# TODO(#2306): Replace @rt4914 with @vinitamurthi after 2021-01-05
-/domain/src/main/java/org/oppia/android/domain/oppialogger/ @rt4914
+/domain/src/main/java/org/oppia/android/domain/oppialogger/ @vinitamurthi
 
 #####################################################################################
 #                                  testing module                                   #
@@ -191,8 +189,7 @@ LICENSE @rt4914
 /utility/src/*/java/org/oppia/android/util/accessibility/ @rt4914
 
 # Core logging infrastructure.
-# TODO(#2306): Replace @rt4914 with @vinitamurthi after 2021-01-05
-/utility/src/*/java/org/oppia/android/util/logging/ @rt4914
+/utility/src/*/java/org/oppia/android/util/logging/ @vinitamurthi
 
 # Miscellaneous statusbar UI utilities.
 /utility/src/*/java/org/oppia/android/util/statusbar/ @rt4914
@@ -211,12 +208,10 @@ LICENSE @rt4914
 
 # Global proto file ownership (for protos outside the model directory since all protos should belong in models).
 # TODO(#2304): Replace @rt4914 with @BenHenning after 2021-01-05.
-# TODO(#2306): Replace @rt4914 with @vinitamurthi after 2021-01-05
-*.proto @rt4914
+*.proto @rt4914 @vinitamurthi
 
 # Global model ownership (secondary).
-# TODO(#2306): Replace @rt4914 with @vinitamurthi after 2021-01-05
-/model/ @rt4914
+/model/ @vinitamurthi
 
 # Global model ownership (primary).
 # TODO(#2304): Replace @rt4914 with @BenHenning after 2021-01-05.


### PR DESCRIPTION
Fix #2306

Reverts oppia/oppia-android#2307 to restore @vinitamurthi ownership.