### PR TITLE
Fixes #2564 & Fixes part of #2606: Changed the dimens files w.r.t Content Item

### DIFF
--- a/app/src/main/res/layout-land/content_item.xml
+++ b/app/src/main/res/layout-land/content_item.xml
@@ -14,6 +14,22 @@
       type="org.oppia.android.app.player.state.itemviewmodel.ContentViewModel" />
   </data>
 
+  <!-- EXPLORATION SPLIT VIEW -->
+  <!-- Overall Outer Space: 24, 40, 40, 0 -->
+  <!-- Overall Inner Space: 12, 16, 12, 16 -->
+
+  <!-- EXPLORATION VIEW -->
+  <!-- Overall Outer Space: 48, 16, 80, 0 -->
+  <!-- Overall Inner Space: 12, 16, 12, 16 -->
+
+  <!-- QUESTION SPLIT VIEW -->
+  <!-- Overall Outer Space: 32, 40, 32, 16 -->
+  <!-- Overall Inner Space: 0, 0, 0, 0 -->
+
+  <!-- QUESTION VIEW -->
+  <!-- Overall Outer Space: 64, 32, 64, 16 -->
+  <!-- Overall Inner Space: 0, 0, 0, 0 -->
+
   <FrameLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"

--- a/app/src/main/res/layout-sw600dp-land/content_item.xml
+++ b/app/src/main/res/layout-sw600dp-land/content_item.xml
@@ -46,7 +46,7 @@
     app:explorationSplitViewPaddingTop="@{@dimen/content_item_exploration_split_view_padding_top}"
     app:explorationViewMarginApplicable="@{viewModel.hasConversationView &amp;&amp; !viewModel.isSplitView}"
     app:explorationViewMarginBottom="@{@dimen/space_0dp}"
-    app:explorationViewMarginEnd="@{@dimen/content_item_exploration_margin_end}"
+    app:explorationViewMarginEnd="@{@dimen/content_item_exploration_view_margin_end}"
     app:explorationViewMarginStart="@{@dimen/content_item_exploration_view_margin_start}"
     app:explorationViewMarginTop="@{@dimen/content_item_exploration_view_margin_top}"
     app:explorationViewPaddingApplicable="@{viewModel.hasConversationView &amp;&amp; !viewModel.isSplitView}"

--- a/app/src/main/res/layout-sw600dp-land/content_item.xml
+++ b/app/src/main/res/layout-sw600dp-land/content_item.xml
@@ -14,6 +14,22 @@
       type="org.oppia.android.app.player.state.itemviewmodel.ContentViewModel" />
   </data>
 
+  <!-- EXPLORATION SPLIT VIEW -->
+  <!-- Overall Outer Space: 24, 40, 40, 0 -->
+  <!-- Overall Inner Space: 12, 16, 12, 16 -->
+
+  <!-- EXPLORATION VIEW -->
+  <!-- Overall Outer Space: 176, 40, 208, 0 -->
+  <!-- Overall Inner Space: 12, 16, 12, 16 -->
+
+  <!-- QUESTION SPLIT VIEW -->
+  <!-- Overall Outer Space: 32, 40, 32, 0 -->
+  <!-- Overall Inner Space: 0, 0, 0, 0 -->
+
+  <!-- QUESTION VIEW -->
+  <!-- Overall Outer Space: 192, 40, 192, 0 -->
+  <!-- Overall Inner Space: 0, 0, 0, 0 -->
+
   <FrameLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"

--- a/app/src/main/res/layout-sw600dp-port/content_item.xml
+++ b/app/src/main/res/layout-sw600dp-port/content_item.xml
@@ -14,6 +14,22 @@
       type="org.oppia.android.app.player.state.itemviewmodel.ContentViewModel" />
   </data>
 
+  <!-- EXPLORATION SPLIT VIEW -->
+  <!-- Overall Outer Space: 24, 40, 40, 0 -->
+  <!-- Overall Inner Space: 12, 16, 12, 16 -->
+
+  <!-- EXPLORATION VIEW -->
+  <!-- Overall Outer Space: 112, 36, 144, 0 -->
+  <!-- Overall Inner Space: 12, 16, 12, 16 -->
+
+  <!-- QUESTION SPLIT VIEW -->
+  <!-- Overall Outer Space: 32, 40, 32, 0 -->
+  <!-- Overall Inner Space: 0, 0, 0, 0 -->
+
+  <!-- QUESTION VIEW -->
+  <!-- Overall Outer Space: 128, 36, 128, 0 -->
+  <!-- Overall Inner Space: 0, 0, 0, 0 -->
+
   <FrameLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/content_item.xml
+++ b/app/src/main/res/layout/content_item.xml
@@ -14,6 +14,22 @@
       type="org.oppia.android.app.player.state.itemviewmodel.ContentViewModel" />
   </data>
 
+  <!-- EXPLORATION SPLIT VIEW -->
+  <!-- Overall Outer Space: 24, 40, 40, 0 -->
+  <!-- Overall Inner Space: 12, 16, 12, 16 -->
+
+  <!-- EXPLORATION VIEW -->
+  <!-- Overall Outer Space: 24, 24, 40, 0 -->
+  <!-- Overall Inner Space: 8, 12, 8, 12 -->
+
+  <!-- QUESTION SPLIT VIEW -->
+  <!-- Overall Outer Space: 32, 40, 32, 12 -->
+  <!-- Overall Inner Space: 0, 0, 0, 0 -->
+
+  <!-- QUESTION VIEW -->
+  <!-- Overall Outer Space: 32, 36, 32, 12 -->
+  <!-- Overall Inner Space: 00, 00, 00, 00 -->
+
   <FrameLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/content_item.xml
+++ b/app/src/main/res/layout/content_item.xml
@@ -28,7 +28,7 @@
 
   <!-- QUESTION VIEW -->
   <!-- Overall Outer Space: 32, 36, 32, 12 -->
