### PR TITLE
Fix part of #2833: Added named args in functions of TopicRevisionFragmentTest

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentTest.kt
@@ -112,9 +112,7 @@ class TopicRevisionFragmentTest {
   }
 
   private fun setUpTestApplicationComponent() {
-    ApplicationProvider.getApplicationContext<TestApplication>().inject(
-      topicRevisionFragmentTest = this
-    )
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
   @Test
@@ -279,18 +277,16 @@ class TopicRevisionFragmentTest {
   class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerTopicRevisionFragmentTest_TestApplicationComponent.builder()
-        .setApplication(application = this)
+        .setApplication(this)
         .build() as TestApplicationComponent
     }
 
     fun inject(topicRevisionFragmentTest: TopicRevisionFragmentTest) {
-      component.inject(topicRevisionFragmentTest = topicRevisionFragmentTest)
+      component.inject(topicRevisionFragmentTest)
     }
 
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
-      return component.getActivityComponentBuilderProvider().get().setActivity(
-        appCompatActivity = activity
-      ).build()
+      return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
     }
 
     override fun getApplicationInjector(): ApplicationInjector = component

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentTest.kt
@@ -112,36 +112,58 @@ class TopicRevisionFragmentTest {
   }
 
   private fun setUpTestApplicationComponent() {
-    ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
+    ApplicationProvider.getApplicationContext<TestApplication>().inject(
+      topicRevisionFragmentTest = this
+    )
   }
 
   @Test
   fun testTopicRevisionFragment_loadFragment_displayRevisionTopics_isSuccessful() {
-    launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(
+      internalProfileId = internalProfileId,
+      topicId = FRACTIONS_TOPIC_ID
+    ).use {
       testCoroutineDispatchers.runCurrent()
       clickRevisionTab()
-      onView(atPosition(R.id.revision_recycler_view, 0))
+      onView(atPosition(recyclerViewId = R.id.revision_recycler_view, position = 0))
         .check(matches(hasDescendant(withId(R.id.subtopic_title))))
     }
   }
 
   @Test
   fun testTopicRevisionFragment_loadFragment_selectRevisionTopics_opensRevisionCardActivity() {
-    launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(
+      internalProfileId = internalProfileId,
+      topicId = FRACTIONS_TOPIC_ID
+    ).use {
       testCoroutineDispatchers.runCurrent()
       clickRevisionTab()
       scrollToPosition(position = 0)
-      onView(atPosition(R.id.revision_recycler_view, 0)).perform(click())
+      onView(
+        atPosition(
+          recyclerViewId = R.id.revision_recycler_view,
+          position = 0
+        )
+      ).perform(click())
       intended(hasComponent(RevisionCardActivity::class.java.name))
     }
   }
 
   @Test
   fun testTopicRevisionFragment_loadFragment_checkTopicThumbnail_isCorrect() {
-    launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(
+      internalProfileId = internalProfileId,
+      topicId = FRACTIONS_TOPIC_ID
+    ).use {
       testCoroutineDispatchers.runCurrent()
       clickRevisionTab()
-      onView(atPositionOnView(R.id.revision_recycler_view, 0, R.id.subtopic_image_view)).check(
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.revision_recycler_view,
+          position = 0,
+          targetViewId = R.id.subtopic_image_view
+        )
+      ).check(
         matches(
           withDrawable(
             subtopicThumbnail
@@ -153,22 +175,34 @@ class TopicRevisionFragmentTest {
 
   @Test
   fun testTopicPracticeFragment_loadFragment_configurationChange_revisionSubtopicsAreDisplayed() {
-    launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(
+      internalProfileId = internalProfileId,
+      topicId = FRACTIONS_TOPIC_ID
+    ).use {
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
       clickRevisionTab()
-      onView(atPosition(R.id.revision_recycler_view, 0))
+      onView(atPosition(recyclerViewId = R.id.revision_recycler_view, position = 0))
         .check(matches(hasDescendant(withId(R.id.subtopic_title))))
     }
   }
 
   @Test
   fun testTopicRevisionFragment_loadFragment_configurationChange_checkTopicThumbnail_isCorrect() {
-    launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(
+      internalProfileId = internalProfileId,
+      topicId = FRACTIONS_TOPIC_ID
+    ).use {
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
       clickRevisionTab()
-      onView(atPositionOnView(R.id.revision_recycler_view, 0, R.id.subtopic_image_view)).check(
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.revision_recycler_view,
+          position = 0,
+          targetViewId = R.id.subtopic_image_view
+        )
+      ).check(
         matches(
           withDrawable(
             subtopicThumbnail
@@ -180,7 +214,9 @@ class TopicRevisionFragmentTest {
 
   private fun createTopicActivityIntent(internalProfileId: Int, topicId: String): Intent {
     return TopicActivity.createTopicActivityIntent(
-      ApplicationProvider.getApplicationContext(), internalProfileId, topicId
+      context = ApplicationProvider.getApplicationContext(),
+      internalProfileId = internalProfileId,
+      topicId = topicId
     )
   }
 
@@ -188,13 +224,15 @@ class TopicRevisionFragmentTest {
     internalProfileId: Int,
     topicId: String
   ): ActivityScenario<TopicActivity> {
-    return launch(createTopicActivityIntent(internalProfileId, topicId))
+    return launch(
+      createTopicActivityIntent(internalProfileId = internalProfileId, topicId = topicId)
+    )
   }
 
   private fun clickRevisionTab() {
     onView(
       allOf(
-        withText(TopicTab.getTabForPosition(3).name),
+        withText(TopicTab.getTabForPosition(position = 3).name),
         isDescendantOfA(withId(R.id.topic_tabs_container))
       )
     ).perform(click())
@@ -241,16 +279,18 @@ class TopicRevisionFragmentTest {
   class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerTopicRevisionFragmentTest_TestApplicationComponent.builder()
-        .setApplication(this)
+        .setApplication(application = this)
         .build() as TestApplicationComponent
     }
 
     fun inject(topicRevisionFragmentTest: TopicRevisionFragmentTest) {
-      component.inject(topicRevisionFragmentTest)
+      component.inject(topicRevisionFragmentTest = topicRevisionFragmentTest)
     }
 
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
-      return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
+      return component.getActivityComponentBuilderProvider().get().setActivity(
+        appCompatActivity = activity
+      ).build()
     }
 
     override fun getApplicationInjector(): ApplicationInjector = component


### PR DESCRIPTION
## Explanation
Fix part of  #2833 . Added missing named arguments in the functions of TopicRevisionFragmentTest

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
