### PR TITLE
Fix #3097: Fix force-dark theme in Xiaomi devices

### DIFF
--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -2,6 +2,7 @@
 <resources>
 
   <style name="OppiaThemeWithoutActionBar" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccent</item>
@@ -13,21 +14,25 @@
   <style name="Animation" />
   <!-- Standard animations for a full-screen window or activity. -->
   <style name="Animation.Activity">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:activityOpenEnterAnimation">@anim/slide_in_right</item>
     <item name="android:activityOpenExitAnimation">@anim/slide_out_left</item>
   </style>
 
   <style name="AudioSeekBar" parent="Widget.AppCompat.SeekBar">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:progressBackgroundTint">@color/progressBackgroundTint</item>
     <item name="android:progressTint">@color/white</item>
     <item name="android:colorControlActivated">@color/progressBackgroundTint</item>
   </style>
 
   <style name="SwitchCompatTheme" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:colorControlActivated">@color/colorPrimary</item>
   </style>
 
   <style name="AlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorPrimary</item>
@@ -36,6 +41,7 @@
   </style>
 
   <style name="ReadingTextSizeSeekBar" parent="Widget.AppCompat.SeekBar">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:progressBackgroundTint">@color/black_26</item>
     <item name="android:progressTint">@color/oppiaPrimaryLight</item>
     <item name="android:colorControlActivated">@color/oppiaPrimaryLight</item>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -2,7 +2,6 @@
 <resources>
 
   <style name="OppiaThemeWithoutActionBar" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
-    <item name="android:forceDarkAllowed">false</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccent</item>
@@ -14,25 +13,22 @@
   <style name="Animation" />
   <!-- Standard animations for a full-screen window or activity. -->
   <style name="Animation.Activity">
-    <item name="android:forceDarkAllowed">false</item>
     <item name="android:activityOpenEnterAnimation">@anim/slide_in_right</item>
     <item name="android:activityOpenExitAnimation">@anim/slide_out_left</item>
   </style>
 
   <style name="AudioSeekBar" parent="Widget.AppCompat.SeekBar">
-    <item name="android:forceDarkAllowed">false</item>
     <item name="android:progressBackgroundTint">@color/progressBackgroundTint</item>
     <item name="android:progressTint">@color/white</item>
     <item name="android:colorControlActivated">@color/progressBackgroundTint</item>
   </style>
 
   <style name="SwitchCompatTheme" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
-    <item name="android:forceDarkAllowed">false</item>
+    
     <item name="android:colorControlActivated">@color/colorPrimary</item>
   </style>
 
   <style name="AlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
-    <item name="android:forceDarkAllowed">false</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorPrimary</item>
@@ -41,7 +37,6 @@
   </style>
 
   <style name="ReadingTextSizeSeekBar" parent="Widget.AppCompat.SeekBar">
-    <item name="android:forceDarkAllowed">false</item>
     <item name="android:progressBackgroundTint">@color/black_26</item>
     <item name="android:progressTint">@color/oppiaPrimaryLight</item>
     <item name="android:colorControlActivated">@color/oppiaPrimaryLight</item>

--- a/app/src/main/res/values-v29/styles.xml
+++ b/app/src/main/res/values-v29/styles.xml
@@ -2,16 +2,14 @@
 <resources>
 
   <style name="OppiaTheme" parent="Theme.MaterialComponents.Light.DarkActionBar.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorPrimary</item>
   </style>
-  <!-- This style specifies the Text Size of the Toolbar Title. -->
-  <style name="ToolbarTitle" parent="@style/TextAppearance.Widget.AppCompat.Toolbar.Title">
-    <item name="android:textSize">20sp</item>
-  </style>
 
   <style name="OppiaThemeWithoutActionBar" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccent</item>
@@ -21,6 +19,7 @@
   </style>
 
   <style name="OppiaThemeNoActionBarColorAccentColorPrimary" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorPrimary</item>
@@ -28,31 +27,32 @@
     <item name="windowNoTitle">true</item>
     <item name="android:windowAnimationStyle">@style/Animation.Activity</item>
   </style>
-  <!-- Base style for animations.  This style specifies no animations. -->
-  <style name="Animation" />
-  <!-- Standard animations for a full-screen window or activity. -->
+
   <style name="Animation.Activity">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:activityOpenEnterAnimation">@anim/slide_in_right</item>
     <item name="android:activityOpenExitAnimation">@anim/slide_out_left</item>
   </style>
 
   <style name="OppiaDialogFragmentTheme" parent="OppiaTheme">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorAccent">@color/colorPrimary</item>
   </style>
 
   <style name="SplashScreenTheme" parent="OppiaThemeWithoutActionBar">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:windowBackground">@drawable/splash_page</item>
     <item name="android:windowAnimationStyle">@style/FadeTransitionAnimation.Activity</item>
   </style>
