### PR TITLE
Fix #2324: Changes in Submitted Answer List Items [A11y]

### DIFF
--- a/app/src/main/res/layout/submitted_answer_item.xml
+++ b/app/src/main/res/layout/submitted_answer_item.xml
@@ -55,7 +55,7 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:background="@drawable/submitted_answer_background"
-      android:contentDescription="@{accessibleAnswer ?? submittedAnswer}"
+      android:contentDescription="@{viewModel.isCorrectAnswer() ? String.format(@string/correct_submitted_answer_with_append, submittedAnswer) : String.format(@string/incorrect_submitted_answer_with_append, submittedAnswer)}"
       android:padding="12dp"
       android:text="@{submittedAnswer}"
       android:textColor="@color/oppiaPrimaryText"
@@ -67,19 +67,27 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent" />
 
-    <androidx.recyclerview.widget.RecyclerView
-      android:id="@+id/submitted_answer_recycler_view"
+    <LinearLayout
+      android:id="@+id/submitted_answer_recycler_view_container"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:background="@drawable/submitted_answer_background"
-      android:paddingStart="8dp"
-      android:paddingEnd="8dp"
-      android:visibility="gone"
-      app:itemDecorator="@{@drawable/divider}"
-      app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+      android:orientation="vertical"
+      android:contentDescription="@{viewModel.isCorrectAnswer ? @string/correct_submitted_answer : @string/incorrect_submitted_answer}"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent"
-      app:list="@{submittedListAnswer.setOfHtmlStringsList}" />
+      app:layout_constraintTop_toTopOf="parent">
+
+      <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/submitted_answer_recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/submitted_answer_background"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:visibility="gone"
+        app:itemDecorator="@{@drawable/divider}"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:list="@{submittedListAnswer.setOfHtmlStringsList}" />
+    </LinearLayout>
 
     <ImageView
       android:id="@+id/answer_tick"
@@ -87,6 +95,7 @@
       android:layout_height="@dimen/answer_tick_size"
       android:layout_gravity="center_vertical"
       android:layout_marginStart="@dimen/answer_tick_margin"
+      android:importantForAccessibility="no"
       android:src="@drawable/ic_check_primary"
       android:visibility="@{viewModel.isCorrectAnswer &amp;&amp; !viewModel.hasConversationView ? View.VISIBLE : View.GONE}"
       app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/submitted_answer_item.xml
+++ b/app/src/main/res/layout/submitted_answer_item.xml
@@ -55,7 +55,7 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:background="@drawable/submitted_answer_background"
-      android:contentDescription="@{viewModel.isCorrectAnswer() ? String.format(@string/correct_submitted_answer_with_append, submittedAnswer) : String.format(@string/incorrect_submitted_answer_with_append, submittedAnswer)}"
+      android:contentDescription="@{viewModel.isCorrectAnswer() ? String.format(@string/correct_submitted_answer_with_append, accessibleAnswer.length() > 0  ? accessibleAnswer : submittedAnswer) : String.format(@string/incorrect_submitted_answer_with_append, accessibleAnswer.length() > 0  ? accessibleAnswer : submittedAnswer)}"
       android:padding="12dp"
       android:text="@{submittedAnswer}"
       android:textColor="@color/oppiaPrimaryText"
@@ -71,8 +71,8 @@
       android:id="@+id/submitted_answer_recycler_view_container"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:orientation="vertical"
       android:contentDescription="@{viewModel.isCorrectAnswer ? @string/correct_submitted_answer : @string/incorrect_submitted_answer}"
+      android:orientation="vertical"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent">
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -441,4 +441,8 @@
   <string name="audio_player_on">Audio, ON</string>
   <string name="audio_player_off">Audio, OFF</string>
   <string name="hints_android_solution_correct_answer">%s/%s</string>
+  <string name="correct_submitted_answer">Correct submitted answer</string>
+  <string name="correct_submitted_answer_with_append">Correct submitted answer: %s</string>
+  <string name="incorrect_submitted_answer">Incorrect submitted answer</string>
+  <string name="incorrect_submitted_answer_with_append">Incorrect submitted answer: %s</string>
 </resources>

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -471,6 +471,48 @@ class StateFragmentTest {
   }
 
   @Test
