### PR TITLE
Fix #2258: Update error color for A11y Scanner Contrast Ratio

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -149,7 +149,8 @@
   <style name="textAllCaps">
     <item name="android:textAllCaps">true</item>
   </style>
-  <!-- TOPIC TABLAYOUT STYLE --><style name="AppTabLayout" parent="Widget.Design.TabLayout">
+  <!-- TOPIC TABLAYOUT STYLE -->
+  <style name="AppTabLayout" parent="Widget.Design.TabLayout">
   <item name="tabIndicatorColor">@color/white</item>
   <item name="tabIndicatorHeight">4dp</item>
   <item name="tabPaddingStart">8dp</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -149,17 +149,16 @@
   <style name="textAllCaps">
     <item name="android:textAllCaps">true</item>
   </style>
-  <!-- TOPIC TABLAYOUT STYLE -->
-  <style name="AppTabLayout" parent="Widget.Design.TabLayout">
-    <item name="tabIndicatorColor">@color/white</item>
-    <item name="tabIndicatorHeight">4dp</item>
-    <item name="tabPaddingStart">8dp</item>
-    <item name="tabPaddingEnd">8dp</item>
-    <item name="tabBackground">?attr/selectableItemBackground</item>
-    <item name="tabTextAppearance">@style/AppTabTextAppearance</item>
-    <item name="tabIconTint">@color/tab_icon_color_selector</item>
-    <item name="tabSelectedTextColor">@color/white</item>
-  </style>
+  <!-- TOPIC TABLAYOUT STYLE --><style name="AppTabLayout" parent="Widget.Design.TabLayout">
+  <item name="tabIndicatorColor">@color/white</item>
+  <item name="tabIndicatorHeight">4dp</item>
+  <item name="tabPaddingStart">8dp</item>
+  <item name="tabPaddingEnd">8dp</item>
+  <item name="tabBackground">?attr/selectableItemBackground</item>
+  <item name="tabTextAppearance">@style/AppTabTextAppearance</item>
+  <item name="tabIconTint">@color/tab_icon_color_selector</item>
+  <item name="tabSelectedTextColor">@color/white</item>
+</style>
 
   <style name="AppTabTextAppearance" parent="TextAppearance.Design.Tab">
     <item name="android:textSize">14sp</item>
@@ -187,6 +186,9 @@
     <item name="boxStrokeColor">@color/oppiaPrimaryText</item>
     <item name="boxStrokeWidth">@dimen/text_input_layout_stroke_width</item>
     <item name="errorEnabled">true</item>
+    <item name="errorIconTint">@color/oppiaRed</item>
+    <item name="errorTextColor">@color/oppiaRed</item>
+    <item name="boxStrokeErrorColor">@color/oppiaRed</item>
     <item name="hintTextColor">@color/oppiaPrimaryText</item>
     <item name="android:textAlignment">viewStart</item>
   </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -151,15 +151,15 @@
   </style>
   <!-- TOPIC TABLAYOUT STYLE -->
   <style name="AppTabLayout" parent="Widget.Design.TabLayout">
-  <item name="tabIndicatorColor">@color/white</item>
-  <item name="tabIndicatorHeight">4dp</item>
-  <item name="tabPaddingStart">8dp</item>
-  <item name="tabPaddingEnd">8dp</item>
-  <item name="tabBackground">?attr/selectableItemBackground</item>
-  <item name="tabTextAppearance">@style/AppTabTextAppearance</item>
-  <item name="tabIconTint">@color/tab_icon_color_selector</item>
-  <item name="tabSelectedTextColor">@color/white</item>
-</style>
+    <item name="tabIndicatorColor">@color/white</item>
+    <item name="tabIndicatorHeight">4dp</item>
+    <item name="tabPaddingStart">8dp</item>
+    <item name="tabPaddingEnd">8dp</item>
+    <item name="tabBackground">?attr/selectableItemBackground</item>
+    <item name="tabTextAppearance">@style/AppTabTextAppearance</item>
+    <item name="tabIconTint">@color/tab_icon_color_selector</item>
+    <item name="tabSelectedTextColor">@color/white</item>
+  </style>
 
   <style name="AppTabTextAppearance" parent="TextAppearance.Design.Tab">
     <item name="android:textSize">14sp</item>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #2258 

### Before
<img src="https://user-images.githubusercontent.com/9396084/108995478-2e27e980-76c3-11eb-8548-1cde85e71cc4.png" width="250" />

### Problem
We need to update the error color so that the contrast ratio is more than 4.5

### Final UI which passes on A11y Scanner
<img src="https://user-images.githubusercontent.com/9396084/108995597-54e62000-76c3-11eb-963d-8c3efdba7ee1.png" width="250" />

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
