### PR TITLE
Fix #2355: shifted helper function to central utility testing module

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
@@ -395,7 +395,7 @@ class AddProfileActivityTest {
       onView(withId(R.id.add_profile_activity_create_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_user_name))
-        .check(matches(hasErrorText(R.string.add_profile_error_name_not_unique)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.add_profile_error_name_not_unique)))
     }
   }
 
@@ -417,7 +417,7 @@ class AddProfileActivityTest {
       onView(withId(R.id.add_profile_activity_create_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_user_name))
-        .check(matches(hasErrorText(R.string.add_profile_error_name_not_unique)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.add_profile_error_name_not_unique)))
     }
   }
 
@@ -447,7 +447,7 @@ class AddProfileActivityTest {
       )
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_user_name))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -486,7 +486,7 @@ class AddProfileActivityTest {
       )
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_user_name))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -506,7 +506,7 @@ class AddProfileActivityTest {
       onView(withId(R.id.add_profile_activity_create_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_user_name))
-        .check(matches(hasErrorText(R.string.add_profile_error_name_only_letters)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.add_profile_error_name_only_letters)))
     }
   }
 
@@ -529,7 +529,7 @@ class AddProfileActivityTest {
       onView(withId(R.id.add_profile_activity_create_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_user_name))
-        .check(matches(hasErrorText(R.string.add_profile_error_name_only_letters)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.add_profile_error_name_only_letters)))
     }
   }
 
@@ -559,7 +559,7 @@ class AddProfileActivityTest {
       )
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_user_name))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -596,7 +596,7 @@ class AddProfileActivityTest {
       )
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_user_name))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -628,7 +628,7 @@ class AddProfileActivityTest {
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
       onView(withId(R.id.add_profile_activity_create_button)).perform(click())
       onView(withId(R.id.add_profile_activity_pin))
-        .check(matches(hasErrorText(R.string.add_profile_error_pin_length)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.add_profile_error_pin_length)))
     }
   }
 
@@ -667,7 +667,7 @@ class AddProfileActivityTest {
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
       onView(withId(R.id.add_profile_activity_create_button)).perform(click())
       onView(withId(R.id.add_profile_activity_pin))
-        .check(matches(hasErrorText(R.string.add_profile_error_pin_length)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.add_profile_error_pin_length)))
     }
   }
 
@@ -698,7 +698,7 @@ class AddProfileActivityTest {
       )
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -734,7 +734,7 @@ class AddProfileActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -778,7 +778,7 @@ class AddProfileActivityTest {
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
       onView(withId(R.id.add_profile_activity_create_button)).perform(click())
       onView(withId(R.id.add_profile_activity_confirm_pin))
-        .check(matches(hasErrorText(R.string.add_profile_error_pin_confirm_wrong)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.add_profile_error_pin_confirm_wrong)))
     }
   }
 
@@ -839,7 +839,7 @@ class AddProfileActivityTest {
         )
       ).perform(scrollTo())
       onView(withId(R.id.add_profile_activity_confirm_pin))
-        .check(matches(hasErrorText(R.string.add_profile_error_pin_confirm_wrong)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.add_profile_error_pin_confirm_wrong)))
     }
   }
 
@@ -896,7 +896,7 @@ class AddProfileActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_confirm_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -942,7 +942,7 @@ class AddProfileActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_confirm_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -1345,7 +1345,7 @@ class AddProfileActivityTest {
       onView(isRoot()).perform(orientationLandscape())
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_user_name))
-        .check(matches(hasErrorText(R.string.add_profile_error_name_not_unique)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.add_profile_error_name_not_unique)))
     }
   }
 
@@ -1459,7 +1459,7 @@ class AddProfileActivityTest {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
       onView(withId(R.id.add_profile_activity_confirm_pin))
-        .check(matches(hasErrorText(R.string.add_profile_error_pin_confirm_wrong)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.add_profile_error_pin_confirm_wrong)))
     }
   }
 
@@ -1529,30 +1529,7 @@ class AddProfileActivityTest {
     }
   }
 
