### PR TITLE
Fix #2947: Test cases are flaking in the FakeOppiaClockTest

### DIFF
--- a/testing/src/test/java/org/oppia/android/testing/time/FakeOppiaClockTest.kt
+++ b/testing/src/test/java/org/oppia/android/testing/time/FakeOppiaClockTest.kt
@@ -134,10 +134,10 @@ class FakeOppiaClockTest {
     val currentTimeMs = System.currentTimeMillis()
     val reportedTimeMs = fakeOppiaClock.getCurrentTimeMs()
 
-    // Verify that the reported time is within 4ms of actual time (to provide some guard against
+    // Verify that the reported time is within 100ms of actual time (to provide some guard against
     // flakiness since this is testing real clock time).
     assertThat(reportedTimeMs).isWithin((currentTimeMs - 50)..(currentTimeMs + 50))
-    // Sanity check that the fake is, indeed, using real clock time
+    // Sanity check that the fake is, indeed, using real clock time.
     assertThat(reportedTimeMs).isNotEqualTo(0)
   }
 
@@ -190,7 +190,7 @@ class FakeOppiaClockTest {
     val currentTimeMs = System.currentTimeMillis()
     val calendar = fakeOppiaClock.getCurrentCalendar()
 
-    // The calendar should be inited to a value close to the clock time at the time it was created.
+    // The calendar should be initiated to a value close to the clock time at the time it was created.
     assertThat(calendar.timeInMillis).isWithin((currentTimeMs - 50)..(currentTimeMs + 50))
   }
 

--- a/testing/src/test/java/org/oppia/android/testing/time/FakeOppiaClockTest.kt
+++ b/testing/src/test/java/org/oppia/android/testing/time/FakeOppiaClockTest.kt
@@ -136,7 +136,7 @@ class FakeOppiaClockTest {
 
     // Verify that the reported time is within 4ms of actual time (to provide some guard against
     // flakiness since this is testing real clock time).
-    assertThat(reportedTimeMs).isWithin((currentTimeMs - 2)..(currentTimeMs + 2))
+    assertThat(reportedTimeMs).isWithin((currentTimeMs - 50)..(currentTimeMs + 50))
     // Sanity check that the fake is, indeed, using real clock time
     assertThat(reportedTimeMs).isNotEqualTo(0)
   }
@@ -191,7 +191,7 @@ class FakeOppiaClockTest {
     val calendar = fakeOppiaClock.getCurrentCalendar()
 
     // The calendar should be inited to a value close to the clock time at the time it was created.
-    assertThat(calendar.timeInMillis).isWithin((currentTimeMs - 2)..(currentTimeMs + 2))
+    assertThat(calendar.timeInMillis).isWithin((currentTimeMs - 50)..(currentTimeMs + 50))
   }
 
   @Test


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #2947: Delay between reported time and current time increased to 100m/s
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
## Screenshots of Tests
1. ``` testGetCurrentCalendar_wallClockMode_returnsCalendarWithCurrentTimeMillis()``` run 100 times

![image](https://user-images.githubusercontent.com/55680995/112547512-daeba880-8de0-11eb-95ed-de8f7d4ab58d.png)

``` testGetCurrentCalendar_wallClockMode_returnsCalendarWithCurrentTimeMillis()``` run 1000 times

![image](https://user-images.githubusercontent.com/55680995/112610165-66495600-8e42-11eb-8148-8964c2842152.png)


2. ```testGetCurrentTimeMs_wallClockMode_returnsCurrentTimeMillis()``` run 100 times

![image](https://user-images.githubusercontent.com/55680995/112547485-d2936d80-8de0-11eb-9f71-e300b48df060.png)

```testGetCurrentTimeMs_wallClockMode_returnsCurrentTimeMillis()``` run 1000 times

![image](https://user-images.githubusercontent.com/55680995/112610591-dfe14400-8e42-11eb-8fcb-d0b63655d1f0.png)


3. Complete Test File ```FakeOppiaClockTest.kt``` run 100 times

![image](https://user-images.githubusercontent.com/55680995/112547547-e343e380-8de0-11eb-8144-1483cb76e934.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