-  <!-- Base style for animations.  This style specifies no animations. -->
-  <style name="FadeTransitionAnimation" />
-  <!-- Standard animations for a full-screen window or activity. -->
+
   <style name="FadeTransitionAnimation.Activity">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:activityOpenEnterAnimation">@anim/fade_in</item>
     <item name="android:activityOpenExitAnimation">@anim/fade_out</item>
   </style>
 
   <style name="FullScreenDialogStyle" parent="Theme.MaterialComponents.Dialog.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:windowNoTitle">true</item>
     <item name="colorPrimaryDark">@color/colorConceptToolbarHeading</item>
     <!-- Set this to true if you want Full Screen without status bar -->
@@ -66,6 +66,7 @@
   </style>
 
   <style name="FullScreenReviewDialogStyle" parent="Theme.MaterialComponents.Dialog.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:windowNoTitle">true</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <!-- Set this to true if you want Full Screen without status bar -->
@@ -79,6 +80,7 @@
   </style>
 
   <style name="FullScreenHintDialogStyle" parent="Theme.MaterialComponents.Dialog.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:windowNoTitle">true</item>
     <item name="colorPrimaryDark">@color/hintFullDialogStatusBar</item>
     <!-- Set this to true if you want Full Screen without status bar -->
@@ -90,8 +92,9 @@
     <item name="android:windowEnterAnimation">@anim/slide_up</item>
     <item name="android:windowExitAnimation">@anim/slide_down</item>
   </style>
-  <!-- STATE BUTTON ACTIVE STYLE -->
+
   <style name="StateButtonActive" parent="TextAppearance.AppCompat.Widget.Button">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:background">@drawable/state_button_primary_background</item>
@@ -107,29 +110,35 @@
   </style>
 
   <style name="SwitchCompatTheme" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorControlActivated">@color/colorPrimary</item>
   </style>
 
   <style name="TabLayout" parent="Widget.Design.TabLayout">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="tabTextAppearance">@style/TabLayoutTextAppearance</item>
   </style>
 
   <style name="ToolbarTextAppearance" parent="TextAppearance.Widget.AppCompat.Toolbar.Title">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:textSize">20sp</item>
     <item name="android:textColor">@color/white</item>
   </style>
 
   <style name="TabLayoutTextAppearance" parent="TextAppearance.Design.Tab">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="textAllCaps">true</item>
     <item name="android:textAllCaps">true</item>
   </style>
 
   <style name="AppTheme.TabLayout" parent="Widget.Design.TabLayout">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="tabSelectedTextColor">@android:color/white</item>
     <item name="tabTextColor">@android:color/white</item>
   </style>
-  <!-- STATE BUTTON INACTIVE STYLE -->
+
   <style name="StateButtonInactive" parent="TextAppearance.AppCompat.Widget.Button">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:padding">8dp</item>
@@ -141,16 +150,14 @@
   </style>
 
   <style name="AlertDialogTheme" parent="Theme.MaterialComponents.Light.Dialog.Alert.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorPrimary</item>
   </style>
 
-  <style name="textAllCaps">
-    <item name="android:textAllCaps">true</item>
-  </style>
-  <!-- TOPIC TABLAYOUT STYLE -->
   <style name="AppTabLayout" parent="Widget.Design.TabLayout">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="tabIndicatorColor">@color/white</item>
     <item name="tabIndicatorHeight">4dp</item>
     <item name="tabPaddingStart">8dp</item>
@@ -162,6 +169,7 @@
   </style>
 
   <style name="AppTabTextAppearance" parent="TextAppearance.Design.Tab">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:textSize">14sp</item>
     <item name="android:textColor">@color/tab_icon_color_selector</item>
     <item name="android:fontFamily">sans-serif-medium</item>
@@ -169,6 +177,7 @@
   </style>
 
   <style name="LanguageRadioButton" parent="Base.Widget.AppCompat.CompoundButton.RadioButton">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:button">@drawable/radio_button_drawable</item>
     <item name="android:windowIsTranslucent">true</item>
     <item name="android:windowBackground">@android:color/transparent</item>
@@ -179,6 +188,7 @@
   </style>
 
   <style name="TextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="boxBackgroundColor">@color/white</item>
     <item name="boxCornerRadiusBottomEnd">@dimen/text_input_layout_corner_radius</item>
     <item name="boxCornerRadiusBottomStart">@dimen/text_input_layout_corner_radius</item>
@@ -195,6 +205,7 @@
   </style>
 
   <style name="TextInputEditText" parent="Widget.AppCompat.EditText">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="fontFamily">sans-serif</item>
     <item name="android:fontFamily">sans-serif</item>
     <item name="textAllCaps">false</item>
