### PR TITLE
Fix #2810: Added label for CompletedStoryListActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
       android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.completedstorylist.CompletedStoryListActivity"
+      android:label="@string/completed_story_list_activity_title"
       android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.help.faq.FAQListActivity"

--- a/app/src/main/res/layout-land/completed_story_list_fragment.xml
+++ b/app/src/main/res/layout-land/completed_story_list_fragment.xml
@@ -32,7 +32,7 @@
         android:minHeight="?attr/actionBarSize"
         app:navigationContentDescription="@string/navigate_up"
         app:navigationIcon="?attr/homeAsUpIndicator"
-        app:title="@string/stories_completed"
+        app:title="@string/completed_story_list_activity_title"
         app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout-sw600dp-land/completed_story_list_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-land/completed_story_list_fragment.xml
@@ -32,7 +32,7 @@
         android:minHeight="?attr/actionBarSize"
         app:navigationContentDescription="@string/navigate_up"
         app:navigationIcon="?attr/homeAsUpIndicator"
-        app:title="@string/stories_completed"
+        app:title="@string/completed_story_list_activity_title"
         app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout-sw600dp-port/completed_story_list_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-port/completed_story_list_fragment.xml
@@ -33,7 +33,7 @@
         app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:navigationContentDescription="@string/navigate_up"
         app:navigationIcon="?attr/homeAsUpIndicator"
-        app:title="@string/stories_completed"
+        app:title="@string/completed_story_list_activity_title"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/layout/completed_story_list_fragment.xml
+++ b/app/src/main/res/layout/completed_story_list_fragment.xml
@@ -32,7 +32,7 @@
         android:minHeight="?attr/actionBarSize"
         app:navigationContentDescription="@string/navigate_up"
         app:navigationIcon="?attr/homeAsUpIndicator"
-        app:title="@string/stories_completed"
+        app:title="@string/completed_story_list_activity_title"
         app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white" />
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -350,6 +350,8 @@
   <string name="topic_in_progress">Topic in Progress</string>
   <string name="stories_completed">Stories Completed</string>
   <string name="story_completed">Story Completed</string>
+  <!-- CompletedStoryListActivity -->
+  <string name="completed_story_list_activity_title">Stories Completed</string>
   <!-- WalkthroughActivity -->
   <string name="walkthrough_welcome_description">Learn new math skills with stories that show you how to use them in your daily life</string>
   <string name="welcome">"Welcome %s!"</string>

--- a/app/src/sharedTest/java/org/oppia/android/app/completedstorylist/CompletedStoryListActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/completedstorylist/CompletedStoryListActivityTest.kt
@@ -96,7 +96,9 @@ class CompletedStoryListActivityTest {
 
   @get:Rule
   val activityTestRule = ActivityTestRule(
-    CompletedStoryListActivity::class.java,/* initialTouchMode= */ true,/* launchActivity= */ false
+    CompletedStoryListActivity::class.java,
+    /* initialTouchMode= */ true,
+    /* launchActivity= */ false
   )
 
   @Inject

--- a/app/src/sharedTest/java/org/oppia/android/app/completedstorylist/CompletedStoryListActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/completedstorylist/CompletedStoryListActivityTest.kt
@@ -20,10 +20,13 @@ import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import com.google.common.truth.Truth.assertThat
 import dagger.Component
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -91,6 +94,9 @@ class CompletedStoryListActivityTest {
   private val internalProfileId = 0
   private val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
 
+  @get:Rule
+  val activityTestRule = ActivityTestRule(CompletedStoryListActivity::class.java)
+
   @Inject
   lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
 
@@ -128,6 +134,16 @@ class CompletedStoryListActivityTest {
 
   private fun setUpTestApplicationComponent() {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
+  }
+
+  @Test
+  fun testFAQListActivity_hasCorrectActivityLabel() {
+    activityTestRule.launchActivity(createCompletedStoryListActivityIntent(internalProfileId))
+    val title = activityTestRule.activity.title
+
+    // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
+    // correct string when it's read out.
+    assertThat(title).isEqualTo(context.getString(R.string.completed_story_list_activity_title))
   }
 
   @Test

--- a/app/src/sharedTest/java/org/oppia/android/app/completedstorylist/CompletedStoryListActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/completedstorylist/CompletedStoryListActivityTest.kt
@@ -95,7 +95,9 @@ class CompletedStoryListActivityTest {
   private val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
 
   @get:Rule
-  val activityTestRule = ActivityTestRule(CompletedStoryListActivity::class.java)
+  val activityTestRule = ActivityTestRule(
+    CompletedStoryListActivity::class.java,/* initialTouchMode= */ true,/* launchActivity= */ false
+  )
 
   @Inject
   lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
@@ -137,7 +139,7 @@ class CompletedStoryListActivityTest {
   }
 
   @Test
-  fun testFAQListActivity_hasCorrectActivityLabel() {
+  fun testCompletedStoryList_hasCorrectActivityLabel() {
     activityTestRule.launchActivity(createCompletedStoryListActivityIntent(internalProfileId))
     val title = activityTestRule.activity.title
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation

Fixes #2810

Added label for CompletedStoryListActivity to read "Stories Completed" when talkback is on.

Created a common string resource "completed_story_list_activity_title" for all layouts of this activty.

Added test for CompletedStoryListActivity title.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
