### PR TITLE
Fix #3348: [RTL] High-fi Selection Interaction View

### DIFF
--- a/app/src/main/res/layout/item_selection_interaction_items.xml
+++ b/app/src/main/res/layout/item_selection_interaction_items.xml
@@ -35,9 +35,10 @@
 
     <TextView
       android:id="@+id/item_selection_contents_text_view"
-      android:layout_width="match_parent"
+      android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginStart="8dp"
+      android:layout_marginEnd="8dp"
       android:layout_marginTop="4dp"
       android:layout_toEndOf="@+id/item_selection_checkbox"
       android:fontFamily="sans-serif"

--- a/app/src/main/res/layout/multiple_choice_interaction_items.xml
+++ b/app/src/main/res/layout/multiple_choice_interaction_items.xml
@@ -35,9 +35,10 @@
 
     <TextView
       android:id="@+id/multiple_choice_content_text_view"
-      android:layout_width="match_parent"
+      android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginStart="12dp"
+      android:layout_marginEnd="12dp"
       android:layout_marginTop="4dp"
       android:layout_toEndOf="@+id/multiple_choice_radio_button"
       android:fontFamily="sans-serif"

--- a/app/src/main/res/layout/selection_interaction_item.xml
+++ b/app/src/main/res/layout/selection_interaction_item.xml
@@ -20,7 +20,6 @@
     android:background="@{viewModel.hasConversationView ? @drawable/rounded_rect_grey_border_white_background : @drawable/rounded_rect_white_background}"
     android:descendantFocusability="beforeDescendants"
     android:focusableInTouchMode="true"
-    android:orientation="vertical"
     android:paddingStart="@dimen/selection_interaction_item_padding_start"
     android:paddingTop="12dp"
     android:paddingEnd="@dimen/selection_interaction_item_padding_end"
@@ -32,6 +31,7 @@
     app:layout_constraintTop_toTopOf="parent">
 
     <TextView
+      android:id="@+id/selection_interaction_textview"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginTop="4dp"
@@ -41,7 +41,6 @@
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="14sp"
       android:textStyle="italic"
-      app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
       android:visibility="@{viewModel.getSelectionItemInputType() == SelectionItemInputType.RADIO_BUTTONS ? View.GONE : View. VISIBLE}" />
@@ -56,7 +55,7 @@
       app:entityId="@{viewModel.entityId}"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/selection_interaction_textview"
       app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/selection_interaction_item.xml
+++ b/app/src/main/res/layout/selection_interaction_item.xml
@@ -13,44 +13,51 @@
       type="org.oppia.android.app.player.state.itemviewmodel.SelectionInteractionViewModel" />
   </data>
 
-  <LinearLayout
-    android:id="@+id/interaction_container_linear_layout"
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@{viewModel.hasConversationView ? @drawable/rounded_rect_grey_border_white_background : @drawable/rounded_rect_white_background}"
-    android:descendantFocusability="beforeDescendants"
-    android:focusableInTouchMode="true"
-    android:orientation="vertical"
-    android:paddingStart="@dimen/selection_interaction_item_padding_start"
-    android:paddingTop="12dp"
-    android:paddingEnd="@dimen/selection_interaction_item_padding_end"
-    android:paddingBottom="12dp"
     app:layoutMarginEnd="@{viewModel.hasConversationView ? @dimen/interaction_item_exploration_view_margin_end : @dimen/interaction_item_question_view_margin_end}"
     app:layoutMarginStart="@{viewModel.hasConversationView ? @dimen/interaction_item_exploration_view_margin_start : @dimen/interaction_item_question_view_margin_start}"
-    app:layoutMarginTop="@{viewModel.hasConversationView ? @dimen/interaction_item_exploration_view_margin_top : @dimen/interaction_item_question_view_margin_top}"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintTop_toTopOf="parent">
+    app:layoutMarginTop="@{viewModel.hasConversationView ? @dimen/interaction_item_exploration_view_margin_top : @dimen/interaction_item_question_view_margin_top}">
 
