### PR TITLE
Fix #2431: Upgrade kotlin to 1.4

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,6 +71,19 @@ rules_java_dependencies()
 
 rules_java_toolchains()
 
+http_archive(
+    name = "rules_proto",
+    sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
+    strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+    ],
+)
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()
+
 # Add support for Dagger
 DAGGER_TAG = "2.28.1"
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,15 +33,19 @@ RULES_KOTLIN_SHA = "6194a864280e1989b6d8118a4aee03bb50edeeae4076e5bc30eef8a98dcd
 
 http_archive(
     name = "io_bazel_rules_kotlin",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/%s/rules_kotlin_release.tgz" % RULES_KOTLIN_VERSION],
     sha256 = RULES_KOTLIN_SHA,
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/%s/rules_kotlin_release.tgz" % RULES_KOTLIN_VERSION],
 )
+
 # TODO(#1535): Remove once rules_kotlin is released because these lines become unnecessary
 load("@io_bazel_rules_kotlin//kotlin:dependencies.bzl", "kt_download_local_dev_dependencies")
+
 kt_download_local_dev_dependencies()
 
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
+
 kotlin_repositories()
+
 kt_register_toolchains()
 
 """
@@ -60,18 +64,20 @@ bind(
     actual = "//tools:java_toolchain",
 )
 
-"""
-The rules_proto contains the javalite_toolchain needed for the java_lite_proto_library rule used in the
-model module.
-"""
+
+# The rules_proto contains the javalite_toolchain needed for the java_lite_proto_library rule used in the
+# model module.
 http_archive(
     name = "rules_proto",
     sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
     strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
     urls = ["https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz"],
 )
+
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
 rules_proto_dependencies()
+
 rules_proto_toolchains()
 
 # Add support for Dagger

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,15 +60,6 @@ bind(
     actual = "//tools:java_toolchain",
 )
 
-http_archive(
-    name = "rules_java",
-    url = "https://github.com/bazelbuild/rules_java/releases/download/0.1.1/rules_java-0.1.1.tar.gz",
-    sha256 = "220b87d8cfabd22d1c6d8e3cdb4249abd4c93dcc152e0667db061fb1b957ee68",
-)
-load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
-rules_java_dependencies()
-rules_java_toolchains()
-
 """
 The rules_proto contains the javalite_toolchain needed for java_lite_proto_library rule used in the
 model module.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,15 +27,23 @@ http_archive(
 )
 
 # Add support for Kotlin: https://github.com/bazelbuild/rules_kotlin.
-RULES_KOTLIN_VERSION = "v1.5.0-alpha-2"
+RULES_KOTLIN_VERSION = "legacy-1.4.0-rcx-oppia-exclusive-rc01"
 
-RULES_KOTLIN_SHA = "6194a864280e1989b6d8118a4aee03bb50edeeae4076e5bc30eef8a98dcd4f07"
+RULES_KOTLIN_SHA = "600f3d916eda5531dd70614ec96dc92b4ac24da0e1d815eb94559976e9bea8aa"
 
 http_archive(
     name = "io_bazel_rules_kotlin",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/%s/rules_kotlin_release.tgz" % RULES_KOTLIN_VERSION],
     sha256 = RULES_KOTLIN_SHA,
+    strip_prefix = "rules_kotlin-%s" % RULES_KOTLIN_VERSION,
+    type = "zip",
+    urls = ["https://github.com/oppia/rules_kotlin/archive/%s.zip" % RULES_KOTLIN_VERSION],
 )
+
+# TODO(#1535): Remove once rules_kotlin is released because these lines become unnecessary
+load("@io_bazel_rules_kotlin//kotlin:dependencies.bzl", "kt_download_local_dev_dependencies")
+
+kt_download_local_dev_dependencies()
+
 
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
 
@@ -81,7 +89,9 @@ http_archive(
     ],
 )
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
 rules_proto_dependencies()
+
 rules_proto_toolchains()
 
 # Add support for Dagger

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,11 +37,6 @@ http_archive(
     sha256 = RULES_KOTLIN_SHA,
 )
 
-# TODO(#1535): Remove once rules_kotlin is released because these lines become unnecessary
-load("@io_bazel_rules_kotlin//kotlin:dependencies.bzl", "kt_download_local_dev_dependencies")
-
-kt_download_local_dev_dependencies()
-
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
 
 kotlin_repositories()
