### PR TITLE
Fix #1658 : LessonThumbnailImageView causes a "Render Problem" in Android studio

### DIFF
--- a/app/src/main/java/org/oppia/android/app/customview/LessonThumbnailImageView.kt
+++ b/app/src/main/java/org/oppia/android/app/customview/LessonThumbnailImageView.kt
@@ -10,6 +10,7 @@ import org.oppia.android.app.model.LessonThumbnail
 import org.oppia.android.app.model.LessonThumbnailGraphic
 import org.oppia.android.app.shim.ViewComponentFactory
 import org.oppia.android.util.gcsresource.DefaultResourceBucketName
+import org.oppia.android.util.logging.ConsoleLogger
 import org.oppia.android.util.parser.DefaultGcsPrefix
 import org.oppia.android.util.parser.ImageLoader
 import org.oppia.android.util.parser.ImageViewTarget
@@ -44,6 +45,9 @@ class LessonThumbnailImageView @JvmOverloads constructor(
   @field:DefaultGcsPrefix
   lateinit var gcsPrefix: String
 
+  @Inject
+  lateinit var logger: ConsoleLogger
+
   fun setEntityId(entityId: String) {
     this.entityId = entityId
     checkIfLoadingIsPossible()
@@ -66,7 +70,8 @@ class LessonThumbnailImageView @JvmOverloads constructor(
       ::thumbnailDownloadUrlTemplate.isInitialized &&
       ::resourceBucketName.isInitialized &&
       ::gcsPrefix.isInitialized &&
-      ::imageLoader.isInitialized
+      ::imageLoader.isInitialized &&
+      ::logger.isInitialized
     ) {
       loadLessonThumbnail()
     }
@@ -98,9 +103,18 @@ class LessonThumbnailImageView @JvmOverloads constructor(
   }
 
   override fun onAttachedToWindow() {
-    super.onAttachedToWindow()
-    (FragmentManager.findFragment<Fragment>(this) as ViewComponentFactory)
-      .createViewComponent(this).inject(this)
+    try {
+      super.onAttachedToWindow()
+      (FragmentManager.findFragment<Fragment>(this) as ViewComponentFactory)
+        .createViewComponent(this).inject(this)
+    } catch (e: IllegalStateException) {
+      if (::logger.isInitialized)
+        logger.e(
+          "LessonThumbnailImageView",
+          "Throws exception on attach to window",
+          e
+        )
+    }
   }
 
   private fun getLessonDrawableResource(lessonThumbnail: LessonThumbnail): Int {


### PR DESCRIPTION


<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation

Fix #1658 : Add try - catch block for onAttachedWindow as while rendering it was throwing IllegalStateException.
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