-  <!-- Overall Inner Space: 00, 00, 00, 00 -->
+  <!-- Overall Inner Space: 0, 0, 0, 0 -->
 
   <FrameLayout
     android:layout_width="match_parent"

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -119,7 +119,7 @@
   <dimen name="content_item_question_split_view_margin_end">32dp</dimen>
   <dimen name="content_item_question_split_view_margin_bottom">16dp</dimen>
 
-  <!-- Content Item: QUESTION View -->
+  <!-- Content Item: Question View -->
   <dimen name="content_item_question_view_margin_start">64dp</dimen>
   <dimen name="content_item_question_view_margin_top">32dp</dimen>
   <dimen name="content_item_question_view_margin_end">64dp</dimen>

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -93,7 +93,7 @@
   <dimen name="feedback_item_exploration_split_view_margin_end">40dp</dimen>
   <dimen name="submitted_answer_exploration_split_view_margin_start">40dp</dimen>
 
-  <!-- CONTENT ITEM: EXPLORATION SPLIT VIEW -->
+  <!-- Content Item: Exploration Split View -->
   <dimen name="content_item_exploration_split_view_margin_start">24dp</dimen>
   <dimen name="content_item_exploration_split_view_margin_top">40dp</dimen>
   <dimen name="content_item_exploration_split_view_margin_end">40dp</dimen>
@@ -103,7 +103,7 @@
   <dimen name="content_item_exploration_split_view_padding_end">12dp</dimen>
   <dimen name="content_item_exploration_split_view_padding_bottom">16dp</dimen>
 
-  <!-- CONTENT ITEM: EXPLORATION VIEW -->
+  <!-- Content Item: Exploration View -->
   <dimen name="content_item_exploration_view_margin_start">48dp</dimen>
   <dimen name="content_item_exploration_view_margin_top">16dp</dimen>
   <dimen name="content_item_exploration_view_margin_end">80dp</dimen>
@@ -113,16 +113,15 @@
   <dimen name="content_item_exploration_view_padding_end">12dp</dimen>
   <dimen name="content_item_exploration_view_padding_bottom">16dp</dimen>
 
-  <!-- CONTENT ITEM: QUESTION SPLIT VIEW -->
+  <!-- Content Item: Question Split View -->
   <dimen name="content_item_question_split_view_margin_start">32dp</dimen>
   <dimen name="content_item_question_split_view_margin_top">40dp</dimen>
   <dimen name="content_item_question_split_view_margin_end">32dp</dimen>
   <dimen name="content_item_question_split_view_margin_bottom">16dp</dimen>
 
-  <!-- CONTENT ITEM: QUESTION VIEW -->
+  <!-- Content Item: QUESTION View -->
   <dimen name="content_item_question_view_margin_start">64dp</dimen>
   <dimen name="content_item_question_view_margin_top">32dp</dimen>
   <dimen name="content_item_question_view_margin_end">64dp</dimen>
   <dimen name="content_item_question_view_margin_bottom">16dp</dimen>
-
 </resources>

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -6,10 +6,6 @@
   <dimen name="home_inner_margin">36dp</dimen>
   <dimen name="recently_played_margin_max">72dp</dimen>
   <dimen name="recently_played_margin_min">36dp</dimen>
-  <dimen name="content_item_exploration_view_margin_start">48dp</dimen>
-  <dimen name="content_item_question_view_margin_top">32dp</dimen>
-  <dimen name="content_item_question_split_view_margin_end">32dp</dimen>
-  <dimen name="content_item_question_split_view_margin_start">32dp</dimen>
   <dimen name="drag_drop_item_exploration_split_view_margin_start">32dp</dimen>
   <dimen name="drag_drop_item_exploration_split_view_margin_end">32dp</dimen>
   <dimen name="drag_drop_item_question_split_view_margin_end">32dp</dimen>
@@ -21,8 +17,6 @@
 
   <dimen name="state_fragment_split_view_margin_end">64dp</dimen>
   <dimen name="state_fragment_split_view_margin_start">64dp</dimen>
-  <dimen name="content_item_question_view_margin_end">64dp</dimen>
-  <dimen name="content_item_question_view_margin_start">64dp</dimen>
   <dimen name="drag_drop_item_question_view_margin_end">64dp</dimen>
   <dimen name="drag_drop_item_question_view_margin_start">64dp</dimen>
   <dimen name="feedback_item_question_view_margin_end">64dp</dimen>
@@ -43,7 +37,6 @@
   <dimen name="numeric_input_interaction_item_conversation_view_margin_end">48dp</dimen>
   <dimen name="selection_interaction_item_conversation_view_margin_end">48dp</dimen>
   <dimen name="text_input_interaction_item_conversation_view_margin_end">48dp</dimen>
-  <dimen name="content_item_exploration_split_view_margin_start">24dp</dimen>
   <dimen name="drag_drop_item_exploration_view_margin_top">24dp</dimen>
   <dimen name="drag_drop_item_question_view_margin_top">24dp</dimen>
   <dimen name="feedback_item_exploration_split_view_margin_start">24dp</dimen>
@@ -65,13 +58,6 @@
   <dimen name="submitted_answer_question_view_margin_top">24dp</dimen>
   <dimen name="walkthrough_final_fragment_card_content_padding">24dp</dimen>
 
-  <dimen name="content_item_exploration_split_view_padding_bottom">16dp</dimen>
-  <dimen name="content_item_exploration_split_view_padding_top">16dp</dimen>
-  <dimen name="content_item_exploration_view_margin_top">16dp</dimen>
-  <dimen name="content_item_exploration_view_padding_bottom">16dp</dimen>
-  <dimen name="content_item_exploration_view_padding_top">16dp</dimen>
-  <dimen name="content_item_question_split_view_margin_bottom">16dp</dimen>
-  <dimen name="content_item_question_view_margin_bottom">16dp</dimen>
   <dimen name="feedback_item_exploration_split_view_padding_bottom">16dp</dimen>
   <dimen name="feedback_item_exploration_split_view_padding_top">16dp</dimen>
   <dimen name="feedback_item_exploration_view_padding_bottom">16dp</dimen>
@@ -86,10 +72,6 @@
 
   <dimen name="feedback_item_exploration_split_view_padding_start">12dp</dimen>
   <dimen name="feedback_item_exploration_split_view_padding_end">12dp</dimen>