-  private fun hasErrorText(@StringRes expectedErrorTextId: Int): Matcher<View> {
-    return object : TypeSafeMatcher<View>() {
-      override fun matchesSafely(view: View): Boolean {
-        val expectedErrorText = context.resources.getString(expectedErrorTextId)
-        return (view as TextInputLayout).error == expectedErrorText
-      }
 
-      override fun describeTo(description: Description) {
-        description.appendText("TextInputLayout's error")
-      }
-    }
-  }
-
-  private fun hasNoErrorText(): Matcher<View> {
-    return object : TypeSafeMatcher<View>() {
-      override fun matchesSafely(view: View): Boolean {
-        return (view as TextInputLayout).error.isNullOrEmpty()
-      }
-
-      override fun describeTo(description: Description) {
-        description.appendText("")
-      }
-    }
-  }
 
   private fun createGalleryPickActivityResultStub(): ActivityResult {
     val resources: Resources = context.resources

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
@@ -234,7 +234,7 @@ class AdminAuthActivityTest {
       )
       onView(withId(R.id.admin_auth_submit_button)).perform(click())
       onView(withId(R.id.admin_auth_input_pin))
-        .check(matches(hasErrorText(R.string.admin_auth_incorrect)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.admin_auth_incorrect)))
     }
   }
 
@@ -259,7 +259,7 @@ class AdminAuthActivityTest {
         pressImeActionButton()
       )
       onView(withId(R.id.admin_auth_input_pin))
-        .check(matches(hasErrorText(R.string.admin_auth_incorrect)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.admin_auth_incorrect)))
     }
   }
 
@@ -294,7 +294,7 @@ class AdminAuthActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_auth_input_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -328,7 +328,7 @@ class AdminAuthActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_auth_input_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -517,10 +517,10 @@ class AdminAuthActivityTest {
       )
       onView(withId(R.id.admin_auth_submit_button)).perform(click())
       onView(withId(R.id.admin_auth_input_pin))
-        .check(matches(hasErrorText(R.string.admin_auth_incorrect)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.admin_auth_incorrect)))
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.admin_auth_input_pin))
-        .check(matches(hasErrorText(R.string.admin_auth_incorrect)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.admin_auth_incorrect)))
     }
   }
 
@@ -546,37 +546,14 @@ class AdminAuthActivityTest {
         pressImeActionButton()
       )
       onView(withId(R.id.admin_auth_input_pin))
-        .check(matches(hasErrorText(R.string.admin_auth_incorrect)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.admin_auth_incorrect)))
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.admin_auth_input_pin))
-        .check(matches(hasErrorText(R.string.admin_auth_incorrect)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.admin_auth_incorrect)))
     }
   }
 
