### PR TITLE
Fix #2617: A11y add profile switch

### DIFF
--- a/app/src/main/res/layout-land/add_profile_activity.xml
+++ b/app/src/main/res/layout-land/add_profile_activity.xml
@@ -189,6 +189,7 @@
               android:layout_marginStart="28dp"
               android:layout_marginTop="32dp"
               android:layout_marginEnd="32dp"
+              android:focusable="true"
               app:layout_constraintTop_toBottomOf="@+id/add_profile_activity_confirm_pin">
 
               <TextView
@@ -218,7 +219,7 @@
                 android:id="@+id/add_profile_activity_allow_download_switch"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:clickable="@{viewModel.validPin ? true : false}"
+                android:enabled="@{viewModel.validPin ? true : false}"
                 android:minWidth="48dp"
                 android:minHeight="48dp"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -234,7 +235,6 @@
             android:layout_marginTop="60dp"
             android:layout_marginEnd="28dp"
             android:background="@{viewModel.isButtonActive() ? @drawable/state_button_primary_background : @drawable/start_button_transparent_background}"
-            android:clickable="@{viewModel.isButtonActive()}"
             android:enabled="@{viewModel.isButtonActive()}"
             android:gravity="center"
             android:text="@string/add_profile_create_btn"

--- a/app/src/main/res/layout-sw600dp-land/add_profile_activity.xml
+++ b/app/src/main/res/layout-sw600dp-land/add_profile_activity.xml
@@ -182,6 +182,7 @@
               android:layout_height="wrap_content"
               android:layout_marginStart="28dp"
               android:layout_marginTop="32dp"
+              android:focusable="true"
               app:layout_constraintTop_toBottomOf="@+id/add_profile_activity_confirm_pin">
 
               <TextView
@@ -211,7 +212,7 @@
                 android:id="@+id/add_profile_activity_allow_download_switch"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:clickable="@{viewModel.validPin ? true : false}"
+                android:enabled="@{viewModel.validPin ? true : false}"
                 android:minWidth="48dp"
                 android:minHeight="48dp"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -226,7 +227,6 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="60dp"
             android:background="@{viewModel.isButtonActive() ? @drawable/state_button_primary_background : @drawable/start_button_transparent_background}"
-            android:clickable="@{viewModel.isButtonActive()}"
             android:enabled="@{viewModel.isButtonActive()}"
             android:gravity="center"
             android:text="@string/add_profile_create_btn"

--- a/app/src/main/res/layout-sw600dp-port/add_profile_activity.xml
+++ b/app/src/main/res/layout-sw600dp-port/add_profile_activity.xml
@@ -179,6 +179,7 @@
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:layout_marginTop="24dp"
+              android:focusable="true"
               app:layout_constraintTop_toBottomOf="@+id/add_profile_activity_confirm_pin">
 
               <TextView
@@ -208,7 +209,7 @@
                 android:id="@+id/add_profile_activity_allow_download_switch"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:clickable="@{viewModel.validPin ? true : false}"
+                android:enabled="@{viewModel.validPin ? true : false}"
                 android:minWidth="48dp"
                 android:minHeight="48dp"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -223,7 +224,6 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="60dp"
             android:background="@{viewModel.isButtonActive() ? @drawable/state_button_primary_background : @drawable/start_button_transparent_background}"
-            android:clickable="@{viewModel.isButtonActive()}"
             android:enabled="@{viewModel.isButtonActive()}"
             android:gravity="center"
             android:text="@string/add_profile_create_btn"

--- a/app/src/main/res/layout/add_profile_activity.xml
+++ b/app/src/main/res/layout/add_profile_activity.xml
@@ -187,6 +187,7 @@
               android:layout_marginStart="28dp"
               android:layout_marginTop="24dp"
               android:layout_marginEnd="32dp"
+              android:focusable="true"
               app:layout_constraintTop_toBottomOf="@+id/add_profile_activity_confirm_pin">
 
               <TextView
@@ -216,7 +217,7 @@
                 android:id="@+id/add_profile_activity_allow_download_switch"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:clickable="@{viewModel.validPin ? true : false}"
+                android:enabled="@{viewModel.validPin ? true : false}"
                 android:minWidth="48dp"
                 android:minHeight="48dp"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -232,7 +233,6 @@
             android:layout_marginTop="60dp"
             android:layout_marginEnd="28dp"
             android:background="@{viewModel.isButtonActive() ? @drawable/state_button_primary_background : @drawable/start_button_transparent_background}"
-            android:clickable="@{viewModel.isButtonActive()}"
             android:enabled="@{viewModel.isButtonActive()}"
             android:gravity="center"
             android:text="@string/add_profile_create_btn"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,8 +230,8 @@
   <string name="add_profile_error_pin_confirm_wrong">Please make sure that both PINs match.</string>
   <string name="add_profile_info_content_description">More information on 3-digit PINs.</string>
   <string name="required_fields_content_description">Fields marked with an * are required.</string>
