### PR TITLE
Fixes part of #2627: Pin Verification screen A11y

### DIFF
--- a/app/src/main/res/layout-land/pin_password_activity.xml
+++ b/app/src/main/res/layout-land/pin_password_activity.xml
@@ -103,7 +103,7 @@
       android:textSize="14sp"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/input_pin" />
+      app:layout_constraintTop_toBottomOf="@+id/show_pin" />
 
     <LinearLayout
       android:id="@+id/show_pin"

--- a/app/src/main/res/layout-land/pin_password_activity.xml
+++ b/app/src/main/res/layout-land/pin_password_activity.xml
@@ -67,11 +67,12 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginTop="8dp"
+      android:contentDescription="@string/enter_your_pin"
       android:cursorVisible="true"
       android:fontFamily="sans-serif"
       android:inputType="numberPassword"
-      android:showPassword="@{viewModel.showPassword}"
       android:itemBackground="@color/white"
+      android:showPassword="@{viewModel.showPassword}"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="14sp"
       app:cursorColor="@color/oppiaPrimaryText"
@@ -121,8 +122,8 @@
         android:layout_width="32dp"
         android:layout_height="32dp"
         android:layout_gravity="center_horizontal"
-        android:contentDescription="@string/show_hide_password_icon"
-        android:src="@{viewModel.showPassword ? @drawable/ic_hide_eye_icon : @drawable/ic_show_eye_icon}" />
+        android:contentDescription="@{viewModel.showPassword ? @string/password_shown_icon : @string/password_hidden_icon}"
+        android:src="@{viewModel.showPassword ? @drawable/ic_show_eye_icon : @drawable/ic_hide_eye_icon}" />
 
       <TextView
         android:id="@+id/show_hide_password_text_view"

--- a/app/src/main/res/layout-sw600dp-land/pin_password_activity.xml
+++ b/app/src/main/res/layout-sw600dp-land/pin_password_activity.xml
@@ -20,26 +20,26 @@
 
     <TextView
       android:id="@+id/hello_text_view"
+      style="@style/Heading1"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:layout_marginTop="104dp"
       android:gravity="center_horizontal"
       android:lines="1"
       android:text="@{String.format(@string/pin_password_hello, viewModel.profile.name)}"
       android:textColor="@color/oppiaPrimaryText"
       app:layout_constraintEnd_toEndOf="parent"
-      style="@style/Heading1"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent"
-      android:layout_marginTop="104dp"/>
+      app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
       android:id="@+id/enter_text_view"
+      style="@style/Heading4"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginTop="8dp"
-      android:maxWidth="240dp"
-      style="@style/Heading4"
       android:gravity="center_horizontal"
+      android:maxWidth="240dp"
       android:text="@{viewModel.profile.isAdmin ? @string/pin_password_admin_enter : @string/pin_password_user_enter}"
       android:textColor="@color/oppiaPrimaryText"
       app:layout_constraintEnd_toEndOf="parent"
@@ -65,11 +65,12 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginTop="8dp"
+      android:contentDescription="@string/enter_your_pin"
       android:cursorVisible="true"
       android:fontFamily="sans-serif"
       android:inputType="numberPassword"
-      android:showPassword="@{viewModel.showPassword}"
       android:itemBackground="@color/white"
+      android:showPassword="@{viewModel.showPassword}"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="14sp"
       app:cursorColor="@color/oppiaPrimaryText"
@@ -89,9 +90,9 @@
 
     <TextView
       android:id="@+id/forgot_pin"
+      style="@style/Subtitle2"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      style="@style/Subtitle2"
       android:minHeight="48dp"
       android:paddingTop="18dp"
       android:text="@string/pin_password_forgot_pin"
@@ -118,8 +119,8 @@
         android:layout_width="36dp"
         android:layout_height="40dp"
         android:layout_gravity="center_horizontal"
