### PR TITLE
[RunAllTests] Fixes #2961: Prepare release-0.5 branch for alpha MR2

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -63,4 +63,3 @@ android_binary(
         "//app",
     ],
 )
-1

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -55,11 +55,12 @@ android_binary(
         "applicationId": "org.oppia.android",
         "minSdkVersion": "19",
         "targetSdkVersion": "29",
-        "versionCode": "0",
-        "versionName": "0.1-alpha",
+        "versionCode": "5",
+        "versionName": "0.5-alpha-0dbe671eb8",
     },
     multidex = "native",  # TODO(#1875): Re-enable legacy for optimized release builds.
     deps = [
         "//app",
     ],
 )
+1

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
     applicationId "org.oppia.android"
     minSdkVersion 19
     targetSdkVersion 29
-    versionCode 1
-    versionName "1.0"
+    versionCode 5
+    versionName "0.5-alpha-0dbe671eb8"
     multiDexEnabled true
     testInstrumentationRunner "org.oppia.android.testing.OppiaTestRunner"
     // https://developer.android.com/training/testing/junit-runner#ato-gradle

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,10 +22,10 @@
       android:value="false" />
     <meta-data
       android:name="automatic_app_expiration_enabled"
-      android:value="false" />
+      android:value="true" />
     <meta-data
       android:name="expiration_date"
-      android:value="2020-09-01" />
+      android:value="2021-10-31" />
 
     <activity
       android:name=".app.administratorcontrols.AdministratorControlsActivity"

--- a/app/src/main/java/org/oppia/android/app/topic/PracticeTabModule.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/PracticeTabModule.kt
@@ -8,5 +8,5 @@ import dagger.Provides
 class PracticeTabModule {
   @Provides
   @EnablePracticeTab
-  fun provideEnablePracticeTab(): Boolean = true
+  fun provideEnablePracticeTab(): Boolean = false
 }

--- a/domain/src/main/java/org/oppia/android/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/TopicListController.kt
@@ -444,6 +444,15 @@ class TopicListController @Inject constructor(
     return TimeUnit.MILLISECONDS.toDays(oppiaClock.getCurrentTimeMs() - this.lastPlayedTimestamp)
   }
 
+  private val REAL_PLACE_VALUES_TOPIC_ID = "iX9kYCjnouWN"
+  private val REAL_MULTIPLICATION_TOPIC_ID = "C4fqwrvqWpRm"
+  private val REAL_FRACTIONS_TOPIC_ID = "0abdeaJhmfPm"
+  private val REAL_RATIOS_TOPIC_ID = "5g0nxGUmx5J5"
+
+  // Not yet released/available to the app (and thus shouldn't be dependencies below since they can't be played).
+  private val REAL_DIVISION_TOPIC_ID = "qW12maD4hiA8"
+  private val REAL_ADDITION_AND_SUBTRACTION_TOPIC_ID = "sWBXKH4PZcK6"
+
   // TODO(#2550): Remove hardcoded order of topics. Compute list of suggested stories from backend structures
   /**
    * Returns a list of topic IDs for which the specified topic ID expects to be completed before
@@ -453,17 +462,19 @@ class TopicListController @Inject constructor(
     // The comments describe the correct dependencies, but those might not be available until the
     // topic is introduced into the app.
     return when (topicId) {
-      // TEST_TOPIC_ID_0 (depends on Fractions)
-      TEST_TOPIC_ID_0 -> listOf(FRACTIONS_TOPIC_ID)
-      // TEST_TOPIC_ID_1 (depends on TEST_TOPIC_ID_0,Ratios)
-      TEST_TOPIC_ID_1 -> listOf(TEST_TOPIC_ID_0, RATIOS_TOPIC_ID)
+      // Place values depends on nothing since it's the first set of lessons to play.
+      REAL_PLACE_VALUES_TOPIC_ID -> listOf()
       // Fractions (depends on A+S, Multiplication, Division)
-      FRACTIONS_TOPIC_ID -> listOf()
+      REAL_FRACTIONS_TOPIC_ID -> listOf(REAL_MULTIPLICATION_TOPIC_ID)
       // Ratios (depends on A+S, Multiplication, Division)
-      RATIOS_TOPIC_ID -> listOf()
+      REAL_RATIOS_TOPIC_ID -> listOf(REAL_MULTIPLICATION_TOPIC_ID)
       // Addition and Subtraction (depends on Place Values)
-      // Multiplication (depends on Addition and Subtraction)
+      REAL_ADDITION_AND_SUBTRACTION_TOPIC_ID -> listOf(REAL_PLACE_VALUES_TOPIC_ID)
+      // Multiplication (depends on Addition and Subtraction); depend instead on Place Values as a
+      // poor proxy for A+S since that topic isn't yet available in the app.
+      REAL_MULTIPLICATION_TOPIC_ID -> listOf(REAL_PLACE_VALUES_TOPIC_ID)
       // Division (depends on Multiplication)
+      REAL_DIVISION_TOPIC_ID -> listOf(REAL_MULTIPLICATION_TOPIC_ID)
       // Expressions and Equations (depends on A+S, Multiplication, Division)
       // Decimals (depends on A+S, Multiplication, Division)
       else -> listOf()

--- a/utility/src/main/java/org/oppia/android/util/caching/CachingModule.kt
+++ b/utility/src/main/java/org/oppia/android/util/caching/CachingModule.kt
@@ -19,9 +19,9 @@ class CachingModule {
 
   @Provides
   @LoadLessonProtosFromAssets
-  fun provideLoadLessonProtosFromAssets(): Boolean = false
+  fun provideLoadLessonProtosFromAssets(): Boolean = true
 
   @Provides
   @LoadImagesFromAssets
-  fun provideLoadImagesFromAssets(): Boolean = false
+  fun provideLoadImagesFromAssets(): Boolean = true
 }


### PR DESCRIPTION
## Explanation
Fix #2961

This prepares the 0.5-alpha-0dbe671eb8 release of the app:
- Updates version (base branch: https://github.com/oppia/oppia-android/commit/0dbe671eb8)
- Updates version code (+1 from https://github.com/oppia/oppia-android/pull/1800/files)
- Disabled question tab
- Enables local image/proto loading
- Fixes the recommendations graph
- Enables app expiration for ~6 months from now (31 October 2021); we're expecting another alpha release (MR3) or beta MR1 before this point in time

This PR will never be merged into the develop branch.