### PR TITLE
Fix #2464: Remove textDirection property from reset_pin_dialog

### DIFF
--- a/app/src/main/res/layout-land/reset_pin_dialog.xml
+++ b/app/src/main/res/layout-land/reset_pin_dialog.xml
@@ -33,8 +33,7 @@
         android:imeOptions="actionDone"
         android:inputType="numberPassword"
         android:maxLength="3"
-        android:text="@{viewModel.inputPin}"
-        android:textDirection="locale" />
+        android:text="@{viewModel.inputPin}"/>
     </com.google.android.material.textfield.TextInputLayout>
   </RelativeLayout>
 </layout>

--- a/app/src/main/res/layout/reset_pin_dialog.xml
+++ b/app/src/main/res/layout/reset_pin_dialog.xml
@@ -33,8 +33,7 @@
         android:imeOptions="actionDone"
         android:inputType="numberPassword"
         android:maxLength="3"
-        android:text="@{viewModel.inputPin}"
-        android:textDirection="locale" />
+        android:text="@{viewModel.inputPin}"/>
     </com.google.android.material.textfield.TextInputLayout>
   </RelativeLayout>
 </layout>


### PR DESCRIPTION
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #2464:  Remove android:textDirection="locale" from textInputLayout from the following files
        layout/reset_pin_dialog
        layout-land/reset_pin_dialog

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