-        android:contentDescription="@string/show_hide_password_icon"
-        android:src="@{viewModel.showPassword ? @drawable/ic_hide_eye_icon : @drawable/ic_show_eye_icon}" />
+        android:contentDescription="@{viewModel.showPassword ? @string/password_shown_icon : @string/password_hidden_icon}"
+        android:src="@{viewModel.showPassword ? @drawable/ic_show_eye_icon : @drawable/ic_hide_eye_icon}" />
 
       <TextView
         android:id="@+id/show_hide_password_text_view"

--- a/app/src/main/res/layout-sw600dp-land/pin_password_activity.xml
+++ b/app/src/main/res/layout-sw600dp-land/pin_password_activity.xml
@@ -100,7 +100,7 @@
       android:textColor="@color/colorPrimary"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/input_pin" />
+      app:layout_constraintTop_toBottomOf="@+id/show_pin" />
 
     <LinearLayout
       android:id="@+id/show_pin"

--- a/app/src/main/res/layout-sw600dp-port/pin_password_activity.xml
+++ b/app/src/main/res/layout-sw600dp-port/pin_password_activity.xml
@@ -100,7 +100,7 @@
       android:textColor="@color/colorPrimary"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/input_pin" />
+      app:layout_constraintTop_toBottomOf="@+id/show_pin" />
 
     <LinearLayout
       android:id="@+id/show_pin"

--- a/app/src/main/res/layout-sw600dp-port/pin_password_activity.xml
+++ b/app/src/main/res/layout-sw600dp-port/pin_password_activity.xml
@@ -20,28 +20,28 @@
 
     <TextView
       android:id="@+id/hello_text_view"
+      style="@style/Heading1"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:layout_marginTop="216dp"
       android:gravity="center_horizontal"
-      style="@style/Heading1"
       android:lines="1"
       android:text="@{String.format(@string/pin_password_hello, viewModel.profile.name)}"
       android:textColor="@color/oppiaPrimaryText"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent"
-      android:layout_marginTop="216dp"/>
+      app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
       android:id="@+id/enter_text_view"
+      style="@style/Heading4"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginTop="8dp"
-      style="@style/Heading4"
       android:gravity="center_horizontal"
+      android:maxWidth="240dp"
       android:text="@{viewModel.profile.isAdmin ? @string/pin_password_admin_enter : @string/pin_password_user_enter}"
       android:textColor="@color/oppiaPrimaryText"
-      android:maxWidth="240dp"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toBottomOf="@+id/hello_text_view" />
@@ -65,11 +65,12 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginTop="8dp"
+      android:contentDescription="@string/enter_your_pin"
       android:cursorVisible="true"
       android:fontFamily="sans-serif"
       android:inputType="numberPassword"
-      android:showPassword="@{viewModel.showPassword}"
       android:itemBackground="@color/white"
+      android:showPassword="@{viewModel.showPassword}"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="14sp"
       app:cursorColor="@color/oppiaPrimaryText"
@@ -89,9 +90,9 @@
 
     <TextView
       android:id="@+id/forgot_pin"
+      style="@style/Subtitle2"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      style="@style/Subtitle2"
       android:minHeight="48dp"
       android:paddingTop="18dp"
       android:text="@string/pin_password_forgot_pin"
@@ -118,8 +119,8 @@
         android:layout_width="36dp"
         android:layout_height="40dp"
         android:layout_gravity="center_horizontal"
-        android:contentDescription="@string/show_hide_password_icon"
-        android:src="@{viewModel.showPassword ? @drawable/ic_hide_eye_icon : @drawable/ic_show_eye_icon}" />
+        android:contentDescription="@{viewModel.showPassword ? @string/password_shown_icon : @string/password_hidden_icon}"
+        android:src="@{viewModel.showPassword ? @drawable/ic_show_eye_icon : @drawable/ic_hide_eye_icon}" />
 
       <TextView
         android:id="@+id/show_hide_password_text_view"

