### PR TITLE
Set max parallel property for Bazel tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
+      max-parallel: 5
       matrix: ${{fromJson(needs.bazel_compute_affected_targets.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
We're starting to see significant resource starvation in GitHub Actions, likely due to #1904 leading to >130 tests running in separate actions. This PR sets a max parallelization of 5 which means:
1. No more than 5 Bazel tests will run simultaneously. At ~15 minutes per test, this means it will take 7-8 hours for the whole suite to run. This actually seems fine to me. In reality, people should _not_ be relying on CI for tests passing/failing, they should be relying on running the tests locally. Further, code reviewers shouldn't hinge their approval on actions passing since GitHub already guards this. In general, the asynchronous nature of code reviews should result in an ~8 hour CI turnaround not causing too much issue. This does mean that more trivial changes might take longer than expected to get in, but as we continue to modularize Bazel this situation will get better (since the number of affected targets will go down for each PR).
2. Per https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration a maximum of 20 jobs can run simultaneously across the whole project. This change will let us load-balance tests so that new PRs can get linter results & tests started without having to wait ~8 hours for all other workflows to complete.

Reference documentation: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymax-parallel.