### PR TITLE
[RunAllTests] Fix part of #1861: Enable GitHub Actions caching for Bazel CI workflows

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -45,8 +45,10 @@ jobs:
         id: cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
-          key: ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-${{ github.sha }}
+          key: ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-
+            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-tests-
             ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-
 
       # This check is needed to ensure that Bazel's unbounded cache growth doesn't result in a

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-18.04]
     env:
       ENABLE_CACHING: false
-      CACHE_DIRECTORY: $HOME/.bazel_cache
+      CACHE_DIRECTORY: ~/.bazel_cache
     steps:
       - uses: actions/checkout@v2
 
@@ -86,7 +86,11 @@ jobs:
 
       - name: Configure Bazel to use a local cache
         run: |
-          echo "build --disk_cache=$BAZEL_CACHE_DIR" >> $HOME/.bazelrc
+          # See https://stackoverflow.com/a/27485157 for reference.
+          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
+          echo "Using $EXPANDED_BAZEL_CACHE_PATH as Bazel's cache path"
+          echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
+        shell: bash
         env:
           BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
 

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -154,5 +154,5 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: oppia-bazel-apk
+          name: oppia-bazel.apk
           path: /home/runner/work/oppia-android/oppia-android/oppia.apk

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           path: ${{ env.CACHE_DIRECTORY }}
           key: ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-${{ github.sha }}
-          restory-keys: |
+          restore-keys: |
             ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-
 
       # This check is needed to ensure that Bazel's unbounded cache growth doesn't result in a

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -55,8 +55,12 @@ jobs:
       # few slower CI actions around the time cache is detected to be too large, but it should
       # incrementally improve thereafter.
       - name: Ensure cache size
+        env:
+          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
         run: |
-          CACHE_SIZE_MB=$(du -smc $BAZEL_CACHE_DIR | grep total | cut -f1)
+          # See https://stackoverflow.com/a/27485157 for reference.
+          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
+          CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_PATH | grep total | cut -f1)
           echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
           # Use a 4.5GB threshold since actions/cache compresses the results, and Bazel caches seem
           # to only increase by a few hundred megabytes across changes for unrelated branches. This
@@ -65,10 +69,8 @@ jobs:
           # compressed cache).
           if [[ "$CACHE_SIZE_MB" -gt 4500 ]]; then
             echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
-            rm -rf $BAZEL_CACHE_DIR
+            rm -rf $EXPANDED_BAZEL_CACHE_PATH
           fi
-        env:
-          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
 
       - name: Set up Bazel
         uses: abhinavsingh/setup-bazel@v3
@@ -85,14 +87,13 @@ jobs:
           echo "build:linux --sandbox_tmpfs_path=/tmp" >> $HOME/.bazelrc
 
       - name: Configure Bazel to use a local cache
+        env:
+          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
         run: |
-          # See https://stackoverflow.com/a/27485157 for reference.
           EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
           echo "Using $EXPANDED_BAZEL_CACHE_PATH as Bazel's cache path"
           echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
         shell: bash
-        env:
-          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
 
       - name: Check Bazel environment
         run: bazel info

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -19,6 +19,7 @@ jobs:
         os: [ubuntu-18.04]
     env:
       ENABLE_CACHING: false
+      CACHE_DIRECTORY: $HOME/.bazel_cache
     steps:
       - uses: actions/checkout@v2
 
@@ -34,6 +35,41 @@ jobs:
           echo "Java home: $JAVA_HOME"
           $JAVA_HOME/bin/java -version
 
