### PR TITLE
Partially fix #2844: force Gradle tests to run on JDK 9 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,20 +35,27 @@ jobs:
        with:
           java-version: 1.9
       
-     - name: Check Java version
-       run: java -version
+     - name: Check Java version & path
+       run: |
+         which java
+         java -version
+         echo "Java home: $JAVA_HOME"
+         $JAVA_HOME/bin/java -version
 
      - name: Install Dependencies
        if: steps.cache.outputs.cache-hit != 'true'
-       run: ./gradlew --full-stacktrace androidDependencies
+       run: ./gradlew --full-stacktrace androidDependencies -Dorg.gradle.java.home=$JAVA_HOME
+
+     - name: Check Gradle environment
+       run: ./gradlew -Dorg.gradle.java.home=$JAVA_HOME -v
 
      - name: Build App
        # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
-       run: sudo ./gradlew --full-stacktrace assembleDebug
+       run: sudo ./gradlew --full-stacktrace assembleDebug -Dorg.gradle.java.home=$JAVA_HOME
 
      - name: Utility tests
        # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
-       run:  sudo ./gradlew --full-stacktrace :utility:testDebugUnitTest
+       run:  sudo ./gradlew --full-stacktrace :utility:testDebugUnitTest -Dorg.gradle.java.home=$JAVA_HOME
      - name: Upload Utility Test Reports
        uses: actions/upload-artifact@v2
        if: ${{ always() }} # IMPORTANT: Upload reports regardless of status
@@ -58,7 +65,7 @@ jobs:
 
      - name: Domain tests
        # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
-       run:  sudo ./gradlew --full-stacktrace :domain:testDebugUnitTest
+       run:  sudo ./gradlew --full-stacktrace :domain:testDebugUnitTest -Dorg.gradle.java.home=$JAVA_HOME
      - name: Upload Domain Test Reports
        uses: actions/upload-artifact@v2
        if: ${{ always() }} # IMPORTANT: Upload reports regardless of status
@@ -68,7 +75,7 @@ jobs:
 
      - name: Testing tests
        # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
-       run:  sudo ./gradlew --full-stacktrace :testing:testDebugUnitTest
+       run:  sudo ./gradlew --full-stacktrace :testing:testDebugUnitTest -Dorg.gradle.java.home=$JAVA_HOME
      - name: Upload Testing Test Reports
        uses: actions/upload-artifact@v2
        if: ${{ always() }} # IMPORTANT: Upload reports regardless of status
@@ -94,14 +101,21 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.9
-      
-      - name: Check Java version
-        run: java -version
+
+      - name: Check Java version & path
+        run: |
+          which java
+          java -version
+          echo "Java home: $JAVA_HOME"
+          $JAVA_HOME/bin/java -version
+
+      - name: Check Gradle environment
+        run: ./gradlew -Dorg.gradle.java.home=$JAVA_HOME -v
 
       - name: Robolectric tests - App Module
         # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
         run: |
-          sudo ./gradlew --full-stacktrace :app:testDebugUnitTest
+          sudo ./gradlew --full-stacktrace :app:testDebugUnitTest -Dorg.gradle.java.home=$JAVA_HOME
       - name: Upload App Test Reports
         uses: actions/upload-artifact@v2
         if: ${{ always() }} # IMPORTANT: Upload reports regardless of status

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,9 @@ jobs:
        uses: actions/setup-java@v1
        with:
           java-version: 1.9
+      
+     - name: Check Java version
+       run: java -version
 
      - name: Install Dependencies
        if: steps.cache.outputs.cache-hit != 'true'
@@ -91,6 +94,9 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.9
+      
+      - name: Check Java version
+        run: java -version
 
       - name: Robolectric tests - App Module
         # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,7 +128,11 @@ dependencies {
       'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1',
       'org.mockito:mockito-core:2.7.22',
   )
