### PR TITLE
Fixes #2427: added configChanges flag to AdministratorControlsActivity in AndroidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
     <meta-data android:name="expiration_date" android:value="2020-09-01" />
     <activity
       android:name=".app.administratorcontrols.AdministratorControlsActivity"
-      android:theme="@style/OppiaThemeWithoutActionBar" />
+      android:theme="@style/OppiaThemeWithoutActionBar"
+      android:configChanges="orientation|screenSize"/>
     <activity
       android:name=".app.administratorcontrols.appversion.AppVersionActivity"
       android:theme="@style/OppiaThemeWithoutActionBar" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
     <activity
       android:name=".app.administratorcontrols.AdministratorControlsActivity"
       android:theme="@style/OppiaThemeWithoutActionBar"
-      android:configChanges="orientation|screenSize"/>
+      android:configChanges="orientation|screenSize" />
     <activity
       android:name=".app.administratorcontrols.appversion.AppVersionActivity"
       android:theme="@style/OppiaThemeWithoutActionBar" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,8 +19,7 @@
     <meta-data android:name="expiration_date" android:value="2020-09-01" />
     <activity
       android:name=".app.administratorcontrols.AdministratorControlsActivity"
-      android:theme="@style/OppiaThemeWithoutActionBar"
-      android:configChanges="orientation|screenSize" />
+      android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.administratorcontrols.appversion.AppVersionActivity"
       android:theme="@style/OppiaThemeWithoutActionBar" />

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivity.kt
@@ -16,6 +16,7 @@ const val SELECTED_CONTROLS_TITLE_SAVED_KEY =
 const val LAST_LOADED_FRAGMENT_KEY = "LAST_LOADED_FRAGMENT_KEY"
 const val PROFILE_LIST_FRAGMENT = "PROFILE_LIST_FRAGMENT"
 const val APP_VERSION_FRAGMENT = "APP_VERSION_FRAGMENT"
+const val CHECK_DIALOG = "CHECK_DIALOG"
 
 /** Activity for Administrator Controls. */
 class AdministratorControlsActivity :
@@ -40,6 +41,10 @@ class AdministratorControlsActivity :
     }
     administratorControlsActivityPresenter.handleOnCreate(extraControlsTitle, lastLoadedFragment)
     title = getString(R.string.administrator_controls)
+    if (savedInstanceState != null) {
+      if (savedInstanceState.getBoolean(CHECK_DIALOG))
+        callDialog()
+    }
   }
 
   override fun onCreateOptionsMenu(menu: Menu?): Boolean {
@@ -81,8 +86,18 @@ class AdministratorControlsActivity :
     administratorControlsActivityPresenter.loadAppVersion()
   }
 
+  fun getDialog(): Boolean? = administratorControlsActivityPresenter.getDialog()
+
+  private fun callDialog() {
+    administratorControlsActivityPresenter.callDialog()
+  }
+
   override fun onSaveInstanceState(outState: Bundle) {
     administratorControlsActivityPresenter.handleOnSaveInstanceState(outState)
+    val check = getDialog()
+    if (check != null) {
+      outState.putBoolean(CHECK_DIALOG, check)
+    }
     super.onSaveInstanceState(outState)
   }
 }

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityPresenter.kt
@@ -101,4 +101,10 @@ class AdministratorControlsActivityPresenter @Inject constructor(
     }
     outState.putString(LAST_LOADED_FRAGMENT_KEY, lastLoadedFragment)
   }
+
+  fun getDialog(): Boolean? = getAdministratorControlsFragment()?.getDialog()
+
+  fun callDialog() {
+    getAdministratorControlsFragment()?.callDialog()
+  }
 }

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragment.kt
@@ -46,4 +46,10 @@ class AdministratorControlsFragment : InjectableFragment() {
   fun setSelectedFragment(selectedFragment: String) {
     administratorControlsFragmentPresenter.setSelectedFragment(selectedFragment)
   }
+
+  fun getDialog(): Boolean = administratorControlsFragmentPresenter.getDialog()
+
+  fun callDialog() {
+    administratorControlsFragmentPresenter.callDialog()
+  }
 }

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentPresenter.kt
@@ -165,6 +165,12 @@ class AdministratorControlsFragmentPresenter @Inject constructor(
     }
   }
 
+  fun getDialog(): Boolean = administratorControlsViewModel.getDialog()
+
+  fun callDialog() {
+    administratorControlsViewModel.callDialog()
+  }
+
   private enum class ViewType {
     VIEW_TYPE_GENERAL,
     VIEW_TYPE_PROFILE,

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsViewModel.kt
@@ -35,6 +35,8 @@ class AdministratorControlsViewModel @Inject constructor(
   private val loadProfileListListener = activity as LoadProfileListListener
   private lateinit var userProfileId: ProfileId
   val selectedFragmentIndex = ObservableField<Int>(1)
+  val administratorControlsAccountActionsViewModel =
+    AdministratorControlsAccountActionsViewModel(fragment, IntentFactoryShim)
 
   private val deviceSettingsLiveData: LiveData<DeviceSettings> by lazy {
     Transformations.map(
@@ -90,6 +92,12 @@ class AdministratorControlsViewModel @Inject constructor(
     )
 
     return itemViewModelList
+  }
+
+  fun getDialog(): Boolean = administratorControlsAccountActionsViewModel.getDialog()
+
+  fun callDialog() {
+    administratorControlsAccountActionsViewModel.onLogOutClicked()
   }
 
   fun setProfileId(profileId: ProfileId) {

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/administratorcontrolsitemviewmodel/AdministratorControlsAccountActionsViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/administratorcontrolsitemviewmodel/AdministratorControlsAccountActionsViewModel.kt
@@ -6,6 +6,8 @@ import androidx.fragment.app.Fragment
 import org.oppia.android.R
 import org.oppia.android.app.shim.IntentFactoryShim
 
+private var isDialogVisible = false
+
 /** [ViewModel] for the recycler view in [AdministratorControlsFragment]. */
 class AdministratorControlsAccountActionsViewModel(
   private val fragment: Fragment,
@@ -13,6 +15,7 @@ class AdministratorControlsAccountActionsViewModel(
 ) : AdministratorControlsItemViewModel() {
 
   fun onLogOutClicked() {
+    isDialogVisible = true
     AlertDialog.Builder(fragment.context!!, R.style.AlertDialogTheme)
       .setMessage(R.string.log_out_dialog_message)
       .setNegativeButton(R.string.log_out_dialog_cancel_button) { dialog, _ ->
@@ -24,6 +27,10 @@ class AdministratorControlsAccountActionsViewModel(
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         fragment.activity!!.startActivity(intent)
         fragment.activity!!.finish()
+      }.setOnDismissListener {
+        isDialogVisible = false
       }.create().show()
   }
+
+  fun getDialog(): Boolean = isDialogVisible
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #2427 
Since the Administrator Controls Activity doesn't need to update resources during orientation change so I have used configChanges flag for the activity in android manifest. So putting that in the configuration file avoids the system to destroy the AdministratorControlsActivity. Instead, it invokes the onConfigurationChanged(Configuration) method
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
