### PR TITLE
Introduce check to prevent PRs from being merged into non-develop branches

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -27,13 +27,13 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: "[PLEASE READ] Branch is not based on develop"
-        if: ${{ github.base_ref != 'develop' && !startsWith(github.base_ref, "release-") }}
+        if: ${{ github.base_ref != 'develop' && !startsWith(github.base_ref, 'release-') }}
         run: |
           echo "Note: this check is expected to fail for chained PRs so that they can't accidentally be merged. PRs should only ever be merged directly into develop."
           exit 1
 
       - name: "Branch verified as based on develop/release branch"
-        if: ${{ github.base_ref == 'develop' || startsWith(github.base_ref, "release-") }}
+        if: ${{ github.base_ref == 'develop' || startsWith(github.base_ref, 'release-') }}
         run: |
           echo "Branch is correctly branched off of valid branch to merge PRs into: $BASE_BRANCH"
         env:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -30,7 +30,7 @@ jobs:
           echo "Note: this check is expected to fail for chained PRs so that they can't accidentally be merged. PRs should only ever be merged directly into develop."
 
       - name: Check branch
-      - uses: a-b-r-o-w-n/check-base-branch-action@v1.1
+        uses: a-b-r-o-w-n/check-base-branch-action@v1.1
         with:
           protected-branches: "develop"
 

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -29,8 +29,11 @@ jobs:
       - name: "[PLEASE READ] Branch is not based on develop"
         if: ${{ github.base_ref != 'develop' && !startsWith(github.base_ref, 'release-') }}
         run: |
-          echo "Note: this check is expected to fail for chained PRs so that they can't accidentally be merged. PRs should only ever be merged directly into develop."
+          echo "Current branch: $BASE_BRANCH"
+          echo "Note: this check is expected to fail for chained PRs so that they can't accidentally be merged. PRs should only ever be merged directly into develop or a release branch."
           exit 1
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
 
       - name: "Branch verified as based on develop/release branch"
         if: ${{ github.base_ref == 'develop' || startsWith(github.base_ref, 'release-') }}

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -30,7 +30,7 @@ jobs:
           echo "Note: this check is expected to fail for chained PRs so that they can't accidentally be merged. PRs should only ever be merged directly into develop."
 
       - name: Check branch
-        uses: a-b-r-o-w-n/check-base-branch-action@v1.1
+        uses: a-b-r-o-w-n/check-base-branch-action@1e1362d871c53c95e848a0b720d23377297f0931
         with:
           protected-branches: "develop"
 

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -20,6 +20,19 @@ jobs:
         with:
           checks: "duppatterns,files,syntax"
           experimental_checks: "notowned"
+          
+  check_base_branch:
+    name: Check base branch is develop
+    runs-on: ubuntu-18.04
+    steps:
+      - name: "[PLEASE READ] Notification for the developer"
+        run: |
+          echo "Note: this check is expected to fail for chained PRs so that they can't accidentally be merged. PRs should only ever be merged directly into develop."
+
+      - name: Check branch
+      - uses: a-b-r-o-w-n/check-base-branch-action@v1.1
+        with:
+          protected-branches: "develop"
 
   linters:
     name: Lint Tests

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -38,11 +38,6 @@ jobs:
         env:
           BASE_BRANCH: ${{ github.base_ref }}
 
-      - name: Check branch
-        uses: a-b-r-o-w-n/check-base-branch-action@32418a4d06acad92f75ab8075fb78715a22be763
-        with:
-          protected-branches: "develop"
-
   linters:
     name: Lint Tests
     runs-on: ubuntu-18.04

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -20,14 +20,23 @@ jobs:
         with:
           checks: "duppatterns,files,syntax"
           experimental_checks: "notowned"
-          
+
   check_base_branch:
     name: Check base branch is develop
     runs-on: ubuntu-18.04
+    if: github.event_name == 'pull_request'
     steps:
-      - name: "[PLEASE READ] Notification for the developer"
+      - name: "[PLEASE READ] Branch is not based on develop"
+        if: ${{ github.base_ref != 'develop' && !github.base_ref.startsWith("release-") }}
         run: |
           echo "Note: this check is expected to fail for chained PRs so that they can't accidentally be merged. PRs should only ever be merged directly into develop."
