### PR TITLE
Fix #2814: Add label for AdminAuthActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,6 +73,7 @@
       android:name=".app.profile.AddProfileActivity"
       android:theme="@style/OppiaThemeNoActionBarColorAccentColorPrimary" />
     <activity
+      android:label="@string/admin_auth_controls_label"
       android:name=".app.profile.AdminAuthActivity"
       android:theme="@style/OppiaThemeWithoutActionBar"
       android:windowSoftInputMode="adjustResize" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,9 +73,9 @@
       android:name=".app.profile.AddProfileActivity"
       android:theme="@style/OppiaThemeNoActionBarColorAccentColorPrimary" />
     <activity
-      android:label="@string/admin_auth_controls_label"
       android:name=".app.profile.AdminAuthActivity"
       android:theme="@style/OppiaThemeWithoutActionBar"
+      android:label="@string/admin_auth_activity_access_controls_title"
       android:windowSoftInputMode="adjustResize" />
     <activity
       android:name=".app.profile.AdminPinActivity"

--- a/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivityPresenter.kt
@@ -99,7 +99,7 @@ class AdminAuthActivityPresenter @Inject constructor(
   private fun setTitleAndSubTitle(binding: AdminAuthActivityBinding?) {
     when (activity.intent.getIntExtra(ADMIN_AUTH_ENUM_EXTRA_KEY, 0)) {
       AdminAuthEnum.PROFILE_ADMIN_CONTROLS.value -> {
-        activity.title = context.getString(R.string.admin_auth_controls_label)
+        activity.title = context.getString(R.string.admin_auth_activity_access_controls_title)
         binding?.adminAuthToolbar?.title =
           context.resources.getString(R.string.administrator_controls)
         binding?.adminAuthHeadingTextview?.text =
@@ -108,7 +108,7 @@ class AdminAuthActivityPresenter @Inject constructor(
           context.resources.getString(R.string.admin_auth_admin_controls_sub)
       }
       AdminAuthEnum.PROFILE_ADD_PROFILE.value -> {
-        activity.title = context.getString(R.string.admin_auth_add_profiles_label)
+        activity.title = context.getString(R.string.admin_auth_activity_add_profiles_title)
         binding?.adminAuthToolbar?.title = context.resources.getString(R.string.add_profile_title)
         binding?.adminAuthHeadingTextview?.text =
           context.resources.getString(R.string.admin_auth_heading)

--- a/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivityPresenter.kt
@@ -99,6 +99,7 @@ class AdminAuthActivityPresenter @Inject constructor(
   private fun setTitleAndSubTitle(binding: AdminAuthActivityBinding?) {
     when (activity.intent.getIntExtra(ADMIN_AUTH_ENUM_EXTRA_KEY, 0)) {
       AdminAuthEnum.PROFILE_ADMIN_CONTROLS.value -> {
+        activity.title = context.getString(R.string.admin_auth_controls_label)
         binding?.adminAuthToolbar?.title =
           context.resources.getString(R.string.administrator_controls)
         binding?.adminAuthHeadingTextview?.text =
@@ -107,6 +108,7 @@ class AdminAuthActivityPresenter @Inject constructor(
           context.resources.getString(R.string.admin_auth_admin_controls_sub)
       }
       AdminAuthEnum.PROFILE_ADD_PROFILE.value -> {
+        activity.title = context.getString(R.string.admin_auth_add_profiles_label)
         binding?.adminAuthToolbar?.title = context.resources.getString(R.string.add_profile_title)
         binding?.adminAuthHeadingTextview?.text =
           context.resources.getString(R.string.admin_auth_heading)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,8 +198,8 @@
   <string name="profile_chooser_language">Language</string>
   <!-- AdminAuthActivity -->
   <string name="admin_auth_toolbar">Administrator Controls</string>
-  <string name="admin_auth_add_profiles_label">Authorise to add profiles</string>
-  <string name="admin_auth_controls_label">Authorise to access Administrator Controls</string>
+  <string name="admin_auth_activity_add_profiles_title">Authorise to add profiles</string>
+  <string name="admin_auth_activity_access_controls_title">Authorise to access Administrator Controls</string>
   <string name="admin_auth_heading">Administrator Authorization Required</string>
   <string name="admin_auth_sub">Enter the Administrator PIN in order to create a new account.</string>
   <string name="admin_auth_admin_controls_sub">Enter the Administrator PIN in order to access Administrator Controls.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,8 @@
   <string name="profile_chooser_language">Language</string>
   <!-- AdminAuthActivity -->
   <string name="admin_auth_toolbar">Administrator Controls</string>
+  <string name="admin_auth_add_profiles_label">Authorise to add profiles</string>
+  <string name="admin_auth_controls_label">Authorise to access Administrator Controls</string>
   <string name="admin_auth_heading">Administrator Authorization Required</string>
   <string name="admin_auth_sub">Enter the Administrator PIN in order to create a new account.</string>
   <string name="admin_auth_admin_controls_sub">Enter the Administrator PIN in order to access Administrator Controls.</string>

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
@@ -25,7 +25,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.google.android.material.textfield.TextInputLayout
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import dagger.Component
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -633,7 +633,7 @@ class AdminAuthActivityTest {
 
     // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
     // correct string when it's read out.
-    Truth.assertThat(title).isEqualTo(context.getString(R.string.admin_auth_controls_label))
+    assertThat(title).isEqualTo(context.getString(R.string.admin_auth_activity_access_controls_title))
   }
 
   @Test
@@ -651,7 +651,7 @@ class AdminAuthActivityTest {
 
     // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
     // correct string when it's read out.
-    Truth.assertThat(title).isEqualTo(context.getString(R.string.admin_auth_add_profiles_label))
+    assertThat(title).isEqualTo(context.getString(R.string.admin_auth_activity_add_profiles_title))
   }
 
   private fun hasErrorText(@StringRes expectedErrorTextId: Int): Matcher<View> {

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
@@ -619,7 +619,7 @@ class AdminAuthActivityTest {
   }
 
   @Test
-  fun testAdminAuthActivity_hasCorrectActivityLabel_adminControls() {
+  fun testAdminAuthActivity_forProfileAdminControls_hasAuthorizeAccessControlsTitle() {
     activityTestRule.launchActivity(
       AdminAuthActivity.createAdminAuthActivityIntent(
         context = context,
@@ -639,7 +639,7 @@ class AdminAuthActivityTest {
   }
 
   @Test
-  fun testAdminAuthActivity_hasCorrectActivityLabel_addProfiles() {
+  fun testAdminAuthActivity_forAddProfile_hasAuthorizeAddProfileTitle() {
     activityTestRule.launchActivity(
       AdminAuthActivity.createAdminAuthActivityIntent(
         context = context,

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
@@ -23,7 +23,9 @@ import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
 import com.google.android.material.textfield.TextInputLayout
+import com.google.common.truth.Truth
 import dagger.Component
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -32,6 +34,7 @@ import org.hamcrest.Matchers.not
 import org.hamcrest.TypeSafeMatcher
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -100,6 +103,11 @@ class AdminAuthActivityTest {
   lateinit var editTextInputAction: EditTextInputAction
 
   private val internalProfileId: Int = 0
+
+  @get:Rule
+  val activityTestRule: ActivityTestRule<AdminAuthActivity> = ActivityTestRule(
+    AdminAuthActivity::class.java, /* initialTouchMode= */ true, /* launchActivity= */ false
+  )
 
   @Before
   fun setUp() {
@@ -608,6 +616,42 @@ class AdminAuthActivityTest {
       onView(withId(R.id.admin_auth_input_pin))
         .check(matches(hasErrorText(R.string.admin_auth_incorrect)))
     }
+  }
+
+  @Test
+  fun testAdminAuthActivity_hasCorrectActivityLabel_adminControls() {
+    activityTestRule.launchActivity(
+      AdminAuthActivity.createAdminAuthActivityIntent(
+        context = context,
+        adminPin = "12345",
+        profileId = internalProfileId,
+        colorRgb = -10710042,
+        adminPinEnum = AdminAuthEnum.PROFILE_ADMIN_CONTROLS.value
+      )
+    )
+    val title = activityTestRule.activity.title
+
+    // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
+    // correct string when it's read out.
+    Truth.assertThat(title).isEqualTo(context.getString(R.string.admin_auth_controls_label))
+  }
+
+  @Test
+  fun testAdminAuthActivity_hasCorrectActivityLabel_addProfiles() {
+    activityTestRule.launchActivity(
+      AdminAuthActivity.createAdminAuthActivityIntent(
+        context = context,
+        adminPin = "12345",
+        profileId = internalProfileId,
+        colorRgb = -10710042,
+        adminPinEnum = AdminAuthEnum.PROFILE_ADD_PROFILE.value
+      )
+    )
+    val title = activityTestRule.activity.title
+
+    // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
+    // correct string when it's read out.
+    Truth.assertThat(title).isEqualTo(context.getString(R.string.admin_auth_add_profiles_label))
   }
 
   private fun hasErrorText(@StringRes expectedErrorTextId: Int): Matcher<View> {

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
@@ -633,7 +633,9 @@ class AdminAuthActivityTest {
 
     // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
     // correct string when it's read out.
-    assertThat(title).isEqualTo(context.getString(R.string.admin_auth_activity_access_controls_title))
+    assertThat(title).isEqualTo(
+      context.getString(R.string.admin_auth_activity_access_controls_title)
+    )
   }
 
   @Test


### PR DESCRIPTION
## Explanation
Fixes #2814 : Add label for AdminAuthActivity for correct talkback output.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
