### PR TITLE
Fix #3141 Moved OptionsFragmentTest.kt from unit test folder to Instrumentation test folder

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/options/OptionsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/OptionsFragmentTest.kt
@@ -15,6 +15,9 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
@@ -83,6 +86,11 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
+
+private const val KEY_READING_TEXT_SIZE_PREFERENCE_TITLE = "READING_TEXT_SIZE_PREFERENCE"
+private const val APP_LANGUAGE_PREFERENCE_TITLE_EXTRA_KEY =
+  "AppLanguageActivity.app_language_preference_title"
+private const val KEY_AUDIO_LANGUAGE_PREFERENCE_TITLE = "AUDIO_LANGUAGE_PREFERENCE"
 
 /** Tests for [OptionsFragment]. */
 @RunWith(AndroidJUnit4::class)
@@ -320,6 +328,60 @@ class OptionsFragmentTest {
       ).check(
         matches(withText("French"))
       )
+    }
+  }
+
+  @Test
+  fun testOptionsFragment_clickReadingTextSize_checkSendingTheCorrectIntent() {
+    launch<OptionsActivity>(createOptionActivityIntent(0, true)).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(
+        atPositionOnView(
+          R.id.options_recyclerview,
+          0,
+          R.id.reading_text_size_item_layout
+        )
+      ).perform(
+        click()
+      )
+      intended(hasComponent(ReadingTextSizeActivity::class.java.name))
+      intended(hasExtra(KEY_READING_TEXT_SIZE_PREFERENCE_TITLE, READING_TEXT_SIZE))
+    }
+  }
+
+  @Test
+  fun testOptionsFragment_clickAppLanguage_checkSendingTheCorrectIntent() {
+    launch<OptionsActivity>(createOptionActivityIntent(0, true)).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(
+        atPositionOnView(
+          R.id.options_recyclerview,
+          1,
+          R.id.app_language_item_layout
+        )
+      ).perform(
+        click()
+      )
+      intended(hasComponent(AppLanguageActivity::class.java.name))
+      intended(hasExtra(APP_LANGUAGE_PREFERENCE_TITLE_EXTRA_KEY, APP_LANGUAGE))
+    }
+  }
+
+  @Test
+  fun testOptionsFragment_clickDefaultAudioLanguage_checkSendingTheCorrectIntent() {
+    launch<OptionsActivity>(createOptionActivityIntent(0, true)).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(
+        atPositionOnView(
+          R.id.options_recyclerview,
+          2,
+          R.id.audio_laguage_item_layout
+        )
+      ).perform(
+        click()
+      )
+      intended(hasComponent(AudioLanguageActivity::class.java.name))
+      intended(hasExtra(KEY_AUDIO_LANGUAGE_PREFERENCE_TITLE, AUDIO_LANGUAGE))
     }
   }
 

--- a/app/src/test/java/org/oppia/android/app/testing/options/OptionsFragmentTest.kt
+++ b/app/src/test/java/org/oppia/android/app/testing/options/OptionsFragmentTest.kt
@@ -8,9 +8,6 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.Intents.intended
-import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
-import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.Component
@@ -26,15 +23,9 @@ import org.oppia.android.app.application.ApplicationInjector
 import org.oppia.android.app.application.ApplicationInjectorProvider
 import org.oppia.android.app.application.ApplicationModule
 import org.oppia.android.app.application.ApplicationStartupListenerModule
-import org.oppia.android.app.options.APP_LANGUAGE
-import org.oppia.android.app.options.AUDIO_LANGUAGE
-import org.oppia.android.app.options.AppLanguageActivity
 import org.oppia.android.app.options.AppLanguageFragment
-import org.oppia.android.app.options.AudioLanguageActivity
 import org.oppia.android.app.options.AudioLanguageFragment
 import org.oppia.android.app.options.OptionsActivity
-import org.oppia.android.app.options.READING_TEXT_SIZE
-import org.oppia.android.app.options.ReadingTextSizeActivity
 import org.oppia.android.app.options.ReadingTextSizeFragment
 import org.oppia.android.app.player.state.hintsandsolution.HintsAndSolutionConfigModule
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
@@ -75,11 +66,6 @@ import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
 
-private const val KEY_READING_TEXT_SIZE_PREFERENCE_TITLE = "READING_TEXT_SIZE_PREFERENCE"
-private const val APP_LANGUAGE_PREFERENCE_TITLE_EXTRA_KEY =
-  "AppLanguageActivity.app_language_preference_title"
-private const val KEY_AUDIO_LANGUAGE_PREFERENCE_TITLE = "AUDIO_LANGUAGE_PREFERENCE"
-
 @RunWith(AndroidJUnit4::class)
 @Config(application = OptionsFragmentTest.TestApplication::class)
 class OptionsFragmentTest {
@@ -102,60 +88,6 @@ class OptionsFragmentTest {
 
   private fun setUpTestApplicationComponent() {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
-  }
-
-  @Test
-  fun testOptionsFragment_clickReadingTextSize_checkSendingTheCorrectIntent() {
-    launch<OptionsActivity>(createOptionActivityIntent(0, true)).use {
-      testCoroutineDispatchers.runCurrent()
-      onView(
-        atPositionOnView(
-          R.id.options_recyclerview,
-          0,
-          R.id.reading_text_size_item_layout
-        )
-      ).perform(
-        click()
-      )
-      intended(hasComponent(ReadingTextSizeActivity::class.java.name))
-      intended(hasExtra(KEY_READING_TEXT_SIZE_PREFERENCE_TITLE, READING_TEXT_SIZE))
-    }
-  }
-
-  @Test
-  fun testOptionsFragment_clickAppLanguage_checkSendingTheCorrectIntent() {
-    launch<OptionsActivity>(createOptionActivityIntent(0, true)).use {
-      testCoroutineDispatchers.runCurrent()
-      onView(
-        atPositionOnView(
-          R.id.options_recyclerview,
-          1,
-          R.id.app_language_item_layout
-        )
-      ).perform(
-        click()
-      )
-      intended(hasComponent(AppLanguageActivity::class.java.name))
-      intended(hasExtra(APP_LANGUAGE_PREFERENCE_TITLE_EXTRA_KEY, APP_LANGUAGE))
-    }
-  }
-
-  @Test
-  fun testOptionsFragment_clickDefaultAudioLanguage_checkSendingTheCorrectIntent() {
-    launch<OptionsActivity>(createOptionActivityIntent(0, true)).use {
-      testCoroutineDispatchers.runCurrent()
-      onView(
-        atPositionOnView(
-          R.id.options_recyclerview,
-          2,
-          R.id.audio_laguage_item_layout
-        )
-      ).perform(
-        click()
-      )
-      intended(hasComponent(AudioLanguageActivity::class.java.name))
-      intended(hasExtra(KEY_AUDIO_LANGUAGE_PREFERENCE_TITLE, AUDIO_LANGUAGE))
-    }
   }
 
   @Test


### PR DESCRIPTION
## Explanation
Fixes #3141 
Screenshot of all the instruments tests passing.
![image](https://user-images.githubusercontent.com/46752548/116984488-edfb6d80-ace8-11eb-8c01-b01c6f37df01.png)
Screenshot of the unit test passing
![image](https://user-images.githubusercontent.com/46752548/117014960-f23a8180-ad0e-11eb-98ff-782886dfc717.png)





## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