+      # For reference on this & the later cache actions, see:
+      # https://github.com/actions/cache/issues/239#issuecomment-606950711 &
+      # https://github.com/actions/cache/issues/109#issuecomment-558771281. Note that these work
+      # with Bazel since Bazel can share the most recent cache from an unrelated build and still
+      # benefit from incremental build performance (assuming that actions/cache aggressively removes
+      # older caches due to the 5GB cache limit size & Bazel's large cache size).
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: ${{ env.CACHE_DIRECTORY }}
+          key: ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-${{ github.sha }}
+          restory-keys: |
+            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-
+
+      # This check is needed to ensure that Bazel's unbounded cache growth doesn't result in a
+      # situation where the cache never updates (e.g. due to exceeding GitHub's cache size limit)
+      # thereby only ever using the last successful cache version. This solution will result in a
+      # few slower CI actions around the time cache is detected to be too large, but it should
+      # incrementally improve thereafter.
+      - name: Ensure cache size
+        run: |
+          CACHE_SIZE_MB=$(du -smc $BAZEL_CACHE_DIR | grep total | cut -f1)
+          echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
+          # Use a 4.5GB threshold since actions/cache compresses the results, and Bazel caches seem
+          # to only increase by a few hundred megabytes across changes for unrelated branches. This
+          # is also a reasonable upper-bound (local tests as of 2021-03-31 suggest that a full build
+          # of the codebase (e.g. //...) from scratch only requires a ~2.1GB uncompressed/~900MB
+          # compressed cache).
+          if [[ "$CACHE_SIZE_MB" -gt 4500 ]]; then
+            echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
+            rm -rf $BAZEL_CACHE_DIR
+          fi
+        env:
+          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
+
       - name: Set up Bazel
         uses: abhinavsingh/setup-bazel@v3
         with:
@@ -47,7 +83,13 @@ jobs:
         run: |
           echo "build --enable_platform_specific_config" >> $HOME/.bazelrc
           echo "build:linux --sandbox_tmpfs_path=/tmp" >> $HOME/.bazelrc
-          
+
+      - name: Configure Bazel to use a local cache
+        run: |
+          echo "build --disk_cache=$BAZEL_CACHE_DIR" >> $HOME/.bazelrc
+        env:
+          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
+
       - name: Check Bazel environment
         run: bazel info
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,6 @@ jobs:
   robolectric_tests:
     name: Non-app Module Robolectric Tests
     runs-on: ${{ matrix.os }}
-    if: false
     strategy:
       matrix:
         os: [ubuntu-18.04]
@@ -86,7 +85,6 @@ jobs:
 
   app_tests:
     name: App Module Robolectric Tests
-    if: false
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
   robolectric_tests:
     name: Non-app Module Robolectric Tests
     runs-on: ${{ matrix.os }}
+    if: false
     strategy:
       matrix:
         os: [ubuntu-18.04]
@@ -85,6 +86,7 @@ jobs:
 
   app_tests:
     name: App Module Robolectric Tests
+    if: false
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,6 +16,7 @@ jobs:
   bazel_compute_affected_targets:
     name: Compute affected tests
     runs-on: ubuntu-18.04
