### PR TITLE
Update compute_affected_tests.sh

### DIFF
--- a/scripts/compute_affected_tests.sh
+++ b/scripts/compute_affected_tests.sh
@@ -15,7 +15,7 @@
 BAZEL_BINARY=$1
 
 # Reference: https://stackoverflow.com/a/6245587.
-current_branch=$(git branch --show-current)
+current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 if [[ "$current_branch" != "develop" ]]; then
   # Compute all files that have been changed on this branch. https://stackoverflow.com/a/9294015 for


### PR DESCRIPTION
Update affected targets script to work on versions of git older than 2.22. See https://stackoverflow.com/a/6245587 for specifics.

I ran into this locally--I'm using git 2.7.4 and can't seem to update it, so having the more compatible approach seems ideal.