### PR TITLE
Fix #2686: Aligned homeActivitiy component Recently played story items in landscape mode.

### DIFF
--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <dimen name="home_padding_end">72dp</dimen>
-  <dimen name="home_padding_start">72dp</dimen>
+  <dimen name="home_padding_start">65dp</dimen>
   <dimen name="home_outer_margin">72dp</dimen>
   <dimen name="home_inner_margin">36dp</dimen>
   <dimen name="recently_played_margin_max">72dp</dimen>


### PR DESCRIPTION


<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
This PR Fixes #2686: This includes a change in **land/dimens.xml** value of **home_padding_start** is changed, which change the configuration to landscape of Recently played story items.
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
## ScreenShot
![1](https://user-images.githubusercontent.com/60266468/107847535-6ea97c80-6e12-11eb-8633-e92d09aefdac.PNG)

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