+    if: false
     outputs:
       matrix: ${{ steps.compute-test-matrix-from-affected.outputs.matrix || steps.compute-test-matrix-from-all.outputs.matrix }}
       have_tests_to_run: ${{ steps.compute-test-matrix-from-affected.outputs.have_tests_to_run || steps.compute-test-matrix-from-all.outputs.have_tests_to_run }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,7 +16,6 @@ jobs:
   bazel_compute_affected_targets:
     name: Compute affected tests
     runs-on: ubuntu-18.04
-    if: false
     outputs:
       matrix: ${{ steps.compute-test-matrix-from-affected.outputs.matrix || steps.compute-test-matrix-from-all.outputs.matrix }}
       have_tests_to_run: ${{ steps.compute-test-matrix-from-affected.outputs.have_tests_to_run || steps.compute-test-matrix-from-all.outputs.have_tests_to_run }}
@@ -64,6 +63,7 @@ jobs:
       matrix: ${{fromJson(needs.bazel_compute_affected_targets.outputs.matrix)}}
     env:
       ENABLE_CACHING: false
+      CACHE_DIRECTORY: ~/.bazel_cache
     steps:
       - uses: actions/checkout@v2
 
@@ -79,6 +79,43 @@ jobs:
           echo "Java home: $JAVA_HOME"
           $JAVA_HOME/bin/java -version
 
+      # For reference on this & the later cache actions, see:
+      # https://github.com/actions/cache/issues/239#issuecomment-606950711 &
+      # https://github.com/actions/cache/issues/109#issuecomment-558771281. Note that these work
+      # with Bazel since Bazel can share the most recent cache from an unrelated build and still
+      # benefit from incremental build performance (assuming that actions/cache aggressively removes
+      # older caches due to the 5GB cache limit size & Bazel's large cache size).
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: ${{ env.CACHE_DIRECTORY }}
+          key: ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-
+
+      # This check is needed to ensure that Bazel's unbounded cache growth doesn't result in a
+      # situation where the cache never updates (e.g. due to exceeding GitHub's cache size limit)
+      # thereby only ever using the last successful cache version. This solution will result in a
+      # few slower CI actions around the time cache is detected to be too large, but it should
+      # incrementally improve thereafter.
+      - name: Ensure cache size
+        env:
+          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
+        run: |
+          # See https://stackoverflow.com/a/27485157 for reference.
+          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
+          CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_PATH | grep total | cut -f1)
+          echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
+          # Use a 4.5GB threshold since actions/cache compresses the results, and Bazel caches seem
+          # to only increase by a few hundred megabytes across changes for unrelated branches. This
+          # is also a reasonable upper-bound (local tests as of 2021-03-31 suggest that a full build
+          # of the codebase (e.g. //...) from scratch only requires a ~2.1GB uncompressed/~900MB
+          # compressed cache).
+          if [[ "$CACHE_SIZE_MB" -gt 4500 ]]; then
+            echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
+            rm -rf $EXPANDED_BAZEL_CACHE_PATH
+          fi
+
       - name: Set up Bazel
         uses: abhinavsingh/setup-bazel@v3
         with:
@@ -92,6 +129,15 @@ jobs:
         run: |
           echo "build --enable_platform_specific_config" >> $HOME/.bazelrc
           echo "build:linux --sandbox_tmpfs_path=/tmp" >> $HOME/.bazelrc
+
+      - name: Configure Bazel to use a local cache
+        env:
+          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
+        run: |
+          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
+          echo "Using $EXPANDED_BAZEL_CACHE_PATH as Bazel's cache path"
+          echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
+        shell: bash
 
       - name: Check Bazel environment
         run: bazel info

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -86,7 +86,7 @@ jobs:
           echo "Test target: $TEST_TARGET"
           TEST_CATEGORY=$(echo "$TEST_TARGET" | grep -oP 'org/oppia/android/(.+?)/' | cut -f 4 -d "/")
           echo "Test category: $TEST_CATEGORY"
-          echo "::set-env name=TEST_CACHING_BUCKET::$TEST_CATEGORY"
+          echo "TEST_CACHING_BUCKET=$TEST_CATEGORY" >> $GITHUB_ENV
 
       # For reference on this & the later cache actions, see:
       # https://github.com/actions/cache/issues/239#issuecomment-606950711 &

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -79,6 +79,15 @@ jobs:
           echo "Java home: $JAVA_HOME"
           $JAVA_HOME/bin/java -version
 
+      - name: Compute test caching bucket
+        env:
+          TEST_TARGET: ${{ matrix.test-target }}
+        run: |
+          echo "Test target: $TEST_TARGET"
+          TEST_CATEGORY=$(echo "$TEST_TARGET" | grep -oP 'org/oppia/android/(.+?)/' | cut -f 4 -d "/")
+          echo "Test category: $TEST_CATEGORY"
+          echo "::set-env name=TEST_CACHING_BUCKET::$TEST_CATEGORY"
+
       # For reference on this & the later cache actions, see:
       # https://github.com/actions/cache/issues/239#issuecomment-606950711 &
       # https://github.com/actions/cache/issues/109#issuecomment-558771281. Note that these work
@@ -89,8 +98,11 @@ jobs:
         id: cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
