### PR TITLE
Add support for putting/getting protos in Bundles

### DIFF
--- a/app/src/main/java/org/oppia/android/app/utility/BundleExtensions.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/BundleExtensions.kt
@@ -1,0 +1,35 @@
+package org.oppia.android.app.utility
+
+import android.os.Bundle
+import com.google.protobuf.ByteString
+import com.google.protobuf.MessageLite
+
+/**
+ * Saves the specified proto in the bundle under the specified key name.
+ *
+ * The proto can then be retrieved from the bundle using [Bundle.getProto].
+ */
+fun <T: MessageLite> Bundle.putProto(name: String, message: T) {
+  putSerializable(name, message.toByteString())
+}
+
+/**
+ * Returns the proto stored in this bundle corresponding to the specified name, or the default value
+ * if there is no proto stored under the specified name.
+ *
+ * This should only be used by protos stored using [Bundle.putProto].
+ *
+ * Note that the type of [defaultValue] must correspond to the type stored in the bundle, otherwise
+ * this function will throw. The proto stored in the bundle must also be interoperable with the
+ * current version of the proto (in case the persisted proto survives across app processes which may
+ * be possible in some circumstances such as low-memory process kills).
+ */
+fun <T: MessageLite> Bundle.getProto(name: String, defaultValue: T): T {
+  val deserializedByteString = getSerializable(name) as? ByteString
+  return deserializedByteString?.let {
+    // Type safety is *generally* guaranteed by newBuilderForType. If the bundle actually has an
+    // incorrect type, then the mergeFrom() call should fail.
+    @Suppress("UNCHECKED_CAST")
+    defaultValue.newBuilderForType().mergeFrom(it).build() as T
+  } ?: defaultValue
+}

--- a/model/BUILD.bazel
+++ b/model/BUILD.bazel
@@ -1,10 +1,11 @@
 # TODO(#1532): Rename file to 'BUILD' post-Gradle.
