### PR TITLE
Fix #2870: Revert "Fix #2642: Fix data module tests and make them run on Github Actions"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,16 +63,6 @@ jobs:
          name: utility reports
          path: utility/build/reports
 
-     - name: Data tests
-       # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
-       run: sudo ./gradlew --full-stacktrace :data:testDebugUnitTest
-     - name: Upload Data Test Reports
-       uses: actions/upload-artifact@v2
-       if: ${{ always() }} # IMPORTANT: Upload reports regardless of status
-       with:
-         name: data reports
-         path: data/build/reports
-
      - name: Domain tests
        # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
        run:  sudo ./gradlew --full-stacktrace :domain:testDebugUnitTest -Dorg.gradle.java.home=$JAVA_HOME

--- a/data/src/test/java/org/oppia/android/data/persistence/PersistentCacheStoreTest.kt
+++ b/data/src/test/java/org/oppia/android/data/persistence/PersistentCacheStoreTest.kt
@@ -55,8 +55,8 @@ private const val CACHE_NAME_2 = "test_cache_2"
 @Config(application = PersistentCacheStoreTest.TestApplication::class)
 class PersistentCacheStoreTest {
   private companion object {
-    private val TEST_MESSAGE_VERSION_1 = TestMessage.newBuilder().setIntValue(1).build()
-    private val TEST_MESSAGE_VERSION_2 = TestMessage.newBuilder().setIntValue(2).build()
+    private val TEST_MESSAGE_VERSION_1 = TestMessage.newBuilder().setVersion(1).build()
+    private val TEST_MESSAGE_VERSION_2 = TestMessage.newBuilder().setVersion(2).build()
   }
 
   @Rule


### PR DESCRIPTION
Fixes #2870.

Reverts oppia/oppia-android#2843