### PR TITLE
Fix Part of #2833 : Add missing named argument in ProfileProgressFragmentTest

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/profileprogress/ProfileProgressFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profileprogress/ProfileProgressFragmentTest.kt
@@ -552,9 +552,9 @@ class ProfileProgressFragmentTest {
       testCoroutineDispatchers.runCurrent()
       onView(
         atPositionOnView(
-          R.id.profile_progress_list,
-          0,
-          R.id.ongoing_topics_container
+          recyclerViewId = R.id.profile_progress_list,
+          position = 0,
+          targetViewId = R.id.ongoing_topics_container
         )
       ).check(matches(not(isClickable())))
     }
@@ -566,9 +566,9 @@ class ProfileProgressFragmentTest {
       testCoroutineDispatchers.runCurrent()
       onView(
         atPositionOnView(
-          R.id.profile_progress_list,
-          0,
-          R.id.completed_stories_container
+          recyclerViewId = R.id.profile_progress_list,
+          position = 0,
+          targetViewId = R.id.completed_stories_container
         )
       ).check(matches(not(isClickable())))
     }
@@ -582,9 +582,9 @@ class ProfileProgressFragmentTest {
       testCoroutineDispatchers.runCurrent()
       onView(
         atPositionOnView(
-          R.id.profile_progress_list,
-          0,
-          R.id.completed_stories_container
+          recyclerViewId = R.id.profile_progress_list,
+          position = 0,
+          targetViewId = R.id.completed_stories_container
         )
       ).check(matches(not(isClickable())))
     }
@@ -663,9 +663,9 @@ class ProfileProgressFragmentTest {
   ) {
     onView(
       atPositionOnView(
-        R.id.profile_progress_list,
-        itemPosition,
-        targetViewId
+        recyclerViewId = R.id.profile_progress_list,
+        position = itemPosition,
+        targetViewId = targetViewId
       )
     ).check(matches(withText(stringToMatch)))
   }
@@ -673,9 +673,9 @@ class ProfileProgressFragmentTest {
   private fun clickProfileProgressItem(itemPosition: Int, targetViewId: Int) {
     onView(
       atPositionOnView(
-        R.id.profile_progress_list,
-        itemPosition,
-        targetViewId
+        recyclerViewId = R.id.profile_progress_list,
+        position = itemPosition,
+        targetViewId = targetViewId
       )
     ).perform(click())
     testCoroutineDispatchers.runCurrent()


### PR DESCRIPTION

## Explanation
Fixes Part of #2833, Added missing named argument in ProfileProgressFragmentTest

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
