### PR TITLE
[RunAllTests] Remove caching for Bazel CI workflows

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -17,6 +17,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04]
+    env:
+      ENABLE_CACHING: false
     steps:
       - uses: actions/checkout@v2
       - name: Clone Oppia Bazel
@@ -38,7 +40,7 @@ jobs:
       # This also uses a different directory to install git-secret to avoid requiring root access
       # when running the git secret command.
       - name: Install git-secret (non-fork only)
-        if: ${{ github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
+        if: ${{ env.ENABLE_CACHING && github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
         shell: bash
         run: |
           cd $HOME
@@ -49,7 +51,7 @@ jobs:
           echo "$HOME/gitsecret" >> $GITHUB_PATH
           echo "$HOME/gitsecret/bin" >> $GITHUB_PATH
       - name: Decrypt secrets (non-fork only)
-        if: ${{ github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
+        if: ${{ env.ENABLE_CACHING && github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
         env:
           GIT_SECRET_GPG_PRIVATE_KEY: ${{ secrets.GIT_SECRET_GPG_PRIVATE_KEY }}
         run: |
@@ -67,13 +69,13 @@ jobs:
           chmod a+x $HOME/oppia-bazel/bazel
       # Note that caching only works on non-forks.
       - name: Build Oppia binary (with caching, non-fork only)
-        if: ${{ github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
+        if: ${{ env.ENABLE_CACHING && github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
         env:
           BAZEL_REMOTE_CACHE_URL: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
         run: |
           $HOME/oppia-bazel/bazel build --override_repository=android_tools=$GITHUB_WORKSPACE/tmp/android_tools --remote_http_cache=$BAZEL_REMOTE_CACHE_URL --google_credentials=./config/oppia-dev-workflow-remote-cache-credentials.json -- //:oppia
-      - name: Build Oppia binary (without caching, fork only)
-        if: ${{ github.event.pull_request.head.repo.full_name != 'oppia/oppia-android' }}
+      - name: Build Oppia binary (without caching, or on a fork)
+        if: ${{ !env.ENABLE_CACHING || github.event.pull_request.head.repo.full_name != 'oppia/oppia-android' }}
         run: |
           $HOME/oppia-bazel/bazel build --override_repository=android_tools=$GITHUB_WORKSPACE/tmp/android_tools -- //:oppia
       - name: Copy Oppia APK for uploading

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -40,7 +40,7 @@ jobs:
       # This also uses a different directory to install git-secret to avoid requiring root access
       # when running the git secret command.
       - name: Install git-secret (non-fork only)
-        if: ${{ env.ENABLE_CACHING && github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
+        if: ${{ env.ENABLE_CACHING == 'true' && github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
         shell: bash
         run: |
           cd $HOME
@@ -51,7 +51,7 @@ jobs:
           echo "$HOME/gitsecret" >> $GITHUB_PATH
           echo "$HOME/gitsecret/bin" >> $GITHUB_PATH
       - name: Decrypt secrets (non-fork only)
-        if: ${{ env.ENABLE_CACHING && github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
+        if: ${{ env.ENABLE_CACHING == 'true' && github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
         env:
           GIT_SECRET_GPG_PRIVATE_KEY: ${{ secrets.GIT_SECRET_GPG_PRIVATE_KEY }}
         run: |
@@ -69,13 +69,13 @@ jobs:
           chmod a+x $HOME/oppia-bazel/bazel
       # Note that caching only works on non-forks.
       - name: Build Oppia binary (with caching, non-fork only)
-        if: ${{ env.ENABLE_CACHING && github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
+        if: ${{ env.ENABLE_CACHING == 'true' && github.event.pull_request.head.repo.full_name == 'oppia/oppia-android' }}
         env:
           BAZEL_REMOTE_CACHE_URL: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
         run: |
           $HOME/oppia-bazel/bazel build --override_repository=android_tools=$GITHUB_WORKSPACE/tmp/android_tools --remote_http_cache=$BAZEL_REMOTE_CACHE_URL --google_credentials=./config/oppia-dev-workflow-remote-cache-credentials.json -- //:oppia
       - name: Build Oppia binary (without caching, or on a fork)
-        if: ${{ !env.ENABLE_CACHING || github.event.pull_request.head.repo.full_name != 'oppia/oppia-android' }}
+        if: ${{ env.ENABLE_CACHING == 'false' || github.event.pull_request.head.repo.full_name != 'oppia/oppia-android' }}
         run: |
           $HOME/oppia-bazel/bazel build --override_repository=android_tools=$GITHUB_WORKSPACE/tmp/android_tools -- //:oppia
       - name: Copy Oppia APK for uploading

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -81,7 +81,7 @@ jobs:
           echo build --android_databinding_use_androidx >> $HOME/.bazelrc
       # See explanation in bazel_build_app for how this is installed.
       - name: Install git-secret (non-fork only)
-        if: ${{ env.ENABLE_CACHING && ((github.ref == 'refs/heads/develop' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == 'oppia/oppia-android')) }}
+        if: ${{ env.ENABLE_CACHING == 'true' && ((github.ref == 'refs/heads/develop' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == 'oppia/oppia-android')) }}
         shell: bash
         run: |
           cd $HOME
@@ -92,7 +92,7 @@ jobs:
           echo "$HOME/gitsecret" >> $GITHUB_PATH
           echo "$HOME/gitsecret/bin" >> $GITHUB_PATH
       - name: Decrypt secrets (non-fork only)
-        if: ${{ env.ENABLE_CACHING && ((github.ref == 'refs/heads/develop' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == 'oppia/oppia-android')) }}
+        if: ${{ env.ENABLE_CACHING == 'true' && ((github.ref == 'refs/heads/develop' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == 'oppia/oppia-android')) }}
         env:
           GIT_SECRET_GPG_PRIVATE_KEY: ${{ secrets.GIT_SECRET_GPG_PRIVATE_KEY }}
         run: |
@@ -103,12 +103,12 @@ jobs:
           cd $GITHUB_WORKSPACE
           git secret reveal
       - name: Run Oppia Test (with caching, non-fork only)
-        if: ${{ env.ENABLE_CACHING && ((github.ref == 'refs/heads/develop' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == 'oppia/oppia-android')) }}
+        if: ${{ env.ENABLE_CACHING == 'true' && ((github.ref == 'refs/heads/develop' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == 'oppia/oppia-android')) }}
         env:
           BAZEL_REMOTE_CACHE_URL: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
         run: bazel test --remote_http_cache=$BAZEL_REMOTE_CACHE_URL --google_credentials=./config/oppia-dev-workflow-remote-cache-credentials.json -- ${{ matrix.test-target }}
       - name: Run Oppia Test (without caching, or on a fork)
-        if: ${{ !env.ENABLE_CACHING || ((github.ref != 'refs/heads/develop' || github.event_name != 'push') && (github.event.pull_request.head.repo.full_name != 'oppia/oppia-android')) }}
+        if: ${{ env.ENABLE_CACHING == 'false' || ((github.ref != 'refs/heads/develop' || github.event_name != 'push') && (github.event.pull_request.head.repo.full_name != 'oppia/oppia-android')) }}
         env:
           BAZEL_REMOTE_CACHE_URL: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
         run: bazel test -- ${{ matrix.test-target }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -60,6 +60,8 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix: ${{fromJson(needs.bazel_compute_affected_targets.outputs.matrix)}}
+    env:
+      ENABLE_CACHING: false
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 9
@@ -79,7 +81,7 @@ jobs:
           echo build --android_databinding_use_androidx >> $HOME/.bazelrc
       # See explanation in bazel_build_app for how this is installed.
       - name: Install git-secret (non-fork only)
-        if: ${{ (github.ref == 'refs/heads/develop' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == 'oppia/oppia-android') }}
+        if: ${{ env.ENABLE_CACHING && ((github.ref == 'refs/heads/develop' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == 'oppia/oppia-android')) }}
         shell: bash
         run: |
           cd $HOME
@@ -90,7 +92,7 @@ jobs:
           echo "$HOME/gitsecret" >> $GITHUB_PATH
           echo "$HOME/gitsecret/bin" >> $GITHUB_PATH
       - name: Decrypt secrets (non-fork only)
-        if: ${{ (github.ref == 'refs/heads/develop' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == 'oppia/oppia-android') }}
+        if: ${{ env.ENABLE_CACHING && ((github.ref == 'refs/heads/develop' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == 'oppia/oppia-android')) }}
         env:
           GIT_SECRET_GPG_PRIVATE_KEY: ${{ secrets.GIT_SECRET_GPG_PRIVATE_KEY }}
         run: |
@@ -101,12 +103,12 @@ jobs:
           cd $GITHUB_WORKSPACE
           git secret reveal
       - name: Run Oppia Test (with caching, non-fork only)
-        if: ${{ (github.ref == 'refs/heads/develop' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == 'oppia/oppia-android') }}
+        if: ${{ env.ENABLE_CACHING && ((github.ref == 'refs/heads/develop' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == 'oppia/oppia-android')) }}
         env:
           BAZEL_REMOTE_CACHE_URL: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
         run: bazel test --remote_http_cache=$BAZEL_REMOTE_CACHE_URL --google_credentials=./config/oppia-dev-workflow-remote-cache-credentials.json -- ${{ matrix.test-target }}
-      - name: Run Oppia Test (without caching, fork only)
-        if: ${{ (github.ref != 'refs/heads/develop' || github.event_name != 'push') && (github.event.pull_request.head.repo.full_name != 'oppia/oppia-android') }}
+      - name: Run Oppia Test (without caching, or on a fork)
+        if: ${{ !env.ENABLE_CACHING || ((github.ref != 'refs/heads/develop' || github.event_name != 'push') && (github.event.pull_request.head.repo.full_name != 'oppia/oppia-android')) }}
         env:
           BAZEL_REMOTE_CACHE_URL: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
         run: bazel test -- ${{ matrix.test-target }}


### PR DESCRIPTION
Bazel caching is currently not cost effective: it only caches 25-30% of actions, and we're not seeing worthwhile performance benefits from it. This PR makes caching configurable for both unit tests and binary builds, and disables it for CI workflows. #1861 is tracking improving this over time, including upstream patching Bazel itself to fix some of the caching issues. We may revisit 
reenabling caching at that time.

Runs verifying that caching is now disabled:
- [Builds](https://github.com/oppia/oppia-android/pull/2884/checks?check_run_id=2084344439)
- [Unit tests](https://github.com/oppia/oppia-android/pull/2884/checks?check_run_id=2084348177)

*Builds*
![image](https://user-images.githubusercontent.com/12983742/110753818-e72a1000-81fb-11eb-962d-9b7165c0ca29.png)

*Unit tests*
![image](https://user-images.githubusercontent.com/12983742/110753949-104aa080-81fc-11eb-9c6d-e5202a401aef.png)