-    <TextView
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="4dp"
-      android:layout_marginBottom="4dp"
-      android:fontFamily="sans-serif-light"
-      android:text="@string/item_selection_text"
-      android:textColor="@color/oppiaPrimaryText"
-      android:textSize="14sp"
-      android:textStyle="italic"
-      android:visibility="@{viewModel.getSelectionItemInputType() == SelectionItemInputType.RADIO_BUTTONS ? View.GONE : View. VISIBLE}" />
-
-    <org.oppia.android.app.player.state.SelectionInteractionView
-      android:id="@+id/selection_interaction_recyclerview"
+    <LinearLayout
+      android:id="@+id/interaction_container_linear_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:divider="@android:color/transparent"
-      app:allOptionsItemInputType="@{viewModel.getSelectionItemInputType()}"
-      app:data="@{viewModel.choiceItems}"
-      app:entityId="@{viewModel.entityId}"
-      app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
-  </LinearLayout>
+      android:background="@{viewModel.hasConversationView ? @drawable/rounded_rect_grey_border_white_background : @drawable/rounded_rect_white_background}"
+      android:descendantFocusability="beforeDescendants"
+      android:focusableInTouchMode="true"
+      android:orientation="vertical"
+      android:paddingStart="@dimen/selection_interaction_item_padding_start"
+      android:paddingTop="12dp"
+      android:paddingEnd="@dimen/selection_interaction_item_padding_end"
+      android:paddingBottom="12dp"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent">
+
+      <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"
+        android:fontFamily="sans-serif-light"
+        android:text="@string/item_selection_text"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="14sp"
+        android:textStyle="italic"
+        android:visibility="@{viewModel.getSelectionItemInputType() == SelectionItemInputType.RADIO_BUTTONS ? View.GONE : View. VISIBLE}" />
+
+      <org.oppia.android.app.player.state.SelectionInteractionView
+        android:id="@+id/selection_interaction_recyclerview"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:divider="@android:color/transparent"
+        app:allOptionsItemInputType="@{viewModel.getSelectionItemInputType()}"
+        app:data="@{viewModel.choiceItems}"
+        app:entityId="@{viewModel.entityId}"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+    </LinearLayout>
+  </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/selection_interaction_item.xml
+++ b/app/src/main/res/layout/selection_interaction_item.xml
@@ -32,7 +32,7 @@
     android:paddingTop="12dp"
     android:paddingEnd="@dimen/selection_interaction_item_padding_end"
     android:paddingBottom="12dp"
-     app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent">
 

--- a/app/src/main/res/layout/selection_interaction_item.xml
+++ b/app/src/main/res/layout/selection_interaction_item.xml
@@ -7,57 +7,56 @@
     <import type="android.view.View" />
 
     <import type="org.oppia.android.app.player.state.itemviewmodel.SelectionItemInputType" />
-
+    <variable
+      name="hasConversationView"
+      type="androidx.databinding.ObservableField&lt;Boolean&gt;" />
     <variable
       name="viewModel"
       type="org.oppia.android.app.player.state.itemviewmodel.SelectionInteractionViewModel" />
   </data>
