### PR TITLE
Fix affected target computation breaking CI workflows when no targets are affected

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ on:
 jobs:
   linters:
     name: Lint Tests
-    if: "false"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -66,7 +65,6 @@ jobs:
 
   robolectric_tests:
     name: Robolectric Tests (Non-App Modules)
-    if: "false"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -124,7 +122,6 @@ jobs:
 
   app_tests:
     name: Robolectric Tests - App Module (Non-Flaky)
-    if: "false"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -155,7 +152,6 @@ jobs:
 
   bazel_build_app:
     name: Build Binary with Bazel
-    if: "false"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   linters:
     name: Lint Tests
+    if: "false"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -65,6 +66,7 @@ jobs:
 
   robolectric_tests:
     name: Robolectric Tests (Non-App Modules)
+    if: "false"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -122,6 +124,7 @@ jobs:
 
   app_tests:
     name: Robolectric Tests - App Module (Non-Flaky)
+    if: "false"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -152,6 +155,7 @@ jobs:
 
   bazel_build_app:
     name: Build Binary with Bazel
+    if: "false"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -38,7 +38,7 @@ jobs:
           TEST_TARGET_LIST=$(bash ./scripts/compute_affected_tests.sh $HOME/oppia-bazel/bazel | sed 's/^\|$/"/g' | paste -sd, -)
           echo "Affected tests (note that this might be all tests if on the develop branch): $TEST_TARGET_LIST"
           echo "::set-output name=matrix::{\"test-target\":[$TEST_TARGET_LIST]}"
-          if [[ ! -z "$TEST_TARGET_LIST" ]];
+          if [[ ! -z "$TEST_TARGET_LIST" ]]; then
             echo "::set-output name=have_tests_to_run::true"
           else
             echo "::set-output name=have_tests_to_run::false"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-18.04
     outputs:
       matrix: ${{ steps.compute-test-matrix-from-affected.outputs.matrix || steps.compute-test-matrix-from-all.outputs.matrix }}
+      have_tests_to_run: ${{ steps.compute-test-matrix-from-affected.outputs.have_tests_to_run || steps.compute-test-matrix-from-all.outputs.have_tests_to_run }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -37,6 +38,11 @@ jobs:
           TEST_TARGET_LIST=$(bash ./scripts/compute_affected_tests.sh $HOME/oppia-bazel/bazel | sed 's/^\|$/"/g' | paste -sd, -)
           echo "Affected tests (note that this might be all tests if on the develop branch): $TEST_TARGET_LIST"
           echo "::set-output name=matrix::{\"test-target\":[$TEST_TARGET_LIST]}"
+          if [[ ! -z "$TEST_TARGET_LIST" ]];
+            echo "::set-output name=have_tests_to_run::true"
+          else
+            echo "::set-output name=have_tests_to_run::false"
+          fi
       - name: Compute test matrix based on all tests
         id: compute-test-matrix-from-all
         if: "contains(github.event.pull_request.title, '[RunAllTests]')"
@@ -44,10 +50,12 @@ jobs:
           TEST_TARGET_LIST=$($HOME/oppia-bazel/bazel query "kind(test, //...)" | sed 's/^\|$/"/g' | paste -sd, -)
           echo "Affected tests (note that this might be all tests if on the develop branch): $TEST_TARGET_LIST"
           echo "::set-output name=matrix::{\"test-target\":[$TEST_TARGET_LIST]}"
+          echo "::set-output name=have_tests_to_run::true"
 
   bazel_run_test:
     name: Run Bazel Test
     needs: bazel_compute_affected_targets
+    if: ${{ needs.bazel_compute_affected_targets.outputs.have_tests_to_run == 'true' }}
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -118,10 +118,11 @@ jobs:
   # Reference: https://github.community/t/127354/7.
   check_test_results:
       name: Check Bazel Test Results
-      needs: bazel_run_test
+      needs: [bazel_compute_affected_targets, bazel_run_test]
       if: ${{ always() }}
       runs-on: ubuntu-18.04
       steps:
-        - name: Check tests passed
-          if: ${{ needs.bazel_run_test.result != 'success' }}
+        # This step will be skipped if there are no tests to run, so the overall job should pass.
+        - name: Check tests passed (for tests that ran)
+          if: ${{ needs.bazel_compute_affected_targets.outputs.have_tests_to_run == 'true' && needs.bazel_run_test.result != 'success' }}
           run: exit 1

--- a/scripts/compute_affected_tests.sh
+++ b/scripts/compute_affected_tests.sh
@@ -70,7 +70,7 @@ if [[ "$current_branch" != "develop" ]]; then
   )
 
   # Print all of the affected targets without duplicates.
-  printf "%s\n" "${all_affected_targets_with_potential_duplicated[@]}" | sort -u
+  printf "%s" "${all_affected_targets_with_potential_duplicated[@]}" | sort -u
 else
   # Print all test targets.
   $BAZEL_BINARY query --noshow_progress "kind(test, //...)" 2>/dev/null

--- a/scripts/compute_affected_tests.sh
+++ b/scripts/compute_affected_tests.sh
@@ -70,7 +70,7 @@ if [[ "$current_branch" != "develop" ]]; then
   )
 
   # Print all of the affected targets without duplicates.
-  printf "%s" "${all_affected_targets_with_potential_duplicated[@]}" | sort -u
+  printf "%s\n" "${all_affected_targets_with_potential_duplicated[@]}" | sort -u
 else
   # Print all test targets.
   $BAZEL_BINARY query --noshow_progress "kind(test, //...)" 2>/dev/null


### PR DESCRIPTION
See https://github.com/oppia/oppia-android/issues/2691#issuecomment-777995766 & https://github.com/oppia/oppia-android/actions/runs/560112155 for context. It seems when there are no affected targets an empty line will be printed which breaks something between the jobs. I think this will fix it.

Conveniently, this PR should trigger the "no affected targets" workflow & can self-verify itself.