### PR TITLE
Revert "Enable D8 dex merging"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@ build --android_databinding_use_v3_4_args \
     --experimental_android_databinding_v2 \
     --java_header_compilation=false \
     --noincremental_dexing \
-    --nouse_workers_with_dexbuilder
+    --define=android_standalone_dexing_tool=d8_compat_dx
 
 # Show all test output by default (for better debugging).
 test --test_output=all


### PR DESCRIPTION
Reverts oppia/oppia-android#3014

It turns out that my issue was actually due to upgrading my build tools version past 31.0 which we don't currently support. While switching to R8 is preferable, it doesn't currently work with desugared classes. This seems like a Bazel issue that needs to be addressed, but we can mitigate it for now by keeping D8 compat and ensuring we don't use newer Android build tools.