### PR TITLE
Fix #3138: Answer is improperly aligned in exploration

### DIFF
--- a/app/src/main/res/layout/submitted_answer_item.xml
+++ b/app/src/main/res/layout/submitted_answer_item.xml
@@ -65,7 +65,7 @@
       android:textSize="16sp"
       android:visibility="gone"
       app:layout_constrainedWidth="true"
-      app:layout_constraintEnd_toEndOf="@{viewModel.isCorrectAnswer ? @id/answer_tick_guideline : ConstraintSet.PARENT_ID}"
+      app:layout_constraintEnd_toEndOf="@{viewModel.isCorrectAnswer &amp;&amp; !viewModel.hasConversationView ? @id/answer_tick_guideline : ConstraintSet.PARENT_ID}"
       app:layout_constraintHorizontal_bias="@{viewModel.hasConversationView ? 1 : 0}"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #3138 

## Before vs. After

<img src="https://user-images.githubusercontent.com/53645584/116356387-d3bd1d80-a818-11eb-95ad-0caa3159428b.png" width="250" />  <img src="https://user-images.githubusercontent.com/9396084/117309568-2abd9500-aea0-11eb-9c5b-c26ddf2b27fa.png" width="250" />


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