@@ -206,66 +217,77 @@
   </style>
 
   <style name="Heading1" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif</item>
     <item name="android:textSize">24sp</item>
     <item name="fontFamily">sans-serif</item>
   </style>
 
   <style name="Heading2" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif-medium</item>
     <item name="android:textSize">20sp</item>
     <item name="fontFamily">sans-serif-medium</item>
   </style>
 
   <style name="Heading3" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif-medium</item>
     <item name="android:textSize">18sp</item>
     <item name="fontFamily">sans-serif-medium</item>
   </style>
 
   <style name="Heading4" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif</item>
     <item name="android:textSize">18sp</item>
     <item name="fontFamily">sans-serif</item>
   </style>
 
   <style name="Heading5" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif-medium</item>
     <item name="android:textSize">14sp</item>
     <item name="fontFamily">sans-serif-medium</item>
   </style>
 
   <style name="Subtitle1" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif</item>
     <item name="android:textSize">16sp</item>
     <item name="fontFamily">sans-serif</item>
   </style>
 
   <style name="Subtitle2" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif</item>
     <item name="android:textSize">14sp</item>
     <item name="fontFamily">sans-serif</item>
   </style>
 
   <style name="TextFieldLabel" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif</item>
     <item name="android:textSize">12sp</item>
     <item name="fontFamily">sans-serif</item>
   </style>
 
   <style name="Body" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif</item>
     <item name="android:textSize">16sp</item>
     <item name="fontFamily">sans-serif</item>
   </style>
 
   <style name="Caption" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif-medium</item>
     <item name="android:textSize">14sp</item>
     <item name="fontFamily">sans-serif-medium</item>
   </style>