@@ -54,7 +49,6 @@ module while helping us avoid the unnecessary compilation of protoc. Referecence
 - https://github.com/google/startup-os/blob/5f30a62/WORKSPACE#L179-L187
 - https://github.com/bazelbuild/bazel/issues/7095
 """
-
 bind(
     name = "proto_compiler",
     actual = "//tools:protoc",
@@ -63,6 +57,12 @@ bind(
 bind(
     name = "proto_java_toolchain",
     actual = "//tools:java_toolchain",
+)
+
+http_archive(
+    name = "rules_java",
+    url = "https://github.com/bazelbuild/rules_java/releases/download/0.1.1/rules_java-0.1.1.tar.gz",
+    sha256 = "220b87d8cfabd22d1c6d8e3cdb4249abd4c93dcc152e0667db061fb1b957ee68",
 )
 
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,9 +27,9 @@ http_archive(
 )
 
 # Add support for Kotlin: https://github.com/bazelbuild/rules_kotlin.
-RULES_KOTLIN_VERSION = "v1.5.0-alpha-1"
+RULES_KOTLIN_VERSION = "v1.5.0-alpha-2"
 
-RULES_KOTLIN_SHA = "600f3d916eda5531dd70614ec96dc92b4ac24da0e1d815eb94559976e9bea8aa"
+RULES_KOTLIN_SHA = "6194a864280e1989b6d8118a4aee03bb50edeeae4076e5bc30eef8a98dcd4f07"
 
 http_archive(
     name = "io_bazel_rules_kotlin",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -64,9 +64,20 @@ bind(
     actual = "//tools:java_toolchain",
 )
 
+# The rules_java contains the java_lite_proto_library rule used in the model module.
+http_archive(
+    name = "rules_java",
+    url = "https://github.com/bazelbuild/rules_java/releases/download/0.1.1/rules_java-0.1.1.tar.gz",
+    sha256 = "220b87d8cfabd22d1c6d8e3cdb4249abd4c93dcc152e0667db061fb1b957ee68",
+)
 
-# The rules_proto contains the javalite_toolchain needed for the java_lite_proto_library rule used in the
-# model module.
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+rules_java_toolchains()
+
+# The rules_proto contains the proto_library rule used in the gitmodel module.
 http_archive(
     name = "rules_proto",
     sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,16 +27,14 @@ http_archive(
 )
 
 # Add support for Kotlin: https://github.com/bazelbuild/rules_kotlin.
-RULES_KOTLIN_VERSION = "legacy-1.4.0-rcx-oppia-exclusive-rc01"
+RULES_KOTLIN_VERSION = "v1.5.0-alpha-1"
 
 RULES_KOTLIN_SHA = "600f3d916eda5531dd70614ec96dc92b4ac24da0e1d815eb94559976e9bea8aa"
 
 http_archive(
     name = "io_bazel_rules_kotlin",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/%s/rules_kotlin_release.tgz" % RULES_KOTLIN_VERSION],
     sha256 = RULES_KOTLIN_SHA,
-    strip_prefix = "rules_kotlin-%s" % RULES_KOTLIN_VERSION,
-    type = "zip",
-    urls = ["https://github.com/oppia/rules_kotlin/archive/%s.zip" % RULES_KOTLIN_VERSION],
 )
 
 # TODO(#1535): Remove once rules_kotlin is released because these lines become unnecessary

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,7 +61,7 @@ bind(
 )
 
 """
