### PR TITLE
Fix Part of #2833 : Add missing named argument in ProfileChooserFragmentTest

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
@@ -155,13 +155,11 @@ class ProfileChooserFragmentTest {
         targetView = R.id.profile_name_text,
         stringToMatch = "Ben"
       )
-      onView(
-        atPositionOnView(
+      onView(atPositionOnView(
           recyclerViewId = R.id.profile_recycler_view,
           position = 1,
           targetViewId = R.id.profile_is_admin_text
-        )
-      ).check(matches(not(isDisplayed())))
+      )).check(matches(not(isDisplayed())))
       scrollToPosition(position = 3)
       verifyTextOnProfileListItemAtPosition(
         itemPosition = 4,
@@ -181,13 +179,11 @@ class ProfileChooserFragmentTest {
         profileTestHelper.waitForOperationToComplete(data)
       }
       testCoroutineDispatchers.runCurrent()
-      onView(
-        atPositionOnView(
+      onView(atPositionOnView(
           recyclerViewId = R.id.profile_recycler_view,
           position = 0,
           targetViewId = R.id.profile_last_visited
-        )
-      ).check(matches(isDisplayed()))
+      )).check(matches(isDisplayed()))
       verifyTextOnProfileListItemAtPosition(
         itemPosition = 0,
         targetView = R.id.profile_last_visited,
@@ -207,13 +203,11 @@ class ProfileChooserFragmentTest {
       }
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
-      onView(
-        atPositionOnView(
+      onView(atPositionOnView(
           recyclerViewId = R.id.profile_recycler_view,
           position = 0,
           targetViewId = R.id.profile_last_visited
-        )
-      ).check(matches(isDisplayed()))
+      )).check(matches(isDisplayed()))
       verifyTextOnProfileListItemAtPosition(
         itemPosition = 0,
         targetView = R.id.profile_last_visited,
@@ -296,7 +290,10 @@ class ProfileChooserFragmentTest {
     profileTestHelper.initializeProfiles()
     launch(ProfileChooserActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
-      onView(atPosition(recyclerViewId = R.id.profile_recycler_view, position = 0)).perform(click())
+      onView(atPosition(
+        recyclerViewId = R.id.profile_recycler_view,
+        position = 0
+      )).perform(click())
       intended(hasComponent(PinPasswordActivity::class.java.name))
     }
   }
@@ -313,13 +310,11 @@ class ProfileChooserFragmentTest {
     ).toLiveData()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()
-      onView(
-        atPositionOnView(
+      onView(atPositionOnView(
           recyclerViewId = R.id.profile_recycler_view,
           position = 1,
           targetViewId = R.id.add_profile_item
-        )
-      ).perform(click())
+        )).perform(click())
       intended(hasComponent(AdminPinActivity::class.java.name))
       intended(hasExtra(ADMIN_PIN_ENUM_EXTRA_KEY, AdminAuthEnum.PROFILE_ADD_PROFILE.value))
     }
@@ -377,13 +372,11 @@ class ProfileChooserFragmentTest {
     profileTestHelper.addOnlyAdminProfile()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()
-      onView(
-        atPositionOnView(
+      onView(atPositionOnView(
           recyclerViewId = R.id.profile_recycler_view,
           position = 1,
           targetViewId = R.id.add_profile_description_text
-        )
-      ).check(matches(isDisplayed()))
+      )).check(matches(isDisplayed()))
     }
   }
 
@@ -405,13 +398,11 @@ class ProfileChooserFragmentTest {
     profileTestHelper.initializeProfiles()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()
-      onView(
-        atPositionOnView(
+      onView(atPositionOnView(
           recyclerViewId = R.id.profile_recycler_view,
           position = 4,
           targetViewId = R.id.add_profile_description_text
-        )
-      ).check(matches(not(isDisplayed())))
+      )).check(matches(not(isDisplayed())))
     }
   }
 
@@ -431,7 +422,10 @@ class ProfileChooserFragmentTest {
     profileTestHelper.initializeProfiles()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()
-      onView(atPosition(R.id.profile_recycler_view, 4)).perform(click())
+      onView(atPosition(
+        recyclerViewId =  R.id.profile_recycler_view,
+        position = 4
+      )).perform(click())
       intended(hasComponent(AdminAuthActivity::class.java.name))
       intended(hasExtra(ADMIN_AUTH_ENUM_EXTRA_KEY, AdminAuthEnum.PROFILE_ADD_PROFILE.value))
     }
@@ -455,13 +449,11 @@ class ProfileChooserFragmentTest {
     targetView: Int,
     stringToMatch: String
   ) {
-    onView(
-      atPositionOnView(
+    onView(atPositionOnView(
         recyclerViewId = R.id.profile_recycler_view,
         position = itemPosition,
         targetViewId = targetView
-      )
-    ).check(matches(withText(stringToMatch)))
+    )).check(matches(withText(stringToMatch)))
   }
 
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
@@ -155,11 +155,13 @@ class ProfileChooserFragmentTest {
         targetView = R.id.profile_name_text,
         stringToMatch = "Ben"
       )