--- a/app/src/main/res/layout/pin_password_activity.xml
+++ b/app/src/main/res/layout/pin_password_activity.xml
@@ -66,12 +66,12 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginTop="8dp"
+      android:contentDescription="@string/enter_your_pin"
       android:cursorVisible="true"
       android:fontFamily="sans-serif"
       android:inputType="numberPassword"
-      android:contentDescription="@string/enter_your_pin"
-      android:showPassword="@{viewModel.showPassword}"
       android:itemBackground="@color/white"
+      android:showPassword="@{viewModel.showPassword}"
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="14sp"
       app:cursorColor="@color/oppiaPrimaryText"
@@ -102,7 +102,7 @@
       android:textSize="14sp"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/input_pin" />
+      app:layout_constraintTop_toBottomOf="@+id/show_pin" />
 
     <LinearLayout
       android:id="@+id/show_pin"

--- a/app/src/main/res/layout/pin_password_activity.xml
+++ b/app/src/main/res/layout/pin_password_activity.xml
@@ -69,6 +69,7 @@
       android:cursorVisible="true"
       android:fontFamily="sans-serif"
       android:inputType="numberPassword"
+      android:contentDescription="@string/enter_your_pin"
       android:showPassword="@{viewModel.showPassword}"
       android:itemBackground="@color/white"
       android:textColor="@color/oppiaPrimaryText"
@@ -120,8 +121,8 @@
         android:layout_width="32dp"
         android:layout_height="32dp"
         android:layout_gravity="center_horizontal"
-        android:contentDescription="@string/show_hide_password_icon"
-        android:src="@{viewModel.showPassword ? @drawable/ic_hide_eye_icon : @drawable/ic_show_eye_icon}" />
+        android:contentDescription="@{viewModel.showPassword ? @string/password_shown_icon : @string/password_hidden_icon}"
+        android:src="@{viewModel.showPassword ? @drawable/ic_show_eye_icon : @drawable/ic_hide_eye_icon}" />
 
       <TextView
         android:id="@+id/show_hide_password_text_view"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -265,6 +265,9 @@
   <string name="pin_password_forgot_message">To reset your PIN, please uninstall Oppia and then reinstall it.\n\nKeep in mind that if the device has not been online, you may lose user progress on multiple accounts. </string>
   <string name="pin_password_play_store">Go to the play store</string>
   <string name="show_hide_password_icon">Show/Hide password icon</string>
+  <string name="password_shown_icon">Password shown icon</string>
+  <string name="password_hidden_icon">Password hidden icon</string>
+  <string name="enter_your_pin">Enter your PIN</string>
   <!-- AdminSettingsDialogFragment -->
   <string name="admin_settings_label">Administrator\'s PIN</string>
   <string name="admin_settings_heading">Access to Administrator Settings</string>

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
@@ -19,6 +19,7 @@ import androidx.test.espresso.matcher.ViewMatchers.hasFocus
 import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withInputType
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -136,6 +137,27 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.input_pin)).check(matches(hasFocus()))
+    }
+  }
+
+  @Test
+  fun testPinPassword_pinView_hasContentDescription() {
+    ActivityScenario.launch<PinPasswordActivity>(
+      PinPasswordActivity.createPinPasswordActivityIntent(
+        context = context,
+        adminPin = adminPin,
+        profileId = adminId
+      )
+    ).use {
+      onView(withId(R.id.input_pin)).check(
+        matches(
+          withContentDescription(
+            context.resources.getString(
+              R.string.enter_your_pin
+            )
+          )
+        )
+      )
     }
   }
 
