### PR TITLE
[RunAllTests] Fix #2923: Remove direct bintray/jcenter dependence

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,7 +116,7 @@ google_services_workspace_dependencies()
 
 git_repository(
     name = "circularimageview",
-    commit = "8a65ba42b3fee21b5e19ca5c8690185f7c60f65d",
+    commit = "35d08ba88a4a22e6e9ac96bdc5a68be27b55d09f",
     remote = "https://github.com/oppia/CircularImageview",
 )
 
@@ -146,7 +146,6 @@ maven_install(
     artifacts = DAGGER_ARTIFACTS + get_maven_dependencies(),
     fetch_sources = True,
     repositories = DAGGER_REPOSITORIES + [
-        "https://jcenter.bintray.com/",
         "https://maven.fabric.io/public",
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -120,7 +120,7 @@ dependencies {
       'com.google.firebase:firebase-core:17.5.0',
       'com.google.firebase:firebase-crashlytics:17.0.0',
       'com.google.guava:guava:28.1-android',
-      'com.jackandphantom.android:circularimageview:1.2.0',
+      'com.github.oppia:CircularImageview:35d08ba88a',
       'de.hdodenhof:circleimageview:3.0.1',
       'nl.dionsegijn:konfetti:1.2.5',
       "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version",

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
   ext.fragment_version = '1.2.0-rc01'
   repositories {
     google()
-    jcenter()
     gradlePluginPortal()
   }
   dependencies {
@@ -22,7 +21,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
     maven { url 'https://jitpack.io' }
   }
 }

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -104,9 +104,6 @@ dependencies {
   implementation project(':model')
   implementation project(':utility')
 }
-repositories {
-  mavenCentral()
-}
 // The GeneratedMessageLite implementations of protobufs are depending on protobuf-java
 // instead of protobuf-lite after Android Studio 3.5,
 // The below command stops that from happening: https://github.com/google/tink/issues/282


### PR DESCRIPTION
Fix #2923 

## Explanation
This PR removes dependence on JCenter/Bintray given the service is now frozen & can no longer receive updated dependencies (and will likely be turned down at some point). This required effectively no work on the Bazel side since it seems Bazel builds already didn't depend on JCenter as of #3249.

Our CircularImageview dependency was the only one exclusively available on JCenter, but we fortunately already had an Oppia-specific fork of it that, with a few updates, became jitpack compatible. Interestingly, we also had a bunch of other dependencies coming from JCenter that could easily be replaced with Maven Central. This will likely improve build reliability since JCenter has had some service issues over the past few months.