+
+      - name: "Branch verified as based on develop/release branch"
+        if: ${{ github.base_ref == 'develop' || github.base_ref.startsWith("release-") }}
+        run: |
+          echo "Branch is correctly branched off of valid branch to merge PRs into: $BASE_BRANCH"
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
 
       - name: Check branch
         uses: a-b-r-o-w-n/check-base-branch-action@32418a4d06acad92f75ab8075fb78715a22be763

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -30,7 +30,7 @@ jobs:
           echo "Note: this check is expected to fail for chained PRs so that they can't accidentally be merged. PRs should only ever be merged directly into develop."
 
       - name: Check branch
-        uses: a-b-r-o-w-n/check-base-branch-action@1e1362d871c53c95e848a0b720d23377297f0931
+        uses: a-b-r-o-w-n/check-base-branch-action@32418a4d06acad92f75ab8075fb78715a22be763
         with:
           protected-branches: "develop"
 

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -22,14 +22,14 @@ jobs:
           experimental_checks: "notowned"
 
   check_base_branch:
-    name: Check base branch is develop
+    name: Check base branch
     runs-on: ubuntu-18.04
     if: github.event_name == 'pull_request'
     steps:
-      - name: "[PLEASE READ] Branch is not based on develop"
+      - name: "Branch is not based on develop or release branch"
         if: ${{ github.base_ref != 'develop' && !startsWith(github.base_ref, 'release-') }}
         run: |
-          echo "Current branch: $BASE_BRANCH"
+          echo "Current base branch: $BASE_BRANCH"
           echo "Note: this check is expected to fail for chained PRs so that they can't accidentally be merged. PRs should only ever be merged directly into develop or a release branch."
           exit 1
         env:
@@ -38,7 +38,7 @@ jobs:
       - name: "Branch verified as based on develop/release branch"
         if: ${{ github.base_ref == 'develop' || startsWith(github.base_ref, 'release-') }}
         run: |
-          echo "Branch is correctly branched off of valid branch to merge PRs into: $BASE_BRANCH"
+          echo "Branch is correctly branched off of valid base branch to merge PRs into: $BASE_BRANCH"
         env:
           BASE_BRANCH: ${{ github.base_ref }}
 

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -27,12 +27,13 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: "[PLEASE READ] Branch is not based on develop"
-        if: ${{ github.base_ref != 'develop' && !github.base_ref.startsWith("release-") }}
+        if: ${{ github.base_ref != 'develop' && !startsWith(github.base_ref, "release-") }}
         run: |
           echo "Note: this check is expected to fail for chained PRs so that they can't accidentally be merged. PRs should only ever be merged directly into develop."
+          exit 1
 
       - name: "Branch verified as based on develop/release branch"
-        if: ${{ github.base_ref == 'develop' || github.base_ref.startsWith("release-") }}
+        if: ${{ github.base_ref == 'develop' || startsWith(github.base_ref, "release-") }}
         run: |
           echo "Branch is correctly branched off of valid branch to merge PRs into: $BASE_BRANCH"
         env:


### PR DESCRIPTION
Introduce a check that prevents PRs from being merged unless they are based on develop. This makes chaining more user-friendly since it prevents accidental merges that would break history. It also provides confidence to code reviewers of chained PRs that they can approve them without worrying about the author merging their code into the base branch (technically the branch could still be changed to develop & merged, but sometimes codeowners will prevent that). This is a reasonable step toward a  reliable chaining mechanism.

Demonstration of the check failing with an arbitrary base branch ([workflow](https://github.com/oppia/oppia-android/pull/2832/checks?check_run_id=2329185121)):
![image](https://user-images.githubusercontent.com/12983742/114483729-bbfd5c80-9bbd-11eb-8195-4fdf4ab8715e.png)

Demonstration of the check passing with a release base branch ([workflow](https://github.com/oppia/oppia-android/pull/2832/checks?check_run_id=2329277518)):
![image](https://user-images.githubusercontent.com/12983742/114483784-ddf6df00-9bbd-11eb-9caf-f4d43a94cce1.png)

To see demonstration of it working with 'develop' see the passing CI for this PR.

I will mark the new workflow as required to enforce the check once the PR is merged. I'll also send out a mail to oppia-android-dev explaining this will require merging in the latest develop changes in order to pass CI.