### PR TITLE
Fix#2483: Spacing issue in `colors` folder xml files(#2483)

### DIFF
--- a/app/src/main/res/color-sw600dp-land/tab_icon_color_selector.xml
+++ b/app/src/main/res/color-sw600dp-land/tab_icon_color_selector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:color="@color/white" android:state_selected="true"/>
-  <item android:color="@color/white_80"/>
+  <item android:color="@color/white" android:state_selected="true" />
+  <item android:color="@color/white_80" />
 </selector>

--- a/app/src/main/res/color-sw600dp-port/tab_icon_color_selector.xml
+++ b/app/src/main/res/color-sw600dp-port/tab_icon_color_selector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:color="@color/white" android:state_selected="true"/>
-  <item android:color="@color/white_80"/>
+  <item android:color="@color/white" android:state_selected="true" />
+  <item android:color="@color/white_80" />
 </selector>

--- a/app/src/main/res/color/drawer_item.xml
+++ b/app/src/main/res/color/drawer_item.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:color="@color/highlightedNavMenuItem" android:state_checked="true" />
-  <item android:color="@color/black"/>
+  <item android:color="@color/black" />
 </selector>

--- a/app/src/main/res/color/tab_icon_color_selector.xml
+++ b/app/src/main/res/color/tab_icon_color_selector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:color="@color/white" android:state_selected="true"/>
-  <item android:color="@color/white_70"/>
+  <item android:color="@color/white" android:state_selected="true" />
+  <item android:color="@color/white_70" />
 </selector>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #2483 reformating XML codes by inserting one blank space before ```/>```  .

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
