### PR TITLE
Fix #2205: Stack TextViews in profile_chooser_profile_view vertically regardless of their position relative to the user icon

### DIFF
--- a/app/src/main/res/layout-land/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-land/profile_chooser_profile_view.xml
@@ -25,7 +25,7 @@
 
     <LinearLayout
       android:id="@+id/profile_chooser_item"
-      android:layout_width="wrap_content"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginStart="@dimen/profile_chooser_profile_view_margin_start"
       android:layout_marginEnd="@dimen/profile_chooser_profile_view_margin_end"

--- a/app/src/main/res/layout-land/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-land/profile_chooser_profile_view.xml
@@ -46,39 +46,45 @@
         app:civ_border_width="1dp"
         profile:src="@{viewModel.profile.avatar}" />
 
-      <TextView
-        android:id="@+id/profile_name_text"
-        style="@style/Caption"
-        android:ellipsize="end"
-        android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-        android:maxLines="2"
-        android:singleLine="false"
-        android:text="@{viewModel.profile.name}"
-        android:textColor="@color/white" />
-
-      <TextView
-        android:id="@+id/profile_last_visited"
-        android:layout_width="wrap_content"
+      <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fontFamily="sans-serif-light"
-        android:gravity="center"
-        android:textColor="@color/white"
-        android:textSize="12sp"
-        android:textStyle="italic"
-        android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
-        profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+        <TextView
+          android:id="@+id/profile_name_text"
+          style="@style/Caption"
+          android:ellipsize="end"
+          android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
+          android:maxLines="2"
+          android:singleLine="false"
+          android:text="@{viewModel.profile.name}"
+          android:textColor="@color/white" />
 
-      <TextView
-        android:id="@+id/profile_is_admin_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:fontFamily="sans-serif-light"
-        android:gravity="center"
-        android:text="@string/profile_chooser_admin"
-        android:textColor="@color/white"
-        android:textSize="12sp"
-        android:textStyle="italic"
-        android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}" />
+        <TextView
+          android:id="@+id/profile_last_visited"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:fontFamily="sans-serif-light"
+          android:gravity="center"
+          android:textColor="@color/white"
+          android:textSize="12sp"
+          android:textStyle="italic"
+          android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
+          profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
+
+        <TextView
+          android:id="@+id/profile_is_admin_text"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:fontFamily="sans-serif-light"
+          android:gravity="center"
+          android:text="@string/profile_chooser_admin"
+          android:textColor="@color/white"
+          android:textSize="12sp"
+          android:textStyle="italic"
+          android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}" />
+      </LinearLayout>
     </LinearLayout>
 
     <View

--- a/app/src/main/res/layout-land/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-land/profile_chooser_profile_view.xml
@@ -27,8 +27,6 @@
       android:id="@+id/profile_chooser_item"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginStart="@dimen/profile_chooser_profile_view_margin_start"
-      android:layout_marginEnd="@dimen/profile_chooser_profile_view_margin_end"
       android:gravity="center_horizontal"
       android:orientation="vertical"
       app:layoutMarginBottom="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_margin_bottom_profile_already_added : @dimen/profile_chooser_profile_view_margin_bottom_profile_not_added}"

--- a/app/src/main/res/layout-sw600dp-land/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout-sw600dp-land/profile_chooser_add_view.xml
@@ -58,7 +58,7 @@
         android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
         android:orientation="vertical"
         app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_view_already_added_description_parent_margin_top : @dimen/space_0dp}"
-        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_add_view_description_margin_start_profile_not_added}">
+        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_description_margin_start_profile_not_added}">
 
         <TextView
           android:id="@+id/add_profile_text"

--- a/app/src/main/res/layout-sw600dp-land/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-sw600dp-land/profile_chooser_profile_view.xml
@@ -31,7 +31,7 @@
 
     <LinearLayout
       android:id="@+id/profile_chooser_item"
-      android:layout_width="wrap_content"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER}"
       android:orientation="@{hasProfileEverBeenAddedValue ? LinearLayout.VERTICAL : LinearLayout.HORIZONTAL}"

--- a/app/src/main/res/layout-sw600dp-land/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-sw600dp-land/profile_chooser_profile_view.xml
@@ -88,7 +88,7 @@
         android:textColor="@color/white"
         android:textSize="16sp"
         android:textStyle="italic"
-        android:visibility="@{viewModel.profile.isAdmin &amp;&amp; hasProfileEverBeenAddedValue ? View.VISIBLE : View.GONE}"
+        android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}"
         app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}"
         app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_is_admin_margin_top_profile_already_added : @dimen/space_0dp}" />
     </LinearLayout>

