### PR TITLE
Fix #2423: Mathematical Naming in classify rules

### DIFF
--- a/domain/src/test/java/org/oppia/android/domain/classify/AnswerClassificationControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/AnswerClassificationControllerTest.kt
@@ -69,8 +69,8 @@ class AnswerClassificationControllerTest {
     private val TEST_ITEM_SELECTION_SET_1 =
       createSetOfTranslatableHtmlContentIds("content_id_0", "content_id_2", "content_id_3")
 
-    private val TEST_MULTIPLE_CHOICE_OPTION_0 = createUnsingnedInteger(value = 0)
-    private val TEST_MULTIPLE_CHOICE_OPTION_1 = createUnsingnedInteger(value = 1)
+    private val TEST_MULTIPLE_CHOICE_OPTION_0 = createNonNegativeInteger(value = 0)
+    private val TEST_MULTIPLE_CHOICE_OPTION_1 = createNonNegativeInteger(value = 1)
 
     private val TEST_NUMBER_WITH_UNITS_0 = InteractionObject.newBuilder()
       .setNumberWithUnits(

--- a/domain/src/test/java/org/oppia/android/domain/classify/AnswerClassificationControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/AnswerClassificationControllerTest.kt
@@ -9,6 +9,8 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,7 +25,6 @@ import org.oppia.android.app.model.RuleSpec
 import org.oppia.android.app.model.SubtitledHtml
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createFraction
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createMixedNumber
-import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createNonNegativeInt
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createReal
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createSetOfTranslatableHtmlContentIds
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createString
@@ -41,8 +42,6 @@ import org.oppia.android.domain.classify.rules.textinput.TextInputRuleModule
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 // For context:
 // https://github.com/oppia/oppia/blob/37285a/extensions/interactions/Continue/directives/oppia-interactive-continue.directive.ts.
@@ -70,8 +69,8 @@ class AnswerClassificationControllerTest {
     private val TEST_ITEM_SELECTION_SET_1 =
       createSetOfTranslatableHtmlContentIds("content_id_0", "content_id_2", "content_id_3")
 
-    private val TEST_MULTIPLE_CHOICE_OPTION_0 = createNonNegativeInt(value = 0)
-    private val TEST_MULTIPLE_CHOICE_OPTION_1 = createNonNegativeInt(value = 1)
+    private val TEST_MULTIPLE_CHOICE_OPTION_0 = createUnsingnedInteger(value = 0)
+    private val TEST_MULTIPLE_CHOICE_OPTION_1 = createUnsingnedInteger(value = 1)
 
     private val TEST_NUMBER_WITH_UNITS_0 = InteractionObject.newBuilder()
       .setNumberWithUnits(

--- a/domain/src/test/java/org/oppia/android/domain/classify/InteractionObjectTestBuilder.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/InteractionObjectTestBuilder.kt
@@ -16,7 +16,7 @@ import org.oppia.android.app.model.TranslatableSetOfNormalizedString
  */
 object InteractionObjectTestBuilder {
 
-  fun createNonNegativeInt(value: Int): InteractionObject {
+  fun createUnsingnedInteger(value: Int): InteractionObject {
     return InteractionObject.newBuilder().setNonNegativeInt(value).build()
   }
 
@@ -72,11 +72,11 @@ object InteractionObjectTestBuilder {
       }.build()
   }.build()
 
-  fun createWholeNumber(isNegative: Boolean, value: Int): InteractionObject {
+  fun createWholeNumber(value: Int): InteractionObject {
     // Whole number fractions imply '0/1' fractional parts.
     return InteractionObject.newBuilder().setFraction(
       Fraction.newBuilder()
-        .setIsNegative(isNegative)
+        .setIsNegative(false)//using false in place of putting isNegative Parameter
         .setWholeNumber(value)
         .setNumerator(0)
         .setDenominator(1)
@@ -118,24 +118,24 @@ object InteractionObjectTestBuilder {
   /** Creates fraction part for [NumberWithUnits]. */
   fun createNumberWithUnitsForFraction(number: Fraction, units: List<NumberUnit>):
     InteractionObject {
-      val numberWithUnits = NumberWithUnits.newBuilder()
-        .addAllUnit(units)
-        .setFraction(number)
-        .build()
+    val numberWithUnits = NumberWithUnits.newBuilder()
+      .addAllUnit(units)
+      .setFraction(number)
+      .build()
 
-      return InteractionObject.newBuilder().setNumberWithUnits(numberWithUnits).build()
-    }
+    return InteractionObject.newBuilder().setNumberWithUnits(numberWithUnits).build()
+  }
 
   /** Creates real part for [NumberWithUnits]. */
   fun createNumberWithUnitsForReal(number: Double, units: List<NumberUnit>):
     InteractionObject {
-      val numberWithUnits = NumberWithUnits.newBuilder()
-        .addAllUnit(units)
-        .setReal(number)
-        .build()
+    val numberWithUnits = NumberWithUnits.newBuilder()
+      .addAllUnit(units)
+      .setReal(number)
+      .build()
 
-      return InteractionObject.newBuilder().setNumberWithUnits(numberWithUnits).build()
-    }
+    return InteractionObject.newBuilder().setNumberWithUnits(numberWithUnits).build()
+  }
 
   /** Creates [NumberUnit] using the [unit] and [exponent] for [NumberWithUnits]. */
   fun createNumberUnit(unit: String, exponent: Int): NumberUnit {

--- a/domain/src/test/java/org/oppia/android/domain/classify/InteractionObjectTestBuilder.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/InteractionObjectTestBuilder.kt
@@ -72,7 +72,7 @@ object InteractionObjectTestBuilder {
       }.build()
   }.build()
 
-  fun createWholeNumber(isNegative: Boolean, value: Int): InteractionObject {
+  fun createWholeNumber(isNegative: Boolean = false, value: Int): InteractionObject {
     // Whole number fractions imply '0/1' fractional parts.
     return InteractionObject.newBuilder().setFraction(
       Fraction.newBuilder()
@@ -118,24 +118,24 @@ object InteractionObjectTestBuilder {
   /** Creates fraction part for [NumberWithUnits]. */
   fun createNumberWithUnitsForFraction(number: Fraction, units: List<NumberUnit>):
     InteractionObject {
-      val numberWithUnits = NumberWithUnits.newBuilder()
-        .addAllUnit(units)
-        .setFraction(number)
-        .build()
+    val numberWithUnits = NumberWithUnits.newBuilder()
+      .addAllUnit(units)
+      .setFraction(number)
+      .build()
 
-      return InteractionObject.newBuilder().setNumberWithUnits(numberWithUnits).build()
-    }
+    return InteractionObject.newBuilder().setNumberWithUnits(numberWithUnits).build()
+  }
 
   /** Creates real part for [NumberWithUnits]. */
   fun createNumberWithUnitsForReal(number: Double, units: List<NumberUnit>):
     InteractionObject {
-      val numberWithUnits = NumberWithUnits.newBuilder()
-        .addAllUnit(units)
-        .setReal(number)
-        .build()
+    val numberWithUnits = NumberWithUnits.newBuilder()
+      .addAllUnit(units)
+      .setReal(number)
+      .build()
 
-      return InteractionObject.newBuilder().setNumberWithUnits(numberWithUnits).build()
-    }
+    return InteractionObject.newBuilder().setNumberWithUnits(numberWithUnits).build()
+  }
 
   /** Creates [NumberUnit] using the [unit] and [exponent] for [NumberWithUnits]. */
   fun createNumberUnit(unit: String, exponent: Int): NumberUnit {

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputHasElementXAtPositionYRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputHasElementXAtPositionYRuleClassifierProviderTest.kt
@@ -13,6 +13,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createListOfSetsOfTranslatableHtmlContentIds
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createTranslatableHtmlContentId
+import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createUnsingnedInteger
 import org.oppia.android.domain.classify.RuleClassifier
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputHasElementXAtPositionYRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputHasElementXAtPositionYRuleClassifierProviderTest.kt
@@ -6,18 +6,17 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createListOfSetsOfTranslatableHtmlContentIds
-import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createNonNegativeInt
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createTranslatableHtmlContentId
 import org.oppia.android.domain.classify.RuleClassifier
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [DragDropSortInputHasElementXAtPositionYClassifierProvider]. */
 @Suppress("PrivatePropertyName") // Truly immutable constants can be named in CONSTANT_CASE.
@@ -26,8 +25,8 @@ import javax.inject.Singleton
 @Config(manifest = Config.NONE)
 class DragDropSortInputHasElementXAtPositionYRuleClassifierProviderTest {
 
-  private val NON_NEGATIVE_VALUE_0 = createNonNegativeInt(value = 1)
-  private val NON_NEGATIVE_VALUE_1 = createNonNegativeInt(value = 2)
+  private val NON_NEGATIVE_VALUE_0 = createUnsingnedInteger(value = 1)
+  private val NON_NEGATIVE_VALUE_1 = createUnsingnedInteger(value = 2)
   private val VALID_CONTENT_ID_2 = createTranslatableHtmlContentId(contentId = "valid_content_id_2")
   private val INVALID_CONTENT_ID = createTranslatableHtmlContentId(contentId = "invalid_content_id")
   private val LIST_OF_SETS_OF_CONTENT_IDS =

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputHasElementXBeforeElementYRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputHasElementXBeforeElementYRuleClassifierProviderTest.kt
@@ -13,6 +13,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createListOfSetsOfTranslatableHtmlContentIds
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createTranslatableHtmlContentId
+import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createUnsingnedInteger
 import org.oppia.android.domain.classify.RuleClassifier
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputHasElementXBeforeElementYRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputHasElementXBeforeElementYRuleClassifierProviderTest.kt
@@ -6,18 +6,17 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createListOfSetsOfTranslatableHtmlContentIds
-import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createNonNegativeInt
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createTranslatableHtmlContentId
 import org.oppia.android.domain.classify.RuleClassifier
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [DragDropSortInputHasElementXBeforeElementYClassifierProvider]. */
 @Suppress("PrivatePropertyName") // Truly immutable constants can be named in CONSTANT_CASE.
@@ -29,7 +28,7 @@ class DragDropSortInputHasElementXBeforeElementYRuleClassifierProviderTest {
   private val VALID_CONTENT_ID_1 = createTranslatableHtmlContentId(contentId = "content_id_1")
   private val VALID_CONTENT_ID_2 = createTranslatableHtmlContentId(contentId = "content_id_2")
   private val INVALID_CONTENT_ID = createTranslatableHtmlContentId(contentId = "invalid_content_id")
-  private val NON_NEGATIVE_VALUE_1 = createNonNegativeInt(value = 1)
+  private val NON_NEGATIVE_VALUE_1 = createUnsingnedInteger(value = 1)
   private val LIST_OF_SETS_OF_CONTENT_IDS =
     createListOfSetsOfTranslatableHtmlContentIds(
       listOf("content_id_1"), listOf("content_id_2"), listOf("content_id_3")

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputIsEqualToOrderingWithOneItemAtIncorrectPositionClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputIsEqualToOrderingWithOneItemAtIncorrectPositionClassifierProviderTest.kt
@@ -12,6 +12,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createListOfSetsOfTranslatableHtmlContentIds
+import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createUnsingnedInteger
 import org.oppia.android.domain.classify.RuleClassifier
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputIsEqualToOrderingWithOneItemAtIncorrectPositionClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputIsEqualToOrderingWithOneItemAtIncorrectPositionClassifierProviderTest.kt
@@ -6,17 +6,16 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createListOfSetsOfTranslatableHtmlContentIds
-import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createNonNegativeInt
 import org.oppia.android.domain.classify.RuleClassifier
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [DragDropSortInputIsEqualToOrderingWithOneItemAtIncorrectPositionClassifierProvider]. */
 @Suppress("PrivatePropertyName") // Truly immutable constants can be named in CONSTANT_CASE.
@@ -25,7 +24,7 @@ import javax.inject.Singleton
 @Config(manifest = Config.NONE)
 class DragDropSortInputIsEqualToOrderingWithOneItemAtIncorrectPositionClassifierProviderTest {
 
-  private val NON_NEGATIVE_VALUE_0 = createNonNegativeInt(value = 0)
+  private val NON_NEGATIVE_VALUE_0 = createUnsingnedInteger(value = 0)
   private val ITEM_SET_1_ITEMS_12 = listOf("content_id_1", "content_id_2")
   private val ITEM_SET_1_ITEMS_123 = listOf("content_id_1", "content_id_2", "content_id_3")
   private val ITEM_SET_1_ITEM_1 = listOf("content_id_1")

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasDenominatorEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasDenominatorEqualToRuleClassifierProviderTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,8 +16,6 @@ import org.oppia.android.domain.classify.RuleClassifier
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [FractionInputHasDenominatorEqualToRuleClassifierProvider]. */
 @RunWith(AndroidJUnit4::class)
@@ -25,7 +25,6 @@ class FractionInputHasDenominatorEqualToRuleClassifierProviderTest {
 
   private val WHOLE_NUMBER_VALUE_TEST_123 =
     InteractionObjectTestBuilder.createWholeNumber(
-      isNegative = false,
       value = 123
     )
   private val FRACTION_VALUE_TEST_1_OVER_2 =
@@ -41,11 +40,11 @@ class FractionInputHasDenominatorEqualToRuleClassifierProviderTest {
       denominator = 4
     )
   private val NON_NEGATIVE_VALUE_TEST_1 =
-    InteractionObjectTestBuilder.createNonNegativeInt(
+    InteractionObjectTestBuilder.createUnsingnedInteger(
       value = 1
     )
   private val NON_NEGATIVE_VALUE_TEST_2 =
-    InteractionObjectTestBuilder.createNonNegativeInt(
+    InteractionObjectTestBuilder.createUnsingnedInteger(
       value = 2
     )
 

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,8 +16,6 @@ import org.oppia.android.domain.classify.RuleClassifier
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [FractionInputHasFractionalPartExactlyEqualToRuleClassifierProvider]. */
 @RunWith(AndroidJUnit4::class)
@@ -24,17 +24,15 @@ import javax.inject.Singleton
 class FractionInputHasFractionalPartExactlyEqualToRuleClassifierProviderTest {
 
   private val NON_NEGATIVE_VALUE_TEST_0 =
-    InteractionObjectTestBuilder.createNonNegativeInt(
+    InteractionObjectTestBuilder.createUnsingnedInteger(
       value = 0
     )
   private val WHOLE_NUMBER_VALUE_TEST_123 =
     InteractionObjectTestBuilder.createWholeNumber(
-      isNegative = false,
       value = 123
     )
   private val WHOLE_NUMBER_VALUE_TEST_321 =
     InteractionObjectTestBuilder.createWholeNumber(
-      isNegative = false,
       value = 321
     )
   private val FRACTION_VALUE_TEST_2_OVER_4 =

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasIntegerPartEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasIntegerPartEqualToRuleClassifierProviderTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,8 +15,6 @@ import org.oppia.android.domain.classify.InteractionObjectTestBuilder
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [FractionInputHasIntegerPartEqualToRuleClassifierProvider]. */
 @RunWith(AndroidJUnit4::class)
@@ -105,23 +105,23 @@ class FractionInputHasIntegerPartEqualToRuleClassifierProviderTest {
       value = "test"
     )
   private val WHOLE_NUMBER_VALUE_TEST_0 =
-    InteractionObjectTestBuilder.createNonNegativeInt(
+    InteractionObjectTestBuilder.createUnsingnedInteger(
       value = 0
     )
   private val WHOLE_NUMBER_VALUE_TEST_1 =
-    InteractionObjectTestBuilder.createNonNegativeInt(
+    InteractionObjectTestBuilder.createUnsingnedInteger(
       value = 1
     )
   private val WHOLE_NUMBER_VALUE_TEST_2 =
-    InteractionObjectTestBuilder.createNonNegativeInt(
+    InteractionObjectTestBuilder.createUnsingnedInteger(
       value = 2
     )
   private val WHOLE_NUMBER_VALUE_TEST_3 =
-    InteractionObjectTestBuilder.createNonNegativeInt(
+    InteractionObjectTestBuilder.createUnsingnedInteger(
       value = 3
     )
   private val WHOLE_NUMBER_VALUE_TEST_123 =
-    InteractionObjectTestBuilder.createNonNegativeInt(
+    InteractionObjectTestBuilder.createUnsingnedInteger(
       value = 123
     )
 

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNoFractionalPartRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNoFractionalPartRuleClassifierProviderTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,8 +16,6 @@ import org.oppia.android.domain.classify.InteractionObjectTestBuilder
 import org.oppia.android.domain.classify.RuleClassifier
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [FractionInputHasNoFractionalPartRuleClassifierProvider]. */
 @RunWith(AndroidJUnit4::class)
@@ -25,7 +25,6 @@ class FractionInputHasNoFractionalPartRuleClassifierProviderTest {
 
   private val WHOLE_NUMBER_VALUE_TEST_123 =
     InteractionObjectTestBuilder.createWholeNumber(
-      isNegative = false,
       value = 123
     )
   private val FRACTION_VALUE_TEST_2_OVER_4 =

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProviderTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,8 +16,6 @@ import org.oppia.android.domain.classify.RuleClassifier
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [FractionInputHasNumeratorEqualToRuleClassifierProvider]. */
 @RunWith(AndroidJUnit4::class)
@@ -24,12 +24,11 @@ import javax.inject.Singleton
 class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
 
   private val NON_NEGATIVE_VALUE_TEST_0 =
-    InteractionObjectTestBuilder.createNonNegativeInt(
+    InteractionObjectTestBuilder.createUnsingnedInteger(
       value = 0
     )
   private val WHOLE_NUMBER_VALUE_TEST_123 =
     InteractionObjectTestBuilder.createWholeNumber(
-      isNegative = false,
       value = 123
     )
   private val FRACTION_VALUE_TEST_2_OVER_4 =

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputIsEquivalentToAndInSimplestFormRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputIsEquivalentToAndInSimplestFormRuleClassifierProviderTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,8 +15,6 @@ import org.oppia.android.domain.classify.InteractionObjectTestBuilder
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [FractionInputIsEquivalentToAndInSimplestFormRuleClassifierProvider]. */
 @RunWith(AndroidJUnit4::class)
@@ -24,17 +24,14 @@ class FractionInputIsEquivalentToAndInSimplestFormRuleClassifierProviderTest {
 
   private val WHOLE_NUMBER_VALUE_TEST_5 =
     InteractionObjectTestBuilder.createWholeNumber(
-      isNegative = false,
       value = 5
     )
   private val WHOLE_NUMBER_VALUE_TEST_2 =
     InteractionObjectTestBuilder.createWholeNumber(
-      isNegative = false,
       value = 2
     )
-  private val NEGATIVE_WHOLE_NUMBER_VALUE_TEST_2 =
-    InteractionObjectTestBuilder.createWholeNumber(
-      isNegative = true,
+  private val NEGATIVE_INTEGER_NUMBER_VALUE_TEST_2 =
+    InteractionObjectTestBuilder.createSignedInt(
       value = 2
     )
   private val FRACTION_VALUE_TEST_1_OVER_2 =
@@ -124,8 +121,8 @@ class FractionInputIsEquivalentToAndInSimplestFormRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquivalentAndSimplest_wholeNumber2Answer_negativeWholeNumber2Input_doesNotMatch() {
-    val inputs = mapOf("f" to NEGATIVE_WHOLE_NUMBER_VALUE_TEST_2)
+  fun testEquivalentAndSimplest_wholeNumber2Answer_negativeIntegerNumber2Input_doesNotMatch() {
+    val inputs = mapOf("f" to NEGATIVE_INTEGER_NUMBER_VALUE_TEST_2)
     val answer = WHOLE_NUMBER_VALUE_TEST_2
 
     val matches =

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputIsEquivalentToAndInSimplestFormRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputIsEquivalentToAndInSimplestFormRuleClassifierProviderTest.kt
@@ -32,7 +32,7 @@ class FractionInputIsEquivalentToAndInSimplestFormRuleClassifierProviderTest {
       isNegative = false,
       value = 2
     )
-  private val NEGATIVE_WHOLE_NUMBER_VALUE_TEST_2 =
+  private val NEGATIVE_INTEGER_NUMBER_VALUE_TEST_2 =
     InteractionObjectTestBuilder.createWholeNumber(
       isNegative = true,
       value = 2
@@ -124,8 +124,8 @@ class FractionInputIsEquivalentToAndInSimplestFormRuleClassifierProviderTest {
   }
 
   @Test
-  fun testEquivalentAndSimplest_wholeNumber2Answer_negativeWholeNumber2Input_doesNotMatch() {
-    val inputs = mapOf("f" to NEGATIVE_WHOLE_NUMBER_VALUE_TEST_2)
+  fun testEquivalentAndSimplest_wholeNumber2Answer_negativeIntegerNumber2Input_doesNotMatch() {
+    val inputs = mapOf("f" to NEGATIVE_INTEGER_NUMBER_VALUE_TEST_2)
     val answer = WHOLE_NUMBER_VALUE_TEST_2
 
     val matches =

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputIsEquivalentToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputIsEquivalentToRuleClassifierProviderTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,8 +15,6 @@ import org.oppia.android.domain.classify.InteractionObjectTestBuilder
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
@@ -23,12 +23,10 @@ class FractionInputIsEquivalentToRuleClassifierProviderTest {
 
   private val WHOLE_NUMBER_VALUE_TEST_123 =
     InteractionObjectTestBuilder.createWholeNumber(
-      isNegative = false,
       value = 123
     )
   private val WHOLE_NUMBER_VALUE_TEST_254 =
     InteractionObjectTestBuilder.createWholeNumber(
-      isNegative = false,
       value = 254
     )
   private val FRACTION_VALUE_TEST_2_OVER_8 =

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputIsExactlyEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputIsExactlyEqualToRuleClassifierProviderTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,8 +16,6 @@ import org.oppia.android.domain.classify.RuleClassifier
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [FractionInputIsExactlyEqualToRuleClassifierProvider]. */
 @RunWith(AndroidJUnit4::class)
@@ -24,17 +24,15 @@ import javax.inject.Singleton
 class FractionInputIsExactlyEqualToRuleClassifierProviderTest {
 
   private val NON_NEGATIVE_VALUE_TEST_0 =
-    InteractionObjectTestBuilder.createNonNegativeInt(
+    InteractionObjectTestBuilder.createUnsingnedInteger(
       value = 0
     )
   private val WHOLE_NUMBER_VALUE_TEST_123 =
     InteractionObjectTestBuilder.createWholeNumber(
-      isNegative = false,
       value = 123
     )
   private val WHOLE_NUMBER_VALUE_TEST_321 =
     InteractionObjectTestBuilder.createWholeNumber(
-      isNegative = false,
       value = 321
     )
   private val FRACTION_VALUE_TEST_2_OVER_4 =

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/multiplechoiceinput/MultipleChoiceInputEqualsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/multiplechoiceinput/MultipleChoiceInputEqualsRuleClassifierProviderTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,8 +15,6 @@ import org.oppia.android.domain.classify.InteractionObjectTestBuilder
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [MultipleChoiceInputEqualsRuleClassifierProvider]. */
 @RunWith(AndroidJUnit4::class)
@@ -23,9 +23,9 @@ import javax.inject.Singleton
 class MultipleChoiceInputEqualsRuleClassifierProviderTest {
 
   private val NON_NEGATIVE_VALUE_TEST_0 =
-    InteractionObjectTestBuilder.createNonNegativeInt(value = 0)
+    InteractionObjectTestBuilder.createUnsingnedInteger(value = 0)
   private val NON_NEGATIVE_VALUE_TEST_1 =
-    InteractionObjectTestBuilder.createNonNegativeInt(value = 1)
+    InteractionObjectTestBuilder.createUnsingnedInteger(value = 1)
   private val STRING_VALUE_TEST = InteractionObjectTestBuilder.createString(value = "test")
 
   @Inject

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/numberwithunits/NumberWithUnitsIsEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/numberwithunits/NumberWithUnitsIsEqualToRuleClassifierProviderTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,8 +15,6 @@ import org.oppia.android.domain.classify.InteractionObjectTestBuilder
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [NumberWithUnitsIsEqualToRuleClassifierProvider]. */
 @RunWith(AndroidJUnit4::class)
@@ -24,7 +24,7 @@ class NumberWithUnitsIsEqualToRuleClassifierProviderTest {
 
   private val WHOLE_NUMBER_VALUE_9 =
     InteractionObjectTestBuilder.createWholeNumber(
-      isNegative = false, value = 9
+      value = 9
     )
   private val FRACTION_VALUE_TEST_2_OVER_5 =
     InteractionObjectTestBuilder.createFraction(

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/ratioinput/RatioInputEqualsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/ratioinput/RatioInputEqualsRuleClassifierProviderTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,8 +16,6 @@ import org.oppia.android.domain.classify.RuleClassifier
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [RatioInputEqualsRuleClassifierProvider]. */
 @RunWith(AndroidJUnit4::class)
@@ -24,7 +24,7 @@ import javax.inject.Singleton
 class RatioInputEqualsRuleClassifierProviderTest {
 
   private val NON_NEGATIVE_VALUE_TEST_0 =
-    InteractionObjectTestBuilder.createNonNegativeInt(
+    InteractionObjectTestBuilder.createUnsingnedInteger(
       value = 0
     )
   private val RATIO_VALUE_TEST_1_2_3 =

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/ratioinput/RatioInputHasNumberOfTermsEqualToClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/ratioinput/RatioInputHasNumberOfTermsEqualToClassifierProviderTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,8 +16,6 @@ import org.oppia.android.domain.classify.RuleClassifier
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [RatioInputHasNumberOfTermsEqualToClassifierProvider]. */
 @RunWith(AndroidJUnit4::class)
@@ -24,11 +24,11 @@ import javax.inject.Singleton
 class RatioInputHasNumberOfTermsEqualToClassifierProviderTest {
 
   private val NON_NEGATIVE_VALUE_TEST_3 =
-    InteractionObjectTestBuilder.createNonNegativeInt(
+    InteractionObjectTestBuilder.createUnsingnedInteger(
       value = 3
     )
   private val NON_NEGATIVE_VALUE_TEST_4 =
-    InteractionObjectTestBuilder.createNonNegativeInt(
+    InteractionObjectTestBuilder.createUnsingnedInteger(
       value = 4
     )
   private val RATIO_VALUE_TEST_1_2_3 =

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/ratioinput/RatioInputIsEquivalentRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/ratioinput/RatioInputIsEquivalentRuleClassifierProviderTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,8 +16,6 @@ import org.oppia.android.domain.classify.RuleClassifier
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [RatioInputIsEquivalentRuleClassifierProvider]. */
 @RunWith(AndroidJUnit4::class)
@@ -24,7 +24,7 @@ import javax.inject.Singleton
 class RatioInputIsEquivalentRuleClassifierProviderTest {
 
   private val NON_NEGATIVE_VALUE_TEST_0 =
-    InteractionObjectTestBuilder.createNonNegativeInt(
+    InteractionObjectTestBuilder.createUnsingnedInteger(
       value = 0
     )
   private val RATIO_VALUE_TEST_1_2_3 =

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputContainsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputContainsRuleClassifierProviderTest.kt
@@ -6,17 +6,16 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createNonNegativeInt
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createString
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createTranslatableSetOfNormalizedString
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [TextInputContainsRuleClassifierProvider]. */
 @Suppress("PrivatePropertyName") // Truly immutable constants can be named in CONSTANT_CASE.
@@ -29,7 +28,7 @@ class TextInputContainsRuleClassifierProviderTest {
   private val STRING_VALUE_IS_ANSWER = createString(value = "is")
   private val STRING_VALUE_NOT_ANSWER = createString(value = "not")
   private val STRING_VALUE_TEST_ANSWER = createString(value = "this is a test")
-  private val NON_NEGATIVE_VALUE_TEST_1 = createNonNegativeInt(value = 1)
+  private val NON_NEGATIVE_VALUE_TEST_1 = createUnsingnedInteger(value = 1)
 
   private val STRING_VALUE_TEST_CONTAINS_ANSWER_INPUT_SET =
     createTranslatableSetOfNormalizedString("this is a test i will break")

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputEqualsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputEqualsRuleClassifierProviderTest.kt
@@ -6,17 +6,16 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createNonNegativeInt
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createString
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createTranslatableSetOfNormalizedString
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [TextInputEqualsRuleClassifierProvider]. */
 @Suppress("PrivatePropertyName") // Truly immutable constants can be named in CONSTANT_CASE.
@@ -32,7 +31,7 @@ class TextInputEqualsRuleClassifierProviderTest {
   private val STRING_VALUE_THIS = createString(value = "this")
   private val STRING_VALUE_A_TEST = createString(value = "a test")
   private val STRING_VALUE_NOT_A_TEST = createString(value = "not a test")
-  private val INT_VALUE_TEST_NON_NEGATIVE = createNonNegativeInt(value = 1)
+  private val INT_VALUE_TEST_NON_NEGATIVE = createUnsingnedInteger(value = 1)
 
   private val STRING_VALUE_TEST_UPPERCASE_INPUT_SET =
     createTranslatableSetOfNormalizedString("TEST")

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputFuzzyEqualsRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputFuzzyEqualsRuleClassifierProviderTest.kt
@@ -6,17 +6,16 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createNonNegativeInt
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createString
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createTranslatableSetOfNormalizedString
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [TextInputFuzzyEqualsRuleClassifierProvider]. */
 @Suppress("PrivatePropertyName") // Truly immutable constants can be named in CONSTANT_CASE.
@@ -34,7 +33,7 @@ class TextInputFuzzyEqualsRuleClassifierProviderTest {
   private val STRING_VALUE_THIS = createString(value = "this")
   private val STRING_VALUE_TEST = createString(value = "test")
   private val STRING_VALUE_TESTING = createString(value = "testing")
-  private val NON_NEGATIVE_TEST_VALUE_1 = createNonNegativeInt(value = 1)
+  private val NON_NEGATIVE_TEST_VALUE_1 = createUnsingnedInteger(value = 1)
 
   private val STRING_VALUE_TEST_UPPERCASE_INPUT_SET =
     createTranslatableSetOfNormalizedString("TEST")

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputStartsWithRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/textinput/TextInputStartsWithRuleClassifierProviderTest.kt
@@ -6,17 +6,16 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createNonNegativeInt
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createString
 import org.oppia.android.domain.classify.InteractionObjectTestBuilder.createTranslatableSetOfNormalizedString
 import org.oppia.android.testing.assertThrows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [TextInputStartsWithRuleClassifierProvider]. */
 @Suppress("PrivatePropertyName") // Truly immutable constants can be named in CONSTANT_CASE.
@@ -33,7 +32,7 @@ class TextInputStartsWithRuleClassifierProviderTest {
   private val STRING_VALUE_ANTIDERIVATIVE = createString(value = "antiderivative")
   private val STRING_VALUE_PREFIX = createString(value = "prefix")
   private val STRING_VALUE_SOMETHING_ELSE = createString(value = "something else")
-  private val NON_NEGATIVE_TEST_VALUE_1 = createNonNegativeInt(value = 1)
+  private val NON_NEGATIVE_TEST_VALUE_1 = createUnsingnedInteger(value = 1)
 
   private val STRING_VALUE_TEST_STRING_LOWERCASE_INPUT_SET =
     createTranslatableSetOfNormalizedString("test string")


### PR DESCRIPTION
Fixes #2423 
changed NEGATIVE_WHOLE_NUMBER variable to NEGATIVE_INTEGER_NUMBER

changed function naming in InteractionObjectTestBuilder.kt

<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
