### PR TITLE
Fix #3090: Removing context initialization from test setup

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -142,7 +142,6 @@ class ExplorationActivityTest {
   fun setUp() {
     Intents.init()
     setUpTestApplicationComponent()
-    context = ApplicationProvider.getApplicationContext()
     testCoroutineDispatchers.registerIdlingResource()
   }
 


### PR DESCRIPTION
Fix #3090: 
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation

In the `ExplorationActivityTest` dagger has been setup and the `context` is now injected, the line in the setup is unnecessary as noted in #3090 
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Screenshot of tests

![image](https://user-images.githubusercontent.com/1699877/115596943-4fa9e980-a29e-11eb-8961-ad5186514635.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