-  <dimen name="content_item_exploration_split_view_padding_end">12dp</dimen>
-  <dimen name="content_item_exploration_split_view_padding_start">12dp</dimen>
-  <dimen name="content_item_exploration_view_padding_end">12dp</dimen>
-  <dimen name="content_item_exploration_view_padding_start">12dp</dimen>
   <dimen name="feedback_item_exploration_view_padding_end">12dp</dimen>
   <dimen name="feedback_item_exploration_view_padding_start">12dp</dimen>
 
@@ -99,7 +81,6 @@
   <dimen name="state_fragment_split_view_with_audio_bar_visible_padding_top">96dp</dimen>
   <dimen name="state_fragment_non_split_view_margin_end">120dp</dimen>
   <dimen name="state_fragment_non_split_view_margin_start">120dp</dimen>
-  <dimen name="content_item_exploration_view_margin_end">80dp</dimen>
   <dimen name="feedback_item_exploration_view_margin_end">80dp</dimen>
   <dimen name="numeric_input_interaction_item_conversation_view_margin_start">80dp</dimen>
   <dimen name="previous_responses_item_exploration_view_margin_end">80dp</dimen>
@@ -107,12 +88,41 @@
   <dimen name="previous_responses_item_question_view_margin_end">80dp</dimen>
   <dimen name="previous_responses_item_question_view_margin_start">80dp</dimen>
   <dimen name="selection_interaction_item_conversation_view_margin_start">80dp</dimen>
-  <dimen name="content_item_exploration_split_view_margin_end">40dp</dimen>
-  <dimen name="content_item_exploration_split_view_margin_top">40dp</dimen>
-  <dimen name="content_item_question_split_view_margin_top">40dp</dimen>
   <dimen name="drag_drop_item_exploration_split_view_margin_top">40dp</dimen>
   <dimen name="drag_drop_item_question_split_view_margin_top">40dp</dimen>
   <dimen name="feedback_item_exploration_split_view_margin_end">40dp</dimen>
   <dimen name="submitted_answer_exploration_split_view_margin_start">40dp</dimen>
+
+  <!-- CONTENT ITEM: EXPLORATION SPLIT VIEW -->
+  <dimen name="content_item_exploration_split_view_margin_start">24dp</dimen>
+  <dimen name="content_item_exploration_split_view_margin_top">40dp</dimen>
+  <dimen name="content_item_exploration_split_view_margin_end">40dp</dimen>
+
+  <dimen name="content_item_exploration_split_view_padding_start">12dp</dimen>
+  <dimen name="content_item_exploration_split_view_padding_top">16dp</dimen>
+  <dimen name="content_item_exploration_split_view_padding_end">12dp</dimen>
+  <dimen name="content_item_exploration_split_view_padding_bottom">16dp</dimen>
+
+  <!-- CONTENT ITEM: EXPLORATION VIEW -->
+  <dimen name="content_item_exploration_view_margin_start">48dp</dimen>
+  <dimen name="content_item_exploration_view_margin_top">16dp</dimen>
+  <dimen name="content_item_exploration_view_margin_end">80dp</dimen>
+
+  <dimen name="content_item_exploration_view_padding_start">12dp</dimen>
+  <dimen name="content_item_exploration_view_padding_top">16dp</dimen>
+  <dimen name="content_item_exploration_view_padding_end">12dp</dimen>
+  <dimen name="content_item_exploration_view_padding_bottom">16dp</dimen>
+
+  <!-- CONTENT ITEM: QUESTION SPLIT VIEW -->
+  <dimen name="content_item_question_split_view_margin_start">32dp</dimen>
+  <dimen name="content_item_question_split_view_margin_top">40dp</dimen>
+  <dimen name="content_item_question_split_view_margin_end">32dp</dimen>
+  <dimen name="content_item_question_split_view_margin_bottom">16dp</dimen>
+
+  <!-- CONTENT ITEM: QUESTION VIEW -->
+  <dimen name="content_item_question_view_margin_start">64dp</dimen>
+  <dimen name="content_item_question_view_margin_top">32dp</dimen>
+  <dimen name="content_item_question_view_margin_end">64dp</dimen>
+  <dimen name="content_item_question_view_margin_bottom">16dp</dimen>
 
 </resources>

--- a/app/src/main/res/values-sw600dp-land/dimens.xml
+++ b/app/src/main/res/values-sw600dp-land/dimens.xml
@@ -6,8 +6,6 @@
   <dimen name="home_inner_margin">64dp</dimen>
   <dimen name="recently_played_margin_max">96dp</dimen>
   <dimen name="recently_played_margin_min">64dp</dimen>
-  <dimen name="content_item_question_split_view_margin_end">32dp</dimen>
-  <dimen name="content_item_question_split_view_margin_start">32dp</dimen>
   <dimen name="drag_drop_item_exploration_split_view_margin_start">32dp</dimen>
   <dimen name="drag_drop_item_exploration_split_view_margin_end">32dp</dimen>
   <dimen name="drag_drop_item_question_split_view_margin_end">32dp</dimen>
@@ -19,7 +17,6 @@
 
   <dimen name="state_fragment_split_view_margin_end">64dp</dimen>
   <dimen name="state_fragment_split_view_margin_start">64dp</dimen>
-  <dimen name="content_item_exploration_split_view_margin_start">24dp</dimen>
   <dimen name="drag_drop_item_exploration_view_margin_top">24dp</dimen>
   <dimen name="drag_drop_item_question_view_margin_top">24dp</dimen>
   <dimen name="feedback_item_exploration_split_view_margin_start">24dp</dimen>
@@ -43,10 +40,6 @@
   <dimen name="continue_navigation_item_exploration_view_margin_top">72dp</dimen>
   <dimen name="continue_navigation_item_question_view_margin_top">72dp</dimen>
 
