### PR TITLE
Fix #2092: Profile Edit delete account dialog orientation change dismiss issue fixed

### DIFF
--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivityPresenter.kt
@@ -26,8 +26,8 @@ class ProfileEditActivityPresenter @Inject constructor(
   private val viewModelProvider: ViewModelProvider<ProfileEditViewModel>
 ) {
 
-  private val profileEditViewModel: ProfileEditViewModel by lazy {
-    getProfileEditViewModelFromFactory()
+  private val viewModel: ProfileEditViewModel by lazy {
+    getProfileEditViewModel()
   }
 
   private var profileId by Delegates.notNull<Int>()
@@ -41,10 +41,10 @@ class ProfileEditActivityPresenter @Inject constructor(
       R.layout.profile_edit_activity
     )
     profileId = activity.intent.getIntExtra(PROFILE_EDIT_PROFILE_ID_EXTRA_KEY, 0)
-    profileEditViewModel.setProfileId(profileId)
+    viewModel.setProfileId(profileId)
 
     binding.apply {
-      viewModel = profileEditViewModel
+      viewModel = viewModel
       lifecycleOwner = activity
     }
 
@@ -57,30 +57,30 @@ class ProfileEditActivityPresenter @Inject constructor(
         ProfileResetPinActivity.createProfileResetPinActivity(
           activity,
           profileId,
-          profileEditViewModel.isAdmin
+          viewModel.isAdmin
         )
       )
     }
 
     binding.profileDeleteButton.setOnClickListener {
-      profileEditViewModel.isProfileDeletionDialogShown.postValue(true)
+      viewModel.isProfileDeletionDialogShown.postValue(true)
     }
 
-    profileEditViewModel.profile.observe(
+    viewModel.profile.observe(
       activity,
       Observer {
         activity.title = it.name
       }
     )
 
-    profileEditViewModel.isAllowedDownloadAccess.observe(
+    viewModel.isAllowedDownloadAccess.observe(
       activity,
       Observer {
         binding.profileEditAllowDownloadSwitch.isChecked = it
       }
     )
 
-    profileEditViewModel.isProfileDeletionDialogShown.observe(
+    viewModel.isProfileDeletionDialogShown.observe(
       activity,
       Observer {
         if (it) {
@@ -137,11 +137,11 @@ class ProfileEditActivityPresenter @Inject constructor(
             }
           )
       }.setOnDismissListener {
-        profileEditViewModel.isProfileDeletionDialogShown.postValue(false)
+        viewModel.isProfileDeletionDialogShown.postValue(false)
       }.create().show()
   }
 
-  private fun getProfileEditViewModelFromFactory(): ProfileEditViewModel {
+  private fun getProfileEditViewModel(): ProfileEditViewModel {
     return viewModelProvider.getForActivity(activity, ProfileEditViewModel::class.java)
   }
 }

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditViewModel.kt
@@ -26,6 +26,8 @@ class ProfileEditViewModel @Inject constructor(
   /** Specifies whether download access has been enabled by the user. */
   val isAllowedDownloadAccess: LiveData<Boolean> = isAllowedDownloadAccessMutableLiveData
 
+  val isProfileDeletionDialogShown = MutableLiveData<Boolean>()
+
   val profile: LiveData<Profile> by lazy {
     Transformations.map(
       profileManagementController.getProfile(profileId).toLiveData(),

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -303,6 +303,26 @@ class ProfileEditActivityTest {
   }
 
   @Test
+  fun testProfileEdit_startWithUserProfile_clickDelete_configChange_checkIfDialogRemains() {
+    launch<ProfileEditActivity>(
+      ProfileEditActivity.createProfileEditActivity(
+        context,
+        1
+      )
+    ).use {
+      onView(withId(R.id.profile_delete_button)).perform(click())
+      onView(isRoot()).perform(orientationLandscape())
+      onView(withText(R.string.profile_edit_delete_dialog_title))
+        .inRoot(isDialog())
+        .check(
+          matches(
+            isDisplayed()
+          )
+        )
+    }
+  }
+
+  @Test
   fun testProfileEdit_deleteProfile_checkReturnsToProfileListOnPhoneOrAdminControlOnTablet() {
     launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(


### PR DESCRIPTION
Fixes: #2092 dialog dismiss issue fixed

ProfileEditViewModel, ProfileEditActivityTest, ProfileEditActivityPresenter is changed

## Explanation
We are using ProfileEditViewModel as proper viewmodel class. Previously it was not used as a viewmodel because it was created after every config changes. So made it word as viewmodel.

I have added a livedata observer in ProfileEditViewModel to check if dialog is shown or not and dialog flag is changed to false when dialog is dismissed by user. ViewModel will hold the shown value in it and when orientation changes. It will again show the dialog.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
