### PR TITLE
Added answer tracking for practice session

### DIFF
--- a/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgress.kt
+++ b/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgress.kt
@@ -35,23 +35,29 @@ internal class QuestionAssessmentProgress {
     }
   }
 
-  /** Called every time the user views a hint to track how many hints the user viewed per question this session.  */
-  internal fun hintViewed() {
+  /**
+   * Tracks how many hints the user viewed per question this session. This is expected to be called
+   * for every hint viewed.
+   */
+  internal fun trackHintViewed() {
     val currentQuestionIndex = getCurrentQuestionIndex()
     questionSessionMetrics[currentQuestionIndex].numberOfHintsUsed++
   }
 
-  /** Called every time the user views a solution to track which question solutions the user viewed this session.  */
-  internal fun solutionViewed() {
+  /**
+   * Tracks which question solutions the user viewed this session. This is expected to be called for
+   * every solution viewed.
+   */
+  internal fun trackSolutionViewed() {
     val currentQuestionIndex = getCurrentQuestionIndex()
     questionSessionMetrics[currentQuestionIndex].didViewSolution = true
   }
 
   /**
-   * Called every time the user submits an answer to track how many answers the user submitted per question, along with
-   * any misconceptions.
+   * Tracks how many answers the user submits for each question, along with any misconceptions. This
+   * is expected to be called for every answer submitted.
    */
-  internal fun answerSubmitted(taggedSkillMisconceptionId: String?) {
+  internal fun trackAnswerSubmitted(taggedSkillMisconceptionId: String?) {
     val currentQuestionIndex = getCurrentQuestionIndex()
     questionSessionMetrics[currentQuestionIndex].numberOfAnswersSubmitted++
     if (taggedSkillMisconceptionId != null) {

--- a/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgress.kt
+++ b/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgress.kt
@@ -47,6 +47,22 @@ internal class QuestionAssessmentProgress {
     questionSessionMetrics[currentQuestionIndex].didViewSolution = true
   }
 
+  /**
+   * Called every time the user submits an answer to track how many answers the user submitted per question, along with
+   * any misconceptions.
+   */
+  internal fun answerSubmitted(taggedSkillMisconceptionId: String?) {
+    val currentQuestionIndex = getCurrentQuestionIndex()
+    questionSessionMetrics[currentQuestionIndex].numberOfAnswersSubmitted++
+    if (taggedSkillMisconceptionId != null) {
+      // Misconceptions are formatted as <skill ID>-<misconception ID> from the AnswerClassificationController,
+      // but we only need the related skill ID for our purposes
+      questionSessionMetrics[currentQuestionIndex].taggedSkillMisconceptionIds.add(
+        taggedSkillMisconceptionId.split("-")[0]
+      )
+    }
+  }
+
   /** Processes when the current question card has just been completed. */
   internal fun completeCurrentQuestion() {
     isTopQuestionCompleted = true

--- a/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgressController.kt
@@ -10,7 +10,7 @@ import org.oppia.android.app.model.Solution
 import org.oppia.android.app.model.State
 import org.oppia.android.app.model.UserAnswer
 import org.oppia.android.domain.classify.AnswerClassificationController
-import org.oppia.android.domain.classify.ClassificationResult
+import org.oppia.android.domain.classify.ClassificationResult.OutcomeWithMisconception
 import org.oppia.android.domain.oppialogger.exceptions.ExceptionsController
 import org.oppia.android.domain.question.QuestionAssessmentProgress.TrainStage
 import org.oppia.android.util.data.AsyncDataSubscriptionManager
@@ -144,13 +144,10 @@ class QuestionAssessmentProgressController @Inject constructor(
           progress.stateDeck.submitAnswer(answer, answeredQuestionOutcome.feedback)
 
           // Track the number of answers the user submitted, including any misconceptions
-          val misconception =
-            if (classificationResult is ClassificationResult.OutcomeWithMisconception) {
-              classificationResult.taggedSkillMisconceptionId
-            } else {
-              null
-            }
-          progress.answerSubmitted(misconception)
+          val misconception = if (classificationResult is OutcomeWithMisconception) {
+            classificationResult.taggedSkillMisconceptionId
+          } else null
+          progress.trackAnswerSubmitted(misconception)
 
           // Do not proceed unless the user submitted the correct answer.
           if (answeredQuestionOutcome.isCorrectAnswer) {
@@ -208,7 +205,7 @@ class QuestionAssessmentProgressController @Inject constructor(
             hintIndex
           )
           progress.stateDeck.pushStateForHint(state, hintIndex)
-          progress.hintViewed()
+          progress.trackHintViewed()
         } finally {
           // Ensure that the user always returns to the VIEWING_STATE stage to avoid getting stuck
           // in an 'always showing hint' situation. This can specifically happen if hint throws an
@@ -242,7 +239,7 @@ class QuestionAssessmentProgressController @Inject constructor(
           progress.stateDeck.submitSolutionRevealed(state)
           solution = progress.stateList.computeSolutionForResult(state)
           progress.stateDeck.pushStateForSolution(state)
-          progress.solutionViewed()
+          progress.trackSolutionViewed()
         } finally {
           // Ensure that the user always returns to the VIEWING_STATE stage to avoid getting stuck
           // in an 'always showing solution' situation. This can specifically happen if solution

--- a/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgressController.kt
@@ -10,6 +10,7 @@ import org.oppia.android.app.model.Solution
 import org.oppia.android.app.model.State
 import org.oppia.android.app.model.UserAnswer
 import org.oppia.android.domain.classify.AnswerClassificationController
+import org.oppia.android.domain.classify.ClassificationResult
 import org.oppia.android.domain.oppialogger.exceptions.ExceptionsController
 import org.oppia.android.domain.question.QuestionAssessmentProgress.TrainStage
 import org.oppia.android.util.data.AsyncDataSubscriptionManager
@@ -141,6 +142,16 @@ class QuestionAssessmentProgressController @Inject constructor(
           answeredQuestionOutcome =
             progress.stateList.computeAnswerOutcomeForResult(classificationResult.outcome)
           progress.stateDeck.submitAnswer(answer, answeredQuestionOutcome.feedback)
+
+          // Track the number of answers the user submitted, including any misconceptions
+          val misconception =
+            if (classificationResult is ClassificationResult.OutcomeWithMisconception) {
+              classificationResult.taggedSkillMisconceptionId
+            } else {
+              null
+            }
+          progress.answerSubmitted(misconception)
+
           // Do not proceed unless the user submitted the correct answer.
           if (answeredQuestionOutcome.isCorrectAnswer) {
             progress.completeCurrentQuestion()


### PR DESCRIPTION
## Description
Added tracking for the answers submitted by a user during a practice session (as per design doc for [score and mastery calculations](https://docs.google.com/document/d/1ISuqvKs6b0xdE0-aEIHXYG7oDbCmDBcgUia0TiR9GpQ/edit?usp=sharing) feature) in `QuestionAssessmentProgress`.