### PR TITLE
Fix part of #2834: Add correct lambda function argument name for TopicSummaryViewModelTest

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/home/TopicSummaryViewModelTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/TopicSummaryViewModelTest.kt
@@ -94,8 +94,8 @@ class TopicSummaryViewModelTest {
   fun testTopicSummaryViewModelEquals_reflexiveBasicTopicSummaryViewModel_isEqual() {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
-    ).use {
-      it.onActivity { homeFragmentTestActivity ->
+    ).use { activityScenario ->
+      activityScenario.onActivity { homeFragmentTestActivity ->
         setUpTestFragment(homeFragmentTestActivity)
         val topicSummaryViewModel = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
 
@@ -109,8 +109,8 @@ class TopicSummaryViewModelTest {
   fun testTopicSummaryViewModelEquals_symmetricBasicTopicSummaryViewModel_isEqual() {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
-    ).use {
-      it.onActivity { homeFragmentTestActivity ->
+    ).use { activityScenario ->
+      activityScenario.onActivity { homeFragmentTestActivity ->
         setUpTestFragment(homeFragmentTestActivity)
         val topicSummaryViewModel = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
         val topicSummaryViewModelCopy = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
@@ -126,8 +126,8 @@ class TopicSummaryViewModelTest {
   fun testTopicSummaryViewModelEquals_transitiveBasicSummaryViewModel_isEqual() {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
-    ).use {
-      it.onActivity { homeFragmentTestActivity ->
+    ).use { activityScenario ->
+      activityScenario.onActivity { homeFragmentTestActivity ->
         setUpTestFragment(homeFragmentTestActivity)
         val topicSummaryViewModelCopy1 = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
         val topicSummaryViewModelCopy2 = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
@@ -145,8 +145,8 @@ class TopicSummaryViewModelTest {
   fun testTopicSummaryViewModelEquals_consistentBasicTopicSummaryViewModel_isEqual() {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
-    ).use {
-      it.onActivity { homeFragmentTestActivity ->
+    ).use { activityScenario ->
+      activityScenario.onActivity { homeFragmentTestActivity ->
         setUpTestFragment(homeFragmentTestActivity)
         val topicSummaryViewModel = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
         val topicSummaryViewModelCopy = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
@@ -163,8 +163,8 @@ class TopicSummaryViewModelTest {
   fun testTopicSummaryViewModelEquals_basicTopicSummaryViewModelAndNull_isNotEqual() {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
-    ).use {
-      it.onActivity { homeFragmentTestActivity ->
+    ).use { activityScenario ->
+      activityScenario.onActivity { homeFragmentTestActivity ->
         setUpTestFragment(homeFragmentTestActivity)
         val topicSummaryViewModel = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
 
@@ -178,8 +178,8 @@ class TopicSummaryViewModelTest {
   fun testTopicSummaryViewModelEquals_topicSummary1AndTopicSummary2_isNotEqual() {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
-    ).use {
-      it.onActivity { homeFragmentTestActivity ->
+    ).use { activityScenario ->
+      activityScenario.onActivity { homeFragmentTestActivity ->
         setUpTestFragment(homeFragmentTestActivity)
         val topicSummaryViewModelTopicSummary1 = TopicSummaryViewModel(
           activity = homeFragmentTestActivity,
@@ -206,8 +206,8 @@ class TopicSummaryViewModelTest {
   fun testTopicSummaryViewModelEquals_entity1AndEntity2_isNotEqual() {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
-    ).use {
-      it.onActivity { homeFragmentTestActivity ->
+    ).use { activityScenario ->
+      activityScenario.onActivity { homeFragmentTestActivity ->
         setUpTestFragment(homeFragmentTestActivity)
         val topicSummaryViewModelEntity1 = TopicSummaryViewModel(
           activity = homeFragmentTestActivity,
@@ -233,8 +233,8 @@ class TopicSummaryViewModelTest {
   fun testTopicSummaryViewModelEquals_position4AndPosition5_isNotEqual() {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
-    ).use {
-      it.onActivity { homeFragmentTestActivity ->
+    ).use { activityScenario ->
+      activityScenario.onActivity { homeFragmentTestActivity ->
         setUpTestFragment(homeFragmentTestActivity)
         val topicSummaryViewModelPosition4 = TopicSummaryViewModel(
           activity = homeFragmentTestActivity,
@@ -260,8 +260,8 @@ class TopicSummaryViewModelTest {
   fun testTopicSummaryViewModelHashCode_viewModelsEqualHashCodesEqual_isEqual() {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
-    ).use {
-      it.onActivity { homeFragmentTestActivity ->
+    ).use { activityScenario ->
+      activityScenario.onActivity { homeFragmentTestActivity ->
         setUpTestFragment(homeFragmentTestActivity)
         val topicSummaryViewModel = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
         val topicSummaryViewModelCopy = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
@@ -277,8 +277,8 @@ class TopicSummaryViewModelTest {
   fun testTopicSummaryViewModelHashCode_sameViewModelHashCodeDoesNotChange_isEqual() {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
-    ).use {
-      it.onActivity { homeFragmentTestActivity ->
+    ).use { activityScenario ->
+      activityScenario.onActivity { homeFragmentTestActivity ->
         setUpTestFragment(homeFragmentTestActivity)
         val topicSummaryViewModel = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
 

--- a/app/src/sharedTest/java/org/oppia/android/app/home/TopicSummaryViewModelTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/TopicSummaryViewModelTest.kt
@@ -95,9 +95,9 @@ class TopicSummaryViewModelTest {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
     ).use {
-      it.onActivity {
-        setUpTestFragment(it)
-        val topicSummaryViewModel = createBasicTopicSummaryViewModel(it)
+      it.onActivity { homeFragmentTestActivity ->
+        setUpTestFragment(homeFragmentTestActivity)
+        val topicSummaryViewModel = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
 
         // Verify the reflexive property of equals(): a == a.
         assertThat(topicSummaryViewModel).isEqualTo(topicSummaryViewModel)
@@ -110,10 +110,10 @@ class TopicSummaryViewModelTest {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
     ).use {
-      it.onActivity {
-        setUpTestFragment(it)
-        val topicSummaryViewModel = createBasicTopicSummaryViewModel(it)
-        val topicSummaryViewModelCopy = createBasicTopicSummaryViewModel(it)
+      it.onActivity { homeFragmentTestActivity ->
+        setUpTestFragment(homeFragmentTestActivity)
+        val topicSummaryViewModel = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
+        val topicSummaryViewModelCopy = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
 
         // Verify the symmetric property of equals(): a == b iff b == a.
         assertThat(topicSummaryViewModel).isEqualTo(topicSummaryViewModelCopy)
@@ -127,11 +127,11 @@ class TopicSummaryViewModelTest {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
     ).use {
-      it.onActivity {
-        setUpTestFragment(it)
-        val topicSummaryViewModelCopy1 = createBasicTopicSummaryViewModel(it)
-        val topicSummaryViewModelCopy2 = createBasicTopicSummaryViewModel(it)
-        val topicSummaryViewModelCopy3 = createBasicTopicSummaryViewModel(it)
+      it.onActivity { homeFragmentTestActivity ->
+        setUpTestFragment(homeFragmentTestActivity)
+        val topicSummaryViewModelCopy1 = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
+        val topicSummaryViewModelCopy2 = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
+        val topicSummaryViewModelCopy3 = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
         assertThat(topicSummaryViewModelCopy1).isEqualTo(topicSummaryViewModelCopy2)
         assertThat(topicSummaryViewModelCopy2).isEqualTo(topicSummaryViewModelCopy3)
 
@@ -146,10 +146,10 @@ class TopicSummaryViewModelTest {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
     ).use {
-      it.onActivity {
-        setUpTestFragment(it)
-        val topicSummaryViewModel = createBasicTopicSummaryViewModel(it)
-        val topicSummaryViewModelCopy = createBasicTopicSummaryViewModel(it)
+      it.onActivity { homeFragmentTestActivity ->
+        setUpTestFragment(homeFragmentTestActivity)
+        val topicSummaryViewModel = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
+        val topicSummaryViewModelCopy = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
         assertThat(topicSummaryViewModel).isEqualTo(topicSummaryViewModelCopy)
 
         // Verify the consistent property of equals(): if neither object is modified, then a == b
@@ -164,9 +164,9 @@ class TopicSummaryViewModelTest {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
     ).use {
-      it.onActivity {
-        setUpTestFragment(it)
-        val topicSummaryViewModel = createBasicTopicSummaryViewModel(it)
+      it.onActivity { homeFragmentTestActivity ->
+        setUpTestFragment(homeFragmentTestActivity)
+        val topicSummaryViewModel = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
 
         // Verify the non-null property of equals(): for any non-null reference a, a != null
         assertThat(topicSummaryViewModel).isNotEqualTo(null)
@@ -179,17 +179,17 @@ class TopicSummaryViewModelTest {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
     ).use {
-      it.onActivity {
-        setUpTestFragment(it)
+      it.onActivity { homeFragmentTestActivity ->
+        setUpTestFragment(homeFragmentTestActivity)
         val topicSummaryViewModelTopicSummary1 = TopicSummaryViewModel(
-          activity = it,
+          activity = homeFragmentTestActivity,
           topicSummary = topicSummary1,
           entityType = "entity_1",
           topicSummaryClickListener = testFragment,
           position = 5
         )
         val topicSummaryViewModelTopicSummary2 = TopicSummaryViewModel(
-          activity = it,
+          activity = homeFragmentTestActivity,
           topicSummary = topicSummary2,
           entityType = "entity_1",
           topicSummaryClickListener = testFragment,
@@ -207,17 +207,17 @@ class TopicSummaryViewModelTest {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
     ).use {
-      it.onActivity {
-        setUpTestFragment(it)
+      it.onActivity { homeFragmentTestActivity ->
+        setUpTestFragment(homeFragmentTestActivity)
         val topicSummaryViewModelEntity1 = TopicSummaryViewModel(
-          activity = it,
+          activity = homeFragmentTestActivity,
           topicSummary = topicSummary1,
           entityType = "entity_1",
           topicSummaryClickListener = testFragment,
           position = 5
         )
         val topicSummaryViewModelEntity2 = TopicSummaryViewModel(
-          activity = it,
+          activity = homeFragmentTestActivity,
           topicSummary = topicSummary1,
           entityType = "entity_2",
           topicSummaryClickListener = testFragment,
@@ -234,17 +234,17 @@ class TopicSummaryViewModelTest {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
     ).use {
-      it.onActivity {
-        setUpTestFragment(it)
+      it.onActivity { homeFragmentTestActivity ->
+        setUpTestFragment(homeFragmentTestActivity)
         val topicSummaryViewModelPosition4 = TopicSummaryViewModel(
-          activity = it,
+          activity = homeFragmentTestActivity,
           topicSummary = topicSummary1,
           entityType = "entity_1",
           topicSummaryClickListener = testFragment,
           position = 4
         )
         val topicSummaryViewModelPosition5 = TopicSummaryViewModel(
-          activity = it,
+          activity = homeFragmentTestActivity,
           topicSummary = topicSummary1,
           entityType = "entity_1",
           topicSummaryClickListener = testFragment,
@@ -261,10 +261,10 @@ class TopicSummaryViewModelTest {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
     ).use {
-      it.onActivity {
-        setUpTestFragment(it)
-        val topicSummaryViewModel = createBasicTopicSummaryViewModel(it)
-        val topicSummaryViewModelCopy = createBasicTopicSummaryViewModel(it)
+      it.onActivity { homeFragmentTestActivity ->
+        setUpTestFragment(homeFragmentTestActivity)
+        val topicSummaryViewModel = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
+        val topicSummaryViewModelCopy = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
         assertThat(topicSummaryViewModel).isEqualTo(topicSummaryViewModelCopy)
 
         // Verify that if a == b, then a.hashCode == b.hashCode
@@ -278,9 +278,9 @@ class TopicSummaryViewModelTest {
     launch<HomeFragmentTestActivity>(
       HomeFragmentTestActivity.createHomeFragmentTestActivity(context)
     ).use {
-      it.onActivity {
-        setUpTestFragment(it)
-        val topicSummaryViewModel = createBasicTopicSummaryViewModel(it)
+      it.onActivity { homeFragmentTestActivity ->
+        setUpTestFragment(homeFragmentTestActivity)
+        val topicSummaryViewModel = createBasicTopicSummaryViewModel(homeFragmentTestActivity)
 
         // Verify that hashCode consistently returns the same value.
         val firstHash = topicSummaryViewModel.hashCode()


### PR DESCRIPTION
## Explanation
Describe the bug:
In most of the places we are using it for the lambda function argument. it is not readable and not helps to understand what it represents.

Expected behavior:
Look for the below-mentioned test files and Replace it with the correct names

Fixes part of #2834 (TopicSummaryViewModelTest )

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [X] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [X] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [X] The PR is made from a branch that's **not** called "develop".
- [X] The PR is made from a branch that is up-to-date with "develop".
- [X] The PR's branch is based on "develop" and not on any other branch.
- [] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
