### PR TITLE
Update Robolectric to 4.4 to avoid 501 error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -141,8 +141,8 @@ dependencies {
       'androidx.test.ext:junit:1.1.1',
       'com.github.bumptech.glide:mocks:4.11.0',
       'com.google.truth:truth:0.43',
-      'org.robolectric:annotations:4.3',
-      'org.robolectric:robolectric:4.3',
+      'org.robolectric:annotations:4.4',
+      'org.robolectric:robolectric:4.4',
       'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.2',
       "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version",
       'org.mockito:mockito-core:2.7.22',
@@ -158,7 +158,7 @@ dependencies {
       'com.google.truth:truth:0.43',
       'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.2',
       'org.mockito:mockito-android:2.7.22',
-      'org.robolectric:annotations:4.3',
+      'org.robolectric:annotations:4.4',
   )
   // Adding the testing module directly causes duplicates of the below groups so we need to
   // exclude them before adding the testing module to the androidTestImplementation dependencies

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -85,7 +85,7 @@ dependencies {
       'junit:junit:4.12',
       'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.2',
       'org.mockito:mockito-core:2.19.0',
-      'org.robolectric:robolectric:4.3',
+      'org.robolectric:robolectric:4.4',
       project(":testing"),
   )
   // TODO (#59): Remove this once Bazel is introduced

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -87,7 +87,7 @@ dependencies {
       'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.2',
       'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.2',
       'org.mockito:mockito-core:2.19.0',
-      'org.robolectric:robolectric:4.3',
+      'org.robolectric:robolectric:4.4',
       project(":testing"),
   )
   kapt(

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -57,7 +57,7 @@ dependencies {
       'com.google.truth:truth:0.43',
       'nl.dionsegijn:konfetti:1.2.5',
       'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.2',
-      'org.robolectric:robolectric:4.3',
+      'org.robolectric:robolectric:4.4',
       'org.jetbrains.kotlin:kotlin-reflect:$kotlin_version',
       'org.mockito:mockito-core:2.19.0',
       project(":domain"),

--- a/third_party/versions.bzl
+++ b/third_party/versions.bzl
@@ -85,8 +85,8 @@ MAVEN_TEST_DEPENDENCY_VERSIONS = {
     "org.jetbrains.kotlin:kotlin-test-junit": "1.3.72",
     "org.jetbrains.kotlinx:kotlinx-coroutines-test": "1.2.2",
     "org.mockito:mockito-core": "2.19.0",
-    "org.robolectric:annotations": "4.3",
-    "org.robolectric:robolectric": "4.3",
+    "org.robolectric:annotations": "4.4",
+    "org.robolectric:robolectric": "4.4",
 }
 
 # Note to developers: Please keep this dict sorted by key to make it easier to find dependencies.

--- a/utility/build.gradle
+++ b/utility/build.gradle
@@ -85,7 +85,7 @@ dependencies {
       "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version",
       'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.2',
       'org.mockito:mockito-core:2.19.0',
-      'org.robolectric:robolectric:4.3',
+      'org.robolectric:robolectric:4.4',
       project(":testing"),
   )
   kapt(


### PR DESCRIPTION
Updating Robolectric from 4.3 to 4.4 to avoid 501 Error when downloading artifacts (Ref - [Error](https://gist.github.com/FareesHussain/354b2a545fb63adfe36074a60d4370b5))

https://github.com/robolectric/robolectric/issues/5456#issuecomment-679350887 for context.