-      onView(atPositionOnView(
+      onView(
+        atPositionOnView(
           recyclerViewId = R.id.profile_recycler_view,
           position = 1,
           targetViewId = R.id.profile_is_admin_text
-      )).check(matches(not(isDisplayed())))
+        )
+      ).check(matches(not(isDisplayed())))
       scrollToPosition(position = 3)
       verifyTextOnProfileListItemAtPosition(
         itemPosition = 4,
@@ -179,11 +181,13 @@ class ProfileChooserFragmentTest {
         profileTestHelper.waitForOperationToComplete(data)
       }
       testCoroutineDispatchers.runCurrent()
-      onView(atPositionOnView(
+      onView(
+        atPositionOnView(
           recyclerViewId = R.id.profile_recycler_view,
           position = 0,
           targetViewId = R.id.profile_last_visited
-      )).check(matches(isDisplayed()))
+        )
+      ).check(matches(isDisplayed()))
       verifyTextOnProfileListItemAtPosition(
         itemPosition = 0,
         targetView = R.id.profile_last_visited,
@@ -203,11 +207,13 @@ class ProfileChooserFragmentTest {
       }
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
-      onView(atPositionOnView(
+      onView(
+        atPositionOnView(
           recyclerViewId = R.id.profile_recycler_view,
           position = 0,
           targetViewId = R.id.profile_last_visited
-      )).check(matches(isDisplayed()))
+        )
+      ).check(matches(isDisplayed()))
       verifyTextOnProfileListItemAtPosition(
         itemPosition = 0,
         targetView = R.id.profile_last_visited,
@@ -290,10 +296,12 @@ class ProfileChooserFragmentTest {
     profileTestHelper.initializeProfiles()
     launch(ProfileChooserActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
-      onView(atPosition(
-        recyclerViewId = R.id.profile_recycler_view,
-        position = 0
-      )).perform(click())
+      onView(
+        atPosition(
+          recyclerViewId = R.id.profile_recycler_view,
+          position = 0
+        )
+      ).perform(click())
       intended(hasComponent(PinPasswordActivity::class.java.name))
     }
   }
@@ -310,11 +318,13 @@ class ProfileChooserFragmentTest {
     ).toLiveData()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()
-      onView(atPositionOnView(
+      onView(
+        atPositionOnView(
           recyclerViewId = R.id.profile_recycler_view,
           position = 1,
           targetViewId = R.id.add_profile_item
-        )).perform(click())
+        )
+      ).perform(click())
       intended(hasComponent(AdminPinActivity::class.java.name))
       intended(hasExtra(ADMIN_PIN_ENUM_EXTRA_KEY, AdminAuthEnum.PROFILE_ADD_PROFILE.value))
     }
@@ -372,11 +382,13 @@ class ProfileChooserFragmentTest {
     profileTestHelper.addOnlyAdminProfile()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()
-      onView(atPositionOnView(
+      onView(
+        atPositionOnView(
           recyclerViewId = R.id.profile_recycler_view,
           position = 1,
           targetViewId = R.id.add_profile_description_text
-      )).check(matches(isDisplayed()))
+        )
+      ).check(matches(isDisplayed()))
     }
   }
 
@@ -398,11 +410,13 @@ class ProfileChooserFragmentTest {
     profileTestHelper.initializeProfiles()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()
-      onView(atPositionOnView(
+      onView(
+        atPositionOnView(
           recyclerViewId = R.id.profile_recycler_view,
           position = 4,
           targetViewId = R.id.add_profile_description_text
-      )).check(matches(not(isDisplayed())))
+        )
+      ).check(matches(not(isDisplayed())))
     }
   }
 
@@ -422,10 +436,12 @@ class ProfileChooserFragmentTest {
     profileTestHelper.initializeProfiles()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()
-      onView(atPosition(
-        recyclerViewId =  R.id.profile_recycler_view,
-        position = 4
-      )).perform(click())
+      onView(
+        atPosition(
+          recyclerViewId = R.id.profile_recycler_view,
+          position = 4
+        )
+      ).perform(click())
       intended(hasComponent(AdminAuthActivity::class.java.name))
       intended(hasExtra(ADMIN_AUTH_ENUM_EXTRA_KEY, AdminAuthEnum.PROFILE_ADD_PROFILE.value))
     }
