### PR TITLE
Fix #2620: A11y profile edit

### DIFF
--- a/app/src/main/res/layout-land/profile_edit_activity.xml
+++ b/app/src/main/res/layout-land/profile_edit_activity.xml
@@ -102,6 +102,7 @@
               android:layout_width="0dp"
               android:layout_height="wrap_content"
               android:layout_marginEnd="24dp"
+              android:focusable="true"
               android:orientation="vertical"
               app:layout_constraintBottom_toBottomOf="parent"
               app:layout_constraintEnd_toStartOf="@id/profile_edit_allow_download_switch"
@@ -127,7 +128,7 @@
                 android:textSize="14sp" />
             </LinearLayout>
 
-            <Switch
+            <androidx.appcompat.widget.SwitchCompat
               android:id="@+id/profile_edit_allow_download_switch"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"

--- a/app/src/main/res/layout/profile_edit_activity.xml
+++ b/app/src/main/res/layout/profile_edit_activity.xml
@@ -101,6 +101,7 @@
               android:layout_width="0dp"
               android:layout_height="wrap_content"
               android:layout_marginEnd="24dp"
+              android:focusable="true"
               android:orientation="vertical"
               app:layout_constraintBottom_toBottomOf="parent"
               app:layout_constraintEnd_toStartOf="@id/profile_edit_allow_download_switch"
@@ -126,7 +127,7 @@
                 android:textSize="14sp" />
             </LinearLayout>
 
-            <Switch
+            <androidx.appcompat.widget.SwitchCompat
               android:id="@+id/profile_edit_allow_download_switch"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"


### PR DESCRIPTION
Fixes #2620 

- [x] Allow Download Access Merge talkback content
Currently talkback reads step by steps for this section: "Allow Download Access", *User Swipes** "User is ... PIN.",  *User Swipes** "not checked, OFF, Switch". Instead it can be reduced to two output as per below flow.
`Allow Download Access, User is ... PIN.` -> **User Swipes** `not checked, OFF, Switch, Double tap to toggle` -> **User double taps** -> `checked`

## Output

https://user-images.githubusercontent.com/9396084/109305808-45eaa380-7864-11eb-99fb-37562d2ae000.mp4

