### PR TITLE
Fixes #2785 & Fixes part of #2743: A11y activity label added

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,11 +19,11 @@
     <meta-data android:name="expiration_date" android:value="2020-09-01" />
     <activity
       android:name=".app.administratorcontrols.AdministratorControlsActivity"
-      android:label="@string/administrator_controls_activity_label"
+      android:label="@string/administrator_controls_activity_title"
       android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.administratorcontrols.appversion.AppVersionActivity"
-      android:label="@string/app_version_activity_label"
+      android:label="@string/app_version_activity_title"
       android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.completedstorylist.CompletedStoryListActivity"
@@ -86,7 +86,7 @@
       android:windowSoftInputMode="adjustResize" />
     <activity
       android:name=".app.profile.ProfileChooserActivity"
-      android:label="@string/profile_chooser_activity_label"
+      android:label="@string/profile_chooser_activity_title"
       android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.profileprogress.ProfilePictureActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,9 +19,11 @@
     <meta-data android:name="expiration_date" android:value="2020-09-01" />
     <activity
       android:name=".app.administratorcontrols.AdministratorControlsActivity"
+      android:label="@string/administrator_controls_activity_label"
       android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.administratorcontrols.appversion.AppVersionActivity"
+      android:label="@string/app_version_activity_label"
       android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.completedstorylist.CompletedStoryListActivity"

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivity.kt
@@ -39,7 +39,6 @@ class AdministratorControlsActivity :
       PROFILE_LIST_FRAGMENT
     }
     administratorControlsActivityPresenter.handleOnCreate(extraControlsTitle, lastLoadedFragment)
-    title = getString(R.string.administrator_controls)
   }
 
   override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/app/src/main/res/layout-land/app_version_activity.xml
+++ b/app/src/main/res/layout-land/app_version_activity.xml
@@ -23,7 +23,7 @@
       app:navigationContentDescription="@string/navigate_up"
       app:navigationIcon="?attr/homeAsUpIndicator"
       app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-      app:title="@string/app_version_activity_label"
+      app:title="@string/app_version_activity_title"
       app:titleTextAppearance="@style/ToolbarTextAppearance"
       app:titleTextColor="@color/white" />
   </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout-land/app_version_activity.xml
+++ b/app/src/main/res/layout-land/app_version_activity.xml
@@ -4,7 +4,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  tools:context=".administratorcontrols.appversion.AppVersionActivity">
+  tools:context=".app.administratorcontrols.appversion.AppVersionActivity">
 
   <com.google.android.material.appbar.AppBarLayout
     android:id="@+id/app_version_app_bar_layout"
@@ -23,7 +23,7 @@
       app:navigationContentDescription="@string/navigate_up"
       app:navigationIcon="?attr/homeAsUpIndicator"
       app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-      app:title="@string/administrator_controls_app_version"
+      app:title="@string/app_version_activity_label"
       app:titleTextAppearance="@style/ToolbarTextAppearance"
       app:titleTextColor="@color/white" />
   </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/app_version_activity.xml
+++ b/app/src/main/res/layout/app_version_activity.xml
@@ -24,7 +24,7 @@
       app:navigationContentDescription="@string/navigate_up"
       app:navigationIcon="?attr/homeAsUpIndicator"
       app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-      app:title="@string/administrator_controls_app_version"
+      app:title="@string/app_version_activity_label"
       app:titleTextAppearance="@style/ToolbarTextAppearance"
       app:titleTextColor="@color/white" />
   </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/app_version_activity.xml
+++ b/app/src/main/res/layout/app_version_activity.xml
@@ -24,7 +24,7 @@
       app:navigationContentDescription="@string/navigate_up"
       app:navigationIcon="?attr/homeAsUpIndicator"
       app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-      app:title="@string/app_version_activity_label"
+      app:title="@string/app_version_activity_title"
       app:titleTextAppearance="@style/ToolbarTextAppearance"
       app:titleTextColor="@color/white" />
   </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
   <string name="menu_help">Help</string>
   <string name="menu_switch_profile">Switch Profile</string>
   <string name="administrator_controls">Administrator Controls</string>
-  <string name="administrator_controls_activity_label">Administrator Controls</string>
+  <string name="administrator_controls_activity_title">Administrator Controls</string>
   <string name="drawer_open_content_description">Navigation Menu Open</string>
   <string name="drawer_close_content_description">Navigation Menu Close</string>
   <string name="welcome_text">Welcome to Oppia!</string>
@@ -188,7 +188,7 @@
   </plurals>
   <string name="bar_separator">\u0020|\u0020</string>
   <!-- ProfileChooserFragment -->
