### PR TITLE
Fix #2207: Admin Auth A11y scanner checks passed

### DIFF
--- a/app/src/main/res/layout-land/admin_auth_activity.xml
+++ b/app/src/main/res/layout-land/admin_auth_activity.xml
@@ -116,7 +116,6 @@
             style="@style/StateButtonActive"
             android:layout_marginTop="44dp"
             android:background="@{viewModel.isSubmitButtonActive ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
-            android:clickable="@{viewModel.isSubmitButtonActive}"
             android:enabled="@{viewModel.isSubmitButtonActive}"
             android:minHeight="48dp"
             android:text="@string/admin_auth_submit"

--- a/app/src/main/res/layout-land/admin_auth_activity.xml
+++ b/app/src/main/res/layout-land/admin_auth_activity.xml
@@ -117,6 +117,7 @@
             android:layout_marginTop="44dp"
             android:background="@{viewModel.isSubmitButtonActive ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
             android:clickable="@{viewModel.isSubmitButtonActive}"
+            android:enabled="@{viewModel.isSubmitButtonActive}"
             android:minHeight="48dp"
             android:text="@string/admin_auth_submit"
             android:textColor="@{viewModel.isSubmitButtonActive ? @color/white : @color/submitButtonInactiveText }"

--- a/app/src/main/res/layout-sw600dp-land/admin_auth_activity.xml
+++ b/app/src/main/res/layout-sw600dp-land/admin_auth_activity.xml
@@ -115,6 +115,7 @@
             android:layout_marginTop="58dp"
             android:background="@{viewModel.isSubmitButtonActive ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
             android:clickable="@{viewModel.isSubmitButtonActive}"
+            android:enabled="@{viewModel.isSubmitButtonActive}"
             android:minHeight="36dp"
             android:text="@string/admin_auth_submit"
             android:textColor="@{viewModel.isSubmitButtonActive ? @color/white : @color/submitButtonInactiveText }"

--- a/app/src/main/res/layout-sw600dp-land/admin_auth_activity.xml
+++ b/app/src/main/res/layout-sw600dp-land/admin_auth_activity.xml
@@ -114,7 +114,6 @@
             style="@style/StateButtonActive"
             android:layout_marginTop="58dp"
             android:background="@{viewModel.isSubmitButtonActive ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
-            android:clickable="@{viewModel.isSubmitButtonActive}"
             android:enabled="@{viewModel.isSubmitButtonActive}"
             android:minHeight="36dp"
             android:text="@string/admin_auth_submit"

--- a/app/src/main/res/layout-sw600dp-port/admin_auth_activity.xml
+++ b/app/src/main/res/layout-sw600dp-port/admin_auth_activity.xml
@@ -105,7 +105,6 @@
           android:layout_marginTop="48dp"
           android:layout_marginBottom="44dp"
           android:background="@{viewModel.isSubmitButtonActive ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
-          android:clickable="@{viewModel.isSubmitButtonActive}"
           android:enabled="@{viewModel.isSubmitButtonActive}"
           android:minHeight="36dp"
           android:text="@string/admin_auth_submit"

--- a/app/src/main/res/layout-sw600dp-port/admin_auth_activity.xml
+++ b/app/src/main/res/layout-sw600dp-port/admin_auth_activity.xml
@@ -106,6 +106,7 @@
           android:layout_marginBottom="44dp"
           android:background="@{viewModel.isSubmitButtonActive ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
           android:clickable="@{viewModel.isSubmitButtonActive}"
+          android:enabled="@{viewModel.isSubmitButtonActive}"
           android:minHeight="36dp"
           android:text="@string/admin_auth_submit"
           android:textColor="@{viewModel.isSubmitButtonActive ? @color/white : @color/submitButtonInactiveText }"

--- a/app/src/main/res/layout/admin_auth_activity.xml
+++ b/app/src/main/res/layout/admin_auth_activity.xml
@@ -111,6 +111,7 @@
           android:layout_marginBottom="44dp"
           android:background="@{viewModel.isSubmitButtonActive ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
           android:clickable="@{viewModel.isSubmitButtonActive}"
+          android:enabled="@{viewModel.isSubmitButtonActive}"
           android:minHeight="48dp"
           android:text="@string/admin_auth_submit"
           android:textColor="@{viewModel.isSubmitButtonActive ? @color/white : @color/submitButtonInactiveText }"