-
-  <androidx.constraintlayout.widget.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:paddingEnd="@{viewModel.hasConversationView ? @dimen/interaction_item_exploration_view_margin_end : @dimen/interaction_item_question_view_margin_end}"
+  android:paddingStart="@{viewModel.hasConversationView ? @dimen/interaction_item_exploration_view_margin_start : @dimen/interaction_item_question_view_margin_start}"
+  android:paddingTop="@{hasConversationView ? @dimen/interaction_item_exploration_view_margin_top : @dimen/interaction_item_question_view_margin_top}">
+  <LinearLayout
+    android:id="@+id/interaction_container_linear_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    app:layoutMarginEnd="@{viewModel.hasConversationView ? @dimen/interaction_item_exploration_view_margin_end : @dimen/interaction_item_question_view_margin_end}"
-    app:layoutMarginStart="@{viewModel.hasConversationView ? @dimen/interaction_item_exploration_view_margin_start : @dimen/interaction_item_question_view_margin_start}"
-    app:layoutMarginTop="@{viewModel.hasConversationView ? @dimen/interaction_item_exploration_view_margin_top : @dimen/interaction_item_question_view_margin_top}">
+    android:background="@{viewModel.hasConversationView ? @drawable/rounded_rect_grey_border_white_background : @drawable/rounded_rect_white_background}"
+    android:descendantFocusability="beforeDescendants"
+    android:focusableInTouchMode="true"
+    android:orientation="vertical"
+    android:paddingStart="@dimen/selection_interaction_item_padding_start"
+    android:paddingTop="12dp"
+    android:paddingEnd="@dimen/selection_interaction_item_padding_end"
+    android:paddingBottom="12dp"
+     app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent">
 
-    <LinearLayout
-      android:id="@+id/interaction_container_linear_layout"
+    <TextView
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="4dp"
+      android:layout_marginBottom="4dp"
+      android:fontFamily="sans-serif-light"
+      android:text="@string/item_selection_text"
+      android:textColor="@color/oppiaPrimaryText"
+      android:textSize="14sp"
+      android:textStyle="italic"
+      android:visibility="@{viewModel.getSelectionItemInputType() == SelectionItemInputType.RADIO_BUTTONS ? View.GONE : View. VISIBLE}" />
+
+    <org.oppia.android.app.player.state.SelectionInteractionView
+      android:id="@+id/selection_interaction_recyclerview"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:background="@{viewModel.hasConversationView ? @drawable/rounded_rect_grey_border_white_background : @drawable/rounded_rect_white_background}"
-      android:descendantFocusability="beforeDescendants"
-      android:focusableInTouchMode="true"
-      android:orientation="vertical"
-      android:paddingStart="@dimen/selection_interaction_item_padding_start"
-      android:paddingTop="12dp"
-      android:paddingEnd="@dimen/selection_interaction_item_padding_end"
-      android:paddingBottom="12dp"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent">
-
-      <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:layout_marginBottom="4dp"
-        android:fontFamily="sans-serif-light"
-        android:text="@string/item_selection_text"
-        android:textColor="@color/oppiaPrimaryText"
-        android:textSize="14sp"
-        android:textStyle="italic"
-        android:visibility="@{viewModel.getSelectionItemInputType() == SelectionItemInputType.RADIO_BUTTONS ? View.GONE : View. VISIBLE}" />
-
-      <org.oppia.android.app.player.state.SelectionInteractionView
-        android:id="@+id/selection_interaction_recyclerview"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:divider="@android:color/transparent"
-        app:allOptionsItemInputType="@{viewModel.getSelectionItemInputType()}"
-        app:data="@{viewModel.choiceItems}"
-        app:entityId="@{viewModel.entityId}"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
-    </LinearLayout>
-  </androidx.constraintlayout.widget.ConstraintLayout>
+      android:divider="@android:color/transparent"
+      app:allOptionsItemInputType="@{viewModel.getSelectionItemInputType()}"
+      app:data="@{viewModel.choiceItems}"
+      app:entityId="@{viewModel.entityId}"
+      app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+  </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/selection_interaction_item.xml
+++ b/app/src/main/res/layout/selection_interaction_item.xml
@@ -7,20 +7,13 @@
     <import type="android.view.View" />
 
     <import type="org.oppia.android.app.player.state.itemviewmodel.SelectionItemInputType" />
-    <variable
-      name="hasConversationView"
-      type="androidx.databinding.ObservableField&lt;Boolean&gt;" />
+
     <variable
       name="viewModel"
       type="org.oppia.android.app.player.state.itemviewmodel.SelectionInteractionViewModel" />
   </data>
