### PR TITLE
Fix #3089: Removed unnecessary context initialization in RevisionCardFragmentTest

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentTest.kt
@@ -111,7 +111,6 @@ class RevisionCardFragmentTest {
   @Before
   fun setUp() {
     Intents.init()
-    context = ApplicationProvider.getApplicationContext()
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 


### PR DESCRIPTION
![RevisionCardFragmentTests Passed](https://user-images.githubusercontent.com/66965591/116238993-bc7e2180-a77f-11eb-972f-c6a3e5a2525f.png)


## Explanation
Fixes #3089: In RevisionCardFragmentTest,  in function setUp() there's no need for initializing context we are already injecting it through dagger.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