-  compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
+  compileOnly(
+      'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2',
+      'javax.annotation:javax.annotation-api:1.3.2',
+      'org.glassfish.jaxb:jaxb-runtime:2.3.2',
+  )
   testImplementation(
       'androidx.test:core:1.2.0',
       'androidx.test.espresso:espresso-contrib:3.1.0',

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,6 +128,7 @@ dependencies {
       'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1',
       'org.mockito:mockito-core:2.7.22',
   )
+  compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
   testImplementation(
       'androidx.test:core:1.2.0',
       'androidx.test.espresso:espresso-contrib:3.1.0',

--- a/build.gradle
+++ b/build.gradle
@@ -29,22 +29,3 @@ allprojects {
 task clean(type: Delete) {
   delete rootProject.buildDir
 }
-
-subprojects{
-  afterEvaluate {
-    // kapt doesn't propagate source version properly so even if we set JDK to be 9, if we
-    // have a local JDK version of 9+, we see a dagger bug in generating annotations
-    // that only occurs in JDK 9+, this is the workaround:
-    // (Lots of useful information here: https://github.com/google/dagger/issues/1449)
-    if (project.hasProperty('kapt')) {
-      // Reference for 'kapt' DSL: https://kotlinlang.org/docs/reference/kapt.html#java-compiler-options
-      kapt {
-        // we expect this closure to run over a org.jetbrains.kotlin.gradle.plugin.KaptExtension
-        javacOptions {
-          option("-source", "8")
-          option("-target", "8")
-        }
-      }
-    }
-  }
-}

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -70,7 +70,11 @@ dependencies {
       'com.squareup.moshi:moshi-kotlin:1.11.0',
       'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.2',
   )
-  compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
+  compileOnly(
+      'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2',
+      'javax.annotation:javax.annotation-api:1.3.2',
+      'org.glassfish.jaxb:jaxb-runtime:2.3.2',
+  )
   testImplementation(
       'android.arch.core:core-testing:1.1.1',
       'androidx.test.ext:junit:1.1.1',

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -70,6 +70,7 @@ dependencies {
       'com.squareup.moshi:moshi-kotlin:1.11.0',
       'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.2',
   )
+  compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
   testImplementation(
       'android.arch.core:core-testing:1.1.1',
       'androidx.test.ext:junit:1.1.1',

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -70,6 +70,7 @@ dependencies {
       'com.google.firebase:firebase-crashlytics:17.0.0',
       "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
   )
+  compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
   testImplementation(
       'android.arch.core:core-testing:1.1.1',
       'androidx.test.espresso:espresso-core:3.2.0',

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -70,7 +70,11 @@ dependencies {
       'com.google.firebase:firebase-crashlytics:17.0.0',
       "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
   )
-  compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
+  compileOnly(
+      'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2',
+      'javax.annotation:javax.annotation-api:1.3.2',
+      'org.glassfish.jaxb:jaxb-runtime:2.3.2',
+  )
   testImplementation(
       'android.arch.core:core-testing:1.1.1',
       'androidx.test.espresso:espresso-core:3.2.0',

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -63,6 +63,7 @@ dependencies {
       project(":domain"),
       project(":utility"),
   )
+  compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
   testImplementation(
       'androidx.lifecycle:lifecycle-livedata-ktx:2.2.0-alpha03',
       'androidx.test.ext:junit:1.1.1',

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -63,7 +63,11 @@ dependencies {
       project(":domain"),
       project(":utility"),
   )
-  compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
+  compileOnly(
+      'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2',
+      'javax.annotation:javax.annotation-api:1.3.2',
+      'org.glassfish.jaxb:jaxb-runtime:2.3.2',
+  )
   testImplementation(
       'androidx.lifecycle:lifecycle-livedata-ktx:2.2.0-alpha03',
       'androidx.test.ext:junit:1.1.1',

--- a/utility/build.gradle
+++ b/utility/build.gradle
@@ -72,7 +72,11 @@ dependencies {
       'com.google.firebase:firebase-crashlytics:17.0.0',
       "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version",
   )
-  compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
+  compileOnly(
+      'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2',
+      'javax.annotation:javax.annotation-api:1.3.2',
+      'org.glassfish.jaxb:jaxb-runtime:2.3.2',
+  )
   testImplementation(
       'androidx.test.ext:junit:1.1.1',
       'com.google.dagger:dagger:2.24',

--- a/utility/build.gradle
+++ b/utility/build.gradle
@@ -72,6 +72,7 @@ dependencies {
       'com.google.firebase:firebase-crashlytics:17.0.0',
       "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version",
   )
+  compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
   testImplementation(
       'androidx.test.ext:junit:1.1.1',
       'com.google.dagger:dagger:2.24',


### PR DESCRIPTION
Fixes part of #2844.

This aims to fix the OpenJDK flakes happening for Gradle tests (per #2844) by forcing the CI environment to use JDK 9 instead of JDK 8 for runtime, since it seems that JDK 8 may have an issue where the JVM can crash when managing many forks (we updated Gradle tests to use forks a while back). However, making the CI environment properly use JDK 9 for Gradle involved a few steps:
- Adding additional steps to add environment diagnostics to ensure that Gradle is actually using JDK 9 (since it seems to use JDK 8 as configured by settings despite 9 being setup). Unfortunately, setup-java doesn't yet seem to support this directly: https://github.com/actions/setup-java/issues/92, and it's important to verify that Gradle itself is using the correct version.
- Note that moving to JDK 9+ requires a compile-time only dependency for some of the annotations needed by Dagger: https://github.com/google/dagger/issues/1449#issuecomment-588277905. It's not clear to me why this wasn't an issue in the JDK 8 world.
- Similarly, JDK 9+ deprecate and eventually remove (JDK 11+) some Java EE libraries that Gradle itself seems to depend on. More compile-only dependencies resolve this issue: https://stackoverflow.com/a/43574427.

Some things to note:
- The build still sets source/target compatibility versions to Java 8 since we don't actually want to use Java 9+ dependencies, we just want to be able to use JDK 9+ to build and run the tests
- I haven't verified this locally to still work with JDK 8, but I'm not expecting there to be issues since the changes are mostly just adding redundancy
- I removed the workaround for the kapt bug since per https://github.com/google/dagger/issues/1449#issuecomment-595238637 this should be fixed in the version of Kotlin that we're now using (though the other fixes above regarding the compile-time dependencies were discovered shortly after & are necessary to make everything work as expected)

We will not actually be able to verify if the issue is fixed until we see no new instances of the crash crop up over the next few weeks. Given that the issue seems to only reproduce occasionally when running the whole batch of tests, it's difficult to make the issue commonplace enough to gain certainty it's been fixed. Given the low volume of the flake, though, waiting a few weeks to ensure it's gone should be reasonable.