-  <dimen name="content_item_exploration_split_view_padding_bottom">16dp</dimen>
-  <dimen name="content_item_exploration_split_view_padding_top">16dp</dimen>
-  <dimen name="content_item_exploration_view_padding_bottom">16dp</dimen>
-  <dimen name="content_item_exploration_view_padding_top">16dp</dimen>
   <dimen name="feedback_item_exploration_split_view_padding_bottom">16dp</dimen>
   <dimen name="feedback_item_exploration_split_view_padding_top">16dp</dimen>
   <dimen name="feedback_item_exploration_view_padding_bottom">16dp</dimen>
@@ -55,10 +48,6 @@
 
   <dimen name="feedback_item_exploration_split_view_padding_start">12dp</dimen>
   <dimen name="feedback_item_exploration_split_view_padding_end">12dp</dimen>
-  <dimen name="content_item_exploration_split_view_padding_end">12dp</dimen>
-  <dimen name="content_item_exploration_split_view_padding_start">12dp</dimen>
-  <dimen name="content_item_exploration_view_padding_end">12dp</dimen>
-  <dimen name="content_item_exploration_view_padding_start">12dp</dimen>
   <dimen name="feedback_item_exploration_view_padding_end">12dp</dimen>
   <dimen name="feedback_item_exploration_view_padding_start">12dp</dimen>
   <dimen name="return_to_topic_item_question_view_margin_top">12dp</dimen>
@@ -70,7 +59,6 @@
   <dimen name="profile_chooser_add_view_parent_margin_end_profile_not_added">298dp</dimen>
   <dimen name="profile_chooser_profile_view_parent_margin_start_profile_not_added">298dp</dimen>
   <dimen name="profile_chooser_profile_view_parent_margin_end_profile_not_added">298dp</dimen>
-  <dimen name="content_item_exploration_view_margin_end">208dp</dimen>
   <dimen name="feedback_item_exploration_view_margin_end">208dp</dimen>
   <dimen name="fraction_interaction_item_conversation_view_margin_start">208dp</dimen>
   <dimen name="numeric_input_interaction_item_conversation_view_margin_start">208dp</dimen>
@@ -83,8 +71,6 @@
   <dimen name="submitted_answer_exploration_view_margin_start">208dp</dimen>
   <dimen name="text_input_interaction_item_conversation_view_margin_start">208dp</dimen>
 
-  <dimen name="content_item_question_view_margin_start">192dp</dimen>
-  <dimen name="content_item_question_view_margin_end">192dp</dimen>
   <dimen name="continue_interaction_item_question_view_margin_end">192dp</dimen>
   <dimen name="continue_interaction_item_question_view_margin_start">192dp</dimen>
   <dimen name="continue_navigation_item_question_view_margin_end">192dp</dimen>
@@ -119,7 +105,6 @@
   <dimen name="text_input_interaction_item_non_conversation_view_margin_end">192dp</dimen>
   <dimen name="text_input_interaction_item_non_conversation_view_margin_start">192dp</dimen>
 
-  <dimen name="content_item_exploration_view_margin_start">176dp</dimen>
   <dimen name="continue_interaction_item_exploration_view_margin_end">176dp</dimen>
   <dimen name="continue_interaction_item_exploration_view_margin_start">176dp</dimen>
   <dimen name="continue_navigation_item_exploration_view_margin_end">176dp</dimen>
@@ -146,11 +131,6 @@
   <dimen name="submit_button_item_exploration_view_margin_top">72dp</dimen>
   <dimen name="submit_button_item_question_view_margin_top">72dp</dimen>
 
-  <dimen name="content_item_exploration_split_view_margin_end">40dp</dimen>
-  <dimen name="content_item_exploration_split_view_margin_top">40dp</dimen>
-  <dimen name="content_item_exploration_view_margin_top">40dp</dimen>
-  <dimen name="content_item_question_split_view_margin_top">40dp</dimen>
-  <dimen name="content_item_question_view_margin_top">40dp</dimen>
   <dimen name="drag_drop_item_exploration_split_view_margin_top">40dp</dimen>
   <dimen name="drag_drop_item_question_split_view_margin_top">40dp</dimen>
   <dimen name="feedback_item_exploration_split_view_margin_end">40dp</dimen>
@@ -160,5 +140,35 @@
   <dimen name="submitted_answer_question_split_view_margin_start_no_extra_interaction_answer">40dp</dimen>
   <dimen name="submitted_answer_question_split_view_margin_top_extra_interaction_answer">40dp</dimen>
   <dimen name="profile_chooser_profile_view_divider_margin_top">40dp</dimen>
+
+  <!-- CONTENT ITEM: EXPLORATION SPLIT VIEW -->
+  <dimen name="content_item_exploration_split_view_margin_start">24dp</dimen>
+  <dimen name="content_item_exploration_split_view_margin_top">40dp</dimen>
+  <dimen name="content_item_exploration_split_view_margin_end">40dp</dimen>
+
+  <dimen name="content_item_exploration_split_view_padding_start">12dp</dimen>
+  <dimen name="content_item_exploration_split_view_padding_top">16dp</dimen>
+  <dimen name="content_item_exploration_split_view_padding_end">12dp</dimen>
+  <dimen name="content_item_exploration_split_view_padding_bottom">16dp</dimen>
+
+  <!-- CONTENT ITEM: EXPLORATION VIEW -->
+  <dimen name="content_item_exploration_view_margin_start">176dp</dimen>
+  <dimen name="content_item_exploration_view_margin_top">40dp</dimen>
+  <dimen name="content_item_exploration_view_margin_end">208dp</dimen>
+
+  <dimen name="content_item_exploration_view_padding_start">12dp</dimen>
+  <dimen name="content_item_exploration_view_padding_top">16dp</dimen>
+  <dimen name="content_item_exploration_view_padding_end">12dp</dimen>
+  <dimen name="content_item_exploration_view_padding_bottom">16dp</dimen>
+
+  <!-- CONTENT ITEM: QUESTION SPLIT VIEW -->
+  <dimen name="content_item_question_split_view_margin_start">32dp</dimen>
+  <dimen name="content_item_question_split_view_margin_top">40dp</dimen>
+  <dimen name="content_item_question_split_view_margin_end">32dp</dimen>
+
+  <!-- CONTENT ITEM: QUESTION VIEW -->
+  <dimen name="content_item_question_view_margin_start">192dp</dimen>
+  <dimen name="content_item_question_view_margin_top">40dp</dimen>
+  <dimen name="content_item_question_view_margin_end">192dp</dimen>
 
 </resources>