--- a/app/src/main/res/layout-sw600dp-land/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-sw600dp-land/profile_chooser_profile_view.xml
@@ -54,7 +54,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_description_margin_start_profile_not_added}">
         <TextView
           android:id="@+id/profile_name_text"
           style="@style/Heading2"
@@ -64,7 +65,6 @@
           android:singleLine="false"
           android:text="@{viewModel.profile.name}"
           android:textColor="@color/white"
-          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}"
           app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_name_margin_top_profile_already_added : @dimen/space_0dp}" />
 
         <TextView
@@ -78,7 +78,6 @@
           android:textSize="16sp"
           android:textStyle="italic"
           android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
-          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}"
           app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_last_visited_margin_top_profile_already_added : @dimen/profile_chooser_profile_view_last_visited_margin_top_profile_not_added}"
           profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
 
@@ -94,7 +93,6 @@
           android:textSize="16sp"
           android:textStyle="italic"
           android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}"
-          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}"
           app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_is_admin_margin_top_profile_already_added : @dimen/space_0dp}" />
       </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout-sw600dp-land/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-sw600dp-land/profile_chooser_profile_view.xml
@@ -50,47 +50,53 @@
         app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_circular_image_margin_top_profile_already_added : @dimen/space_0dp}"
         profile:src="@{viewModel.profile.avatar}" />
 
-      <TextView
-        android:id="@+id/profile_name_text"
-        style="@style/Heading2"
-        android:ellipsize="end"
-        android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-        android:maxLines="2"
-        android:singleLine="false"
-        android:text="@{viewModel.profile.name}"
-        android:textColor="@color/white"
-        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}"
-        app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_name_margin_top_profile_already_added : @dimen/space_0dp}" />
-
-      <TextView
-        android:id="@+id/profile_last_visited"
-        android:layout_width="wrap_content"
+      <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:fontFamily="sans-serif-light"
         android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-        android:textColor="@color/white"
-        android:textSize="16sp"
-        android:textStyle="italic"
-        android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
-        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}"
-        app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_last_visited_margin_top_profile_already_added : @dimen/profile_chooser_profile_view_last_visited_margin_top_profile_not_added}"
-        profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
+        android:orientation="vertical">
+        <TextView
+          android:id="@+id/profile_name_text"
+          style="@style/Heading2"
+          android:ellipsize="end"
+          android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
+          android:maxLines="2"
+          android:singleLine="false"
+          android:text="@{viewModel.profile.name}"
+          android:textColor="@color/white"
+          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}"
+          app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_name_margin_top_profile_already_added : @dimen/space_0dp}" />
 
-      <TextView
-        android:id="@+id/profile_is_admin_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:fontFamily="sans-serif-light"
-        android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-        android:text="@string/profile_chooser_admin"
-        android:textColor="@color/white"
-        android:textSize="16sp"
-        android:textStyle="italic"
-        android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}"
-        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}"
-        app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_is_admin_margin_top_profile_already_added : @dimen/space_0dp}" />
+        <TextView
+          android:id="@+id/profile_last_visited"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:fontFamily="sans-serif-light"
+          android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
+          android:textColor="@color/white"
+          android:textSize="16sp"
+          android:textStyle="italic"
+          android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
+          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}"
+          app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_last_visited_margin_top_profile_already_added : @dimen/profile_chooser_profile_view_last_visited_margin_top_profile_not_added}"
+          profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
+
+        <TextView
+          android:id="@+id/profile_is_admin_text"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:fontFamily="sans-serif-light"
+          android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
+          android:text="@string/profile_chooser_admin"
+          android:textColor="@color/white"
+          android:textSize="16sp"
+          android:textStyle="italic"
+          android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}"
+          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}"
+          app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_is_admin_margin_top_profile_already_added : @dimen/space_0dp}" />
+      </LinearLayout>
     </LinearLayout>
 
     <View

--- a/app/src/main/res/layout-sw600dp-port/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout-sw600dp-port/profile_chooser_add_view.xml
@@ -58,7 +58,7 @@
         android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
         android:orientation="vertical"
         app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_view_already_added_description_parent_margin_top : @dimen/space_0dp}"
-        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_add_view_description_margin_start_profile_not_added}">
+        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_description_margin_start_profile_not_added}">
 
         <TextView
           android:id="@+id/add_profile_text"