-  <string name="current_profile_picture_content_description">Current profile picture.</string>
-  <string name="edit_profile_picture_content_description">Edit profile picture.</string>
+  <string name="current_profile_picture_content_description">Current profile picture</string>
+  <string name="edit_profile_picture_content_description">Edit profile picture</string>
   <!-- OnboardingActivity -->
   <string name="onboarding_slide_0_title">Welcome to Oppia!</string>
   <string name="onboarding_slide_0_description">Learn anything you want in an effective and enjoyable way.</string>

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
@@ -27,9 +27,9 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
-import androidx.test.espresso.matcher.ViewMatchers.isClickable
 import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -328,24 +328,24 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_createIsNotClickable() {
+  fun testAddProfileActivity_createButtonIsDisabled() {
     launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
-      onView(withId(R.id.add_profile_activity_create_button)).check(matches(not(isClickable())))
+      onView(withId(R.id.add_profile_activity_create_button)).check(matches(not(isEnabled())))
     }
   }
 
   @Test
-  fun testAddProfileActivity_configChange_createIsNotClickable() {
+  fun testAddProfileActivity_configChange_createIsDisbaled() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
-      onView(withId(R.id.add_profile_activity_create_button)).check(matches(not(isClickable())))
+      onView(withId(R.id.add_profile_activity_create_button)).check(matches(not(isEnabled())))
     }
   }
 
   @Test
-  fun testAddProfileActivity_inputName_createIsClickable() {
+  fun testAddProfileActivity_inputName_createIsEnabled() {
     profileTestHelper.initializeProfiles()
     launch(AddProfileActivity::class.java).use {
       onView(
@@ -357,12 +357,12 @@ class AddProfileActivityTest {
         editTextInputAction.appendText("Rajat"), closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
-      onView(withId(R.id.add_profile_activity_create_button)).check(matches(isClickable()))
+      onView(withId(R.id.add_profile_activity_create_button)).check(matches(isEnabled()))
     }
   }
 
   @Test
-  fun testAddProfileActivity_inputName_configChange_createIsClickable() {
+  fun testAddProfileActivity_inputName_configChange_createIsEnabled() {
     profileTestHelper.initializeProfiles()
     launch(AddProfileActivity::class.java).use {
       onView(
@@ -375,7 +375,7 @@ class AddProfileActivityTest {
       )
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
-        .check(matches(isClickable()))
+        .check(matches(isEnabled()))
     }
   }
 
@@ -948,7 +948,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_inputPin_checkAllowDownloadNotClickable() {
+  fun testAddProfileActivity_inputPin_checkAllowDownloadIsDisabled() {
     launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(click())
       onView(
@@ -966,7 +966,7 @@ class AddProfileActivityTest {
         .check(
           matches(
             not(
-              isClickable()
+              isEnabled()
             )
           )
         )
@@ -974,7 +974,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_configChange_inputPin_allowDownloadIsNotClickable() {
+  fun testAddProfileActivity_configChange_inputPin_allowDownloadIsDisabled() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo()).perform(click())
@@ -991,7 +991,7 @@ class AddProfileActivityTest {
         .check(
           matches(
             not(
-              isClickable()
+              isEnabled()
             )
           )
         )
@@ -999,7 +999,7 @@ class AddProfileActivityTest {
   }
 
   @Test
-  fun testAddProfileActivity_inputPin_inputConfirmPin_allowDownloadIsClickable() {
+  fun testAddProfileActivity_inputPin_inputConfirmPin_allowDownloadIsEnabled() {
     launch(AddProfileActivity::class.java).use {
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(click())
       onView(
@@ -1032,14 +1032,14 @@ class AddProfileActivityTest {
       onView(withId(R.id.add_profile_activity_allow_download_switch))
         .check(
           matches(
-            isClickable()
+            isEnabled()
           )
         )
     }
   }
 
   @Test
-  fun testAddProfileActivity_configChange_inputPin_allowDownloadIsClickable() {
+  fun testAddProfileActivity_configChange_inputPin_allowDownloadIsEnabled() {
     launch(AddProfileActivity::class.java).use {
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
@@ -1071,7 +1071,7 @@ class AddProfileActivityTest {
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
-      onView(withId(R.id.add_profile_activity_allow_download_switch)).check(matches(isClickable()))
+      onView(withId(R.id.add_profile_activity_allow_download_switch)).check(matches(isEnabled()))
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #2617 

This PR introduces following changes:
1. Updates string to remove full stop as it looks weird when we compare it with results of other apps on Talkback.
2. Replaces `clickable` with `enabled` so that it passes on scanner and also updates the test cases accordingly.
3. Merges the focus of the two text views associated with the `Switch`.

## Note
1. We are not merging the talkback output for Switch with the two textviews because keep the `Switch` only as clickable is a better option as it will easy for non-a11y users to use the app.
2. For switch the output is `checked, ON, Switch`. In this also we are not replaces `ON` with any other text as it will lead to redundant information. The output for the Switch will be following: `not checked, OFF, Switch`, `Double Tap to toggle` -> **Double-Tap** -> `checked` -> **Double-Tap** -> `not checked`

Overall I think this is a very good experience for a switch from user presepective.

## Pending Work
The label of this screen in not available and therefore the output is `Oppia` by Talkback. However this will get fixed in #2743 issue.

## Output Video

https://user-images.githubusercontent.com/9396084/108999942-0a67a200-76c9-11eb-96f9-3f31de3bd481.mp4

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