--- a/app/src/main/res/values-sw600dp-land/dimens.xml
+++ b/app/src/main/res/values-sw600dp-land/dimens.xml
@@ -141,7 +141,7 @@
   <dimen name="submitted_answer_question_split_view_margin_top_extra_interaction_answer">40dp</dimen>
   <dimen name="profile_chooser_profile_view_divider_margin_top">40dp</dimen>
 
-  <!-- CONTENT ITEM: EXPLORATION SPLIT VIEW -->
+  <!-- Content Item: Exploration Split View -->
   <dimen name="content_item_exploration_split_view_margin_start">24dp</dimen>
   <dimen name="content_item_exploration_split_view_margin_top">40dp</dimen>
   <dimen name="content_item_exploration_split_view_margin_end">40dp</dimen>
@@ -151,7 +151,7 @@
   <dimen name="content_item_exploration_split_view_padding_end">12dp</dimen>
   <dimen name="content_item_exploration_split_view_padding_bottom">16dp</dimen>
 
-  <!-- CONTENT ITEM: EXPLORATION VIEW -->
+  <!-- Content Item: Exploration View -->
   <dimen name="content_item_exploration_view_margin_start">176dp</dimen>
   <dimen name="content_item_exploration_view_margin_top">40dp</dimen>
   <dimen name="content_item_exploration_view_margin_end">208dp</dimen>
@@ -161,14 +161,13 @@
   <dimen name="content_item_exploration_view_padding_end">12dp</dimen>
   <dimen name="content_item_exploration_view_padding_bottom">16dp</dimen>
 
-  <!-- CONTENT ITEM: QUESTION SPLIT VIEW -->
+  <!-- Content Item: Question Split View -->
   <dimen name="content_item_question_split_view_margin_start">32dp</dimen>
   <dimen name="content_item_question_split_view_margin_top">40dp</dimen>
   <dimen name="content_item_question_split_view_margin_end">32dp</dimen>
 
-  <!-- CONTENT ITEM: QUESTION VIEW -->
+  <!-- Content Item: Question View -->
   <dimen name="content_item_question_view_margin_start">192dp</dimen>
   <dimen name="content_item_question_view_margin_top">40dp</dimen>
   <dimen name="content_item_question_view_margin_end">192dp</dimen>
-
 </resources>

--- a/app/src/main/res/values-sw600dp-port/dimens.xml
+++ b/app/src/main/res/values-sw600dp-port/dimens.xml
@@ -146,7 +146,7 @@
   <dimen name="submitted_answer_question_split_view_margin_start_no_extra_interaction_answer">40dp</dimen>
   <dimen name="submitted_answer_question_split_view_margin_top_extra_interaction_answer">40dp</dimen>
 
-  <!-- CONTENT ITEM: EXPLORATION SPLIT VIEW -->
+  <!-- Content Item: Exploration Split View -->
   <dimen name="content_item_exploration_split_view_margin_start">24dp</dimen>
   <dimen name="content_item_exploration_split_view_margin_top">40dp</dimen>
   <dimen name="content_item_exploration_split_view_margin_end">40dp</dimen>
@@ -156,7 +156,7 @@
   <dimen name="content_item_exploration_split_view_padding_end">12dp</dimen>
   <dimen name="content_item_exploration_split_view_padding_bottom">16dp</dimen>
 
-  <!-- CONTENT ITEM: EXPLORATION VIEW -->
+  <!-- Content Item: Exploration View -->
   <dimen name="content_item_exploration_view_margin_start">112dp</dimen>
   <dimen name="content_item_exploration_view_margin_top">36dp</dimen>
   <dimen name="content_item_exploration_view_margin_end">144dp</dimen>
@@ -166,12 +166,12 @@
   <dimen name="content_item_exploration_view_padding_end">12dp</dimen>
   <dimen name="content_item_exploration_view_padding_bottom">16dp</dimen>
 
-  <!-- CONTENT ITEM: QUESTION SPLIT VIEW -->
+  <!-- Content Item: Question Split View -->
   <dimen name="content_item_question_split_view_margin_start">32dp</dimen>
   <dimen name="content_item_question_split_view_margin_top">40dp</dimen>
   <dimen name="content_item_question_split_view_margin_end">32dp</dimen>
 
-  <!-- CONTENT ITEM -->
+  <!-- Content Item: Question View -->
   <dimen name="content_item_question_view_margin_start">128dp</dimen>
   <dimen name="content_item_question_view_margin_top">36dp</dimen>
   <dimen name="content_item_question_view_margin_end">128dp</dimen>

--- a/app/src/main/res/values-sw600dp-port/dimens.xml
+++ b/app/src/main/res/values-sw600dp-port/dimens.xml
@@ -8,10 +8,6 @@
   <dimen name="recently_played_margin_min">60dp</dimen>
   <dimen name="previous_responses_item_question_split_view_margin_end">48dp</dimen>
   <dimen name="previous_responses_item_exploration_split_view_margin_end">48dp</dimen>
-  <dimen name="content_item_question_view_margin_top">36dp</dimen>
-  <dimen name="content_item_exploration_view_margin_top">36dp</dimen>
-  <dimen name="content_item_question_split_view_margin_end">32dp</dimen>
-  <dimen name="content_item_question_split_view_margin_start">32dp</dimen>
   <dimen name="drag_drop_item_exploration_split_view_margin_start">32dp</dimen>
   <dimen name="drag_drop_item_exploration_split_view_margin_end">32dp</dimen>
   <dimen name="drag_drop_item_question_split_view_margin_end">32dp</dimen>
@@ -23,8 +19,6 @@
   <dimen name="profile_chooser_description_margin_start_profile_not_added">32dp</dimen>
 
   <dimen name="previous_button_item_question_view_margin_start">128dp</dimen>