-          key: ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-${{ github.sha }}
+          key: ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-tests-${{ env.TEST_CACHING_BUCKET }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-tests-${{ env.TEST_CACHING_BUCKET }}-
+            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-tests-
+            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-
             ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-
 
       # This check is needed to ensure that Bazel's unbounded cache growth doesn't result in a


### PR DESCRIPTION
Fix part of #1861.

## Explanation
This introduces local Bazel caching support in GitHub Actions by leveraging GA's cache via [actions/cache](https://github.com/actions/cache). This approach is largely based on the solutions outlined [here](https://github.com/actions/cache/issues/239#issuecomment-606950711) and [here](https://github.com/actions/cache/issues/109#issuecomment-558771281).

This solution works because Bazel's hermetic & incremental design facilitates strong cache sharing even for completely different builds. The cache will continue to rapidly grow unbounded to maximize caching potential. This behaves similarly to the remote caching functionality we have support for via GCS except it uses GitHub's free resources, and works for forks.

One drawback is that GitHub Actions only allows 5GB of cache storage per app. Due to the unbounded growth factor, we have to forcibly clear the cache otherwise the cache will fail to upload and we'll be stuck using an increasingly out-of-date one. In cases where we detect the cache needs to be cleared, the all actions detecting that will run as if there isn't any cache (e.g. how they run now), and then jobs that run after should be faster since they'll benefit somewhat from the cache.

Since we aren't caching anything else substantial (only Gradle, and that will be going away in the future), this PR establishes a 4.5GB threshold (uncompressed) before forcibly clearing the cache. At current estimates, a full local build requires about a ~2GB uncompressed cache (~900MB compressed), so I'm guessing the 4.5GB threshold will lead to 2-3 force cache resets per day. Given the ~50% compression ratio we're seeing, we might be able to raise this up to 8GB-9GB before actually running into the 5GB limit, but we can tune this if we're seeing issues. The actions provide diagnostic output to track cache size & when the cache needs to be reset,

See the following analysis table for an idea on how actions times seem to improve due to this change:
| Action          | Caching             | Appx. Runtime          |
|-----------------|---------------------|------------------------|
| Build binary    | None                | ~14-15 mins            |
| Build binary    | Full                | ~1-2 mins*             |
| Full test suite | None                | ~9-12 mins (each test) |
| Full test suite | Cached built binary | ~6-9 mins (each test)                    |
| Full test suite | All tests**           | ~2-3 mins (each test)                    |

We saw the full test suite in the last case run in just under 2 hours (a 4x-8x improvement over the previously observed 8-16 hour runtime for the full test suite).

*I noticed one run where back-to-back builds triggered a later build to be a complete rebuild of the app despite having an up-to-date cache. Not quite sure why that happened; maybe something to do with timestamps overlapping since the two builds were happening simultaneously. It's a bit disappointing that the caching didn't seem to help much for the latter build, though it didn complete in under 12 minutes. We'll need to keep an eye out for similar cases in the future.

**Per the issue mentioned above, running the tests in parallel doesn't actually fully cache the results. Also, the cache selection seems a bit random at the moment (though it uses a LRU cache eviction policy), so there's not any guarantee yet that the caches will get better over time.

Finally, I wanted to note a few things:
- Per #1861 we still need to fix some of the caching issues with Android-specific Bazel actions; this will probably substantially improve incremental build performance
- This change alone may not be sufficient to facilitate desharding the Bazel tests, but I suspect a few more build time improvements (e.g. maybe the caching fix above, and our modularization work) will probably let us run 5-10 tests per shard instead of 1 which should result in substantially faster test runs
- There's still a lot more we can do to speed up Bazel CI beyond the above (e.g. only running tests for affected test changes between deltas, moving Android libraries to be kt_jvm_libraries, and more)
- Moving to a proper remote cache that's run through GitHub Actions (this was pitched as a potential option back in 2019, but no traction has been made quite yet)

This is meant to make the Bazel tests in CI a bit more tolerable, but probably won't make them completely pleasant quite y et.