### PR TITLE
Added data classes for score and mastery calculations

### DIFF
--- a/domain/src/main/java/org/oppia/android/domain/question/QuestionSessionMetrics.kt
+++ b/domain/src/main/java/org/oppia/android/domain/question/QuestionSessionMetrics.kt
@@ -1,0 +1,14 @@
+package org.oppia.android.domain.question
+import org.oppia.android.app.model.Question
+
+/**
+ * Mutable data class for tracking a user's interactions with a specific question. This includes
+ * the number of answers they submitted, the number of hints they used, whether they viewed the
+ * solution, and the skill misconception ids related to their wrong answers.
+ */
+data class QuestionSessionMetrics(val question: Question) {
+  var numberOfAnswersSubmitted: Int = 0
+  var numberOfHintsUsed: Int = 0
+  var didViewSolution: Boolean = false
+  var taggedSkillMisconceptionIds: MutableList<String> = mutableListOf()
+}

--- a/domain/src/main/java/org/oppia/android/domain/question/QuestionSessionMetrics.kt
+++ b/domain/src/main/java/org/oppia/android/domain/question/QuestionSessionMetrics.kt
@@ -2,13 +2,22 @@ package org.oppia.android.domain.question
 import org.oppia.android.app.model.Question
 
 /**
- * Mutable data class for tracking a user's interactions with a specific question. This includes
- * the number of answers they submitted, the number of hints they used, whether they viewed the
- * solution, and the skill misconception ids related to their wrong answers.
+ * Mutable data class for tracking a user's interactions with a specific question.
  */
-data class QuestionSessionMetrics(val question: Question) {
+internal data class QuestionSessionMetrics(val question: Question) {
+  /** Tracks the number of answers the user submitted for this question. */
   var numberOfAnswersSubmitted: Int = 0
+
+  /** Tracks the number of hints the user viewed for this question. */
   var numberOfHintsUsed: Int = 0
+
+  /** Tracks whether the user viewed the solution for this question. */
   var didViewSolution: Boolean = false
+
+  /**
+   * Tracks the skill misconception IDs corresponding to the user's wrong answers for this question.
+   * A skill misconception ID is a skill ID which identifies which skill the user needs to work on,
+   * based on which misconception the user had when they submitted a wrong answer for a question.
+   */
   var taggedSkillMisconceptionIds: MutableList<String> = mutableListOf()
 }

--- a/model/src/main/proto/question.proto
+++ b/model/src/main/proto/question.proto
@@ -85,13 +85,13 @@ message AnsweredQuestionOutcome {
 // The final score and mastery calculations of the user after completing a training session.
 message QuestionAssessmentPerformance {
   // User's total session score as a percentage.
-  double totalScore = 1;
+  double total_score = 1;
 
   // User's score per skill for the training session.
   // This maps a skill id to a score.
-  map<string, double> scorePerSkillMapping = 2;
+  map<string, double> score_per_skill_mapping = 2;
 
   // User's mastery per skill for the training session.
   // This maps a skill id to a mastery.
-  map<string, double> masteryPerSkillMapping = 3;
+  map<string, double> mastery_per_skill_mapping = 3;
 }

--- a/model/src/main/proto/question.proto
+++ b/model/src/main/proto/question.proto
@@ -81,3 +81,17 @@ message AnsweredQuestionOutcome {
   // Whether the answer the learner submitted is the correct answer.
   bool is_correct_answer = 2;
 }
+
+// The final score and mastery calculations of the user after completing a training session.
+message QuestionAssessmentPerformance {
+  // User's total session score as a percentage.
+  double totalScore = 1;
+
+  // User's score per skill for the training session.
+  // This maps a skill id to a score.
+  map<string, double> scorePerSkillMapping = 2;
+
+  // User's mastery per skill for the training session.
+  // This maps a skill id to a mastery.
+  map<string, double> masteryPerSkillMapping = 3;
+}

--- a/model/src/main/proto/question.proto
+++ b/model/src/main/proto/question.proto
@@ -82,16 +82,16 @@ message AnsweredQuestionOutcome {
   bool is_correct_answer = 2;
 }
 
-// The final score and mastery calculations of the user after completing a training session.
-message QuestionAssessmentPerformance {
-  // User's total session score as a percentage.
-  double total_score = 1;
+// The final score and mastery calculations of the user after completing a training session. This is an ephemeral data
+// structure that is only relevant to a particular training session.
+message UserAssessmentPerformance {
+  // Stores the user's total session score as a percentage.
+  double total_percentage_score = 1;
 
-  // User's score per skill for the training session.
-  // This maps a skill id to a score.
-  map<string, double> score_per_skill_mapping = 2;
+  // Stores the user's score per skill for the training session via a map of skill IDs to percentage scores.
+  map<string, double> percentage_score_per_skill_mapping = 2;
 
-  // User's mastery per skill for the training session.
-  // This maps a skill id to a mastery.
+  // Stores the user's mastery degree per skill for the training session via a map of skill IDs to mastery degrees.
+  // A mastery degree is a numerical score representing the user's strength in a particular skill.
   map<string, double> mastery_per_skill_mapping = 3;
 }


### PR DESCRIPTION
## Explanation
Added `QuestionAssessmentPerformance` (proto) and `QuestionSessionMetrics` (mutable data class) for score and mastery calculations, as per [design doc](https://docs.google.com/document/d/1ISuqvKs6b0xdE0-aEIHXYG7oDbCmDBcgUia0TiR9GpQ/edit?usp=sharing).

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