--- a/app/src/main/res/layout-sw600dp-port/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-sw600dp-port/profile_chooser_profile_view.xml
@@ -31,7 +31,7 @@
 
     <LinearLayout
       android:id="@+id/profile_chooser_item"
-      android:layout_width="wrap_content"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER}"
       android:orientation="@{hasProfileEverBeenAddedValue ? LinearLayout.VERTICAL : LinearLayout.HORIZONTAL}"

--- a/app/src/main/res/layout-sw600dp-port/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-sw600dp-port/profile_chooser_profile_view.xml
@@ -51,45 +51,51 @@
         app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_circular_image_margin_top_profile_already_added : @dimen/space_0dp}"
         profile:src="@{viewModel.profile.avatar}" />
 
-      <TextView
-        android:id="@+id/profile_name_text"
-        style="@style/Heading2"
-        android:ellipsize="end"
-        android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-        android:maxLines="2"
-        android:singleLine="false"
-        android:text="@{viewModel.profile.name}"
-        android:textColor="@color/white"
-        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}"
-        app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_name_margin_top_profile_already_added : @dimen/space_0dp}" />
-
-      <TextView
-        android:id="@+id/profile_last_visited"
-        android:layout_width="wrap_content"
+      <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:fontFamily="sans-serif-light"
         android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-        android:textColor="@color/white"
-        android:textSize="16sp"
-        android:textStyle="italic"
-        android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
-        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_last_visited_margin_start_profile_not_added}"
-        profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
+        android:orientation="vertical">
+        <TextView
+          android:id="@+id/profile_name_text"
+          style="@style/Heading2"
+          android:ellipsize="end"
+          android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
+          android:maxLines="2"
+          android:singleLine="false"
+          android:text="@{viewModel.profile.name}"
+          android:textColor="@color/white"
+          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}"
+          app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_name_margin_top_profile_already_added : @dimen/space_0dp}" />
 
-      <TextView
-        android:id="@+id/profile_is_admin_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:fontFamily="sans-serif-light"
-        android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-        android:text="@string/profile_chooser_admin"
-        android:textColor="@color/white"
-        android:textSize="16sp"
-        android:textStyle="italic"
-        android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}"
-        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}" />
+        <TextView
+          android:id="@+id/profile_last_visited"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:fontFamily="sans-serif-light"
+          android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
+          android:textColor="@color/white"
+          android:textSize="16sp"
+          android:textStyle="italic"
+          android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
+          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_last_visited_margin_start_profile_not_added}"
+          profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
+
+        <TextView
+          android:id="@+id/profile_is_admin_text"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:fontFamily="sans-serif-light"
+          android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
+          android:text="@string/profile_chooser_admin"
+          android:textColor="@color/white"
+          android:textSize="16sp"
+          android:textStyle="italic"
+          android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}"
+          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}" />
+      </LinearLayout>
     </LinearLayout>
 
     <View

--- a/app/src/main/res/layout-sw600dp-port/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-sw600dp-port/profile_chooser_profile_view.xml
@@ -55,7 +55,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_description_margin_start_profile_not_added}">
         <TextView
           android:id="@+id/profile_name_text"
           style="@style/Heading2"
@@ -65,7 +66,6 @@
           android:singleLine="false"
           android:text="@{viewModel.profile.name}"
           android:textColor="@color/white"
-          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}"
           app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_name_margin_top_profile_already_added : @dimen/space_0dp}" />
 
         <TextView
@@ -79,7 +79,6 @@
           android:textSize="16sp"
           android:textStyle="italic"
           android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
-          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_last_visited_margin_start_profile_not_added}"
           profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
 
         <TextView
@@ -93,8 +92,7 @@
           android:textColor="@color/white"
           android:textSize="16sp"
           android:textStyle="italic"
-          android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}"
-          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}" />
+          android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}" />
       </LinearLayout>
     </LinearLayout>
 

--- a/app/src/main/res/layout-sw600dp-port/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-sw600dp-port/profile_chooser_profile_view.xml
@@ -88,7 +88,7 @@
         android:textColor="@color/white"
         android:textSize="16sp"
         android:textStyle="italic"
-        android:visibility="@{viewModel.profile.isAdmin &amp;&amp; hasProfileEverBeenAddedValue ? View.VISIBLE : View.GONE}"
+        android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}"
         app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_textview_margin_start_profile_not_added}" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout/profile_chooser_add_view.xml
@@ -53,7 +53,7 @@
         android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
         android:orientation="vertical"
         app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_view_already_added_description_parent_margin_top : @dimen/space_0dp}"