-  <string name="profile_chooser_activity_label">Profile selection page</string>
+  <string name="profile_chooser_activity_title">Profile selection page</string>
   <string name="profile_chooser_admin">Administrator</string>
   <string name="profile_chooser_select">Select your profile</string>
   <string name="profile_chooser_add">Add Profile</string>
@@ -330,7 +330,7 @@
   <string name="log_out_dialog_okay_button">Ok</string>
   <string name="log_out_dialog_message">Are you sure you want to log out of your profile?</string>
   <!-- AppVersionFragment -->
-  <string name="app_version_activity_label">App Version</string>
+  <string name="app_version_activity_title">App Version</string>
   <string name="app_version_name">App Version %s</string>
   <string name="app_last_update_date">The last update was installed on %s. Use the above version number to send feedback about bugs.</string>
   <!-- OptionsActivity -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
   <string name="menu_help">Help</string>
   <string name="menu_switch_profile">Switch Profile</string>
   <string name="administrator_controls">Administrator Controls</string>
+  <string name="administrator_controls_activity_label">Administrator Controls</string>
   <string name="drawer_open_content_description">Navigation Menu Open</string>
   <string name="drawer_close_content_description">Navigation Menu Close</string>
   <string name="welcome_text">Welcome to Oppia!</string>
@@ -329,6 +330,7 @@
   <string name="log_out_dialog_okay_button">Ok</string>
   <string name="log_out_dialog_message">Are you sure you want to log out of your profile?</string>
   <!-- AppVersionFragment -->
+  <string name="app_version_activity_label">App Version</string>
   <string name="app_version_name">App Version %s</string>
   <string name="app_last_update_date">The last update was installed on %s. Use the above version number to send feedback about bugs.</string>
   <!-- OptionsActivity -->

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -11,8 +11,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.NestedScrollView
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.core.app.ActivityScenario
-import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.PerformException
@@ -34,8 +32,8 @@ import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.espresso.util.HumanReadables
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.ActivityTestRule
 import com.google.common.truth.Truth.assertThat
 import dagger.Component
 import org.hamcrest.Matchers