-  <dimen name="content_item_question_view_margin_end">128dp</dimen>
-  <dimen name="content_item_question_view_margin_start">128dp</dimen>
   <dimen name="continue_interaction_item_question_view_margin_end">128dp</dimen>
   <dimen name="continue_interaction_item_question_view_margin_start">128dp</dimen>
   <dimen name="continue_navigation_item_question_view_margin_end">128dp</dimen>
@@ -58,7 +52,6 @@
   <dimen name="text_input_interaction_item_non_conversation_view_margin_end">128dp</dimen>
   <dimen name="text_input_interaction_item_non_conversation_view_margin_start">128dp</dimen>
 
-  <dimen name="content_item_exploration_split_view_margin_start">24dp</dimen>
   <dimen name="drag_drop_item_exploration_view_margin_top">24dp</dimen>
   <dimen name="drag_drop_item_question_view_margin_top">24dp</dimen>
   <dimen name="feedback_item_exploration_split_view_margin_start">24dp</dimen>
@@ -83,10 +76,6 @@
   <dimen name="continue_navigation_item_exploration_view_margin_top">72dp</dimen>
   <dimen name="continue_navigation_item_question_view_margin_top">72dp</dimen>
 
-  <dimen name="content_item_exploration_split_view_padding_bottom">16dp</dimen>
-  <dimen name="content_item_exploration_split_view_padding_top">16dp</dimen>
-  <dimen name="content_item_exploration_view_padding_bottom">16dp</dimen>
-  <dimen name="content_item_exploration_view_padding_top">16dp</dimen>
   <dimen name="feedback_item_exploration_split_view_padding_bottom">16dp</dimen>
   <dimen name="feedback_item_exploration_split_view_padding_top">16dp</dimen>
   <dimen name="feedback_item_exploration_view_padding_bottom">16dp</dimen>
@@ -97,10 +86,6 @@
 
   <dimen name="feedback_item_exploration_split_view_padding_start">12dp</dimen>
   <dimen name="feedback_item_exploration_split_view_padding_end">12dp</dimen>
-  <dimen name="content_item_exploration_split_view_padding_end">12dp</dimen>
-  <dimen name="content_item_exploration_split_view_padding_start">12dp</dimen>
-  <dimen name="content_item_exploration_view_padding_end">12dp</dimen>
-  <dimen name="content_item_exploration_view_padding_start">12dp</dimen>
   <dimen name="feedback_item_exploration_view_padding_end">12dp</dimen>
   <dimen name="feedback_item_exploration_view_padding_start">12dp</dimen>
   <dimen name="return_to_topic_item_question_view_margin_top">12dp</dimen>
@@ -113,7 +98,6 @@
   <dimen name="profile_chooser_profile_view_parent_margin_start_profile_not_added">170dp</dimen>
   <dimen name="profile_chooser_profile_view_parent_margin_end_profile_not_added">170dp</dimen>
 
-  <dimen name="content_item_exploration_view_margin_end">144dp</dimen>
   <dimen name="drag_drop_item_exploration_view_margin_start">144dp</dimen>
   <dimen name="feedback_item_exploration_view_margin_end">144dp</dimen>
   <dimen name="fraction_interaction_item_conversation_view_margin_start">144dp</dimen>
@@ -127,7 +111,6 @@
   <dimen name="text_input_interaction_item_conversation_view_margin_start">144dp</dimen>
   <dimen name="profile_chooser_fragment_margin_top_profile_not_added">124dp</dimen>
 
-  <dimen name="content_item_exploration_view_margin_start">112dp</dimen>
   <dimen name="continue_interaction_item_exploration_view_margin_end">112dp</dimen>
   <dimen name="continue_interaction_item_exploration_view_margin_start">112dp</dimen>
   <dimen name="continue_navigation_item_exploration_view_margin_end">112dp</dimen>
@@ -155,9 +138,6 @@
   <dimen name="submit_button_item_exploration_view_margin_top">72dp</dimen>
   <dimen name="submit_button_item_question_view_margin_top">72dp</dimen>
 
-  <dimen name="content_item_exploration_split_view_margin_end">40dp</dimen>
-  <dimen name="content_item_exploration_split_view_margin_top">40dp</dimen>
-  <dimen name="content_item_question_split_view_margin_top">40dp</dimen>
   <dimen name="drag_drop_item_exploration_split_view_margin_top">40dp</dimen>
   <dimen name="drag_drop_item_question_split_view_margin_top">40dp</dimen>
   <dimen name="feedback_item_exploration_split_view_margin_end">40dp</dimen>
@@ -166,4 +146,33 @@
   <dimen name="submitted_answer_question_split_view_margin_start_no_extra_interaction_answer">40dp</dimen>
   <dimen name="submitted_answer_question_split_view_margin_top_extra_interaction_answer">40dp</dimen>
 
+  <!-- CONTENT ITEM: EXPLORATION SPLIT VIEW -->
+  <dimen name="content_item_exploration_split_view_margin_start">24dp</dimen>
+  <dimen name="content_item_exploration_split_view_margin_top">40dp</dimen>
+  <dimen name="content_item_exploration_split_view_margin_end">40dp</dimen>
+
+  <dimen name="content_item_exploration_split_view_padding_start">12dp</dimen>
+  <dimen name="content_item_exploration_split_view_padding_top">16dp</dimen>
+  <dimen name="content_item_exploration_split_view_padding_end">12dp</dimen>
+  <dimen name="content_item_exploration_split_view_padding_bottom">16dp</dimen>
+
+  <!-- CONTENT ITEM: EXPLORATION VIEW -->
+  <dimen name="content_item_exploration_view_margin_start">112dp</dimen>
+  <dimen name="content_item_exploration_view_margin_top">36dp</dimen>
+  <dimen name="content_item_exploration_view_margin_end">144dp</dimen>
+
+  <dimen name="content_item_exploration_view_padding_start">12dp</dimen>
+  <dimen name="content_item_exploration_view_padding_top">16dp</dimen>
+  <dimen name="content_item_exploration_view_padding_end">12dp</dimen>
+  <dimen name="content_item_exploration_view_padding_bottom">16dp</dimen>
+
+  <!-- CONTENT ITEM: QUESTION SPLIT VIEW -->
+  <dimen name="content_item_question_split_view_margin_start">32dp</dimen>
+  <dimen name="content_item_question_split_view_margin_top">40dp</dimen>
+  <dimen name="content_item_question_split_view_margin_end">32dp</dimen>
+
+  <!-- CONTENT ITEM -->
+  <dimen name="content_item_question_view_margin_start">128dp</dimen>
+  <dimen name="content_item_question_view_margin_top">36dp</dimen>
+  <dimen name="content_item_question_view_margin_end">128dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -61,11 +61,7 @@
   <dimen name="return_to_topic_item_question_view_margin_top">56dp</dimen>
   <dimen name="submit_button_item_exploration_view_margin_top">56dp</dimen>
   <dimen name="submit_button_item_question_view_margin_top">56dp</dimen>
