### PR TITLE
Fix #2092: Make dialog survive config change

### DIFF
--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivity.kt
@@ -8,6 +8,8 @@ import javax.inject.Inject
 
 const val PROFILE_EDIT_PROFILE_ID_EXTRA_KEY = "ProfileEditActivity.profile_edit_profile_id"
 const val IS_MULTIPANE_EXTRA_KEY = "ProfileEditActivity.is_multipane"
+const val IS_PROFILE_DELETION_DIALOG_VISIBLE_KEY =
+  "ProfileEditActivity.is_profile_deletion_dialog_visible"
 
 /** Activity that allows user to edit a profile. */
 class ProfileEditActivity : InjectableAppCompatActivity() {
@@ -30,7 +32,7 @@ class ProfileEditActivity : InjectableAppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     activityComponent.inject(this)
-    profileEditActivityPresenter.handleOnCreate()
+    profileEditActivityPresenter.handleOnCreate(savedInstanceState)
   }
 
   override fun onSupportNavigateUp(): Boolean {
@@ -54,5 +56,10 @@ class ProfileEditActivity : InjectableAppCompatActivity() {
       intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
       startActivity(intent)
     }
+  }
+
+  override fun onSaveInstanceState(outState: Bundle) {
+    super.onSaveInstanceState(outState)
+    profileEditActivityPresenter.handleOnSaveInstanceState(outState)
   }
 }

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivityPresenter.kt
@@ -1,6 +1,7 @@
 package org.oppia.android.app.settings.profile
 
 import android.content.Intent
+import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
@@ -26,7 +27,9 @@ class ProfileEditActivityPresenter @Inject constructor(
   @Inject
   lateinit var profileEditViewModel: ProfileEditViewModel
 
-  fun handleOnCreate() {
+  private var dialog: AlertDialog? = null
+
+  fun handleOnCreate(savedInstanceState: Bundle?) {
     activity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
     activity.supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_arrow_back_white_24dp)
 
@@ -93,10 +96,12 @@ class ProfileEditActivityPresenter @Inject constructor(
         )
       }
     }
+    if (savedInstanceState?.getBoolean(IS_PROFILE_DELETION_DIALOG_VISIBLE_KEY) == true)
+      showDeletionDialog(profileId)
   }
 
   private fun showDeletionDialog(profileId: Int) {
-    AlertDialog.Builder(activity, R.style.AlertDialogTheme)
+    dialog = AlertDialog.Builder(activity, R.style.AlertDialogTheme)
       .setTitle(R.string.profile_edit_delete_dialog_title)
       .setMessage(R.string.profile_edit_delete_dialog_message)
       .setNegativeButton(R.string.profile_edit_delete_dialog_negative) { dialog, _ ->
@@ -121,6 +126,11 @@ class ProfileEditActivityPresenter @Inject constructor(
               }
             }
           )
-      }.create().show()
+      }.create()
+    dialog!!.show()
+  }
+
+  fun handleOnSaveInstanceState(outState: Bundle) {
+    outState.putBoolean(IS_PROFILE_DELETION_DIALOG_VISIBLE_KEY, dialog?.isShowing ?: false)
   }
 }

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivityPresenter.kt
@@ -27,7 +27,7 @@ class ProfileEditActivityPresenter @Inject constructor(
   @Inject
   lateinit var profileEditViewModel: ProfileEditViewModel
 
-  private var dialog: AlertDialog? = null
+  private lateinit var dialog: AlertDialog
 
   fun handleOnCreate(savedInstanceState: Bundle?) {
     activity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
@@ -127,10 +127,11 @@ class ProfileEditActivityPresenter @Inject constructor(
             }
           )
       }.create()
-    dialog!!.show()
+    dialog.show()
   }
 
   fun handleOnSaveInstanceState(outState: Bundle) {
-    outState.putBoolean(IS_PROFILE_DELETION_DIALOG_VISIBLE_KEY, dialog?.isShowing ?: false)
+    val isDialogVisible = ::dialog.isInitialized && dialog.isShowing
+    outState.putBoolean(IS_PROFILE_DELETION_DIALOG_VISIBLE_KEY, isDialogVisible)
   }
 }

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -15,6 +15,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
+import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -318,7 +319,7 @@ class ProfileEditActivityTest {
         .inRoot(isDialog())
         .check(
           matches(
-            isDisplayed()
+            isCompletelyDisplayed()
           )
         )
     }

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -304,6 +304,27 @@ class ProfileEditActivityTest {
   }
 
   @Test
+  fun testProfileEdit_startWithUserProfile_clickDelete_configChange_checkDeletionDialogIsVisible() {
+    launch<ProfileEditActivity>(
+      ProfileEditActivity.createProfileEditActivity(
+        context,
+        profileId = 1
+      )
+    ).use {
+      onView(withId(R.id.profile_delete_button)).perform(click())
+      onView(isRoot()).perform(orientationLandscape())
+      testCoroutineDispatchers.runCurrent()
+      onView(withText(R.string.profile_edit_delete_dialog_message))
+        .inRoot(isDialog())
+        .check(
+          matches(
+            isDisplayed()
+          )
+        )
+    }
+  }
+
+  @Test
   fun testProfileEdit_deleteProfile_checkReturnsToProfileListOnPhoneOrAdminControlOnTablet() {
     launch<ProfileEditActivity>(
       ProfileEditActivity.createProfileEditActivity(

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -312,7 +312,7 @@ class ProfileEditActivityTest {
         profileId = 1
       )
     ).use {
-      onView(withId(R.id.profile_delete_button)).perform(click())
+      onView(withId(R.id.profile_delete_button)).perform(scrollTo()).perform(click())
       onView(isRoot()).perform(orientationLandscape())
       testCoroutineDispatchers.runCurrent()
       onView(withText(R.string.profile_edit_delete_dialog_message))


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #2092: I simply saved whether the dialog was visible or not in the saveInstanceState bundle and recreated the dialog in onCreate() if it was open before.

Screenshot of test result:
![image](https://user-images.githubusercontent.com/51705072/113091337-5ac2aa00-9209-11eb-9d12-4ee1f031e574.png)

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