@@ -107,11 +105,8 @@ import javax.inject.Singleton
 class AdministratorControlsActivityTest {
 
   @get:Rule
-  val activityTestRule: ActivityTestRule<AdministratorControlsActivity> = ActivityTestRule(
-    AdministratorControlsActivity::class.java,
-    /* initialTouchMode= */ true,
-    /* launchActivity= */ false
-  )
+  val activityScenarioRule: ActivityScenarioRule<AdministratorControlsActivity> =
+    ActivityScenarioRule(createAdministratorControlsActivityIntent(profileId = 0))
 
   @Inject
   lateinit var profileTestHelper: ProfileTestHelper
@@ -142,308 +137,238 @@ class AdministratorControlsActivityTest {
 
   @Test
   fun testAdministratorControlsActivity_hasCorrectActivityLabel() {
-    activityTestRule.launchActivity(createAdministratorControlsActivityIntent(profileId = 0))
-    val title = activityTestRule.activity.title
-
-    // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
-    // correct string when it's read out.
-    assertThat(title).isEqualTo(context.getString(R.string.administrator_controls_activity_title))
+    activityScenarioRule.scenario.onActivity {
+      // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
+      // correct string when it's read out.
+      assertThat(it.title).isEqualTo(
+        context.getString(R.string.administrator_controls_activity_title)
+      )
+    }
   }
 
   @Test
   fun testAdministratorControlsFragment_generalAndProfileManagementIsDisplayed() {
-    launch<AdministratorControlsActivity>(
-      createAdministratorControlsActivityIntent(
-        profileId = 0
-      )
-    ).use {
-      testCoroutineDispatchers.runCurrent()
-      verifyItemDisplayedOnAdministratorControlListItem(
-        itemPosition = 0,
-        targetView = R.id.general_text_view
-      )
-      verifyTextOnAdministratorListItemAtPosition(
-        itemPosition = 0,
-        targetViewId = R.id.edit_account_text_view,
-        stringIdToMatch = R.string.administrator_controls_edit_account
-      )
-      verifyItemDisplayedOnAdministratorControlListItem(
-        itemPosition = 1,
-        targetView = R.id.profile_management_text_view
-      )
-      verifyTextOnAdministratorListItemAtPosition(
-        itemPosition = 1,
-        targetViewId = R.id.edit_profiles_text_view,
-        stringIdToMatch = R.string.administrator_controls_edit_profiles
-      )
-    }
+    testCoroutineDispatchers.runCurrent()
+    verifyItemDisplayedOnAdministratorControlListItem(
+      itemPosition = 0,
+      targetView = R.id.general_text_view
+    )
+    verifyTextOnAdministratorListItemAtPosition(
+      itemPosition = 0,
+      targetViewId = R.id.edit_account_text_view,
+      stringIdToMatch = R.string.administrator_controls_edit_account
+    )
+    verifyItemDisplayedOnAdministratorControlListItem(
+      itemPosition = 1,
+      targetView = R.id.profile_management_text_view
+    )
+    verifyTextOnAdministratorListItemAtPosition(
+      itemPosition = 1,
+      targetViewId = R.id.edit_profiles_text_view,
+      stringIdToMatch = R.string.administrator_controls_edit_profiles
+    )
   }
 
   @Test
   fun testAdministratorControlsFragment_downloadPermissionsAndSettingsIsDisplayed() {
-    launch<AdministratorControlsActivity>(
-      createAdministratorControlsActivityIntent(
-        profileId = 0
-      )
-    ).use {
-      testCoroutineDispatchers.runCurrent()
-      verifyTextOnAdministratorListItemAtPosition(
-        itemPosition = 2,
-        targetViewId = R.id.download_permissions_text_view,
-        stringIdToMatch = R.string.administrator_controls_download_permissions_label
-      )
-      verifyItemDisplayedOnAdministratorControlListItem(
-        itemPosition = 2,
-        targetView = R.id.topic_update_on_wifi_constraint_layout
-      )
-      scrollToPosition(position = 2)
-      verifyItemDisplayedOnAdministratorControlListItem(
-        itemPosition = 2,
-        targetView = R.id.auto_update_topic_constraint_layout
-      )
-    }
+    testCoroutineDispatchers.runCurrent()
+    verifyTextOnAdministratorListItemAtPosition(
+      itemPosition = 2,
+      targetViewId = R.id.download_permissions_text_view,
+      stringIdToMatch = R.string.administrator_controls_download_permissions_label
+    )
+    verifyItemDisplayedOnAdministratorControlListItem(
+      itemPosition = 2,
+      targetView = R.id.topic_update_on_wifi_constraint_layout
+    )
+    scrollToPosition(position = 2)
+    verifyItemDisplayedOnAdministratorControlListItem(
+      itemPosition = 2,
+      targetView = R.id.auto_update_topic_constraint_layout
+    )
   }
 
   @Test
   fun testAdministratorControlsFragment_applicationSettingsIsDisplayed() {
-    launch<AdministratorControlsActivity>(
-      createAdministratorControlsActivityIntent(
-        profileId = 0
-      )
-    ).use {
-      testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 3)
-      verifyItemDisplayedOnAdministratorControlListItem(
-        itemPosition = 3,
-        targetView = R.id.app_information_text_view
-      )
-      verifyTextOnAdministratorListItemAtPosition(
-        itemPosition = 3,
-        targetViewId = R.id.app_version_text_view,
-        stringIdToMatch = R.string.administrator_controls_app_version
-      )
-      verifyItemDisplayedOnAdministratorControlListItem(
-        itemPosition = 4,
-        targetView = R.id.account_actions_text_view
-      )
-      verifyTextOnAdministratorListItemAtPosition(
-        itemPosition = 4,
-        targetViewId = R.id.log_out_text_view,
-        stringIdToMatch = R.string.administrator_controls_log_out
-      )
-    }
+    testCoroutineDispatchers.runCurrent()
+    scrollToPosition(position = 3)
+    verifyItemDisplayedOnAdministratorControlListItem(
+      itemPosition = 3,
+      targetView = R.id.app_information_text_view
+    )
+    verifyTextOnAdministratorListItemAtPosition(
+      itemPosition = 3,
+      targetViewId = R.id.app_version_text_view,
+      stringIdToMatch = R.string.administrator_controls_app_version
+    )
+    verifyItemDisplayedOnAdministratorControlListItem(
+      itemPosition = 4,
+      targetView = R.id.account_actions_text_view
+    )
+    verifyTextOnAdministratorListItemAtPosition(
+      itemPosition = 4,
+      targetViewId = R.id.log_out_text_view,
+      stringIdToMatch = R.string.administrator_controls_log_out
+    )
   }
 
   @Test
   fun testAdministratorControlsFragment_wifiSwitchIsUncheck_autoUpdateSwitchIsUncheck() {
-    launch<AdministratorControlsActivity>(
-      createAdministratorControlsActivityIntent(
-        profileId = 0
+    testCoroutineDispatchers.runCurrent()
+    onView(
+      atPositionOnView(
+        R.id.administrator_controls_list,
+        2,
+        R.id.topic_update_on_wifi_switch
       )
-    ).use {
-      testCoroutineDispatchers.runCurrent()
-      onView(
-        atPositionOnView(
-          R.id.administrator_controls_list,
-          2,
-          R.id.topic_update_on_wifi_switch
-        )
-      ).check(matches(not(isChecked())))
-      scrollToPosition(position = 2)
-      onView(
-        atPositionOnView(
-          R.id.administrator_controls_list,
-          2,
-          R.id.auto_update_topic_switch
-        )
-      ).check(matches(not(isChecked())))
-    }
+    ).check(matches(not(isChecked())))
+    scrollToPosition(position = 2)
+    onView(
+      atPositionOnView(
+        R.id.administrator_controls_list,
+        2,
+        R.id.auto_update_topic_switch
+      )
+    ).check(matches(not(isChecked())))
   }
 
   @Test
   fun testAdministratorControlsFragment_clickWifiSwitch_configChange_wifiSwitchIsChecked() {
-    launch<AdministratorControlsActivity>(
-      createAdministratorControlsActivityIntent(
-        profileId = 0
+    testCoroutineDispatchers.runCurrent()
+    scrollToPosition(position = 2)
+    onView(
+      atPositionOnView(
+        R.id.administrator_controls_list,
+        2,
+        R.id.topic_update_on_wifi_switch
       )
-    ).use {
-      testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 2)
-      onView(
-        atPositionOnView(
-          R.id.administrator_controls_list,
-          2,
-          R.id.topic_update_on_wifi_switch
-        )
-      ).check(matches(not(isChecked())))
-      onView(
-        atPositionOnView(
-          R.id.administrator_controls_list,
-          2,
-          R.id.auto_update_topic_switch
-        )
-      ).check(matches(not(isChecked())))
-      onView(
-        atPositionOnView(
-          R.id.administrator_controls_list,
-          2,
-          R.id.topic_update_on_wifi_switch
-        )
-      ).perform(click())
-      onView(isRoot()).perform(orientationLandscape())
-      scrollToPosition(position = 2)
-      onView(
-        atPositionOnView(
-          R.id.administrator_controls_list,
-          2,
-          R.id.topic_update_on_wifi_switch
-        )
-      ).check(matches(isChecked()))
-      onView(
-        atPositionOnView(
-          R.id.administrator_controls_list,
-          2,
-          R.id.auto_update_topic_switch
-        )
-      ).check(matches(not(isChecked())))
-      onView(isRoot()).perform(orientationPortrait())
-      scrollToPosition(position = 2)
-      onView(
-        atPositionOnView(
-          R.id.administrator_controls_list,
-          2,
-          R.id.topic_update_on_wifi_switch
-        )
-      ).check(matches(isChecked()))
-      onView(
-        atPositionOnView(
-          R.id.administrator_controls_list,
-          2,
-          R.id.auto_update_topic_switch
-        )
-      ).check(matches(not(isChecked())))
-    }
+    ).check(matches(not(isChecked())))
+    onView(
+      atPositionOnView(
+        R.id.administrator_controls_list,
+        2,
+        R.id.auto_update_topic_switch
+      )
+    ).check(matches(not(isChecked())))
+    onView(
+      atPositionOnView(
+        R.id.administrator_controls_list,
+        2,
+        R.id.topic_update_on_wifi_switch
+      )
+    ).perform(click())
+    onView(isRoot()).perform(orientationLandscape())
+    scrollToPosition(position = 2)
+    onView(
+      atPositionOnView(
+        R.id.administrator_controls_list,
+        2,
+        R.id.topic_update_on_wifi_switch
+      )
+    ).check(matches(isChecked()))
+    onView(
+      atPositionOnView(
+        R.id.administrator_controls_list,
+        2,
+        R.id.auto_update_topic_switch
+      )
+    ).check(matches(not(isChecked())))
+    onView(isRoot()).perform(orientationPortrait())
+    scrollToPosition(position = 2)
+    onView(
+      atPositionOnView(
+        R.id.administrator_controls_list,
+        2,
+        R.id.topic_update_on_wifi_switch
+      )
+    ).check(matches(isChecked()))
+    onView(
+      atPositionOnView(
+        R.id.administrator_controls_list,
+        2,
+        R.id.auto_update_topic_switch
+      )
+    ).check(matches(not(isChecked())))
   }
 
   @Test
   fun testAdministratorControlsFragment_clickEditProfile_opensProfileListActivity() {
-    launch<AdministratorControlsActivity>(
-      createAdministratorControlsActivityIntent(
-        profileId = 0
-      )
-    ).use {
-      testCoroutineDispatchers.runCurrent()
-      onView(withId(R.id.edit_profiles_text_view)).perform(click())
-      intended(hasComponent(ProfileListActivity::class.java.name))
-    }
+    testCoroutineDispatchers.runCurrent()
+    onView(withId(R.id.edit_profiles_text_view)).perform(click())
+    intended(hasComponent(ProfileListActivity::class.java.name))
   }
 
   @Test
   fun testAdministratorControlsFragment_clickLogoutButton_logoutDialogIsDisplayed() {
-    launch<AdministratorControlsActivity>(
-      createAdministratorControlsActivityIntent(
-        profileId = 0
-      )
-    ).use {
-      testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 4)
-      onView(withId(R.id.log_out_text_view)).perform(click())
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button)
-    }
+    testCoroutineDispatchers.runCurrent()
+    scrollToPosition(position = 4)
+    onView(withId(R.id.log_out_text_view)).perform(click())
+    verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
+    verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button)
+    verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button)
   }
 
   @Test
   fun testAdministratorControlsFragment_configChange_clickLogout_logoutDialogIsDisplayed() {
-    launch<AdministratorControlsActivity>(
-      createAdministratorControlsActivityIntent(
-        profileId = 0
-      )
-    ).use {
-      testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 4)
-      onView(isRoot()).perform(orientationLandscape())
-      scrollToPosition(position = 4)
-      onView(withId(R.id.log_out_text_view)).perform(click())
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button)
-    }
+    testCoroutineDispatchers.runCurrent()
+    scrollToPosition(position = 4)
+    onView(isRoot()).perform(orientationLandscape())
+    scrollToPosition(position = 4)
+    onView(withId(R.id.log_out_text_view)).perform(click())
+    verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
+    verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button)
+    verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button)
   }
 
   // TODO(#762): Replace [ProfileChooserActivity] to [LoginActivity] once it is added.
   @Test
   fun testAdministratorControlsFragment_clickOkButtonInLogoutDialog_opensProfileChooserActivity() {
-    launch<AdministratorControlsActivity>(
-      createAdministratorControlsActivityIntent(
-        profileId = 0
-      )
-    ).use {
-      testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 4)
-      onView(withId(R.id.log_out_text_view)).perform(click())
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
-      onView(withText(R.string.log_out_dialog_okay_button)).perform(click())
-      intended(hasComponent(ProfileChooserActivity::class.java.name))
-    }
+    testCoroutineDispatchers.runCurrent()
+    scrollToPosition(position = 4)
+    onView(withId(R.id.log_out_text_view)).perform(click())
+    verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
+    onView(withText(R.string.log_out_dialog_okay_button)).perform(click())
+    intended(hasComponent(ProfileChooserActivity::class.java.name))
   }
 
   @Test
   fun testAdministratorControlsFragment_clickCancelButtonInLogoutDialog_dialogIsDismissed() {
-    launch<AdministratorControlsActivity>(
-      createAdministratorControlsActivityIntent(
-        profileId = 0
-      )
-    ).use {
-      testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 4)
-      onView(withId(R.id.log_out_text_view)).perform(click())
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
-      onView(withText(R.string.log_out_dialog_cancel_button)).perform(click())
-      onView(withId(R.id.log_out_text_view)).check(matches(isDisplayed()))
-    }
+    testCoroutineDispatchers.runCurrent()
+    scrollToPosition(position = 4)
+    onView(withId(R.id.log_out_text_view)).perform(click())
+    verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
+    onView(withText(R.string.log_out_dialog_cancel_button)).perform(click())
+    onView(withId(R.id.log_out_text_view)).check(matches(isDisplayed()))
   }
 
   @Test
   fun testAdministratorControlsFragment_clickAppVersion_opensAppVersionActivity() {
-    launch<AdministratorControlsActivity>(
-      createAdministratorControlsActivityIntent(
-        profileId = 0
-      )
-    ).use {
-      testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 3)
-      onView(withId(R.id.app_version_text_view)).perform(click())
-      intended(hasComponent(AppVersionActivity::class.java.name))
-    }
+    testCoroutineDispatchers.runCurrent()
+    scrollToPosition(position = 3)
+    onView(withId(R.id.app_version_text_view)).perform(click())
+    intended(hasComponent(AppVersionActivity::class.java.name))
   }
 
   @Test
   fun testAdministratorControls_selectAdminNavItem_adminControlsIsDisplayed() {
-    launch<AdministratorControlsActivity>(
-      createAdministratorControlsActivityIntent(
-        0
-      )
-    ).use {
-      it.openNavigationDrawer()
-      onView(withId(R.id.administrator_controls_linear_layout)).perform(nestedScrollTo())
-        .perform(click())
-      onView(withText(context.getString(R.string.administrator_controls_edit_account)))
-        .check(matches(isDisplayed()))
-    }
+    activityScenarioRule.openNavigationDrawer()
+    onView(withId(R.id.administrator_controls_linear_layout)).perform(nestedScrollTo())
+      .perform(click())
+    onView(withText(context.getString(R.string.administrator_controls_edit_account))).check(
+      matches(isDisplayed())
+    )
   }
 