-  
-  <dimen name="content_item_exploration_split_view_margin_end">40dp</dimen>
-  <dimen name="content_item_exploration_split_view_margin_top">40dp</dimen>
-  <dimen name="content_item_exploration_view_margin_end">40dp</dimen>
-  <dimen name="content_item_question_split_view_margin_top">40dp</dimen>
+
   <dimen name="drag_drop_item_exploration_split_view_margin_end">40dp</dimen>
   <dimen name="drag_drop_item_exploration_view_margin_start">40dp</dimen>
   <dimen name="drag_drop_item_question_split_view_margin_top">40dp</dimen>
@@ -117,8 +113,6 @@
 
   <dimen name="ongoing_story_card_view_margin_top_portrait">16dp</dimen>
   <dimen name="font_scale_content_small_text_view_size">16dp</dimen>
-  <dimen name="content_item_exploration_split_view_padding_bottom">16dp</dimen>
-  <dimen name="content_item_exploration_split_view_padding_top">16dp</dimen>
   <dimen name="continue_interaction_item_exploration_view_margin_top">16dp</dimen>
   <dimen name="continue_interaction_item_exploration_view_padding_bottom">16dp</dimen>
   <dimen name="continue_interaction_item_exploration_view_padding_end">16dp</dimen>
@@ -159,12 +153,6 @@
   <dimen name="drag_drop_grouping_hint_non_split_text_view_margin_start">12dp</dimen>
   <dimen name="feedback_item_exploration_split_view_padding_start">12dp</dimen>
   <dimen name="feedback_item_exploration_split_view_padding_end">12dp</dimen>
-  <dimen name="content_item_exploration_split_view_padding_end">12dp</dimen>
-  <dimen name="content_item_exploration_split_view_padding_start">12dp</dimen>
-  <dimen name="content_item_exploration_view_padding_bottom">12dp</dimen>
-  <dimen name="content_item_exploration_view_padding_top">12dp</dimen>
-  <dimen name="content_item_question_split_view_margin_bottom">12dp</dimen>
-  <dimen name="content_item_question_view_margin_bottom">12dp</dimen>
   <dimen name="feedback_item_exploration_view_padding_bottom">12dp</dimen>
   <dimen name="feedback_item_exploration_view_padding_top">12dp</dimen>
   <dimen name="profile_chooser_profile_view_last_visited_margin_start_profile_not_added">12dp</dimen>
@@ -172,10 +160,6 @@
   <dimen name="replay_button_item_question_view_padding_bottom">12dp</dimen>
 
   <dimen name="font_scale_content_large_text_view_size">24dp</dimen>
-  <dimen name="content_item_exploration_view_margin_top">24dp</dimen>
-  <dimen name="content_item_exploration_margin_end">24dp</dimen>
-  <dimen name="content_item_exploration_view_margin_start">24dp</dimen>
-  <dimen name="content_item_exploration_split_view_margin_start">24dp</dimen>
   <dimen name="continue_interaction_item_exploration_view_margin_end">24dp</dimen>
   <dimen name="continue_interaction_item_exploration_view_margin_start">24dp</dimen>
   <dimen name="continue_interaction_item_question_view_margin_end">24dp</dimen>
@@ -242,8 +226,6 @@
   <dimen name="walkthrough_final_fragment_card_content_padding">24dp</dimen>
 
   <dimen name="admin_auth_input_pin_label_margin">8dp</dimen>
-  <dimen name="content_item_exploration_view_padding_end">8dp</dimen>
-  <dimen name="content_item_exploration_view_padding_start">8dp</dimen>
   <dimen name="drag_drop_grouping_hint_non_split_text_view_margin_top">8dp</dimen>
   <dimen name="drag_drop_container_parent_non_split_margin_end">8dp</dimen>
   <dimen name="drag_drop_container_parent_non_split_margin_start">8dp</dimen>
@@ -327,10 +309,6 @@
   <dimen name="submitted_answer_item_exploration_view_margin_start">80dp</dimen>
   <dimen name="text_input_interaction_item_margin_start">80dp</dimen>
 
-  <dimen name="content_item_question_split_view_margin_end">32dp</dimen>
-  <dimen name="content_item_question_split_view_margin_start">32dp</dimen>
-  <dimen name="content_item_question_view_margin_end">32dp</dimen>
-  <dimen name="content_item_question_view_margin_start">32dp</dimen>
   <dimen name="drag_drop_item_exploration_split_view_margin_start">32dp</dimen>
   <dimen name="drag_drop_item_exploration_split_view_margin_top">32dp</dimen>
   <dimen name="drag_drop_item_question_split_view_margin_end">32dp</dimen>
@@ -358,7 +336,6 @@
   <dimen name="text_input_interaction_item_non_conversation_view_margin_start">32dp</dimen>
   <dimen name="text_input_interaction_item_non_conversation_view_margin_end">32dp</dimen>
 
-  <dimen name="content_item_question_view_margin_top">36dp</dimen>
   <dimen name="previous_button_item_question_split_view_margin_start">48dp</dimen>
   <dimen name="previous_button_item_exploration_split_view_margin_start">48dp</dimen>
   <dimen name="previous_button_item_question_view_margin_start">48dp</dimen>
