### PR TITLE
Fix #2711: Improve workflow cancellation support in CI

### DIFF
--- a/.github/workflows/workflow_canceller.yml
+++ b/.github/workflows/workflow_canceller.yml
@@ -9,20 +9,17 @@ name: Automatic Workflow Canceller
 # hash of the tip of the branch to ensure it doesn't cancel previous workflows that aren't related
 # to the branch being evaluated.
 on:
-  workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      # Push events on develop branch
-      - develop
+  workflow_run:
+    workflows: ["Build Tests", "Unit Tests (Robolectric -- Gradle)", "Static Checks", "Unit Tests (Robolectric - Bazel)"]
+    types:
+      - requested
 
 jobs:
   cancel:
     name: Cancel Previous Runs
     runs-on: ubuntu-18.04
     steps:
-      # See https://github.com/styfle/cancel-workflow-action for details on this workflow.
-      - uses: styfle/cancel-workflow-action@0.6.0
+      # See https://github.com/styfle/cancel-workflow-action#advanced-pull-requests-from-forks for details on this workflow.
+      - uses: styfle/cancel-workflow-action@0.8.0
         with:
-          workflow_id: main.yml
-          access_token: ${{ github.token }}
+          workflow_id: ${{ github.event.workflow.id }}


### PR DESCRIPTION
Fix #2711.

Per https://github.com/styfle/cancel-workflow-action#advanced-pull-requests-from-forks functionality was recently added (https://github.com/styfle/cancel-workflow-action/pull/55) to:
1. Allow cancellation based on workflows starting (regardless of where they start)
2. Remove the need for the access token, allowing proper fork support (I actually thought this wasn't an issue, but maybe we didn't realize it before)

Both should substantially reduce actions time since subsequent commits should properly cancel everything previous run, both for forks & non-forks. I'm expecting this to fix #2711 but I will need to verify in this PR.