### PR TITLE
Enable Accessibility Checks in test cases [WIP]

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -150,6 +150,7 @@ dependencies {
   )
   androidTestImplementation(
       'androidx.test:core:1.2.0',
+      'androidx.test.espresso:espresso-accessibility:3.1.0',
       'androidx.test.espresso:espresso-contrib:3.1.0',
       'androidx.test.espresso:espresso-core:3.2.0',
       'androidx.test.espresso:espresso-intents:3.1.0',

--- a/app/src/main/res/layout/profile_rename_activity.xml
+++ b/app/src/main/res/layout/profile_rename_activity.xml
@@ -85,7 +85,7 @@
           android:layout_height="wrap_content"
           android:layout_marginTop="16dp"
           android:layout_marginEnd="28dp"
-          android:background="@{viewModel.inputName.length > 0 ? @drawable/state_button_primary_background :@drawable/start_button_transparent_background}"
+          android:background="@color/white"
           android:clickable="@{viewModel.inputName.length > 0}"
           android:enabled="@{viewModel.inputName.length > 0}"
           android:text="@string/profile_rename_save"

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
@@ -8,11 +8,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.accessibility.AccessibilityChecks
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
 import androidx.test.espresso.action.ViewActions.pressImeActionButton
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.contrib.AccessibilityChecks
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
 import androidx.test.espresso.action.ViewActions.pressImeActionButton
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.AccessibilityChecks
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
@@ -31,6 +32,7 @@ import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
 import org.junit.After
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -101,6 +103,14 @@ class ProfileRenameActivityTest {
 
   @Inject
   lateinit var editTextInputAction: EditTextInputAction
+
+  companion object {
+    @BeforeClass
+    @JvmStatic
+    fun enableA11yChecks() {
+      AccessibilityChecks.enable()
+    }
+  }
 
   @Before
   fun setUp() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

This PR aims as create a demo of how we can enable Accessibility Checks on in either of roboelectric or espresso test cases.

In this PR the solution works for Espresso only. The current test fails with below mentioned error which is correct and was done so as to prove that the implementation works correctly.

`
com.google.android.apps.common.testing.accessibility.framework.integrations.AccessibilityViewCheckException: There was 1 accessibility error:
AppCompatButton{id=2131296812, res-name=profile_rename_save_button, visibility=VISIBLE, width=242, height=132, has-focus=false, has-focusable=true, has-window-focus=false, is-clickable=true, is-enabled=true, is-focused=false, is-focusable=true, is-layout-requested=false, is-selected=false, layout-params=androidx.constraintlayout.widget.ConstraintLayout$LayoutParams@64bf52a, tag=null, root-is-layout-requested=false, has-input-connection=false, x=761.0, y=321.0, text=save, input-type=0, ime-target=false, has-links=false}: TextView does not have required contrast of 3.000000. Actual contrast is 1.000000
`

If we run this PR on Roboelectric then test cases do fail giving error related to Accessibility but it is not clear.
`java.lang.NoClassDefFoundError: Could not initialize class com.google.android.apps.common.testing.accessibility.framework.SpeakableTextPresentViewCheck`

## Problem 1
The [documentation](https://developer.android.com/training/testing/espresso/accessibility-checking#enable-checks) mentions following import: `import androidx.test.espresso.accessibility.AccessibilityChecks`
which requires following import too `'androidx.test.espresso:espresso-accessibility:3.1.0'`

But when I try to run the app with this import
`Unresolved reference: AccessibilityChecks`.

Reference for this problem were following: [documentation](https://developer.android.com/training/testing/espresso/accessibility-checking#enable-checks) and [medium blog](https://medium.com/@artour.bakiev/accessibility-testing-for-android-apps-how-to-start-ce7c09628743)

To solve problem one I had to use the deprecated import as per this suggestion: https://stackoverflow.com/a/51240061

## Problem 2
I tried to enable the `AccessibilityChecks` for Roboelectric by adding the following annotation to the test case `@AccessibilityChecks` but in this case all the tests pass which is incorrect for following activity.


## Summary
I haven't found any working solution for to enable A11y checks for Roboelectric. The solution that worked for Espresso uses a deprecated import and not the import which is mentioned on the developer documentation.

Any suggestion on above problems and how to approach them?


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR is made from a branch that is up-to-date with "develop".
- [ ] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