--- a/app/src/main/res/layout/admin_auth_activity.xml
+++ b/app/src/main/res/layout/admin_auth_activity.xml
@@ -110,7 +110,6 @@
           android:layout_marginEnd="28dp"
           android:layout_marginBottom="44dp"
           android:background="@{viewModel.isSubmitButtonActive ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
-          android:clickable="@{viewModel.isSubmitButtonActive}"
           android:enabled="@{viewModel.isSubmitButtonActive}"
           android:minHeight="48dp"
           android:text="@string/admin_auth_submit"

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
@@ -369,7 +369,7 @@ class AdminAuthActivityTest {
         editTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
-      onView(withId(R.id.admin_auth_submit_button)).check(matches(not(isEnabled())))
+      onView(withId(R.id.admin_auth_submit_button)).check(matches(isEnabled()))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
@@ -15,6 +15,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.matcher.ViewMatchers.isClickable
 import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
 import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
@@ -26,6 +27,7 @@ import dagger.Component
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.not
 import org.hamcrest.TypeSafeMatcher
 import org.junit.After
 import org.junit.Before
@@ -330,6 +332,22 @@ class AdminAuthActivityTest {
       )
       onView(withId(R.id.admin_auth_input_pin))
         .check(matches(hasNoErrorText()))
+    }
+  }
+
+  @Test
+  fun testAdminAuthActivity_buttonState_isDisabled() {
+    launch<AdminAuthActivity>(
+      AdminAuthActivity.createAdminAuthActivityIntent(
+        context = context,
+        adminPin = "12345",
+        profileId = internalProfileId,
+        colorRgb = -10710042,
+        adminPinEnum = AdminAuthEnum.PROFILE_ADMIN_CONTROLS.value
+      )
+    ).use {
+      onView(withId(R.id.admin_auth_submit_button)).check(matches(not(isEnabled())))
+      onView(withId(R.id.admin_auth_submit_button)).check(matches(not(isClickable())))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
@@ -15,7 +15,6 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
-import androidx.test.espresso.matcher.ViewMatchers.isClickable
 import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
 import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
@@ -336,7 +335,7 @@ class AdminAuthActivityTest {
   }
 
   @Test
-  fun testAdminAuthActivity_buttonState_isDisabled() {
+  fun testAdminAuthActivity_defaultButtonState_isDisabled() {
     launch<AdminAuthActivity>(
       AdminAuthActivity.createAdminAuthActivityIntent(
         context = context,
@@ -347,7 +346,30 @@ class AdminAuthActivityTest {
       )
     ).use {
       onView(withId(R.id.admin_auth_submit_button)).check(matches(not(isEnabled())))
-      onView(withId(R.id.admin_auth_submit_button)).check(matches(not(isClickable())))
+    }
+  }
+
+  @Test
+  fun testAdminAuthActivity_inputPin_buttonStateIsEnabled() {
+    launch<AdminAuthActivity>(
+      AdminAuthActivity.createAdminAuthActivityIntent(
+        context = context,
+        adminPin = "12345",
+        profileId = internalProfileId,
+        colorRgb = -10710042,
+        adminPinEnum = AdminAuthEnum.PROFILE_ADMIN_CONTROLS.value
+      )
+    ).use {
+      onView(
+        allOf(
+          withId(R.id.admin_auth_input_pin_edit_text),
+          isDescendantOfA(withId(R.id.admin_auth_input_pin))
+        )
+      ).perform(
+        editTextInputAction.appendText("12345"),
+        closeSoftKeyboard()
+      )
+      onView(withId(R.id.admin_auth_submit_button)).check(matches(not(isEnabled())))
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #2207 

The original issue contains two parts:
Part1: Is obsolete now as the `ProfileInputView` has been replaced with `TextInputEditText`.
Part2: Marking the button as `disabled` passed the A11y Scanner.

## How to test
[Setup A11y Scanner](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide#using-a11y-scanner-in-android) and run that on this particular screen: AdminAuth

## Results
**All tests pass for A11y Scanner**
<img src="https://user-images.githubusercontent.com/9396084/108231805-266ac100-7168-11eb-930b-cb882b321625.png" width="250" />
<img src="https://user-images.githubusercontent.com/9396084/108307419-b7c34d00-71d3-11eb-9470-b58afc13be52.png" width="250" />


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
