### PR TITLE
Fix #2227 : Profile name out-of-bounds fix

### DIFF
--- a/app/src/main/res/layout/profile_edit_activity.xml
+++ b/app/src/main/res/layout/profile_edit_activity.xml
@@ -210,6 +210,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:fontFamily="sans-serif-medium"
+            android:layout_marginEnd="150dp"
             android:text="@{viewModel.profile.name}"
             android:textColor="@color/oppiaPrimaryText"
             android:textSize="20sp"

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -390,9 +390,9 @@ class ProfileEditActivityTest {
   }
 
   @Test
-  fun testProfileEdit_tooLongName_isCompletelyVisible() {
+  fun testProfileEdit_withLongProfileName_nameIsCompletelyVisible() {
     profileManagementController.addProfile(
-      name = "Marijuana Pepsi Jackson Cocacola",
+      name = "Hubert Blaine Wolfeschlegelstein",
       pin = "123",
       avatarImagePath = null,
       allowDownloadAccess = false,
@@ -406,7 +406,32 @@ class ProfileEditActivityTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      onView(withId(R.id.profile_edit_name)).check(matches(withText("Marijuana Pepsi Jackson Cocacola")))
+      onView(withId(R.id.profile_edit_name))
+        .check(matches(withText("Hubert Blaine Wolfeschlegelstein")))
+      onView(withId(R.id.profile_edit_name)).check(matches(ViewMatchers.isCompletelyDisplayed()))
+    }
+  }
+
+  @Test
+  fun testProfileEdit_withLongProfileName_configChange_nameIsCompletelyVisible() {
+    profileManagementController.addProfile(
+      name = "Hubert Blaine Wolfeschlegelstein",
+      pin = "123",
+      avatarImagePath = null,
+      allowDownloadAccess = false,
+      colorRgb = -10710042,
+      isAdmin = false
+    ).toLiveData()
+    launch<ProfileEditActivity>(
+      ProfileEditActivity.createProfileEditActivity(
+        context,
+        profileId = 4
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(isRoot()).perform(orientationLandscape())
+      onView(withId(R.id.profile_edit_name))
+        .check(matches(withText("Hubert Blaine Wolfeschlegelstein")))
       onView(withId(R.id.profile_edit_name)).check(matches(ViewMatchers.isCompletelyDisplayed()))
     }
   }

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -13,6 +13,7 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -385,6 +386,28 @@ class ProfileEditActivityTest {
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.profile_edit_allow_download_switch)).check(matches(isChecked()))
+    }
+  }
+
+  @Test
+  fun testProfileEdit_tooLongName_isCompletelyVisible() {
+    profileManagementController.addProfile(
+      name = "Marijuana Pepsi Jackson Cocacola",
+      pin = "123",
+      avatarImagePath = null,
+      allowDownloadAccess = false,
+      colorRgb = -10710042,
+      isAdmin = false
+    ).toLiveData()
+    launch<ProfileEditActivity>(
+      ProfileEditActivity.createProfileEditActivity(
+        context,
+        profileId = 4
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(withId(R.id.profile_edit_name)).check(matches(withText("Marijuana Pepsi Jackson Cocacola")))
+      onView(withId(R.id.profile_edit_name)).check(matches(ViewMatchers.isCompletelyDisplayed()))
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
It Fixes the out-of-bounds name issue on the Profile Edit page. Also includes a test case.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.

- ### Robolectric result
![Screenshot (237)](https://user-images.githubusercontent.com/25471892/106094481-1dce2e80-6158-11eb-840c-7cae0e72d06c.png)
- ### Espresso result
![Screenshot (238)](https://user-images.githubusercontent.com/25471892/106094548-33dbef00-6158-11eb-9774-81ce8b48cec4.png)


- ### Screenshots
<img src="https://user-images.githubusercontent.com/25471892/106094581-3fc7b100-6158-11eb-892e-e20affce917e.png" width="300"> <img src="https://user-images.githubusercontent.com/25471892/106094596-45bd9200-6158-11eb-8aaa-2c495ee79e04.png" width="600"> 
![Screenshot_1611810550](https://user-images.githubusercontent.com/25471892/106094604-49e9af80-6158-11eb-8ff9-4da489127379.png) 
![Screenshot_1611810544](https://user-images.githubusercontent.com/25471892/106094607-4bb37300-6158-11eb-9c4c-c9268bbe5300.png)