@@ -695,7 +717,27 @@ class PinPasswordActivityTest {
         .check(
           matches(
             withDrawable(
-              R.drawable.ic_show_eye_icon
+              R.drawable.ic_hide_eye_icon
+            )
+          )
+        )
+    }
+  }
+
+  @Test
+  fun testPinPassword_withAdmin_showHideIcon_hasPasswordHiddenContentDescription() {
+    ActivityScenario.launch<PinPasswordActivity>(
+      PinPasswordActivity.createPinPasswordActivityIntent(
+        context = context,
+        adminPin = adminPin,
+        profileId = adminId
+      )
+    ).use {
+      onView(withId(R.id.show_hide_password_image_view))
+        .check(
+          matches(
+            withContentDescription(
+              R.string.password_hidden_icon
             )
           )
         )
@@ -719,7 +761,29 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPassword_withAdmin_showHidePassword_imageChangesToHide() {
+  fun testPinPassword_withAdmin_clickShowHideIcon_hasPasswordShownContentDescription() {
+    ActivityScenario.launch<PinPasswordActivity>(
+      PinPasswordActivity.createPinPasswordActivityIntent(
+        context = context,
+        adminPin = adminPin,
+        profileId = adminId
+      )
+    ).use {
+      closeSoftKeyboard()
+      onView(withId(R.id.show_pin)).perform(click())
+      onView(withId(R.id.show_hide_password_image_view))
+        .check(
+          matches(
+            withContentDescription(
+              R.string.password_shown_icon
+            )
+          )
+        )
+    }
+  }
+
+  @Test
+  fun testPinPassword_withAdmin_showHidePassword_imageChangesToShow() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context = context,
@@ -734,7 +798,7 @@ class PinPasswordActivityTest {
         .check(
           matches(
             withDrawable(
-              R.drawable.ic_hide_eye_icon
+              R.drawable.ic_show_eye_icon
             )
           )
         )
@@ -742,7 +806,7 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPassword_withAdmin_showHidePassword_configChange_hideViewIsShown() {
+  fun testPinPassword_withAdmin_showHidePassword_configChange_showViewIsShown() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
         context = context,
@@ -759,7 +823,7 @@ class PinPasswordActivityTest {
         .check(
           matches(
             withDrawable(
-              R.drawable.ic_hide_eye_icon
+              R.drawable.ic_show_eye_icon
             )
           )
         )

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
@@ -170,6 +170,28 @@ class PinPasswordActivityTest {
   }
 
   @Test
+  fun testPinPassword_configChange_pinView_hasContentDescription() {
+    ActivityScenario.launch<PinPasswordActivity>(
+      PinPasswordActivity.createPinPasswordActivityIntent(
+        context = context,
+        adminPin = adminPin,
+        profileId = adminId
+      )
+    ).use {
+      onView(isRoot()).perform(orientationLandscape())
+      onView(withId(R.id.input_pin)).check(
+        matches(
+          withContentDescription(
+            context.resources.getString(
+              R.string.enter_your_pin
+            )
+          )
+        )
+      )
+    }
+  }
+
+  @Test
   fun testPinPassword_withAdmin_inputCorrectPin_opensHomeActivity() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
@@ -793,6 +793,7 @@ class PinPasswordActivityTest {
         profileId = adminId
       )
     ).use {
+      testCoroutineDispatchers.runCurrent()
       closeSoftKeyboard()
       onView(withId(R.id.show_pin)).perform(click())
       onView(withId(R.id.show_hide_password_image_view))


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes part of #2627 (part 2 & 3)

Fixes part of #2256 (part 1)

This PR mainly focuses on two things:
1. The icons have been reversed. It was mentioned by Chantel [here](https://github.com/oppia/oppia-android/issues/2627#issuecomment-781659348) but it still needs to be reflected in the mocks.
2. Introduces strings which will be used by screen readers.
3. Thr flow for `show/hide password` selection has been fixed.

**Output**
https://user-images.githubusercontent.com/9396084/114103894-891a4680-98e7-11eb-8a5c-8b433cc73445.mp4

**Known Issue**
1. The current output mentions "Oppia" string in between but that is getting solved in #3028 PR.
2. And Part 1 or original issue is pending.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
