### PR TITLE
Fix part of #2637: Added accessibilty label to the RevisionCardActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -157,7 +157,8 @@
       android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.topic.revisioncard.RevisionCardActivity"
-      android:theme="@style/OppiaThemeWithoutActionBar" />
+      android:theme="@style/OppiaThemeWithoutActionBar"
+      android:label="@string/revision_card_activity_title" />
     <activity
       android:name=".app.topic.TopicActivity"
       android:theme="@style/OppiaThemeWithoutActionBar"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -435,4 +435,5 @@
   <string name="coming_soon">Coming Soon</string>
   <string name="recommended_stories">Recommended Stories</string>
   <string name="stories_for_you">Stories For You</string>
+  <string name="revision_card_activity_title">Skill page</string>
 </resources>

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityTest.kt
@@ -1,0 +1,58 @@
+package org.oppia.android.app.topic.revisioncard
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.rule.ActivityTestRule
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.oppia.android.R
+import org.oppia.android.domain.topic.TEST_TOPIC_ID_0
+import javax.inject.Inject
+
+class RevisionCardActivityTest {
+
+  @Inject
+  lateinit var context: Context
+
+  private val internalProfileId = 0
+
+  private val subTopicId = 0
+
+  private fun createRevisionCardActivityIntent(
+    internalProfileId: Int,
+    topicId: String,
+    subTopicId: Int
+  ): Intent {
+    return RevisionCardActivity.createRevisionCardActivityIntent(
+      ApplicationProvider.getApplicationContext(),
+      internalProfileId,
+      topicId,
+      subTopicId
+    )
+  }
+
+  @get:Rule
+  val activityTestRule: ActivityTestRule<RevisionCardActivity> = ActivityTestRule(
+    RevisionCardActivity::class.java,
+    /* initialTouchMode= */ true,
+    /* launchActivity= */ false
+  )
+
+  @Test
+  fun testRevisionCardActivity_hasCorrectLabel() {
+    activityTestRule.launchActivity(
+      createRevisionCardActivityIntent(
+        internalProfileId = internalProfileId,
+        topicId = TEST_TOPIC_ID_0,
+        subTopicId = subTopicId
+      )
+    )
+    val title = activityTestRule.activity.title
+
+    // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
+    // correct string when it's read out.
+    assertThat(title).isEqualTo(context.getString(R.string.revision_card_activity_title))
+  }
+}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->
Whenever RevisionCardActivity was clicked it used to say Oppia instead changed it to Skill page.
Fixes part of #2637 
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