@@ -367,4 +344,37 @@
   <dimen name="profile_chooser_add_view_circular_image_margin_top_profile_already_added">48dp</dimen>
   <dimen name="profile_chooser_profile_view_circular_image_margin_top_profile_already_added">48dp</dimen>
   <dimen name="state_fragment_padding_top_audio_bar_visible">48dp</dimen>
+
+  <!-- CONTENT ITEM: EXPLORATION SPLIT VIEW -->
+  <dimen name="content_item_exploration_split_view_margin_start">24dp</dimen>
+  <dimen name="content_item_exploration_split_view_margin_top">40dp</dimen>
+  <dimen name="content_item_exploration_split_view_margin_end">40dp</dimen>
+
+  <dimen name="content_item_exploration_split_view_padding_start">12dp</dimen>
+  <dimen name="content_item_exploration_split_view_padding_top">16dp</dimen>
+  <dimen name="content_item_exploration_split_view_padding_end">12dp</dimen>
+  <dimen name="content_item_exploration_split_view_padding_bottom">16dp</dimen>
+
+  <!-- CONTENT ITEM: EXPLORATION VIEW -->
+  <dimen name="content_item_exploration_view_margin_start">24dp</dimen>
+  <dimen name="content_item_exploration_view_margin_top">24dp</dimen>
+  <dimen name="content_item_exploration_view_margin_end">40dp</dimen>
+
+  <dimen name="content_item_exploration_view_padding_start">8dp</dimen>
+  <dimen name="content_item_exploration_view_padding_top">12dp</dimen>
+  <dimen name="content_item_exploration_view_padding_end">8dp</dimen>
+  <dimen name="content_item_exploration_view_padding_bottom">12dp</dimen>
+
+  <!-- CONTENT ITEM: QUESTION SPLIT VIEW -->
+  <dimen name="content_item_question_split_view_margin_start">32dp</dimen>
+  <dimen name="content_item_question_split_view_margin_top">40dp</dimen>
+  <dimen name="content_item_question_split_view_margin_end">32dp</dimen>
+  <dimen name="content_item_question_split_view_margin_bottom">12dp</dimen>
+
+  <!-- CONTENT ITEM: QUESTION VIEW -->
+  <dimen name="content_item_question_view_margin_start">32dp</dimen>
+  <dimen name="content_item_question_view_margin_top">36dp</dimen>
+  <dimen name="content_item_question_view_margin_end">32dp</dimen>
+  <dimen name="content_item_question_view_margin_bottom">12dp</dimen>
+
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -345,7 +345,7 @@
   <dimen name="profile_chooser_profile_view_circular_image_margin_top_profile_already_added">48dp</dimen>
   <dimen name="state_fragment_padding_top_audio_bar_visible">48dp</dimen>
 
-  <!-- CONTENT ITEM: EXPLORATION SPLIT VIEW -->
+  <!-- Content Item: Exploration Split View -->
   <dimen name="content_item_exploration_split_view_margin_start">24dp</dimen>
   <dimen name="content_item_exploration_split_view_margin_top">40dp</dimen>
   <dimen name="content_item_exploration_split_view_margin_end">40dp</dimen>
@@ -355,7 +355,7 @@
   <dimen name="content_item_exploration_split_view_padding_end">12dp</dimen>
   <dimen name="content_item_exploration_split_view_padding_bottom">16dp</dimen>
 
-  <!-- CONTENT ITEM: EXPLORATION VIEW -->
+  <!-- Content Item: Exploration View -->
   <dimen name="content_item_exploration_view_margin_start">24dp</dimen>
   <dimen name="content_item_exploration_view_margin_top">24dp</dimen>
   <dimen name="content_item_exploration_view_margin_end">40dp</dimen>
@@ -365,16 +365,15 @@
   <dimen name="content_item_exploration_view_padding_end">8dp</dimen>
   <dimen name="content_item_exploration_view_padding_bottom">12dp</dimen>
 
-  <!-- CONTENT ITEM: QUESTION SPLIT VIEW -->
+  <!-- Content Item: Question Split View -->
   <dimen name="content_item_question_split_view_margin_start">32dp</dimen>
   <dimen name="content_item_question_split_view_margin_top">40dp</dimen>
   <dimen name="content_item_question_split_view_margin_end">32dp</dimen>
   <dimen name="content_item_question_split_view_margin_bottom">12dp</dimen>
 
-  <!-- CONTENT ITEM: QUESTION VIEW -->
+  <!-- Content Item: Question View -->
   <dimen name="content_item_question_view_margin_start">32dp</dimen>
   <dimen name="content_item_question_view_margin_top">36dp</dimen>
   <dimen name="content_item_question_view_margin_end">32dp</dimen>
   <dimen name="content_item_question_view_margin_bottom">12dp</dimen>
-
 </resources>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes part of #2606: Changed the dimens files w.r.t Content Item

Fixes #2564 : Screenshot shown below 

The aim of this PR is just to lay the base for other PRs to come so that it comes easy to review other PRs.

In the end the PR will be solving the issue mentioned in #2558 

For now this PR solve this issue: https://github.com/oppia/oppia-android/pull/2558#issuecomment-772428790 and #2564 
<img src="https://user-images.githubusercontent.com/9396084/106765342-b4ba4f80-665e-11eb-847c-798acda93e6d.png" width="250" />

## How to review this PR?

First just check the dimens file whether they have been rearranged correctly or not. Note: In this the alphabetical order of dimens is not important instead the order follows two general rules: 
(a.) Alphabetical order among `exploration-split-view`, `exploration`, `question-split-view` and `question-view` (this is important because the content-item xml file follows this order) 
(b.) General design convention for padding margin which is: `start/left`, `top`, `end/right` and `bottom`.

Once above is confirmed open paired files in vertical split view as shown in below screenshot. Pairs are: 
(a.) `layout/content-item and values/dimens`
(b.) `layout-land/content-item and values-land/dimens`
(c.) `layout-sw600dp-port/content-item and values-sw600dp-port/dimens`
(d.) `layout-sw600dp-land/content-item and values-sw600dp-land/dimens`

Once all these things match this PR should be ready to merge.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
