### PR TITLE
[RunAllTests] Attempt to fix GitHub actions cache flake

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -86,7 +86,8 @@ jobs:
           echo "Test target: $TEST_TARGET"
           TEST_CATEGORY=$(echo "$TEST_TARGET" | grep -oP 'org/oppia/android/(.+?)/' | cut -f 4 -d "/")
           echo "Test category: $TEST_CATEGORY"
-          echo "TEST_CACHING_BUCKET=$TEST_CATEGORY" >> $GITHUB_ENV
+          echo "TEST_CACHING_BUCKET=${TEST_CATEGORY}" >> $GITHUB_ENV
+        shell: bash
 
       # For reference on this & the later cache actions, see:
       # https://github.com/actions/cache/issues/239#issuecomment-606950711 &


### PR DESCRIPTION
## Explanation
Flakes like [this](https://github.com/oppia/oppia-android/runs/2300787189?check_suite_focus=true) are now being observed after caching was introduced in #3035:

```
Error: Unable to process file command 'env' successfully.
Error: Invalid environment variable format 'util'
```

The variable format change probably won't make a difference, it's just a "correctness" thing per what I saw others doing. I'm hoping that using a bash shell will help, but I'm not confident. It's weird because it seems like echo is outputting the wrong data.

This fix is just experimental--I haven't actually found anyone hitting this problem yet.