### PR TITLE
Fix part of #2691: Add diagnostics to investigate issues with compute affected targets

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -33,6 +33,7 @@ jobs:
         # https://unix.stackexchange.com/a/338124 for reference on creating a JSON-friendly
         # comma-separated list of test targets for the matrix.
         run: |
+          bash ./scripts/compute_affected_tests.sh bazel
           TEST_TARGET_LIST=$(bash ./scripts/compute_affected_tests.sh bazel | sed 's/^\|$/"/g' | paste -sd, -)
           echo "Affected tests (note that this might be all tests if on the develop branch): $TEST_TARGET_LIST"
           echo "::set-output name=matrix::{\"test-target\":[$TEST_TARGET_LIST]}"


### PR DESCRIPTION
Fix part of #2691.

Add extra diagnostic output to investigate issues with the compute affected targets workflow.

See https://github.com/oppia/oppia-android/issues/2691#issuecomment-792150231 for specifics on the issue being investigated here.