-        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_add_view_description_parent_margin_start_profile_not_added}">
+        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_description_margin_start_profile_not_added}">
 
         <TextView
           android:id="@+id/add_profile_text"

--- a/app/src/main/res/layout/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout/profile_chooser_profile_view.xml
@@ -82,7 +82,7 @@
         android:textColor="@color/white"
         android:textSize="12sp"
         android:textStyle="italic"
-        android:visibility="@{viewModel.profile.isAdmin &amp;&amp; hasProfileEverBeenAddedValue ? View.VISIBLE : View.GONE}"
+        android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}"
         app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_view_already_added_margin}" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout/profile_chooser_profile_view.xml
@@ -45,45 +45,52 @@
         app:civ_border_width="1dp"
         profile:src="@{viewModel.profile.avatar}" />
 
-      <TextView
-        android:id="@+id/profile_name_text"
-        style="@style/Caption"
-        android:ellipsize="end"
-        android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-        android:maxLines="2"
-        android:singleLine="false"
-        android:text="@{viewModel.profile.name}"
-        android:textColor="@color/white"
-        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_view_already_added_margin}"
-        app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_name_margin_top_profile_already_added : @dimen/space_0dp}" />
-
-      <TextView
-        android:id="@+id/profile_last_visited"
-        android:layout_width="wrap_content"
+      <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fontFamily="sans-serif-light"
-        android:textColor="@color/white"
-        android:layout_marginTop="4dp"
-        android:textSize="12sp"
-        android:textStyle="italic"
         android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-        android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
-        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_last_visited_margin_start_profile_not_added}"
-        profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
+        android:orientation="vertical">
 
-      <TextView
-        android:id="@+id/profile_is_admin_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/profile_chooser_profile_view_is_admin_margin_top"
-        android:fontFamily="sans-serif-light"
-        android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-        android:text="@string/profile_chooser_admin"
-        android:textColor="@color/white"
-        android:textSize="12sp"
-        android:textStyle="italic"
-        android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}"
-        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_view_already_added_margin}" />
+        <TextView
+          android:id="@+id/profile_name_text"
+          style="@style/Caption"
+          android:ellipsize="end"
+          android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
+          android:maxLines="2"
+          android:singleLine="false"
+          android:text="@{viewModel.profile.name}"
+          android:textColor="@color/white"
+          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_view_already_added_margin}"
+          app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_name_margin_top_profile_already_added : @dimen/space_0dp}" />
+
+        <TextView
+          android:id="@+id/profile_last_visited"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:fontFamily="sans-serif-light"
+          android:textColor="@color/white"
+          android:layout_marginTop="4dp"
+          android:textSize="12sp"
+          android:textStyle="italic"
+          android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
+          android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
+          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_last_visited_margin_start_profile_not_added}"
+          profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
+
+        <TextView
+          android:id="@+id/profile_is_admin_text"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/profile_chooser_profile_view_is_admin_margin_top"
+          android:fontFamily="sans-serif-light"
+          android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
+          android:text="@string/profile_chooser_admin"
+          android:textColor="@color/white"
+          android:textSize="12sp"
+          android:textStyle="italic"
+          android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}"
+          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_view_already_added_margin}" />
+      </LinearLayout>
     </LinearLayout>
 
     <View

--- a/app/src/main/res/layout/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout/profile_chooser_profile_view.xml
@@ -49,7 +49,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_description_margin_start_profile_not_added}">
 
         <TextView
           android:id="@+id/profile_name_text"
@@ -60,7 +61,6 @@
           android:singleLine="false"
           android:text="@{viewModel.profile.name}"
           android:textColor="@color/white"
-          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_view_already_added_margin}"
           app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_name_margin_top_profile_already_added : @dimen/space_0dp}" />
 
         <TextView
@@ -74,7 +74,6 @@
           android:textStyle="italic"
           android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
           android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
-          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_profile_view_last_visited_margin_start_profile_not_added}"
           profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
 
         <TextView
@@ -88,8 +87,7 @@
           android:textColor="@color/white"
           android:textSize="12sp"
           android:textStyle="italic"
-          android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}"
-          app:layoutMarginStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_view_already_added_margin}" />
+          android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}" />
       </LinearLayout>
     </LinearLayout>
 

--- a/app/src/main/res/values-sw600dp-land/dimens.xml
+++ b/app/src/main/res/values-sw600dp-land/dimens.xml
@@ -16,7 +16,6 @@
   <dimen name="feedback_item_question_split_view_margin_start">32dp</dimen>
 
   <dimen name="profile_chooser_profile_view_textview_margin_start_profile_not_added">32dp</dimen>
