### PR TITLE
Fix #2217 and Fixes part of #2620: Profile Edit A11y fixes

### DIFF
--- a/app/src/main/res/layout-land/profile_edit_activity.xml
+++ b/app/src/main/res/layout-land/profile_edit_activity.xml
@@ -127,12 +127,15 @@
                 android:textSize="14sp" />
             </LinearLayout>
 
-            <Switch
+            <androidx.appcompat.widget.SwitchCompat
               android:id="@+id/profile_edit_allow_download_switch"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
-              android:layout_marginTop="4dp"
-              android:layout_marginEnd="24dp"
+              android:minWidth="48dp"
+              android:minHeight="48dp"
+              android:paddingStart="24dp"
+              android:paddingTop="4dp"
+              android:paddingEnd="24dp"
               app:layout_constraintEnd_toEndOf="parent"
               app:layout_constraintTop_toTopOf="parent" />
           </androidx.constraintlayout.widget.ConstraintLayout>
@@ -176,7 +179,7 @@
           android:paddingEnd="36dp"
           android:text="@string/profile_edit_delete"
           android:textAllCaps="false"
-          android:textColor="@color/red"
+          android:textColor="@color/oppiaRed"
           android:textSize="16sp" />
 
         <View
@@ -212,6 +215,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:fontFamily="sans-serif-medium"
+            android:importantForAccessibility="no"
             android:text="@{viewModel.profile.name}"
             android:textColor="@color/oppiaPrimaryText"
             android:textSize="20sp"

--- a/app/src/main/res/layout-land/profile_edit_activity.xml
+++ b/app/src/main/res/layout-land/profile_edit_activity.xml
@@ -127,7 +127,7 @@
                 android:textSize="14sp" />
             </LinearLayout>
 
-            <androidx.appcompat.widget.SwitchCompat
+            <Switch
               android:id="@+id/profile_edit_allow_download_switch"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"

--- a/app/src/main/res/layout-land/profile_edit_activity.xml
+++ b/app/src/main/res/layout-land/profile_edit_activity.xml
@@ -123,7 +123,7 @@
                 android:layout_height="wrap_content"
                 android:fontFamily="sans-serif"
                 android:text="@string/profile_edit_allow_download_sub"
-                android:textColor="@color/light_grey"
+                android:textColor="@color/accessible_light_grey"
                 android:textSize="14sp" />
             </LinearLayout>
 

--- a/app/src/main/res/layout/profile_edit_activity.xml
+++ b/app/src/main/res/layout/profile_edit_activity.xml
@@ -122,16 +122,19 @@
                 android:layout_height="wrap_content"
                 android:fontFamily="sans-serif"
                 android:text="@string/profile_edit_allow_download_sub"
-                android:textColor="@color/light_grey"
+                android:textColor="@color/accessible_light_grey"
                 android:textSize="14sp" />
             </LinearLayout>
 
-            <Switch
+            <androidx.appcompat.widget.SwitchCompat
               android:id="@+id/profile_edit_allow_download_switch"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
-              android:layout_marginTop="4dp"
-              android:layout_marginEnd="12dp"
+              android:minWidth="48dp"
+              android:minHeight="48dp"
+              android:paddingStart="12dp"
+              android:paddingTop="4dp"
+              android:paddingEnd="12dp"
               app:layout_constraintEnd_toEndOf="parent"
               app:layout_constraintTop_toTopOf="parent" />
           </androidx.constraintlayout.widget.ConstraintLayout>
@@ -174,7 +177,7 @@
           android:paddingEnd="16dp"
           android:text="@string/profile_edit_delete"
           android:textAllCaps="false"
-          android:textColor="@color/red"
+          android:textColor="@color/oppiaRed"
           android:textSize="16sp" />
 
         <View
@@ -210,6 +213,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fontFamily="sans-serif-medium"
+            android:importantForAccessibility="no"
             android:text="@{viewModel.profile.name}"
             android:textColor="@color/oppiaPrimaryText"
             android:textSize="20sp"

--- a/app/src/main/res/layout/profile_edit_activity.xml
+++ b/app/src/main/res/layout/profile_edit_activity.xml
@@ -126,7 +126,7 @@
                 android:textSize="14sp" />
             </LinearLayout>
 
-            <androidx.appcompat.widget.SwitchCompat
+            <Switch
               android:id="@+id/profile_edit_allow_download_switch"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -42,6 +42,7 @@
   <color name="oppiaFAQDivider">#707070</color>
   <color name="oppiaProfileChooserDivider">#707070</color>
   <color name="oppiaNavDrawerItemSelected">#D8D8D8</color>
+  <color name="oppiaRed">#B92D00</color>
   <!-- BASIC COLORS -->
   <color name="white">#FFFFFF</color>
   <color name="white_80">#CCFFFFFF</color>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #2217 
Fixes part of #2620 

This PR fixes following issues:
1. Name repetition in `Profile Edit Screen`
2. Color contrast issue for `Profile Deletion`
3. Min width-height for clickable `Switch`
4. Color contrast issue of `User is able to ... password.` text

## Issues Solved
<img src="https://user-images.githubusercontent.com/9396084/108265922-7446ef80-718f-11eb-9dc0-ff24d180e091.png" width="250" />

## How to test
Setup [A11y Scanner](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide#using-a11y-scanner-in-android) and run it on this screen. It will show `0` issues.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
