### PR TITLE
Fix #2825: Added label for profile rename activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,7 +99,8 @@
       android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.settings.profile.ProfileRenameActivity"
-      android:theme="@style/OppiaThemeWithoutActionBar" />
+      android:theme="@style/OppiaThemeWithoutActionBar"
+      android:label="@string/profile_rename_activity_label"/>
     <activity
       android:name=".app.settings.profile.ProfileResetPinActivity"
       android:theme="@style/OppiaThemeWithoutActionBar" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,8 +99,8 @@
       android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.settings.profile.ProfileRenameActivity"
-      android:theme="@style/OppiaThemeWithoutActionBar"
-      android:label="@string/profile_rename_activity_label"/>
+      android:label="@string/profile_rename_title"
+      android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.settings.profile.ProfileResetPinActivity"
       android:theme="@style/OppiaThemeWithoutActionBar" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,7 +99,7 @@
       android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.settings.profile.ProfileRenameActivity"
-      android:label="@string/profile_rename_title"
+      android:label="@string/profile_rename_activity_title"
       android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.settings.profile.ProfileResetPinActivity"

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileRenameActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileRenameActivityPresenter.kt
@@ -31,7 +31,6 @@ class ProfileRenameActivityPresenter @Inject constructor(
   }
 
   fun handleOnCreate() {
-    activity.title = activity.getString(R.string.profile_rename_activity_title)
     activity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
     activity.supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_arrow_back_white_24dp)
 

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileRenameActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileRenameActivityPresenter.kt
@@ -31,7 +31,7 @@ class ProfileRenameActivityPresenter @Inject constructor(
   }
 
   fun handleOnCreate() {
-    activity.title = activity.getString(R.string.profile_rename_title)
+    activity.title = activity.getString(R.string.profile_rename_activity_title)
     activity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
     activity.supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_arrow_back_white_24dp)
 

--- a/app/src/main/res/layout-land/profile_rename_activity.xml
+++ b/app/src/main/res/layout-land/profile_rename_activity.xml
@@ -32,7 +32,7 @@
         android:minHeight="?attr/actionBarSize"
         app:navigationContentDescription="@string/navigate_up"
         app:navigationIcon="?attr/homeAsUpIndicator"
-        app:title="@string/profile_rename_title"
+        app:title="@string/profile_rename_activity_title"
         app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/profile_rename_activity.xml
+++ b/app/src/main/res/layout/profile_rename_activity.xml
@@ -32,7 +32,7 @@
         android:minHeight="?attr/actionBarSize"
         app:navigationContentDescription="@string/navigate_up"
         app:navigationIcon="?attr/homeAsUpIndicator"
-        app:title="@string/profile_rename_title"
+        app:title="@string/profile_rename_activity_title"
         app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -296,7 +296,7 @@
   <string name="profile_picture_edit_alert_dialog_view_profile_picture">View Profile Picture</string>
   <string name="profile_picture_edit_alert_dialog_choose_from_library">Choose From Library</string>
   <!-- ProfileRenameActivity -->
-  <string name="profile_rename_title">Rename Profile</string>
+  <string name="profile_rename_activity_title">Rename Profile</string>
   <string name="profile_rename_label">New Name</string>
   <string name="profile_rename_save">save</string>
   <!-- ProfileResetPinActivity -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -299,6 +299,7 @@
   <string name="profile_rename_title">Rename Profile</string>
   <string name="profile_rename_label">New Name</string>
   <string name="profile_rename_save">save</string>
+  <string name="profile_rename_activity_label">Profile Rename Activity</string>
   <!-- ProfileResetPinActivity -->
   <string name="profile_reset_pin_title">Reset PIN</string>
   <string name="profile_reset_pin_main">Enter a new PIN for the user to enter when accessing their profile.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -299,7 +299,6 @@
   <string name="profile_rename_title">Rename Profile</string>
   <string name="profile_rename_label">New Name</string>
   <string name="profile_rename_save">save</string>
-  <string name="profile_rename_activity_label">Profile Rename Activity</string>
   <!-- ProfileResetPinActivity -->
   <string name="profile_reset_pin_title">Reset PIN</string>
   <string name="profile_reset_pin_main">Enter a new PIN for the user to enter when accessing their profile.</string>

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
@@ -40,10 +40,10 @@ import org.oppia.android.R
 import org.oppia.android.app.activity.ActivityComponent
 import org.oppia.android.app.application.ActivityComponentFactory
 import org.oppia.android.app.application.ApplicationComponent
-import org.oppia.android.app.application.ApplicationInjectorProvider
 import org.oppia.android.app.application.ApplicationInjector
-import org.oppia.android.app.application.ApplicationStartupListenerModule
+import org.oppia.android.app.application.ApplicationInjectorProvider
 import org.oppia.android.app.application.ApplicationModule
+import org.oppia.android.app.application.ApplicationStartupListenerModule
 import org.oppia.android.app.player.state.hintsandsolution.HintsAndSolutionConfigModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.utility.OrientationChangeAction.Companion.orientationLandscape

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
@@ -136,9 +136,7 @@ class ProfileRenameActivityTest {
     )
 
     val title = activityTestRule.activity.title
