### PR TITLE
Add NOTICE file per Apache license

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -86,6 +86,7 @@ buf.yaml @anandwana001
 
 # Important codebase files.
 LICENSE @BenHenning
+NOTICE @BenHenning
 
 #####################################################################################
 #                                    app module                                     #

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Oppia
+Copyright 2014-2021 The Oppia Authors
+
+This product includes software developed at
+The Oppia Foundation (https://www.oppiafoundation.org/).


### PR DESCRIPTION
Added for Oppia Android for similar reasons as determined in https://github.com/oppia/oppia/pull/6568.