### PR TITLE
Fix #3254 : [RTL] High-fi Hints and Solution icon on Exploration Screen

### DIFF
--- a/app/src/main/res/drawable-ldrtl/hints_background.xml
+++ b/app/src/main/res/drawable-ldrtl/hints_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+  android:shape="rectangle">
+  <corners
+    android:topLeftRadius="8dp"/>
+  <solid android:color="@color/audioComponentBackground" />
+</shape>


### PR DESCRIPTION


## Explanation
This PR fixes #3254. Updated Hints and solution icon on Exploration player.

## Screenshot LTR and RTL
<img width="216" alt="screenshot" src="https://user-images.githubusercontent.com/16301028/119562875-7d65df00-bdc4-11eb-9780-8b2d7cb2dbf3.png"> ...... <img width="216" alt="screenshot" src="https://user-images.githubusercontent.com/16301028/119563141-d7ff3b00-bdc4-11eb-8262-f93687d80ada.png">





## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
