### PR TITLE
Fix part of #2210 : Changes in Admin Controls Download Permissions View

### DIFF
--- a/app/src/main/res/layout-land/administrator_controls_download_permissions_view.xml
+++ b/app/src/main/res/layout-land/administrator_controls_download_permissions_view.xml
@@ -69,13 +69,15 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="40dp"
+        android:minWidth="48dp"
+        android:minHeight="48dp"
         android:checked="@{viewModel.isTopicWifiUpdatePermission}"
         android:onCheckedChanged="@{(switch, checked) -> viewModel.onTopicWifiUpdatePermissionChanged(checked)}"
         android:theme="@style/SwitchCompatTheme"
-        app:layout_constraintBottom_toBottomOf="@id/topic_update_on_wifi_description_text_view"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/topic_update_on_wifi_description_text_view"
-        app:layout_constraintTop_toTopOf="@id/topic_update_on_wifi_title_text_view" />
+        app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <View
@@ -129,13 +131,15 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="40dp"
+        android:minWidth="48dp"
+        android:minHeight="48dp"
         android:checked="@{viewModel.isTopicAutoUpdatePermission}"
         android:onCheckedChanged="@{(switch, checked) -> viewModel.onTopicAutoUpdatePermissionChanged(checked)}"
         android:theme="@style/SwitchCompatTheme"
-        app:layout_constraintBottom_toBottomOf="@id/auto_update_topic_description_text_view"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/auto_update_topic_description_text_view"
-        app:layout_constraintTop_toTopOf="@id/auto_update_topic_title_text_view" />
+        app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout-sw600dp/administrator_controls_download_permissions_view.xml
+++ b/app/src/main/res/layout-sw600dp/administrator_controls_download_permissions_view.xml
@@ -70,13 +70,15 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="40dp"
         android:layout_marginEnd="4dp"
+        android:minWidth="48dp"
+        android:minHeight="48dp"
         android:checked="@{viewModel.isTopicWifiUpdatePermission}"
         android:onCheckedChanged="@{(switch, checked) -> viewModel.onTopicWifiUpdatePermissionChanged(checked)}"
         android:theme="@style/SwitchCompatTheme"
-        app:layout_constraintBottom_toBottomOf="@id/topic_update_on_wifi_description_text_view"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/topic_update_on_wifi_description_text_view"
-        app:layout_constraintTop_toTopOf="@id/topic_update_on_wifi_title_text_view" />
+        app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <View
@@ -131,13 +133,15 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="40dp"
         android:layout_marginEnd="4dp"
+        android:minWidth="48dp"
+        android:minHeight="48dp"
         android:checked="@{viewModel.isTopicAutoUpdatePermission}"
         android:onCheckedChanged="@{(switch, checked) -> viewModel.onTopicAutoUpdatePermissionChanged(checked)}"
         android:theme="@style/SwitchCompatTheme"
-        app:layout_constraintBottom_toBottomOf="@id/auto_update_topic_description_text_view"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/auto_update_topic_description_text_view"
-        app:layout_constraintTop_toTopOf="@id/auto_update_topic_title_text_view" />
+        app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/administrator_controls_download_permissions_view.xml
+++ b/app/src/main/res/layout/administrator_controls_download_permissions_view.xml
@@ -70,13 +70,15 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="40dp"
         android:layout_marginEnd="4dp"
+        android:minWidth="48dp"
+        android:minHeight="48dp"
         android:checked="@{viewModel.isTopicWifiUpdatePermission}"
         android:onCheckedChanged="@{(switch, checked) -> viewModel.onTopicWifiUpdatePermissionChanged(checked)}"
         android:theme="@style/SwitchCompatTheme"
-        app:layout_constraintBottom_toBottomOf="@id/topic_update_on_wifi_description_text_view"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/topic_update_on_wifi_description_text_view"
-        app:layout_constraintTop_toTopOf="@id/topic_update_on_wifi_title_text_view" />
+        app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <View
@@ -131,13 +133,15 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="40dp"
         android:layout_marginEnd="4dp"
+        android:minWidth="48dp"
+        android:minHeight="48dp"
         android:checked="@{viewModel.isTopicAutoUpdatePermission}"
         android:onCheckedChanged="@{(switch, checked) -> viewModel.onTopicAutoUpdatePermissionChanged(checked)}"
         android:theme="@style/SwitchCompatTheme"
-        app:layout_constraintBottom_toBottomOf="@id/auto_update_topic_description_text_view"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/auto_update_topic_description_text_view"
-        app:layout_constraintTop_toTopOf="@id/auto_update_topic_title_text_view" />
+        app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes part (`Issue-1`) of issue #2210 

### screenshots

| Before | After |
|--------|-------|
| ![Screenshot_1611312423](https://user-images.githubusercontent.com/54908857/105503566-c1e54f00-5cec-11eb-85f5-2eb7bfe39944.png)       | ![Screenshot_1611314778](https://user-images.githubusercontent.com/54908857/105503636-d7f30f80-5cec-11eb-8f09-d390cf97472d.png) |
| ![Screenshot_1611311879](https://user-images.githubusercontent.com/54908857/105503998-43d57800-5ced-11eb-9645-5b6af098eec5.png)       |   ![Screenshot_1611314897](https://user-images.githubusercontent.com/54908857/105504019-4932c280-5ced-11eb-9c4f-53d879aa60c4.png)    |
|  ![Screenshot_1611312426](https://user-images.githubusercontent.com/54908857/105504238-8b5c0400-5ced-11eb-8070-5486a87b468f.png)      |    ![Screenshot_1611314797](https://user-images.githubusercontent.com/54908857/105504203-7f704200-5ced-11eb-99bf-10dae9840da2.png)   |





### This test fails if constraints of switch button are not changed. But changing the constraints(top,bottom) to `parent` makes this test pass.
![image](https://user-images.githubusercontent.com/54908857/105504854-41bfe900-5cee-11eb-940a-5f2ac23e5d95.png)

 









## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