+  fun testStateFragment_loadExp_secondState_submitWrongAnswer_contentDescriptionIsCorrect() {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
+      startPlayingExploration()
+      clickContinueInteractionButton()
+
+      // Attempt to submit an wrong answer.
+      typeFractionText("1/4")
+      clickSubmitAnswerButton()
+
+      scrollToViewType(SUBMITTED_ANSWER)
+      onView(withId(R.id.submitted_answer_text_view)).check(
+        matches(
+          withContentDescription(
+            "Incorrect submitted answer: 1/4"
+          )
+        )
+      )
+    }
+  }
+
+  @Test
+  fun testStateFragment_loadExp_secondState_submitCorrectAnswer_contentDescriptionIsCorrect() {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
+      startPlayingExploration()
+      clickContinueInteractionButton()
+
+      // Attempt to submit an wrong answer.
+      typeFractionText("1/2")
+      clickSubmitAnswerButton()
+
+      scrollToViewType(SUBMITTED_ANSWER)
+      onView(withId(R.id.submitted_answer_text_view)).check(
+        matches(
+          withContentDescription(
+            "Correct submitted answer: 1/2"
+          )
+        )
+      )
+    }
+  }
+
+  @Test
   fun testStateFragment_loadExp_firstState_previousAndNextButtonIsNotDisplayed() {
     launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
@@ -515,6 +557,53 @@ class StateFragmentTest {
           targetViewId = R.id.submitted_html_answer_recycler_view
         )
       ).check(matches(hasChildCount(2)))
+    }
+  }
+
+  @Test
+  fun testStateFragment_loadDragDropExp_wrongAnswer_contentDescriptionIsCorrect() {
+    launchForExploration(TEST_EXPLORATION_ID_4).use {
+      startPlayingExploration()
+
+      mergeDragAndDropItems(position = 0)
+      clickSubmitAnswerButton()
+
+      scrollToViewType(SUBMITTED_ANSWER)
+      onView(withId(R.id.submitted_answer_recycler_view_container)).check(
+        matches(
+          withContentDescription(
+            context.getString(R.string.incorrect_submitted_answer)
+          )
+        )
+      )
+    }
+  }
+
+  @Test
+  fun testStateFragment_loadDragDropExp_correctAnswer_contentDescriptionIsCorrect() {
+    launchForExploration(TEST_EXPLORATION_ID_4).use {
+      startPlayingExploration()
+      playThroughPrototypeState1()
+      playThroughPrototypeState2()
+      playThroughPrototypeState3()
+      playThroughPrototypeState4()
+      playThroughPrototypeState5()
+      playThroughPrototypeState6()
+      playThroughPrototypeState7()
+      playThroughPrototypeState8()
+
+      // Drag and drop interaction without grouping.
+      // Ninth state: Drag Drop Sort. Correct answer: Move 1st item to 4th position.
+      dragAndDropItem(fromPosition = 0, toPosition = 3)
+      clickSubmitAnswerButton()
+      scrollToViewType(SUBMITTED_ANSWER)
+      onView(withId(R.id.submitted_answer_recycler_view_container)).check(
+        matches(
+          withContentDescription(
+            context.getString(R.string.correct_submitted_answer)
+          )
+        )
+      )
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -581,7 +581,7 @@ class StateFragmentTest {
 
   @Test
   fun testStateFragment_loadDragDropExp_correctAnswer_contentDescriptionIsCorrect() {
-    launchForExploration(TEST_EXPLORATION_ID_4).use {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       playThroughPrototypeState1()
       playThroughPrototypeState2()
@@ -1007,7 +1007,7 @@ class StateFragmentTest {
       clickSubmitAnswerButton()
 
       onView(withId(R.id.submitted_answer_text_view))
-        .check(matches(withContentDescription("4 to 5")))
+        .check(matches(withContentDescription("Correct submitted answer: 4 to 5")))
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fix #2324

## Problem
If learner submits multiple same incorrect answers or atleast 1 incorrect answer in case of DragAndDrop then the A11y Scanner fails because there are multiple same texts.

## Solution
For this problem user experience is more important than A11y Scanner failures and therefore for all correct answers we append `Correct submitted answer` and for all incorrect answers we append `Incorrect submitted answer`. In this case even if learner enters same incorrect answer multiple types (for which Scanner fails) we are prioritising user experience here.

Have a look at following comments: https://github.com/oppia/oppia-android/issues/2324#issuecomment-780799146 and https://github.com/oppia/oppia-android/issues/2324#issuecomment-780858109

## Output

https://user-images.githubusercontent.com/9396084/122798150-e23a2980-d2dd-11eb-94f6-120b6ac0f83b.mp4


https://user-images.githubusercontent.com/9396084/122798180-ec5c2800-d2dd-11eb-8ada-4006e10039d7.mp4


https://user-images.githubusercontent.com/9396084/122798198-f0884580-d2dd-11eb-9331-6ca43c1b14b5.mp4

<img width="1380" alt="Screenshot 2021-06-21 at 10 42 41 PM" src="https://user-images.githubusercontent.com/9396084/122801661-0992f580-d2e2-11eb-94c3-0733bf7c73b6.png">


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
