### PR TITLE
Fix global layout code ownership pattern

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,8 +55,8 @@ gradlew.bat @BenHenning
 # All tests.
 *Test.kt @anandwana001
 
-# All layout files.
-layout*/*.xml @rt4914
+# All resource files.
+**/res/*.xml @rt4914
 
 # Proguard configurations.
 *.pro @BenHenning


### PR DESCRIPTION
Change Rajat's global ownership to all resource XML files rather than exclusively layouts (+ fix the former--it wasn't actually matching any layout directories).