-The rules_proto contains the javalite_toolchain needed for java_lite_proto_library rule used in the
+The rules_proto contains the javalite_toolchain needed for the java_lite_proto_library rule used in the
 model module.
 """
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,23 +27,15 @@ http_archive(
 )
 
 # Add support for Kotlin: https://github.com/bazelbuild/rules_kotlin.
-RULES_KOTLIN_VERSION = "legacy-1.4.0-rcx-oppia-exclusive-rc01"
+RULES_KOTLIN_VERSION = "v1.5.0-alpha-2"
 
-RULES_KOTLIN_SHA = "600f3d916eda5531dd70614ec96dc92b4ac24da0e1d815eb94559976e9bea8aa"
+RULES_KOTLIN_SHA = "6194a864280e1989b6d8118a4aee03bb50edeeae4076e5bc30eef8a98dcd4f07"
 
 http_archive(
     name = "io_bazel_rules_kotlin",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/%s/rules_kotlin_release.tgz" % RULES_KOTLIN_VERSION],
     sha256 = RULES_KOTLIN_SHA,
-    strip_prefix = "rules_kotlin-%s" % RULES_KOTLIN_VERSION,
-    type = "zip",
-    urls = ["https://github.com/oppia/rules_kotlin/archive/%s.zip" % RULES_KOTLIN_VERSION],
 )
-
-# TODO(#1535): Remove once rules_kotlin is released because these lines become unnecessary
-load("@io_bazel_rules_kotlin//kotlin:dependencies.bzl", "kt_download_local_dev_dependencies")
-
-kt_download_local_dev_dependencies()
-
 
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
 
@@ -89,9 +81,7 @@ http_archive(
     ],
 )
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
-
 rules_proto_dependencies()
-
 rules_proto_toolchains()
 
 # Add support for Dagger

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,8 +67,8 @@ bind(
 # The rules_java contains the java_lite_proto_library rule used in the model module.
 http_archive(
     name = "rules_java",
-    url = "https://github.com/bazelbuild/rules_java/releases/download/0.1.1/rules_java-0.1.1.tar.gz",
     sha256 = "220b87d8cfabd22d1c6d8e3cdb4249abd4c93dcc152e0667db061fb1b957ee68",
+    url = "https://github.com/bazelbuild/rules_java/releases/download/0.1.1/rules_java-0.1.1.tar.gz",
 )
 
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,6 +37,11 @@ http_archive(
     sha256 = RULES_KOTLIN_SHA,
 )
 
+# TODO(#1535): Remove once rules_kotlin is released because these lines become unnecessary
+load("@io_bazel_rules_kotlin//kotlin:dependencies.bzl", "kt_download_local_dev_dependencies")
+
+kt_download_local_dev_dependencies()
+
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
 
 kotlin_repositories()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,16 +36,12 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/%s/rules_kotlin_release.tgz" % RULES_KOTLIN_VERSION],
     sha256 = RULES_KOTLIN_SHA,
 )
-
 # TODO(#1535): Remove once rules_kotlin is released because these lines become unnecessary
 load("@io_bazel_rules_kotlin//kotlin:dependencies.bzl", "kt_download_local_dev_dependencies")
-
 kt_download_local_dev_dependencies()
 
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
-
 kotlin_repositories()
-
 kt_register_toolchains()
 
 """
@@ -69,21 +65,19 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_java/releases/download/0.1.1/rules_java-0.1.1.tar.gz",
     sha256 = "220b87d8cfabd22d1c6d8e3cdb4249abd4c93dcc152e0667db061fb1b957ee68",
 )
-
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
-
 rules_java_dependencies()
-
 rules_java_toolchains()
 
+"""
+The rules_proto contains the javalite_toolchain needed for java_lite_proto_library rule used in the
+model module.
+"""
 http_archive(
     name = "rules_proto",
     sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
     strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-    ],
+    urls = ["https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz"],
 )
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 rules_proto_dependencies()

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.1'
+    classpath 'com.android.tools.build:gradle:3.6.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.12'
     classpath 'com.google.gms:google-services:4.3.3'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.3.41'