@@ -449,11 +465,13 @@ class ProfileChooserFragmentTest {
     targetView: Int,
     stringToMatch: String
   ) {
-    onView(atPositionOnView(
+    onView(
+      atPositionOnView(
         recyclerViewId = R.id.profile_recycler_view,
         position = itemPosition,
         targetViewId = targetView
-    )).check(matches(withText(stringToMatch)))
+      )
+    ).check(matches(withText(stringToMatch)))
   }
 
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
@@ -157,9 +157,9 @@ class ProfileChooserFragmentTest {
       )
       onView(
         atPositionOnView(
-          R.id.profile_recycler_view,
-          1,
-          R.id.profile_is_admin_text
+          recyclerViewId = R.id.profile_recycler_view,
+          position = 1,
+          targetViewId = R.id.profile_is_admin_text
         )
       ).check(matches(not(isDisplayed())))
       scrollToPosition(position = 3)
@@ -183,9 +183,9 @@ class ProfileChooserFragmentTest {
       testCoroutineDispatchers.runCurrent()
       onView(
         atPositionOnView(
-          R.id.profile_recycler_view,
-          0,
-          R.id.profile_last_visited
+          recyclerViewId = R.id.profile_recycler_view,
+          position = 0,
+          targetViewId = R.id.profile_last_visited
         )
       ).check(matches(isDisplayed()))
       verifyTextOnProfileListItemAtPosition(
@@ -209,9 +209,9 @@ class ProfileChooserFragmentTest {
       onView(isRoot()).perform(orientationLandscape())
       onView(
         atPositionOnView(
-          R.id.profile_recycler_view,
-          0,
-          R.id.profile_last_visited
+          recyclerViewId = R.id.profile_recycler_view,
+          position = 0,
+          targetViewId = R.id.profile_last_visited
         )
       ).check(matches(isDisplayed()))
       verifyTextOnProfileListItemAtPosition(
@@ -296,7 +296,7 @@ class ProfileChooserFragmentTest {
     profileTestHelper.initializeProfiles()
     launch(ProfileChooserActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
-      onView(atPosition(R.id.profile_recycler_view, 0)).perform(click())
+      onView(atPosition(recyclerViewId = R.id.profile_recycler_view, position = 0)).perform(click())
       intended(hasComponent(PinPasswordActivity::class.java.name))
     }
   }
@@ -304,20 +304,20 @@ class ProfileChooserFragmentTest {
   @Test
   fun testProfileChooserFragment_clickAdminProfileWithNoPin_checkOpensAdminPinActivity() {
     profileManagementController.addProfile(
-      "Admin",
-      "",
-      null,
-      true,
-      -10710042,
-      true
+      name = "Admin",
+      pin = "",
+      avatarImagePath = null,
+      allowDownloadAccess = true,
+      colorRgb = -10710042,
+      isAdmin = true
     ).toLiveData()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()
       onView(
         atPositionOnView(
-          R.id.profile_recycler_view,
-          1,
-          R.id.add_profile_item
+          recyclerViewId = R.id.profile_recycler_view,
+          position = 1,
+          targetViewId = R.id.add_profile_item
         )
       ).perform(click())
       intended(hasComponent(AdminPinActivity::class.java.name))
@@ -328,12 +328,12 @@ class ProfileChooserFragmentTest {
   @Test
   fun testProfileChooserFragment_clickAdminControlsWithNoPin_checkOpensAdminControlsActivity() {
     profileManagementController.addProfile(
-      "Admin",
-      "",
-      null,
-      true,
-      -10710042,
-      true
+      name = "Admin",
+      pin = "",
+      avatarImagePath = null,
+      allowDownloadAccess = true,
+      colorRgb = -10710042,
+      isAdmin = true
     ).toLiveData()
     launch<ProfileChooserActivity>(createProfileChooserActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()
@@ -379,9 +379,9 @@ class ProfileChooserFragmentTest {
       testCoroutineDispatchers.runCurrent()
       onView(
         atPositionOnView(
-          R.id.profile_recycler_view,
-          1,
-          R.id.add_profile_description_text
+          recyclerViewId = R.id.profile_recycler_view,
+          position = 1,
+          targetViewId = R.id.add_profile_description_text
         )
       ).check(matches(isDisplayed()))
     }
@@ -407,9 +407,9 @@ class ProfileChooserFragmentTest {
       testCoroutineDispatchers.runCurrent()
       onView(
         atPositionOnView(
-          R.id.profile_recycler_view,
-          4,
-          R.id.add_profile_description_text
+          recyclerViewId = R.id.profile_recycler_view,
+          position = 4,
+          targetViewId = R.id.add_profile_description_text
         )
       ).check(matches(not(isDisplayed())))
     }
@@ -457,9 +457,9 @@ class ProfileChooserFragmentTest {
   ) {
     onView(
       atPositionOnView(
-        R.id.profile_recycler_view,
-        itemPosition,
-        targetView
+        recyclerViewId = R.id.profile_recycler_view,
+        position = itemPosition,
+        targetViewId = targetView
       )
     ).check(matches(withText(stringToMatch)))
   }


### PR DESCRIPTION
## Explanation
Fixes Part of #2833 : Add missing named argument in ProfileChooserFragmentTest

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
