### PR TITLE
Fix part of #2684: Update CODE_OF_CONDUCT.md

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,9 +1,9 @@
-# Code of Conduct
+# Contributor Covenant Code of Conduct
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment where everyone gets a chance to learn, we as
-contributors and maintainers pledge to making participation in our project, Oppia and
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal
@@ -14,24 +14,22 @@ appearance, race, religion, or sexual identity and orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Being available to help other contributors.
-* Being respectful of differing viewpoints and experiences.
-* Focusing on teaching-oriented communication so that each contributor gets a chance to learn and grow.
-* Focusing on what is best for the Oppia community.
-* Gracefully accepting constructive criticism.
-* Showing empathy towards other community members.
-* Using welcoming and inclusive language.
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
-  advances.
-* Trolling, insulting/derogatory comments, and personal or political attacks.
-* Public or private harassment.
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
 * Publishing others' private information, such as a physical or electronic
-  address, without explicit permission.
+ address, without explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
-  professional setting.
+ professional setting
 
 ## Our Responsibilities
 
@@ -57,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [admin@oppia.org](mailto:admin@oppia.org). All
+reported by contacting the project team at admin@oppia.org. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -73,3 +71,6 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage], versi
 available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq


### PR DESCRIPTION
Fix part of #2684.

This is updating the code of conduct to exactly match the template GitHub expects so that it shows up as completed on the community profile. See https://github.community/t/code-of-conduct-is-present-in-repo-but-insights-community-tab-doesnt-detect-it/1534/7 for context.