-  <!-- This style should not be used in layout/*.xml files.-->
+
   <style name="TextView.Common1" parent="Widget.AppCompat.TextView">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:textAllCaps">false</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -2,6 +2,7 @@
 <resources>
 
   <style name="OppiaTheme" parent="Theme.MaterialComponents.Light.DarkActionBar.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorPrimary</item>
@@ -12,6 +13,7 @@
   </style>
 
   <style name="OppiaThemeWithoutActionBar" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccent</item>
@@ -21,6 +23,7 @@
   </style>
 
   <style name="OppiaThemeNoActionBarColorAccentColorPrimary" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorPrimary</item>
@@ -32,15 +35,18 @@
   <style name="Animation" />
   <!-- Standard animations for a full-screen window or activity. -->
   <style name="Animation.Activity">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:activityOpenEnterAnimation">@anim/slide_in_right</item>
     <item name="android:activityOpenExitAnimation">@anim/slide_out_left</item>
   </style>
 
   <style name="OppiaDialogFragmentTheme" parent="OppiaTheme">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorAccent">@color/colorPrimary</item>
   </style>
 
   <style name="SplashScreenTheme" parent="OppiaThemeWithoutActionBar">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:windowBackground">@drawable/splash_page</item>
     <item name="android:windowAnimationStyle">@style/FadeTransitionAnimation.Activity</item>
   </style>
@@ -48,11 +54,13 @@
   <style name="FadeTransitionAnimation" />
   <!-- Standard animations for a full-screen window or activity. -->
   <style name="FadeTransitionAnimation.Activity">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:activityOpenEnterAnimation">@anim/fade_in</item>
     <item name="android:activityOpenExitAnimation">@anim/fade_out</item>
   </style>
 
   <style name="FullScreenDialogStyle" parent="Theme.MaterialComponents.Dialog.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:windowNoTitle">true</item>
     <item name="colorPrimaryDark">@color/colorConceptToolbarHeading</item>
     <!-- Set this to true if you want Full Screen without status bar -->
@@ -66,6 +74,7 @@
   </style>
 
   <style name="FullScreenReviewDialogStyle" parent="Theme.MaterialComponents.Dialog.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:windowNoTitle">true</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <!-- Set this to true if you want Full Screen without status bar -->
@@ -79,6 +88,7 @@
   </style>
 
   <style name="FullScreenHintDialogStyle" parent="Theme.MaterialComponents.Dialog.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:windowNoTitle">true</item>
     <item name="colorPrimaryDark">@color/hintFullDialogStatusBar</item>
     <!-- Set this to true if you want Full Screen without status bar -->
@@ -92,6 +102,7 @@
   </style>
   <!-- STATE BUTTON ACTIVE STYLE -->
   <style name="StateButtonActive" parent="TextAppearance.AppCompat.Widget.Button">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:background">@drawable/state_button_primary_background</item>
@@ -107,29 +118,35 @@
   </style>
 
   <style name="SwitchCompatTheme" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorControlActivated">@color/colorPrimary</item>
   </style>
 
   <style name="TabLayout" parent="Widget.Design.TabLayout">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="tabTextAppearance">@style/TabLayoutTextAppearance</item>
   </style>
 
   <style name="ToolbarTextAppearance" parent="TextAppearance.Widget.AppCompat.Toolbar.Title">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:textSize">20sp</item>
     <item name="android:textColor">@color/white</item>
   </style>
 
   <style name="TabLayoutTextAppearance" parent="TextAppearance.Design.Tab">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="textAllCaps">true</item>
     <item name="android:textAllCaps">true</item>
   </style>
 
   <style name="AppTheme.TabLayout" parent="Widget.Design.TabLayout">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="tabSelectedTextColor">@android:color/white</item>
     <item name="tabTextColor">@android:color/white</item>
   </style>
   <!-- STATE BUTTON INACTIVE STYLE -->
   <style name="StateButtonInactive" parent="TextAppearance.AppCompat.Widget.Button">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:padding">8dp</item>
@@ -141,6 +158,7 @@
   </style>
 
   <style name="AlertDialogTheme" parent="Theme.MaterialComponents.Light.Dialog.Alert.Bridge">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorPrimary</item>
@@ -151,6 +169,7 @@
   </style>
   <!-- TOPIC TABLAYOUT STYLE -->
   <style name="AppTabLayout" parent="Widget.Design.TabLayout">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="tabIndicatorColor">@color/white</item>
     <item name="tabIndicatorHeight">4dp</item>
     <item name="tabPaddingStart">8dp</item>
@@ -169,6 +188,7 @@
   </style>
 
   <style name="LanguageRadioButton" parent="Base.Widget.AppCompat.CompoundButton.RadioButton">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:button">@drawable/radio_button_drawable</item>
     <item name="android:windowIsTranslucent">true</item>
     <item name="android:windowBackground">@android:color/transparent</item>
@@ -179,6 +199,7 @@
   </style>
 
   <style name="TextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="boxBackgroundColor">@color/white</item>
     <item name="boxCornerRadiusBottomEnd">@dimen/text_input_layout_corner_radius</item>
     <item name="boxCornerRadiusBottomStart">@dimen/text_input_layout_corner_radius</item>
@@ -195,6 +216,7 @@
   </style>
 
   <style name="TextInputEditText" parent="Widget.AppCompat.EditText">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="fontFamily">sans-serif</item>
     <item name="android:fontFamily">sans-serif</item>
     <item name="textAllCaps">false</item>
@@ -206,66 +228,77 @@
   </style>
 
   <style name="Heading1" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif</item>
     <item name="android:textSize">24sp</item>
     <item name="fontFamily">sans-serif</item>
   </style>
 
   <style name="Heading2" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif-medium</item>
     <item name="android:textSize">20sp</item>
     <item name="fontFamily">sans-serif-medium</item>
   </style>
 
   <style name="Heading3" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif-medium</item>
     <item name="android:textSize">18sp</item>
     <item name="fontFamily">sans-serif-medium</item>
   </style>
 
   <style name="Heading4" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif</item>
     <item name="android:textSize">18sp</item>
     <item name="fontFamily">sans-serif</item>
   </style>
 
   <style name="Heading5" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif-medium</item>
     <item name="android:textSize">14sp</item>
     <item name="fontFamily">sans-serif-medium</item>
   </style>
 
   <style name="Subtitle1" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif</item>
     <item name="android:textSize">16sp</item>
     <item name="fontFamily">sans-serif</item>
   </style>
 
   <style name="Subtitle2" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif</item>
     <item name="android:textSize">14sp</item>
     <item name="fontFamily">sans-serif</item>
   </style>
 
   <style name="TextFieldLabel" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif</item>
     <item name="android:textSize">12sp</item>
     <item name="fontFamily">sans-serif</item>
   </style>
 
   <style name="Body" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif</item>
     <item name="android:textSize">16sp</item>
     <item name="fontFamily">sans-serif</item>
   </style>
 
   <style name="Caption" parent="TextView.Common1">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:fontFamily">sans-serif-medium</item>
     <item name="android:textSize">14sp</item>
     <item name="fontFamily">sans-serif-medium</item>
   </style>
   <!-- This style should not be used in layout/*.xml files.-->
   <style name="TextView.Common1" parent="Widget.AppCompat.TextView">
+    <item name="android:forceDarkAllowed">false</item>
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:textAllCaps">false</item>


### PR DESCRIPTION
## Explanation

Fixes #3097: Dark theme is not forced when the system theme is set as dark.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.

Dark theme was forced in MIUI and caused the colours of the app to change. Given below is how it looked on setting the device theme dark.

https://user-images.githubusercontent.com/54766268/116032674-be5fbc00-a67d-11eb-8c55-d4c58073bdbd.mp4


Fixed UI looks like this

https://user-images.githubusercontent.com/54766268/116032960-2ca47e80-a67e-11eb-9872-1281732d9a18.mp4