-  private fun hasErrorText(@StringRes expectedErrorTextId: Int): Matcher<View> {
-    return object : TypeSafeMatcher<View>() {
-      override fun matchesSafely(view: View): Boolean {
-        val expectedErrorText = context.resources.getString(expectedErrorTextId)
-        return (view as TextInputLayout).error == expectedErrorText
-      }
 
-      override fun describeTo(description: Description) {
-        description.appendText("TextInputLayout's error")
-      }
-    }
-  }
-
-  private fun hasNoErrorText(): Matcher<View> {
-    return object : TypeSafeMatcher<View>() {
-      override fun matchesSafely(view: View): Boolean {
-        return (view as TextInputLayout).error.isNullOrEmpty()
-      }
-
-      override fun describeTo(description: Description) {
-        description.appendText("")
-      }
-    }
-  }
 
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.
   // TODO(#1675): Add NetworkModule once data module is migrated off of Moshi.

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
@@ -320,7 +320,7 @@ class AdminPinActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -359,7 +359,7 @@ class AdminPinActivityTest {
       onView(withId(R.id.admin_pin_input_confirm_pin))
         .check(
           matches(
-            hasErrorText(
+            editTextInputAction.hasErrorText(
               R.string.admin_pin_error_pin_confirm_wrong
             )
           )
@@ -399,7 +399,7 @@ class AdminPinActivityTest {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.admin_pin_input_confirm_pin)).check(
         matches(
-          hasErrorText(
+          editTextInputAction.hasErrorText(
             R.string.admin_pin_error_pin_confirm_wrong
           )
         )
@@ -446,7 +446,7 @@ class AdminPinActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -488,7 +488,7 @@ class AdminPinActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -698,7 +698,7 @@ class AdminPinActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -737,7 +737,7 @@ class AdminPinActivityTest {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.admin_pin_input_confirm_pin)).check(
         matches(
-          hasErrorText(
+          editTextInputAction.hasErrorText(
             R.string.admin_pin_error_pin_confirm_wrong
           )
         )
@@ -780,7 +780,7 @@ class AdminPinActivityTest {
       testCoroutineDispatchers.advanceUntilIdle()
       onView(withId(R.id.admin_pin_input_confirm_pin)).check(
         matches(
-          hasErrorText(
+          editTextInputAction.hasErrorText(
             R.string.admin_pin_error_pin_confirm_wrong
           )
         )
@@ -831,7 +831,7 @@ class AdminPinActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -877,7 +877,7 @@ class AdminPinActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -916,7 +916,7 @@ class AdminPinActivityTest {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.admin_pin_input_confirm_pin)).check(
         matches(
-          hasErrorText(
+          editTextInputAction.hasErrorText(
             R.string.admin_pin_error_pin_confirm_wrong
           )
         )
@@ -957,7 +957,7 @@ class AdminPinActivityTest {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.admin_pin_input_confirm_pin)).check(
         matches(
-          hasErrorText(
+          editTextInputAction.hasErrorText(
             R.string.admin_pin_error_pin_confirm_wrong
           )
         )
@@ -994,30 +994,7 @@ class AdminPinActivityTest {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
-  private fun hasErrorText(@StringRes expectedErrorTextId: Int): Matcher<View> {
-    return object : TypeSafeMatcher<View>() {
-      override fun matchesSafely(view: View): Boolean {
-        val expectedErrorText = context.resources.getString(expectedErrorTextId)
-        return (view as TextInputLayout).error == expectedErrorText
-      }
 
-      override fun describeTo(description: Description) {
-        description.appendText("TextInputLayout's error")
-      }
-    }
-  }
-
-  private fun hasNoErrorText(): Matcher<View> {
-    return object : TypeSafeMatcher<View>() {
-      override fun matchesSafely(view: View): Boolean {
-        return (view as TextInputLayout).error.isNullOrEmpty()
-      }
-
-      override fun describeTo(description: Description) {
-        description.appendText("")
-      }
-    }
-  }
 
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.
   // TODO(#1675): Add NetworkModule once data module is migrated off of Moshi.

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
@@ -256,7 +256,7 @@ class PinPasswordActivityTest {
         .inRoot(isDialog())
         .perform(click())
       onView(withId(R.id.admin_settings_input_pin))
-        .check(matches(hasErrorText(R.string.admin_settings_incorrect)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.admin_settings_incorrect)))
       onView(
         allOf(
           withId(R.id.admin_settings_input_pin_edit_text),
@@ -267,7 +267,7 @@ class PinPasswordActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_settings_input_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -308,7 +308,7 @@ class PinPasswordActivityTest {
         .inRoot(isDialog())
         .perform(click())
       onView(withId(R.id.reset_pin_input_pin))
-        .check(matches(hasErrorText(R.string.add_profile_error_pin_length)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.add_profile_error_pin_length)))
       onView(
         allOf(
           withId(R.id.reset_pin_input_pin_edit_text),
@@ -319,7 +319,7 @@ class PinPasswordActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.reset_pin_input_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -559,7 +559,7 @@ class PinPasswordActivityTest {
         .inRoot(isDialog())
         .perform(click())
       onView(withId(R.id.admin_settings_input_pin))
-        .check(matches(hasErrorText(R.string.admin_settings_incorrect)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.admin_settings_incorrect)))
       onView(
         allOf(
           withId(R.id.admin_settings_input_pin_edit_text),
@@ -569,7 +569,7 @@ class PinPasswordActivityTest {
         .perform(editTextInputAction.appendText("5"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.admin_settings_input_pin))
-        .check(matches(hasNoErrorText()))
+        .check(matches(editTextInputAction.hasNoErrorText()))
     }
   }
 
@@ -596,10 +596,10 @@ class PinPasswordActivityTest {
         .inRoot(isDialog())
         .perform(click())
       onView(withId(R.id.admin_settings_input_pin))
-        .check(matches(hasErrorText(R.string.admin_settings_incorrect)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.admin_settings_incorrect)))
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.admin_settings_input_pin))
-        .check(matches(hasErrorText(R.string.admin_settings_incorrect)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.admin_settings_incorrect)))
     }
   }
 
@@ -638,7 +638,7 @@ class PinPasswordActivityTest {
         .perform(click())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.reset_pin_input_pin))
-        .check(matches(hasErrorText(R.string.add_profile_error_pin_length)))
+        .check(matches(editTextInputAction.hasErrorText(R.string.add_profile_error_pin_length)))
     }
   }
 
@@ -788,30 +788,6 @@ class PinPasswordActivityTest {
     }
   }
 
-  private fun hasErrorText(@StringRes expectedErrorTextId: Int): Matcher<View> {
-    return object : TypeSafeMatcher<View>() {
-      override fun matchesSafely(view: View): Boolean {
-        val expectedErrorText = context.resources.getString(expectedErrorTextId)
-        return (view as TextInputLayout).error == expectedErrorText
-      }
-
-      override fun describeTo(description: Description) {
-        description.appendText("TextInputLayout's error")
-      }
-    }
-  }
-
-  private fun hasNoErrorText(): Matcher<View> {
-    return object : TypeSafeMatcher<View>() {
-      override fun matchesSafely(view: View): Boolean {
-        return (view as TextInputLayout).error.isNullOrEmpty()
-      }
-
-      override fun describeTo(description: Description) {
-        description.appendText("")
-      }
-    }
-  }
 
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.
   // TODO(#1675): Add NetworkModule once data module is migrated off of Moshi.

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -24,6 +24,7 @@ kt_android_library(
         artifact("org.robolectric:robolectric"),
         artifact("org.jetbrains.kotlin:kotlin-reflect"),
         artifact("androidx.lifecycle:lifecycle-livedata-ktx"),
+        artifact("com.google.android.material:material:1.2.0-alpha02"),
         artifact("com.google.truth:truth"),
         artifact("androidx.test.ext:junit"),
         artifact("org.mockito:mockito-core"),

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -52,6 +52,7 @@ dependencies {
       'androidx.lifecycle:lifecycle-livedata-ktx:2.2.0-alpha03',
       'androidx.test.espresso:espresso-core:3.2.0',
       'androidx.test:runner:1.2.0',
+      'com.google.android.material:material:1.2.0-alpha02',
       'com.google.dagger:dagger:2.24',
       'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.2',
       'org.robolectric:robolectric:4.3',

--- a/testing/src/main/java/org/oppia/android/testing/EditTextInputAction.kt
+++ b/testing/src/main/java/org/oppia/android/testing/EditTextInputAction.kt
@@ -1,12 +1,17 @@
 package org.oppia.android.testing
 
+import android.content.Context
 import android.os.Build
 import android.view.View
 import android.widget.EditText
+import androidx.annotation.StringRes
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions.typeText
+import com.google.android.material.textfield.TextInputLayout
+import org.hamcrest.Description
 import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
 import javax.inject.Inject
 
 /**
@@ -17,7 +22,7 @@ import javax.inject.Inject
  * for specifics.
  */
 class EditTextInputAction @Inject constructor(
-  val testCoroutineDispatchers: TestCoroutineDispatchers
+  val testCoroutineDispatchers: TestCoroutineDispatchers , val context: Context
 ) {
   // TODO(#1720): Move this to a companion object & use a test-only singleton injector to retrieve
   // the TestCoroutineDispatchers so that the outer class doesn't need to be injected.
@@ -40,6 +45,29 @@ class EditTextInputAction @Inject constructor(
         } else {
           typeTextViewAction.perform(uiController, view)
         }
+      }
+    }
+  }
+  fun hasErrorText(@StringRes expectedErrorTextId: Int): Matcher<View> {
+    return object : TypeSafeMatcher<View>() {
+      override fun matchesSafely(view: View): Boolean {
+        val expectedErrorText = context.resources.getString(expectedErrorTextId)
+        return (view as TextInputLayout).error == expectedErrorText
+      }
+
+      override fun describeTo(description: Description) {
+        description.appendText("TextInputLayout's error")
+      }
+    }
+  }
+  fun hasNoErrorText(): Matcher<View> {
+    return object : TypeSafeMatcher<View>() {
+      override fun matchesSafely(view: View): Boolean {
+        return (view as TextInputLayout).error.isNullOrEmpty()
+      }
+
+      override fun describeTo(description: Description) {
+        description.appendText("")
       }
     }
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
This PR Fixes #2355: In which we Shifted helper function **hasErrorText** and **hasNoErrorText**  from **org.oppia.android.app(test)** > **profile** > ( **AddProfileActivityTest.kt** ,  **AdminAuthActivityTest.kt**  ,  **AdminPinActivityTest.kt**  ,  **PinPasswordActivityTest.kt** ) 
To **org.oppia.android.testing** > **EditTextInputAction.kt**  and added Context Parameter to EditTextInputAction Constructor and added Material Dependency to build.gradle(:testing) and to build.bazel(testing)
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
