### PR TITLE
Fix #3121 : Implemented to force the user to keep the first letter of their username to be uppercase

### DIFF
--- a/app/src/main/java/org/oppia/android/app/profile/AddProfileActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AddProfileActivityPresenter.kt
@@ -32,6 +32,7 @@ import org.oppia.android.databinding.AddProfileActivityBinding
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import java.util.Locale
 import javax.inject.Inject
 
 const val GALLERY_INTENT_RESULT_CODE = 1
@@ -251,10 +252,18 @@ class AddProfileActivityPresenter @Inject constructor(
 
   private fun checkInputsAreValid(name: String, pin: String, confirmPin: String): Boolean {
     var failed = false
-    if (name.isEmpty()) {
+    if (name.isEmpty() || name.isBlank()) {
       profileViewModel.nameErrorMsg.set(
         activity.resources.getString(
           R.string.add_profile_error_name_empty
+        )
+      )
+      failed = true
+    }
+    if (name.compareTo(name.capitalize(Locale.getDefault())) != 0) {
+      profileViewModel.nameErrorMsg.set(
+        activity.resources.getString(
+          R.string.add_profile_error_name_capitalize
         )
       )
       failed = true

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,6 +226,7 @@
   <string name="add_profile_error_image_failed_store">We failed to store your avatar image. Please try again.</string>
   <string name="add_profile_error_name_not_unique">This name is already in use by another profile.</string>
   <string name="add_profile_error_name_empty">Please enter a name for this profile.</string>
+  <string name="add_profile_error_name_capitalize">Please enter the first character of your name in capital.</string>
   <string name="add_profile_error_name_only_letters">Names can only have letters. Try another name?</string>
   <string name="add_profile_error_pin_length">Your PIN should be 3 digits long.</string>
   <string name="add_profile_error_pin_confirm_wrong">Please make sure that both PINs match.</string>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
  - Fixes #3121
  - This PR basically fixes a bug in which user can make profiles with the names which have there first character lowercase
  - So I basically added an edge-case to fix it so now the user can only make profiles with the names which have the first character as uppercase

## Screenshots

### Current UI Behaviour

<ul>
    <li><img src="https://user-images.githubusercontent.com/24369148/117571039-7a8f9c80-b0ea-11eb-9140-183017f68b12.png" width="300" height="656">
    </li>
    <li><img src="https://user-images.githubusercontent.com/24369148/117571049-81b6aa80-b0ea-11eb-8540-e9f89342d14d.png" width="300" height="656">
    </li>
    <li><img src="https://user-images.githubusercontent.com/24369148/117571053-84190480-b0ea-11eb-9f5a-15e0191bebc8.png" width="300" height="656">
    </li>
</ul>

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