-  private fun ActivityScenario<AdministratorControlsActivity>.openNavigationDrawer() {
+  private fun ActivityScenarioRule<AdministratorControlsActivity>.openNavigationDrawer() {
     onView(withContentDescription(R.string.drawer_open_content_description))
       .check(matches(isCompletelyDisplayed()))
       .perform(click())
 
     // Force the drawer animation to start. See https://github.com/oppia/oppia-android/pull/2204 for
     // background context.
-    onActivity { activity ->
+    scenario.onActivity {
       val drawerLayout =
-        activity.findViewById<DrawerLayout>(R.id.administrator_controls_activity_drawer_layout)
+        it.findViewById<DrawerLayout>(R.id.administrator_controls_activity_drawer_layout)
       // Note that this only initiates a single computeScroll() in Robolectric. Normally, Android
       // will compute several of these across multiple draw calls, but one seems sufficient for
       // Robolectric. Note that Robolectric is also *supposed* to handle the animation loop one call
@@ -463,7 +388,7 @@ class AdministratorControlsActivityTest {
 
   private fun createAdministratorControlsActivityIntent(profileId: Int): Intent {
     return AdministratorControlsActivity.createAdministratorControlsActivityIntent(
-      context,
+      ApplicationProvider.getApplicationContext(),
       profileId
     )
   }

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -35,11 +35,14 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.espresso.util.HumanReadables
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import com.google.common.truth.Truth.assertThat
 import dagger.Component
 import org.hamcrest.Matchers
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -103,6 +106,13 @@ import javax.inject.Singleton
 )
 class AdministratorControlsActivityTest {
 
+  @get:Rule
+  val activityTestRule: ActivityTestRule<AdministratorControlsActivity> = ActivityTestRule(
+    AdministratorControlsActivity::class.java,
+    /* initialTouchMode= */true,
+    /* launchActivity= */false
+  )
+
   @Inject
   lateinit var profileTestHelper: ProfileTestHelper
 
@@ -128,6 +138,16 @@ class AdministratorControlsActivityTest {
 
   private fun setUpTestApplicationComponent() {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
+  }
+
+  @Test
+  fun testAdministratorControlsActivity_hasCorrectActivityLabel() {
+    activityTestRule.launchActivity(createAdministratorControlsActivityIntent(profileId = 0))
+    val title = activityTestRule.activity.title
+
+    // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
+    // correct string when it's read out.
+    assertThat(title).isEqualTo(context.getString(R.string.administrator_controls_activity_label))
   }
 
   @Test

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -147,7 +147,7 @@ class AdministratorControlsActivityTest {
 
     // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
     // correct string when it's read out.
-    assertThat(title).isEqualTo(context.getString(R.string.administrator_controls_activity_label))
+    assertThat(title).isEqualTo(context.getString(R.string.administrator_controls_activity_title))
   }
 
   @Test
@@ -485,7 +485,7 @@ class AdministratorControlsActivityTest {
         try {
           val nestedScrollView =
             findFirstParentLayoutOfClass(view, NestedScrollView::class.java) as NestedScrollView
-          nestedScrollView.scrollTo(0, view.getTop())
+          nestedScrollView.scrollTo(0, view.top)
         } catch (e: Exception) {
           throw PerformException.Builder()
             .withActionDescription(this.description)
@@ -499,14 +499,14 @@ class AdministratorControlsActivityTest {
   }
 
   private fun findFirstParentLayoutOfClass(view: View, parentClass: Class<out View>): View {
-    var parent: ViewParent = FrameLayout(view.getContext())
+    var parent: ViewParent = FrameLayout(view.context)
     lateinit var incrementView: ViewParent
     var i = 0
     while (!(parent.javaClass === parentClass)) {
-      if (i == 0) {
-        parent = findParent(view)
+      parent = if (i == 0) {
+        findParent(view)
       } else {
-        parent = findParent(incrementView)
+        findParent(incrementView)
       }
       incrementView = parent
       i++
@@ -515,11 +515,11 @@ class AdministratorControlsActivityTest {
   }
 
   private fun findParent(view: View): ViewParent {
-    return view.getParent()
+    return view.parent
   }
 
   private fun findParent(view: ViewParent): ViewParent {
-    return view.getParent()
+    return view.parent
   }
 
   private fun verifyItemDisplayedOnAdministratorControlListItem(

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -109,8 +109,8 @@ class AdministratorControlsActivityTest {
   @get:Rule
   val activityTestRule: ActivityTestRule<AdministratorControlsActivity> = ActivityTestRule(
     AdministratorControlsActivity::class.java,
-    /* initialTouchMode= */true,
-    /* launchActivity= */false
+    /* initialTouchMode= */ true,
+    /* launchActivity= */ false
   )
 
   @Inject

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AppVersionActivityTest.kt
@@ -123,7 +123,7 @@ class AppVersionActivityTest {
 
     // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
     // correct string when it's read out.
-    assertThat(title).isEqualTo(context.getString(R.string.app_version_activity_label))
+    assertThat(title).isEqualTo(context.getString(R.string.app_version_activity_title))
   }
 
   @Test
@@ -198,9 +198,7 @@ class AppVersionActivityTest {
   }
 
   private fun createAppVersionActivityIntent(): Intent {
-    return AppVersionActivity.createAppVersionActivityIntent(
-      ApplicationProvider.getApplicationContext()
-    )
+    return AppVersionActivity.createAppVersionActivityIntent(context)
   }
 
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AppVersionActivityTest.kt
@@ -4,13 +4,13 @@ import android.app.Application
 import android.content.Context
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
@@ -125,6 +125,11 @@ class AppVersionActivityTest {
   }
 
   @Test
+  fun testAppVersionActivity_loadFragment_backButtonContentDescriptionIsCorrect() {
+    onView(withContentDescription(R.string.navigate_up)).check(matches(isDisplayed()))
+  }
+
+  @Test
   fun testAppVersionActivity_loadFragment_displaysAppVersion() {
     onView(
       withText(
@@ -147,33 +152,9 @@ class AppVersionActivityTest {
   @Test
   fun testAppVersionActivity_configurationChange_appVersionIsDisplayedCorrectly() {
     onView(isRoot()).perform(orientationLandscape())
-    onView(
-      withId(
-        R.id.app_version_text_view
-      )
-    ).check(
-      matches(
-        withText(
-          String.format(
-            context.resources.getString(R.string.app_version_name),
-            context.getVersionName()
-          )
-        )
-      )
-    )
-    onView(
-      withId(
-        R.id.app_last_update_date_text_view
-      )
-    ).check(
-      matches(
-        withText(
-          String.format(
-            context.resources.getString(R.string.app_last_update_date),
-            lastUpdateDate
-          )
-        )
-      )
+    onView(withId(R.id.app_version_text_view)).check(matches(withText(appVersionString())))
+    onView(withId(R.id.app_last_update_date_text_view)).check(
+      matches(withText(lastDateUsedString()))
     )
   }
 
@@ -185,8 +166,15 @@ class AppVersionActivityTest {
     )
   }
 
-  private fun launchAppVersionActivityIntent(): ActivityScenario<AppVersionActivity> {
-    return ActivityScenario.launch(createAppVersionActivityIntent())
+  private fun appVersionString(): String {
+    return String.format(
+      context.resources.getString(R.string.app_version_name),
+      context.getVersionName()
+    )
+  }
+
+  private fun lastDateUsedString(): String {
+    return String.format(context.resources.getString(R.string.app_last_update_date), lastUpdateDate)
   }
 
   private fun createAppVersionActivityIntent(): Intent {

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AppVersionActivityTest.kt
@@ -190,7 +190,9 @@ class AppVersionActivityTest {
   }
 
   private fun createAppVersionActivityIntent(): Intent {
-    return AppVersionActivity.createAppVersionActivityIntent(context)
+    return AppVersionActivity.createAppVersionActivityIntent(
+      ApplicationProvider.getApplicationContext()
+    )
   }
 
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.

--- a/app/src/sharedTest/java/org/oppia/android/app/home/RecentlyPlayedFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/RecentlyPlayedFragmentTest.kt
@@ -21,6 +21,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withParent
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Component
 import org.hamcrest.Matchers.allOf
@@ -29,6 +30,7 @@ import org.hamcrest.Matchers.instanceOf
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -117,6 +119,10 @@ class RecentlyPlayedFragmentTest {
 
   private lateinit var profileId: ProfileId
 
+  @get:Rule
+  val activityScenarioRule: ActivityScenarioRule<RecentlyPlayedActivity> =
+    ActivityScenarioRule(createRecentlyPlayedActivityIntent(internalProfileId))
+
   @Before
   fun setUp() {
     Intents.init()
@@ -139,7 +145,7 @@ class RecentlyPlayedFragmentTest {
 
   private fun createRecentlyPlayedActivityIntent(profileId: Int): Intent {
     return RecentlyPlayedActivity.createRecentlyPlayedActivityIntent(
-      context,
+      ApplicationProvider.getApplicationContext(),
       profileId
     )
   }
@@ -185,23 +191,17 @@ class RecentlyPlayedFragmentTest {
       profileId,
       timestampOlderThanOneWeek = true
     )
-    ActivityScenario.launch<RecentlyPlayedActivity>(
-      createRecentlyPlayedActivityIntent(
-        internalProfileId
+    testCoroutineDispatchers.runCurrent()
+    onView(withId(R.id.ongoing_story_recycler_view)).perform(
+      scrollToPosition<RecyclerView.ViewHolder>(
+        0
       )
-    ).use {
-      testCoroutineDispatchers.runCurrent()
-      onView(withId(R.id.ongoing_story_recycler_view)).perform(
-        scrollToPosition<RecyclerView.ViewHolder>(
-          0
-        )
-      )
-      onView(
-        atPositionOnView(R.id.ongoing_story_recycler_view, 0, R.id.divider_view)
-      ).check(
-        matches(not(isDisplayed()))
-      )
-    }
+    )
+    onView(
+      atPositionOnView(R.id.ongoing_story_recycler_view, 0, R.id.divider_view)
+    ).check(
+      matches(not(isDisplayed()))
+    )
   }
 
   @Test

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
@@ -12,6 +12,7 @@ import android.provider.MediaStore
 import android.view.View
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
@@ -33,6 +34,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.material.textfield.TextInputLayout
 import dagger.Component
@@ -43,6 +45,7 @@ import org.hamcrest.Matchers.not
 import org.hamcrest.TypeSafeMatcher
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -100,6 +103,10 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class AddProfileActivityTest {
+
+  @get:Rule
+  val activityScenarioRule: ActivityScenarioRule<AddProfileActivity> =
+    ActivityScenarioRule(createAddProfileActivityIntent())
 
   @Inject
   lateinit var context: Context
@@ -1137,25 +1144,23 @@ class AddProfileActivityTest {
 
   @Test
   fun testAddProfileActivity_inputName_configChange_nameIsDisplayed() {
-    launch(AddProfileActivity::class.java).use {
-      onView(
-        allOf(
-          withId(R.id.add_profile_activity_user_name_edit_text),
-          isDescendantOfA(withId(R.id.add_profile_activity_user_name))
-        )
-      ).perform(
-        editTextInputAction.appendText("test"),
-        closeSoftKeyboard()
+    onView(
+      allOf(
+        withId(R.id.add_profile_activity_user_name_edit_text),
+        isDescendantOfA(withId(R.id.add_profile_activity_user_name))
       )
-      onView(isRoot()).perform(orientationLandscape())
-      onView(
-        allOf(
-          withId(R.id.add_profile_activity_user_name_edit_text),
-          isDescendantOfA(withId(R.id.add_profile_activity_user_name))
-        )
-      ).perform(scrollTo())
-        .check(matches(withText("test")))
-    }
+    ).perform(
+      editTextInputAction.appendText("test"),
+      closeSoftKeyboard()
+    )
+    onView(isRoot()).perform(orientationLandscape())
+    onView(
+      allOf(
+        withId(R.id.add_profile_activity_user_name_edit_text),
+        isDescendantOfA(withId(R.id.add_profile_activity_user_name))
+      )
+    ).perform(scrollTo())
+      .check(matches(withText("test")))
   }
 
   @Test
@@ -1528,6 +1533,16 @@ class AddProfileActivityTest {
           )
         )
     }
+  }
+
+  private fun createAddProfileActivityIntent(): Intent {
+    return AddProfileActivity.createAddProfileActivityIntent(
+      ApplicationProvider.getApplicationContext(),
+      ContextCompat.getColor(
+        ApplicationProvider.getApplicationContext(),
+        R.color.avatar_background_1
+      )
+    )
   }
 
   private fun hasErrorText(@StringRes expectedErrorTextId: Int): Matcher<View> {

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
@@ -128,7 +128,7 @@ class ProfileChooserFragmentTest {
     val title = activityTestRule.activity.title
     // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
     // correct string when it's read out.
-    assertThat(title).isEqualTo(context.getString(R.string.profile_chooser_activity_label))
+    assertThat(title).isEqualTo(context.getString(R.string.profile_chooser_activity_title))
   }
 
   @Test


### PR DESCRIPTION
Fixes #2785 

While adding the new test cases Ben mentioned that we are using `activityTestRule` as well as `ActivityScenario` for test cases. So it would be nice if somehow we can use only of such thing and keep consistency. I tried using the `ActivityScenarioRule` and it works correctly in `AdministratorControlsActivity` and `AppVersionActivity`

Fixes part of #2743 

This PR adds label for `AdministratorControlsActivity` and `AppVersionActivity`.

Along with that there are some minor changes in this PR to improve the code.

## Output

https://user-images.githubusercontent.com/9396084/109181484-f8156300-77b1-11eb-9f47-b9b46a2c74d6.mp4


## Note for reviewers:
In general while working on #2743 I will need to add test cases across almost all activities in `app` module and therefore I am thinking of optimising and make more consistent test cases. Just majorly this and upcoming PRs will be focused on three things:
- Add label to activity and test case.
- Use `ActivityScenarioRule` in place of `activityTestRule` and `ActivityScenario`.
- General test case optimisation and consistency.

@BenHenning and @anandwana001 WDYT about the use of `ActivityScenarioRule` usage?