-  <dimen name="profile_chooser_add_view_description_margin_start_profile_not_added">32dp</dimen>
 
   <dimen name="state_fragment_split_view_margin_end">64dp</dimen>
   <dimen name="state_fragment_split_view_margin_start">64dp</dimen>

--- a/app/src/main/res/values-sw600dp-land/dimens.xml
+++ b/app/src/main/res/values-sw600dp-land/dimens.xml
@@ -15,7 +15,7 @@
   <dimen name="feedback_item_question_split_view_margin_top">32dp</dimen>
   <dimen name="feedback_item_question_split_view_margin_start">32dp</dimen>
 
-  <dimen name="profile_chooser_profile_view_textview_margin_start_profile_not_added">32dp</dimen>
+  <dimen name="profile_chooser_description_margin_start_profile_not_added">32dp</dimen>
 
   <dimen name="state_fragment_split_view_margin_end">64dp</dimen>
   <dimen name="state_fragment_split_view_margin_start">64dp</dimen>

--- a/app/src/main/res/values-sw600dp-port/dimens.xml
+++ b/app/src/main/res/values-sw600dp-port/dimens.xml
@@ -23,7 +23,7 @@
   <dimen name="feedback_item_question_split_view_margin_start">32dp</dimen>
   <dimen name="state_fragment_split_view_margin_start">32dp</dimen>
   <dimen name="state_fragment_split_view_margin_end">32dp</dimen>
-  <dimen name="profile_chooser_profile_view_textview_margin_start_profile_not_added">32dp</dimen>
+  <dimen name="profile_chooser_description_margin_start_profile_not_added">32dp</dimen>
 
   <dimen name="previous_button_item_question_view_margin_start">128dp</dimen>
   <dimen name="content_item_question_view_margin_end">128dp</dimen>

--- a/app/src/main/res/values-sw600dp-port/dimens.xml
+++ b/app/src/main/res/values-sw600dp-port/dimens.xml
@@ -24,7 +24,6 @@
   <dimen name="state_fragment_split_view_margin_start">32dp</dimen>
   <dimen name="state_fragment_split_view_margin_end">32dp</dimen>
   <dimen name="profile_chooser_profile_view_textview_margin_start_profile_not_added">32dp</dimen>
-  <dimen name="profile_chooser_add_view_description_margin_start_profile_not_added">32dp</dimen>
 
   <dimen name="previous_button_item_question_view_margin_start">128dp</dimen>
   <dimen name="content_item_question_view_margin_end">128dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -210,7 +210,7 @@
   <dimen name="previous_responses_item_question_split_view_margin_top">24dp</dimen>
   <dimen name="previous_responses_item_question_view_margin_top">24dp</dimen>
   <dimen name="profile_chooser_add_view_margin_top_profile_not_added">24dp</dimen>
-  <dimen name="profile_chooser_add_view_description_parent_margin_start_profile_not_added">24dp</dimen>
+  <dimen name="profile_chooser_description_margin_start_profile_not_added">24dp</dimen>
   <dimen name="profile_chooser_add_view_margin_end_profile_not_added">24dp</dimen>
   <dimen name="profile_chooser_add_view_margin_start_profile_not_added">24dp</dimen>
   <dimen name="profile_chooser_profile_view_margin_end_profile_already_added">24dp</dimen>
@@ -360,8 +360,6 @@
   <dimen name="submitted_answer_item_question_view_margin_start">32dp</dimen>
   <dimen name="text_input_interaction_item_non_conversation_view_margin_start">32dp</dimen>
   <dimen name="text_input_interaction_item_non_conversation_view_margin_end">32dp</dimen>
-  <dimen name="profile_chooser_add_view_description_margin_start_profile_not_added">32dp</dimen>
-  <dimen name="profile_chooser_profile_view_textview_margin_start_profile_not_added">32dp</dimen>
 
   <dimen name="content_item_question_view_margin_top">36dp</dimen>
   <dimen name="previous_button_item_question_split_view_margin_start">48dp</dimen>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #2205: adds a vertical-orientation LinearLayout under profile_chooser_profile_view's profile_chooser_item LinearLayout for its TextViews. This keeps said TextViews arranged vertically regardless of whether they're beside or below the icon.

This also makes the "Administrator" label visible regardless of the OOBE status, and cleans up a few minor alignment issues that would have been more work to leave unfixed.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
