### PR TITLE
Fix #2706: Use a more correct pattern for checking forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
       # This also uses a different directory to install git-secret to avoid requiring root access
       # when running the git secret command.
       - name: Install git-secret (non-fork only)
-        if: github.repository == 'oppia/oppia-android'
+        if: ${{ github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
         shell: bash
         run: |
           cd $HOME
@@ -188,7 +188,7 @@ jobs:
           echo "$HOME/gitsecret" >> $GITHUB_PATH
           echo "$HOME/gitsecret/bin" >> $GITHUB_PATH
       - name: Decrypt secrets (non-fork only)
-        if: github.repository == 'oppia/oppia-android'
+        if: ${{ github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
         env:
           GIT_SECRET_GPG_PRIVATE_KEY: ${{ secrets.GIT_SECRET_GPG_PRIVATE_KEY }}
         run: |
@@ -206,13 +206,13 @@ jobs:
           chmod a+x $HOME/oppia-bazel/bazel
       # Note that caching only works on non-forks.
       - name: Build Oppia binary (with caching, non-fork only)
-        if: github.repository == 'oppia/oppia-android'
+        if: ${{ github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
         env:
           BAZEL_REMOTE_CACHE_URL: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
         run: |
           $HOME/oppia-bazel/bazel build --override_repository=android_tools=$GITHUB_WORKSPACE/tmp/android_tools --remote_http_cache=$BAZEL_REMOTE_CACHE_URL --google_credentials=./config/oppia-dev-workflow-remote-cache-credentials.json -- //:oppia
       - name: Build Oppia binary (without caching, fork only)
-        if: github.repository != 'oppia/oppia-android'
+        if: ${{ github.event.pull_request.head.repo.full_name != 'oppia/oppia-android' }}
         run: |
           $HOME/oppia-bazel/bazel build --override_repository=android_tools=$GITHUB_WORKSPACE/tmp/android_tools -- //:oppia
       - name: Copy Oppia APK for uploading

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -68,7 +68,7 @@ jobs:
           tar -xf $HOME/oppia-bazel/android_tools.tar.gz -C $GITHUB_WORKSPACE/tmp/android_tools
       # See explanation in bazel_build_app for how this is installed.
       - name: Install git-secret (non-fork only)
-        if: github.repository == 'oppia/oppia-android'
+        if: ${{ github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
         shell: bash
         run: |
           cd $HOME
@@ -79,7 +79,7 @@ jobs:
           echo "$HOME/gitsecret" >> $GITHUB_PATH
           echo "$HOME/gitsecret/bin" >> $GITHUB_PATH
       - name: Decrypt secrets (non-fork only)
-        if: github.repository == 'oppia/oppia-android'
+        if: ${{ github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
         env:
           GIT_SECRET_GPG_PRIVATE_KEY: ${{ secrets.GIT_SECRET_GPG_PRIVATE_KEY }}
         run: |
@@ -96,12 +96,12 @@ jobs:
           cd $GITHUB_WORKSPACE
           chmod a+x $HOME/oppia-bazel/bazel
       - name: Run Oppia Test (with caching, non-fork only)
-        if: github.repository == 'oppia/oppia-android'
+        if: ${{ github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
         env:
           BAZEL_REMOTE_CACHE_URL: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
         run: $HOME/oppia-bazel/bazel test --override_repository=android_tools=$GITHUB_WORKSPACE/tmp/android_tools --remote_http_cache=$BAZEL_REMOTE_CACHE_URL --google_credentials=./config/oppia-dev-workflow-remote-cache-credentials.json -- ${{ matrix.test-target }}
       - name: Run Oppia Test (without caching, fork only)
-        if: github.repository != 'oppia/oppia-android'
+        if: ${{ github.event.pull_request.head.repo.full_name != 'oppia/oppia-android' }}
         env:
           BAZEL_REMOTE_CACHE_URL: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
         run: $HOME/oppia-bazel/bazel test --override_repository=android_tools=$GITHUB_WORKSPACE/tmp/android_tools -- ${{ matrix.test-target }}


### PR DESCRIPTION
Fixes #2706.

This attempts to fix the CI issue by using a better way to check if the run is actually running on a fork. The original solution might have broken, or maybe it was always wrong. The new one is sourced from https://github.community/t/how-to-detect-a-pull-request-from-a-fork/18363.

**NOTE TO REVIEWERS**: I am doing this as a fix-forward because we can verify full correctness from the CI run on this PR itself. If you prefer for me to revert the original PR per the reversion policy, I will do that instead. Please let me know.