-    assertThat(title).isEqualTo(
-      context.getString(R.string.profile_rename_activity_label)
-    )
+    assertThat(title).isEqualTo(context.getString(R.string.profile_rename_title))
   }
 
   @Test

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
@@ -136,7 +136,7 @@ class ProfileRenameActivityTest {
         profileId = 1
       )
     )
-
+    // Check if the activity title matches the resource string
     val title = activityTestRule.activity.title
     assertThat(title).isEqualTo(context.getString(R.string.profile_rename_activity_title))
   }

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
@@ -136,8 +136,10 @@ class ProfileRenameActivityTest {
         profileId = 1
       )
     )
-    // Check if the activity title matches the resource string
     val title = activityTestRule.activity.title
+
+    // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
+    // correct string when it's read out.
     assertThat(title).isEqualTo(context.getString(R.string.profile_rename_activity_title))
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
@@ -108,8 +108,8 @@ class ProfileRenameActivityTest {
   @get:Rule
   val activityTestRule: ActivityTestRule<ProfileRenameActivity> = ActivityTestRule(
     ProfileRenameActivity::class.java,
-    /* initialTouchMode= */true,
-    /* launchActivity= */false
+    /* initialTouchMode= */ true,
+    /* launchActivity= */ false
   )
 
   @Before

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
@@ -38,7 +38,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
 import org.oppia.android.app.activity.ActivityComponent
-import org.oppia.android.app.application.*
+import org.oppia.android.app.application.ActivityComponentFactory
+import org.oppia.android.app.application.ApplicationComponent
+import org.oppia.android.app.application.ApplicationInjectorProvider
+import org.oppia.android.app.application.ApplicationInjector
+import org.oppia.android.app.application.ApplicationStartupListenerModule
+import org.oppia.android.app.application.ApplicationModule
 import org.oppia.android.app.player.state.hintsandsolution.HintsAndSolutionConfigModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.utility.OrientationChangeAction.Companion.orientationLandscape
@@ -127,7 +132,7 @@ class ProfileRenameActivityTest {
   fun testProfileRenameActivity_hasCorrectActivityLabel() {
     activityTestRule.launchActivity(
       ProfileRenameActivity.createProfileRenameActivity(
-        context = context,
+        context = this.context.applicationContext,
         profileId = 1
       )
     )

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
@@ -38,12 +38,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
 import org.oppia.android.app.activity.ActivityComponent
-import org.oppia.android.app.application.ActivityComponentFactory
-import org.oppia.android.app.application.ApplicationComponent
-import org.oppia.android.app.application.ApplicationInjector
-import org.oppia.android.app.application.ApplicationInjectorProvider
-import org.oppia.android.app.application.ApplicationModule
-import org.oppia.android.app.application.ApplicationStartupListenerModule
+import org.oppia.android.app.application.*
 import org.oppia.android.app.player.state.hintsandsolution.HintsAndSolutionConfigModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.utility.OrientationChangeAction.Companion.orientationLandscape
@@ -107,7 +102,9 @@ class ProfileRenameActivityTest {
 
   @get:Rule
   val activityTestRule: ActivityTestRule<ProfileRenameActivity> = ActivityTestRule(
-    ProfileRenameActivity::class.java, true, false
+    ProfileRenameActivity::class.java,
+    /* initialTouchMode= */true,
+    /* launchActivity= */false
   )
 
   @Before
@@ -136,7 +133,7 @@ class ProfileRenameActivityTest {
     )
 
     val title = activityTestRule.activity.title
-    assertThat(title).isEqualTo(context.getString(R.string.profile_rename_title))
+    assertThat(title).isEqualTo(context.getString(R.string.profile_rename_activity_title))
   }
 
   @Test

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
@@ -22,7 +22,9 @@ import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
 import com.google.android.material.textfield.TextInputLayout
+import com.google.common.truth.Truth.assertThat
 import dagger.Component
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.not
@@ -31,6 +33,7 @@ import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -102,6 +105,11 @@ class ProfileRenameActivityTest {
   @Inject
   lateinit var editTextInputAction: EditTextInputAction
 
+  @get:Rule
+  val activityTestRule: ActivityTestRule<ProfileRenameActivity> = ActivityTestRule(
+    ProfileRenameActivity::class.java, true, false
+  )
+
   @Before
   fun setUp() {
     Intents.init()
@@ -116,6 +124,21 @@ class ProfileRenameActivityTest {
 
   private fun setUpTestApplicationComponent() {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
+  }
+
+  @Test
+  fun testProfileRenameActivity_hasCorrectActivityLabel() {
+    activityTestRule.launchActivity(
+      ProfileRenameActivity.createProfileRenameActivity(
+        context = context,
+        profileId = 1
+      )
+    )
+
+    val title = activityTestRule.activity.title
+    assertThat(title).isEqualTo(
+      context.getString(R.string.profile_rename_activity_label)
+    )
   }
 
   @Test


### PR DESCRIPTION
## Explanation
Fix #2825 Added label for profile rename activity to read the title "Profile Rename Activity" when talkback is on

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
