### PR TITLE
Fix #1769: Re-enable previously failing skipped tests (Espresso only)

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -50,7 +50,6 @@ import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -809,7 +808,7 @@ class StateFragmentTest {
   }
 
   @Test
-  @Ignore("Currently failing due to a regression") // TODO(#1769): Re-enable.
+  @RunOn(TestPlatform.ESPRESSO) // TODO(#1612): Enable for Robolectric.
   fun testStateFragment_loadExp_changeConfiguration_continueToEnd_hasReturnToTopicButton() {
     launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
@@ -840,7 +839,7 @@ class StateFragmentTest {
   }
 
   @Test
-  @Ignore("Currently failing due to a regression") // TODO(#1769): Re-enable.
+  @RunOn(TestPlatform.ESPRESSO) // TODO(#1612): Enable for Robolectric.
   fun testStateFragment_loadExp_changeConfig_continueToEnd_clickReturnToTopic_destroysActivity() {
     launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()


### PR DESCRIPTION
## Explanation

Fixes #1769: Re-enable previously failing skipped tests (Espresso only):

* `testStateFragment_loadExp_continueToEndExploration_hasReturnToTopicButton()`
* `testStateFragment_loadExp_changeConfiguration_continueToEnd_hasReturnToTopicButton()`

Tested on emulators locally.

Leaving TODOs for #1612 to fix them for Robolectric - similar TODOs are present for the parallel portrait tests.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