+  ext.kotlin_version = '1.4.20'
   ext.fragment_version = '1.2.0-rc01'
   repositories {
     google()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.4.20'
+  ext.kotlin_version = '1.3.41'
   ext.fragment_version = '1.2.0-rc01'
   repositories {
     google()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.4.21'
+  ext.kotlin_version = '1.3.61'
   ext.fragment_version = '1.2.0-rc01'
   repositories {
     google()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.3.41'
+  ext.kotlin_version = '1.4.21'
   ext.fragment_version = '1.2.0-rc01'
   repositories {
     google()
@@ -9,7 +9,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.6.1'
+    classpath 'com.android.tools.build:gradle:4.1.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.12'
     classpath 'com.google.gms:google-services:4.3.3'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.4.21'
+  ext.kotlin_version = '1.4.20'
   ext.fragment_version = '1.2.0-rc01'
   repositories {
     google()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.4.21'
+  ext.kotlin_version = '1.3.41'
   ext.fragment_version = '1.2.0-rc01'
   repositories {
     google()
@@ -9,7 +9,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.1'
+    classpath 'com.android.tools.build:gradle:3.6.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.12'
     classpath 'com.google.gms:google-services:4.3.3'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.3.61'
+  ext.kotlin_version = '1.4.21'
   ext.fragment_version = '1.2.0-rc01'
   repositories {
     google()

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -67,7 +67,7 @@ dependencies {
       'com.android.support:multidex:1.0.3',
       'com.google.dagger:dagger:2.24',
       'com.google.protobuf:protobuf-lite:3.0.0',
-      'com.squareup.moshi:moshi-kotlin:1.8.0',
+      'com.squareup.moshi:moshi-kotlin:1.11.0',
       'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.2',
   )
   testImplementation(
@@ -92,7 +92,7 @@ dependencies {
   )
   androidTestImplementation('androidx.test:runner:1.2.0',
       'androidx.test.espresso:espresso-core:3.2.0')
-  kapt("com.squareup.moshi:moshi-kotlin-codegen:1.8.0")
+  kapt("com.squareup.moshi:moshi-kotlin-codegen:1.11.0")
   kaptTest(
       'com.google.dagger:dagger-compiler:2.24'
   )

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -67,7 +67,7 @@ dependencies {
       'com.android.support:multidex:1.0.3',
       'com.google.dagger:dagger:2.24',
       'com.google.protobuf:protobuf-lite:3.0.0',
-      'com.squareup.moshi:moshi-kotlin:1.11.0',
+      'com.squareup.moshi:moshi-kotlin:1.8.0',
       'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.2',
   )
   testImplementation(
@@ -92,7 +92,7 @@ dependencies {
   )
   androidTestImplementation('androidx.test:runner:1.2.0',
       'androidx.test.espresso:espresso-core:3.2.0')
-  kapt("com.squareup.moshi:moshi-kotlin-codegen:1.11.0")
+  kapt("com.squareup.moshi:moshi-kotlin-codegen:1.8.0")
   kaptTest(
       'com.google.dagger:dagger-compiler:2.24'
   )

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/model/BUILD.bazel
+++ b/model/BUILD.bazel
@@ -6,7 +6,6 @@ The proto_library() rule creates a proto file library to be used in multiple lan
 The java_lite_proto_library() rule takes in a proto_library target and generates java code.
 '''
 load("//model:src/main/proto/format_import_proto_library.bzl", "format_import_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 # NOTE TO DEVELOPERS: When adding new protos, each proto will need to have both a proto_library
 # and java_lite_proto_library. See the examples below for context. Further, once the proto lite

--- a/model/BUILD.bazel
+++ b/model/BUILD.bazel
@@ -6,6 +6,7 @@ The proto_library() rule creates a proto file library to be used in multiple lan
 The java_lite_proto_library() rule takes in a proto_library target and generates java code.
 '''
 load("//model:src/main/proto/format_import_proto_library.bzl", "format_import_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library", "java_lite_proto_library")
 
 # NOTE TO DEVELOPERS: When adding new protos, each proto will need to have both a proto_library
 # and java_lite_proto_library. See the examples below for context. Further, once the proto lite

--- a/model/BUILD.bazel
+++ b/model/BUILD.bazel
@@ -6,6 +6,7 @@ The proto_library() rule creates a proto file library to be used in multiple lan
 The java_lite_proto_library() rule takes in a proto_library target and generates java code.
 '''
 load("//model:src/main/proto/format_import_proto_library.bzl", "format_import_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 # NOTE TO DEVELOPERS: When adding new protos, each proto will need to have both a proto_library
 # and java_lite_proto_library. See the examples below for context. Further, once the proto lite

--- a/model/BUILD.bazel
+++ b/model/BUILD.bazel
@@ -6,7 +6,8 @@ The proto_library() rule creates a proto file library to be used in multiple lan
 The java_lite_proto_library() rule takes in a proto_library target and generates java code.
 '''
 load("//model:src/main/proto/format_import_proto_library.bzl", "format_import_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library", "java_lite_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_java//java:defs.bzl", "java_lite_proto_library")
 
 # NOTE TO DEVELOPERS: When adding new protos, each proto will need to have both a proto_library
 # and java_lite_proto_library. See the examples below for context. Further, once the proto lite


### PR DESCRIPTION
Fix #2431 
We need to migrate to Kotlin 1.4 in order to use some libraries (specifically for [Konfetti](https://github.com/DanielMartinus/Konfetti)).
- Updated Kotlin to 1.4.20
- Updates Gradle wrapper to 6.8.0 ([compatibility reference](https://docs.gradle.org/6.8/userguide/compatibility.html))
- Updates Moshi to 1.11.0 for compatibility with Kotlin 1.4
- Updates Bazel rules_kotlin to v1.5.0
- Imports Bazel rules_java & rules_proto
- Uses Starlark versions of libraries in model module

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
