### PR TITLE
Enable D8 dex merging

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@ build --android_databinding_use_v3_4_args \
     --experimental_android_databinding_v2 \
     --java_header_compilation=false \
     --noincremental_dexing \
-    --define=android_standalone_dexing_tool=d8_compat_dx
+    --nouse_workers_with_dexbuilder
 
 # Show all test output by default (for better debugging).
 test --test_output=all


### PR DESCRIPTION
## Explanation
This enables D8 dex merging in Bazel builds since it seems the compatibility version doesn't seem to work with the latest SDK tools (31.0.1).

https://github.com/bazelbuild/bazel/issues/10287#issuecomment-584822816 has a bit more context on why these particular flags are necessary.

Note that the binary building successfully on CI should be a sufficient check to ensure nothing has regressed. I've verified locally that the build runs.