### PR TITLE
Update README to include dev YouTube channel link

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -57,6 +57,6 @@ The Oppia Android code is released under the [Apache v2 license](https://github.
   * [Blog](https://medium.com/oppia-org)
   * [Discussion forum](http://groups.google.com/group/oppia)
   * [Announcements mailing list](http://groups.google.com/group/oppia-announce)
-  * Social media: [Oppia Team YouTube channel](https://www.youtube.com/channel/UC5c1G7BNDCfv1rczcBp9FPw), [Oppia Developer YouTube channel](https://www.youtube.com/channel/UCsrAX-oeqm0-NIQzQrdiUkQ), [FB](https://www.facebook.com/oppiaorg), [Twitter](https://twitter.com/oppiaorg)
+  * Social media: [Oppia.org YouTube channel](https://www.youtube.com/channel/UC5c1G7BNDCfv1rczcBp9FPw), [Oppia Developer YouTube channel](https://www.youtube.com/channel/UCsrAX-oeqm0-NIQzQrdiUkQ), [FB](https://www.facebook.com/oppiaorg), [Twitter](https://twitter.com/oppiaorg)
 
 We also have public chat rooms on Gitter: [https://gitter.im/oppia/oppia-android](https://gitter.im/oppia/oppia-android). Drop by and say hello!

--- a/.github/README.md
+++ b/.github/README.md
@@ -57,6 +57,6 @@ The Oppia Android code is released under the [Apache v2 license](https://github.
   * [Blog](https://medium.com/oppia-org)
   * [Discussion forum](http://groups.google.com/group/oppia)
   * [Announcements mailing list](http://groups.google.com/group/oppia-announce)
-  * Social media: [YouTube](https://www.youtube.com/channel/UC5c1G7BNDCfv1rczcBp9FPw), [FB](https://www.facebook.com/oppiaorg), [Twitter](https://twitter.com/oppiaorg)
+  * Social media: [Oppia Team YouTube channel](https://www.youtube.com/channel/UC5c1G7BNDCfv1rczcBp9FPw), [Oppia Developer YouTube channel](https://www.youtube.com/channel/UCsrAX-oeqm0-NIQzQrdiUkQ), [FB](https://www.facebook.com/oppiaorg), [Twitter](https://twitter.com/oppiaorg)
 
 We also have public chat rooms on Gitter: [https://gitter.im/oppia/oppia-android](https://gitter.im/oppia/oppia-android). Drop by and say hello!


### PR DESCRIPTION
From Android team meeting today, we realized that the README didn't actually include a reference to the team's developer YouTube channel which is updated more often. We'll likely add tech talks here in the future, as well.