-'''
+"""
 This library contains all protos used in the app and is a dependency for all other modules.
 In Bazel, proto files are built using the proto_library() and java_lite_proto_library() rules.
 The proto_library() rule creates a proto file library to be used in multiple languages.
 The java_lite_proto_library() rule takes in a proto_library target and generates java code.
-'''
+"""
+
 load("//model:src/main/proto/format_import_proto_library.bzl", "format_import_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_java//java:defs.bzl", "java_lite_proto_library")
@@ -109,6 +110,16 @@ java_lite_proto_library(
 )
 
 proto_library(
+    name = "test_proto",
+    srcs = ["src/main/proto/test.proto"],
+)
+
+java_lite_proto_library(
+    name = "test_java_proto_lite",
+    deps = [":test_proto"],
+)
+
+proto_library(
     name = "thumbnail_proto",
     srcs = ["src/main/proto/thumbnail.proto"],
 )
@@ -174,9 +185,9 @@ format_import_proto_library(
     name = "exploration",
     src = "src/main/proto/exploration.proto",
     deps = [
+        ":interaction_object_proto",
         ":subtitled_html_proto",
         ":subtitled_unicode_proto",
-        ":interaction_object_proto",
         ":translation_proto",
         ":voiceover_proto",
     ],
@@ -189,20 +200,29 @@ java_lite_proto_library(
 
 android_library(
     name = "model",
+    visibility = ["//visibility:public"],
     exports = [
         ":event_logger_java_proto_lite",
         ":example_java_proto_lite",
+        ":exploration_java_proto_lite",
         ":interaction_object_java_proto_lite",
         ":onboarding_java_proto_lite",
         ":profile_java_proto_lite",
+        ":question_java_proto_lite",
         ":subtitled_html_java_proto_lite",
+        ":subtitled_unicode_java_proto_lite",
         ":thumbnail_java_proto_lite",
+        ":topic_java_proto_lite",
         ":translation_java_proto_lite",
         ":voiceover_java_proto_lite",
-        ":exploration_java_proto_lite",
-        ":question_java_proto_lite",
-        ":topic_java_proto_lite",
-        ":subtitled_unicode_java_proto_lite",
     ],
+)
+
+android_library(
+    name = "test_models",
+    testonly = True,
     visibility = ["//visibility:public"],
+    exports = [
+        ":test_java_proto_lite",
+    ],
 )

--- a/model/src/main/proto/example.proto
+++ b/model/src/main/proto/example.proto
@@ -5,10 +5,6 @@ package model;
 option java_package = "org.oppia.android.app.model";
 option java_multiple_files = true;
 
-message TestMessage {
-  int32 version = 1;
-}
-
 message TestModel {
   oneof model_type {
     string str_value = 1;

--- a/model/src/main/proto/test.proto
+++ b/model/src/main/proto/test.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+package model;
+
+option java_package = "org.oppia.android.app.model";
+option java_multiple_files = true;
+
+// A test message that is meant only to be used in tests.
+message TestMessage {
+  string str_value = 1;
+
+  int32 int_value = 2;
+}
+
+// A version of TestMessage that is binary compatible, but is "newer".
+message TestMessage2 {
+  string str_value = 1;
+
+  reserved 2;
+
+  bool bool_value = 3;
+}
+
+// A proto which is incompatible with TestMessage/TestMessage 2.
+message IncompatibleTestMessage {
+  IncompatibleNestedMessage nested_message = 1;
+
+  int32 int_value = 2;
+}
+
+message IncompatibleNestedMessage {
+  repeated int32 int_value = 1;
+}

--- a/utility/BUILD.bazel
+++ b/utility/BUILD.bazel
@@ -77,6 +77,15 @@ utility_test(
 )
 
 utility_test(
+    name = "BundleExtensionsTest",
+    srcs = ["src/test/java/org/oppia/android/util/extensions/BundleExtensionsTest.kt"],
+    test_class = "org.oppia.android.util.extensions.BundleExtensionsTest",
+    deps = TEST_DEPS + [
+        "//model:test_models",
+    ],
+)
+
+utility_test(
     name = "EventBundleCreatorTest",
     srcs = ["src/test/java/org/oppia/android/util/logging/EventBundleCreatorTest.kt"],
     test_class = "org.oppia.android.util.logging.EventBundleCreatorTest",

--- a/utility/src/main/java/org/oppia/android/util/extensions/BundleExtensions.kt
+++ b/utility/src/main/java/org/oppia/android/util/extensions/BundleExtensions.kt
@@ -1,4 +1,4 @@
-package org.oppia.android.app.utility
+package org.oppia.android.util.extensions
 
 import android.os.Bundle
 import com.google.protobuf.ByteString

--- a/utility/src/test/java/org/oppia/android/util/extensions/BundleExtensionsTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/extensions/BundleExtensionsTest.kt
@@ -1,21 +1,164 @@
 package org.oppia.android.util.extensions
 
+import android.os.Bundle
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
 import org.junit.runner.RunWith
+import org.oppia.android.app.model.IncompatibleTestMessage
+import org.oppia.android.app.model.TestMessage
+import org.oppia.android.app.model.TestMessage2
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 
+/** Tests for BundleExtensions. */
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(manifest = Config.NONE)
 class BundleExtensionsTest {
+  private val TEST_STRING = "String value"
 
-  // testGetProto_noProtoInBundle_returnsDefault
-  // testPutProto_noProtoInBundle_addsDataToProto
-  // testGetProto_protoInBundle_sameType_returnsCorrectProto
-  // testGetProto_protoInBundle_sameType_defaultWithData_returnsUnmergedProto
-  // testPutProto_protoAlreadyInBundle_overridesExistingProto
-  // testGetProto_oldProtoInBundle_differentButCompatibleType_returnsInteroperableProto
-  // testGetProto_protoInBundle_incompatibelType_throws
-  // testPutProto_multipleProtos_eachCanBeRetrieved
+  private val TEST_MESSAGE_WITH_STR_AND_INT =
+    TestMessage.newBuilder().setStrValue(TEST_STRING).setIntValue(1).build()
+
+  private val TEST_MESSAGE_WITH_INT = TestMessage.newBuilder().setIntValue(1).build()
+
+  @Test
+  fun testGetProto_noProtoInBundle_returnsDefault() {
+    val bundle = Bundle()
+
+    val testMessage = bundle.getProto(
+      "test_proto_key", defaultValue = TestMessage.getDefaultInstance()
+    )
+
+    assertThat(testMessage).isEqualTo(testMessage)
+  }
+
+  @Test
+  fun testPutProto_noProtoInBundle_addsDataToProto() {
+    val bundle = Bundle()
+
+    bundle.putProto("test_proto_key", TEST_MESSAGE_WITH_STR_AND_INT)
+
+    assertThat(bundle.keySet()).contains("test_proto_key")
+  }
+
+  @Test
+  fun testGetProto_protoInBundle_sameType_returnsCorrectProto() {
+    val bundle = Bundle()
+    bundle.putProto("test_proto_key", TEST_MESSAGE_WITH_STR_AND_INT)
+
+    val testMessage = bundle.getProto(
+      "test_proto_key", defaultValue = TestMessage.getDefaultInstance()
+    )
+
+    assertThat(testMessage).isEqualTo(TEST_MESSAGE_WITH_STR_AND_INT)
+  }
+
+  @Test
+  fun testGetProto_protoInBundle_sameType_defaultHasData_returnsUnmergedProto() {
+    val bundle = Bundle()
+    bundle.putProto("test_proto_key", TEST_MESSAGE_WITH_INT)
+
+    val testMessage = bundle.getProto(
+      "test_proto_key",
+      defaultValue = TestMessage.newBuilder().setStrValue("Different string value").build()
+    )
+
+    // The string from the default value should not be incorporated since the default is only used
+    // if the proto is not defined yet in the bundle.
+    assertThat(testMessage).isEqualTo(TEST_MESSAGE_WITH_INT)
+  }
+
+  @Test
+  fun testPutProto_protoAlreadyInBundle_overridesExistingProto() {
+    val bundle = Bundle()
+    bundle.putProto("test_proto_key", TEST_MESSAGE_WITH_INT)
+
+    // Override the proto in the bundle.
+    bundle.putProto("test_proto_key", TEST_MESSAGE_WITH_STR_AND_INT)
+    val testMessage = bundle.getProto(
+      "test_proto_key", defaultValue = TestMessage.getDefaultInstance()
+    )
+
+    // The most recent proto value should be retrieved.
+    assertThat(testMessage).isEqualTo(TEST_MESSAGE_WITH_STR_AND_INT)
+  }
+
+  @Test
+  fun testGetProto_protoInBundle_thenRemoved_returnsDefault() {
+    val bundle = Bundle()
+    bundle.putProto("test_proto_key", TEST_MESSAGE_WITH_INT)
+
+    // Remove the proto from the bundle.
+    bundle.remove("test_proto_key")
+    val testMessage = bundle.getProto(
+      "test_proto_key", defaultValue = TestMessage.getDefaultInstance()
+    )
+
+    // The default should be used since the proto was removed.
+    assertThat(testMessage).isEqualTo(TestMessage.getDefaultInstance())
+  }
+
+  @Test
+  fun testPutProto_multipleProtos_eachCanBeRetrieved() {
+    val bundle = Bundle()
+    bundle.putProto("test_proto_key1", TEST_MESSAGE_WITH_INT)
+    bundle.putProto("test_proto_key2", TEST_MESSAGE_WITH_STR_AND_INT)
+
+    val testMessage1 = bundle.getProto(
+      "test_proto_key1", defaultValue = TestMessage.getDefaultInstance()
+    )
+    val testMessage2 = bundle.getProto(
+      "test_proto_key2", defaultValue = TestMessage.getDefaultInstance()
+    )
+
+    // Both protos should be retrievable.
+    assertThat(testMessage1).isEqualTo(TEST_MESSAGE_WITH_INT)
+    assertThat(testMessage2).isEqualTo(TEST_MESSAGE_WITH_STR_AND_INT)
+  }
+
+  @Test
+  fun testGetProto_oldProtoInBundle_differentButCompatibleType_returnsInteroperableProto() {
+    val bundle = Bundle()
+    bundle.putProto("test_proto_key", TEST_MESSAGE_WITH_STR_AND_INT)
+
+    // Retrieve a "newer" version of the proto (using a proto that's binary-compatible).
+    val testMessage = bundle.getProto(
+      "test_proto_key", defaultValue = TestMessage2.getDefaultInstance()
+    )
+
+    // The string should be retrievable from the new proto, and the new field should be defaulted.
+    // The int will be ignored since it was "removed" (but is reserved).
+    assertThat(testMessage.strValue).isEqualTo(TEST_STRING)
+    assertThat(testMessage.boolValue).isFalse()
+  }
+
+  @Test
+  fun testGetProto_protoInBundle_incompatibleType_throws() {
+    val bundle = Bundle()
+    bundle.putProto("test_proto_key", TEST_MESSAGE_WITH_STR_AND_INT)
+
+    // Try retrieving the wrong proto type.
+    val testMessage = bundle.getProto(
+      "test_proto_key", defaultValue = IncompatibleTestMessage.getDefaultInstance()
+    )
+
+    // Proto incompatibilities should lead to the default value being returned.
+    assertThat(testMessage).isEqualTo(IncompatibleTestMessage.getDefaultInstance())
+  }
+
+  @Test
+  fun testGetProto_keyUsed_notAProto_returnsDefaultInstance() {
+    val bundle = Bundle()
+    bundle.putString("test_proto_key", "not_a_proto")
+
+    // Try retrieving a proto when a non-proto was saved.
+    val testMessage = bundle.getProto(
+      "test_proto_key", defaultValue = TestMessage.getDefaultInstance()
+    )
+
+    // Like other bundle retrieval functions, return the default if there's a type incompatibility.
+    assertThat(testMessage).isEqualTo(TestMessage.getDefaultInstance())
+  }
 }

--- a/utility/src/test/java/org/oppia/android/util/extensions/BundleExtensionsTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/extensions/BundleExtensionsTest.kt
@@ -1,0 +1,21 @@
+package org.oppia.android.util.extensions
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+
+@RunWith(AndroidJUnit4::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+@Config(manifest = Config.NONE)
+class BundleExtensionsTest {
+
+  // testGetProto_noProtoInBundle_returnsDefault
+  // testPutProto_noProtoInBundle_addsDataToProto
+  // testGetProto_protoInBundle_sameType_returnsCorrectProto
+  // testGetProto_protoInBundle_sameType_defaultWithData_returnsUnmergedProto
+  // testPutProto_protoAlreadyInBundle_overridesExistingProto
+  // testGetProto_oldProtoInBundle_differentButCompatibleType_returnsInteroperableProto
+  // testGetProto_protoInBundle_incompatibelType_throws
+  // testPutProto_multipleProtos_eachCanBeRetrieved
+}


### PR DESCRIPTION
This PR introduces support for storing/retrieving protos in bundles. Most caveats are defined in the documentation, but one other is that this only supports serializing/deserializing protos that only ever reference proto lite (since it implies using the proto lite extension registry). In reality, I don't think this will ever cause issues with how we use protos.