-<androidx.constraintlayout.widget.ConstraintLayout
-  android:layout_width="match_parent"
-  android:layout_height="wrap_content"
-  android:paddingEnd="@{viewModel.hasConversationView ? @dimen/interaction_item_exploration_view_margin_end : @dimen/interaction_item_question_view_margin_end}"
-  android:paddingStart="@{viewModel.hasConversationView ? @dimen/interaction_item_exploration_view_margin_start : @dimen/interaction_item_question_view_margin_start}"
-  android:paddingTop="@{hasConversationView ? @dimen/interaction_item_exploration_view_margin_top : @dimen/interaction_item_question_view_margin_top}">
-  <LinearLayout
+
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:id="@+id/interaction_container_linear_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -32,8 +25,10 @@
     android:paddingTop="12dp"
     android:paddingEnd="@dimen/selection_interaction_item_padding_end"
     android:paddingBottom="12dp"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
+    app:layoutMarginEnd="@{viewModel.hasConversationView ? @dimen/interaction_item_exploration_view_margin_end : @dimen/interaction_item_question_view_margin_end}"
+    app:layoutMarginStart="@{viewModel.hasConversationView ? @dimen/interaction_item_exploration_view_margin_start : @dimen/interaction_item_question_view_margin_start}"
+    app:layoutMarginTop="@{viewModel.hasConversationView ? @dimen/interaction_item_exploration_view_margin_top : @dimen/interaction_item_question_view_margin_top}"
+    app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintTop_toTopOf="parent">
 
     <TextView
@@ -46,6 +41,9 @@
       android:textColor="@color/oppiaPrimaryText"
       android:textSize="14sp"
       android:textStyle="italic"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
       android:visibility="@{viewModel.getSelectionItemInputType() == SelectionItemInputType.RADIO_BUTTONS ? View.GONE : View. VISIBLE}" />
 
     <org.oppia.android.app.player.state.SelectionInteractionView
@@ -56,7 +54,9 @@
       app:allOptionsItemInputType="@{viewModel.getSelectionItemInputType()}"
       app:data="@{viewModel.choiceItems}"
       app:entityId="@{viewModel.entityId}"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
       app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
-  </LinearLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
+  </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## Explanation
This PR Fixes #3348 . Fixes padding for selection interaction view to support RTL.

## Screenshot LTR and RTL
Mobile

<img width="144" alt="screenshot" src="https://user-images.githubusercontent.com/16301028/122678200-55bb3880-d203-11eb-9f11-bed0b9d22222.png">  ......  <img width="144" alt="screenshot" src="https://user-images.githubusercontent.com/16301028/122680457-e77b7380-d20c-11eb-8586-335f69f5fffc.png">



<img width="256" alt="screenshot" src="https://user-images.githubusercontent.com/16301028/122678185-3ae8c400-d203-11eb-8b25-264c70f98b3f.png">.......<img width="256" alt="screenshot" src="https://user-images.githubusercontent.com/16301028/122680469-f6622600-d20c-11eb-8395-9334802d55dd.png">


Tablet

<img width="160" alt="screenshot" src="https://user-images.githubusercontent.com/16301028/122678382-412b7000-d204-11eb-9b31-6205c71af845.png"> .....  <img width="160" alt="screenshot" src="https://user-images.githubusercontent.com/16301028/122680775-8ce31700-d20e-11eb-9a18-601a062f2de8.png">

<img width="256" alt="screenshot" src="https://user-images.githubusercontent.com/16301028/122678399-556f6d00-d204-11eb-8913-d7b8e2653674.png">........<img width="256" alt="screenshot" src="https://user-images.githubusercontent.com/16301028/122680787-a1bfaa80-d20e-11eb-8798-f544639e2741.png">



<img width="160" alt="screenshot" src="https://user-images.githubusercontent.com/16301028/122680761-750b9300-d20e-11eb-99d0-a66fb700f372.png"> ........<img width="256" alt="screenshot" src="https://user-images.githubusercontent.com/16301028/122680742-5f966900-d20e-11eb-9bdf-a559e6169075.png">




## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
