### PR TITLE
Fixes part of #3362: Used AccessibilityTestRule for Espresso Tests

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -79,6 +79,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.profile.ProfileTestHelper
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -106,6 +107,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class AdministratorControlsActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   private val internalProfileId = 0
 

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AppVersionActivityTest.kt
@@ -60,6 +60,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestCoroutineDispatchers
@@ -88,6 +89,9 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class AppVersionActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
+
   @get:Rule
   val activityTestRule: ActivityTestRule<AppVersionActivity> = ActivityTestRule(
     AppVersionActivity::class.java, /* initialTouchMode= */ true, /* launchActivity= */ false

--- a/app/src/sharedTest/java/org/oppia/android/app/completedstorylist/CompletedStoryListActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/completedstorylist/CompletedStoryListActivityTest.kt
@@ -63,6 +63,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.FRACTIONS_STORY_ID_0
 import org.oppia.android.domain.topic.FRACTIONS_TOPIC_ID
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.story.StoryProgressTestHelper
@@ -91,6 +92,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class CompletedStoryListActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   private val internalProfileId = 0
   private val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()

--- a/app/src/sharedTest/java/org/oppia/android/app/customview/LessonThumbnailImageViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/customview/LessonThumbnailImageViewTest.kt
@@ -44,6 +44,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -68,6 +69,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class LessonThumbnailImageViewTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val activityTestRule = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/faq/FAQListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/faq/FAQListFragmentTest.kt
@@ -23,6 +23,7 @@ import dagger.Component
 import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -58,6 +59,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -79,6 +81,8 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = FAQListFragmentTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class FAQListFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Before
   fun setUp() {

--- a/app/src/sharedTest/java/org/oppia/android/app/faq/FAQSingleActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/faq/FAQSingleActivityTest.kt
@@ -53,6 +53,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -77,6 +78,8 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = FAQSingleActivityTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class FAQSingleActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   private lateinit var launchedActivity: Activity
 

--- a/app/src/sharedTest/java/org/oppia/android/app/faq/FaqListActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/faq/FaqListActivityTest.kt
@@ -42,6 +42,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -64,6 +65,8 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = FaqListActivityTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class FaqListActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val activityTestRule: ActivityTestRule<FAQListActivity> = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/help/HelpActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/help/HelpActivityTest.kt
@@ -41,6 +41,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -63,6 +64,8 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = HelpActivityTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class HelpActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val activityTestRule: ActivityTestRule<HelpActivity> = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/help/HelpFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/help/HelpFragmentTest.kt
@@ -63,6 +63,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestLogReportingModule
@@ -88,6 +89,8 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = HelpFragmentTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class HelpFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val oppiaTestRule = OppiaTestRule()

--- a/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
@@ -35,6 +35,7 @@ import org.hamcrest.TypeSafeMatcher
 import org.hamcrest.core.IsNot.not
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -78,6 +79,7 @@ import org.oppia.android.domain.topic.FRACTIONS_STORY_ID_0
 import org.oppia.android.domain.topic.FRACTIONS_TOPIC_ID
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.domain.topic.TEST_TOPIC_ID_0
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.TestPlatform
@@ -118,6 +120,8 @@ private const val AFTERNOON_TIMESTAMP = 1556029320000
   qualifiers = "port-xxhdpi"
 )
 class HomeActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var profileTestHelper: ProfileTestHelper
@@ -864,7 +868,7 @@ class HomeActivityTest {
 
   // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
   @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
-  @Config(qualifiers = "port-mdpi")
+  @Config(qualifiers = "+port-mdpi")
   @Test
   fun testHomeActivity_longProfileName_welcomeMessageIsDisplayed() {
     launch<HomeActivity>(createHomeActivityIntent(longNameInternalProfileId)).use {
@@ -882,7 +886,7 @@ class HomeActivityTest {
 
   // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
   @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
-  @Config(qualifiers = "land-mdpi")
+  @Config(qualifiers = "+land-mdpi")
   @Test
   fun testHomeActivity_configChange_longProfileName_welcomeMessageIsDisplayed() {
     launch<HomeActivity>(createHomeActivityIntent(longNameInternalProfileId)).use {
@@ -901,7 +905,7 @@ class HomeActivityTest {
 
   // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
   @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
-  @Config(qualifiers = "sw600dp-port")
+  @Config(qualifiers = "+sw600dp-port")
   @Test
   fun testHomeActivity_longProfileName_tabletPortraitWelcomeMessageIsDisplayed() {
     launch<HomeActivity>(createHomeActivityIntent(longNameInternalProfileId)).use {
@@ -919,7 +923,7 @@ class HomeActivityTest {
 
   // TODO(#2057): Remove when TextViews are properly measured in Robolectric.
   @RunOn(TestPlatform.ESPRESSO) // Incorrectly passes on Robolectric and shouldn't be re-enabled
-  @Config(qualifiers = "sw600dp-land")
+  @Config(qualifiers = "+sw600dp-land")
   @Test
   fun testHomeActivity_longProfileName_tabletLandscapeWelcomeMessageIsDisplayed() {
     launch<HomeActivity>(createHomeActivityIntent(longNameInternalProfileId)).use {
@@ -1123,7 +1127,7 @@ class HomeActivityTest {
     }
   }
 
-  @Config(qualifiers = "port")
+  @Config(qualifiers = "+port")
   @Test
   fun testHomeActivity_noTopicsStarted_mobilePortraitDisplaysTopicsIn2Columns() {
     // Only new users will have no progress for any topics.
@@ -1142,7 +1146,7 @@ class HomeActivityTest {
     }
   }
 
-  @Config(qualifiers = "land")
+  @Config(qualifiers = "+land")
   @Test
   fun testHomeActivity_noTopicsStarted_mobileLandscapeDisplaysTopicsIn3Columns() {
     // Only new users will have no progress for any topics.
@@ -1162,7 +1166,7 @@ class HomeActivityTest {
     }
   }
 
-  @Config(qualifiers = "sw600dp-port")
+  @Config(qualifiers = "+sw600dp-port")
   @Test
   fun testHomeActivity_noTopicsStarted_tabletPortraitDisplaysTopicsIn3Columns() {
     // Only new users will have no progress for any topics.
@@ -1177,7 +1181,7 @@ class HomeActivityTest {
     }
   }
 
-  @Config(qualifiers = "sw600dp-land")
+  @Config(qualifiers = "+sw600dp-land")
   @Test
   fun testHomeActivity_noTopicsStarted_tabletLandscapeDisplaysTopicsIn4Columns() {
     // Only new users will have no progress for any topics.
@@ -1228,7 +1232,7 @@ class HomeActivityTest {
     }
   }
 
-  @Config(qualifiers = "sw600dp-port")
+  @Config(qualifiers = "+sw600dp-port")
   @Test
   fun testHomeActivity_multipleRecentlyPlayedStories_tabletPortraitShows3PromotedStories() {
     fakeOppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_UPTIME_MILLIS)
@@ -1265,7 +1269,7 @@ class HomeActivityTest {
     }
   }
 
-  @Config(qualifiers = "sw600dp-land")
+  @Config(qualifiers = "+sw600dp-land")
   @Test
   fun testHomeActivity_multipleRecentlyPlayedStories_tabletLandscapeShows4PromotedStories() {
     fakeOppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_UPTIME_MILLIS)

--- a/app/src/sharedTest/java/org/oppia/android/app/home/RecentlyPlayedFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/RecentlyPlayedFragmentTest.kt
@@ -73,6 +73,7 @@ import org.oppia.android.domain.topic.FRACTIONS_EXPLORATION_ID_0
 import org.oppia.android.domain.topic.FRACTIONS_STORY_ID_0
 import org.oppia.android.domain.topic.FRACTIONS_TOPIC_ID
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.profile.ProfileTestHelper
@@ -102,6 +103,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class RecentlyPlayedFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val activityTestRule: ActivityTestRule<RecentlyPlayedActivity> = ActivityTestRule(
@@ -178,7 +181,7 @@ class RecentlyPlayedFragmentTest {
           withParent(withId(R.id.recently_played_toolbar))
         )
       ).check(
-        matches(withText(R.string.recently_played_activity))
+        matches(withText(R.string.stories_for_you))
       )
     }
   }
@@ -587,7 +590,7 @@ class RecentlyPlayedFragmentTest {
       onView(
         allOf(instanceOf(TextView::class.java), withParent(withId(R.id.recently_played_toolbar)))
       ).check(
-        matches(withText(R.string.recently_played_activity))
+        matches(withText(R.string.stories_for_you))
       )
     }
   }

--- a/app/src/sharedTest/java/org/oppia/android/app/home/RecentlyPlayedFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/RecentlyPlayedFragmentTest.kt
@@ -181,7 +181,7 @@ class RecentlyPlayedFragmentTest {
           withParent(withId(R.id.recently_played_toolbar))
         )
       ).check(
-        matches(withText(R.string.stories_for_you))
+        matches(withText(R.string.recently_played_activity))
       )
     }
   }
@@ -590,7 +590,7 @@ class RecentlyPlayedFragmentTest {
       onView(
         allOf(instanceOf(TextView::class.java), withParent(withId(R.id.recently_played_toolbar)))
       ).check(
-        matches(withText(R.string.stories_for_you))
+        matches(withText(R.string.recently_played_activity))
       )
     }
   }

--- a/app/src/sharedTest/java/org/oppia/android/app/home/TopicSummaryViewModelTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/TopicSummaryViewModelTest.kt
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.Component
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.app.activity.ActivityComponent
@@ -42,6 +43,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -69,6 +71,8 @@ private const val TEST_FRAGMENT_TAG = "topic_summary_view_model_test_fragment"
   manifest = Config.NONE
 )
 class TopicSummaryViewModelTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var context: Context

--- a/app/src/sharedTest/java/org/oppia/android/app/home/WelcomeViewModelTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/WelcomeViewModelTest.kt
@@ -10,6 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.Component
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.app.activity.ActivityComponent
@@ -42,6 +43,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -76,6 +78,9 @@ private const val TEST_FRAGMENT_TAG = "welcome_view_model_test_fragment"
   manifest = Config.NONE
 )
 class WelcomeViewModelTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
+
   @Inject
   lateinit var context: Context
 

--- a/app/src/sharedTest/java/org/oppia/android/app/home/promotedlist/PromotedStoryListViewModelTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/promotedlist/PromotedStoryListViewModelTest.kt
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.Component
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.app.activity.ActivityComponent
@@ -43,6 +44,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -68,6 +70,9 @@ import javax.inject.Singleton
   manifest = Config.NONE
 )
 class PromotedStoryListViewModelTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
+
   @Inject
   lateinit var context: Context
 

--- a/app/src/sharedTest/java/org/oppia/android/app/home/promotedlist/PromotedStoryViewModelTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/promotedlist/PromotedStoryViewModelTest.kt
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.Component
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.app.activity.ActivityComponent
@@ -41,6 +42,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -66,6 +68,8 @@ import javax.inject.Singleton
   manifest = Config.NONE
 )
 class PromotedStoryViewModelTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var context: Context

--- a/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsFragmentTest.kt
@@ -19,6 +19,7 @@ import dagger.Component
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.instanceOf
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -50,6 +51,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -71,6 +73,8 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = MyDownloadsFragmentTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class MyDownloadsFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Before
   fun setUp() {

--- a/app/src/sharedTest/java/org/oppia/android/app/onboarding/OnboardingActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/onboarding/OnboardingActivityTest.kt
@@ -41,6 +41,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -63,6 +64,8 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = OnboardingActivityTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class OnboardingActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val activityTestRule: ActivityTestRule<OnboardingActivity> = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/onboarding/OnboardingFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/onboarding/OnboardingFragmentTest.kt
@@ -34,6 +34,7 @@ import org.hamcrest.CoreMatchers.not
 import org.hamcrest.Matcher
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -66,6 +67,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestCoroutineDispatchers
@@ -92,6 +94,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class OnboardingFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var testCoroutineDispatchers: TestCoroutineDispatchers

--- a/app/src/sharedTest/java/org/oppia/android/app/ongoingtopiclist/OngoingTopicListActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/ongoingtopiclist/OngoingTopicListActivityTest.kt
@@ -61,6 +61,7 @@ import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfiguration
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.domain.topic.RATIOS_TOPIC_ID
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.story.StoryProgressTestHelper
@@ -89,6 +90,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class OngoingTopicListActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   private val internalProfileId = 0
 

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AppLanguageActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AppLanguageActivityTest.kt
@@ -41,6 +41,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -66,6 +67,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class AppLanguageActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val activityTestRule: ActivityTestRule<AppLanguageActivity> = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AppLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AppLanguageFragmentTest.kt
@@ -17,6 +17,7 @@ import dagger.Module
 import dagger.Provides
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -49,6 +50,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.profile.ProfileTestHelper
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -77,6 +79,8 @@ private const val FRENCH = 1
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = AppLanguageFragmentTest.TestApplication::class)
 class AppLanguageFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var context: Context

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageActivityTest.kt
@@ -41,6 +41,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -66,6 +67,9 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class AudioLanguageActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
+
   @get:Rule
   val activityTestRule: ActivityTestRule<AudioLanguageActivity> = ActivityTestRule(
     AudioLanguageActivity::class.java, /* initialTouchMode= */ true, /* launchActivity= */ false

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
@@ -16,6 +16,7 @@ import dagger.Component
 import dagger.Module
 import dagger.Provides
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -48,6 +49,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.profile.ProfileTestHelper
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -76,6 +78,8 @@ private const val FRENCH = 2
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = AudioLanguageFragmentTest.TestApplication::class)
 class AudioLanguageFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var context: Context

--- a/app/src/sharedTest/java/org/oppia/android/app/options/OptionsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/OptionsActivityTest.kt
@@ -41,6 +41,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -63,6 +64,8 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = OptionsActivityTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class OptionsActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val activityTestRule: ActivityTestRule<OptionsActivity> = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/options/OptionsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/OptionsFragmentTest.kt
@@ -62,6 +62,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.profile.ProfileTestHelper
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -93,6 +94,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class OptionsFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var profileTestHelper: ProfileTestHelper

--- a/app/src/sharedTest/java/org/oppia/android/app/options/ReadingTextSizeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/ReadingTextSizeActivityTest.kt
@@ -41,6 +41,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -66,6 +67,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class ReadingTextSizeActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val activityTestRule: ActivityTestRule<ReadingTextSizeActivity> = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/options/ReadingTextSizeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/ReadingTextSizeFragmentTest.kt
@@ -23,6 +23,7 @@ import org.hamcrest.Description
 import org.hamcrest.TypeSafeMatcher
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -55,6 +56,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.profile.ProfileTestHelper
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -94,6 +96,8 @@ private const val EXTRA_LARGE_TEXT_SIZE_INDEX = 3
   qualifiers = "port-xxhdpi"
 )
 class ReadingTextSizeFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var context: Context

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
@@ -78,6 +78,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.espresso.EditTextInputAction
 import org.oppia.android.testing.profile.ProfileTestHelper
@@ -105,6 +106,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class AddProfileActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val activityTestRule = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
@@ -67,6 +67,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.espresso.EditTextInputAction
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -93,6 +94,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class AdminAuthActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var context: Context

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
@@ -75,6 +75,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.espresso.EditTextInputAction
 import org.oppia.android.testing.profile.ProfileTestHelper
@@ -102,6 +103,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class AdminPinActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get: Rule
   val activityTestRule: ActivityTestRule<AdminPinActivity> = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
@@ -96,6 +96,7 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class PinPasswordActivityTest {
+  // TODO(#3362): Use AccessibilityTestRule
 
   @get:Rule
   val activityTestRule: ActivityTestRule<PinPasswordActivity> = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
@@ -27,6 +27,7 @@ import dagger.Component
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -63,6 +64,7 @@ import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfiguration
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.profile.ProfileTestHelper
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -91,6 +93,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class ProfileChooserFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   private val activityTestRule: ActivityTestRule<ProfileChooserActivity> = ActivityTestRule(
     ProfileChooserActivity::class.java, /* initialTouchMode= */ true, /* launchActivity= */ false

--- a/app/src/sharedTest/java/org/oppia/android/app/profileprogress/ProfilePictureActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profileprogress/ProfilePictureActivityTest.kt
@@ -15,6 +15,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Component
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -45,6 +46,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.profile.ProfileTestHelper
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -71,6 +73,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class ProfilePictureActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var profileTestHelper: ProfileTestHelper

--- a/app/src/sharedTest/java/org/oppia/android/app/profileprogress/ProfileProgressActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profileprogress/ProfileProgressActivityTest.kt
@@ -41,6 +41,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -66,6 +67,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class ProfileProgressActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val activityTestRule: ActivityTestRule<ProfileProgressActivity> = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/profileprogress/ProfileProgressFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profileprogress/ProfileProgressFragmentTest.kt
@@ -39,6 +39,7 @@ import org.hamcrest.CoreMatchers.not
 import org.hamcrest.Matcher
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -78,6 +79,8 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.FRACTIONS_STORY_ID_0
 import org.oppia.android.domain.topic.FRACTIONS_TOPIC_ID
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
+import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.profile.ProfileTestHelper
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -110,6 +113,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class ProfileProgressFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var profileTestHelper: ProfileTestHelper
@@ -183,6 +188,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3251): Enable AccessibilityChecks
   fun testProfileProgressFragment_profilePictureEditDialogIsDisplayed() {
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()
@@ -193,6 +199,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3363): Enable AccessibilityChecks
   fun testProfileProgressFragment_openProfilePictureEditDialog_configChange_dialogIsStillOpen() {
     launch<ProfileProgressActivity>(createProfileProgressActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()
@@ -204,6 +211,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3251): Enable AccessibilityChecks
   fun testProfileProgressFragment_imageSelectAvatar_checkGalleryIntent() {
     val expectedIntent: Matcher<Intent> = allOf(
       hasAction(Intent.ACTION_PICK),
@@ -222,6 +230,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3251): Enable AccessibilityChecks
   fun testProfileProgressFragment_imageSelectAvatar_configChange_checkGalleryIntent() {
     val expectedIntent: Matcher<Intent> = allOf(
       hasAction(Intent.ACTION_PICK),
@@ -387,6 +396,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3251): Enable AccessibilityChecks
   fun testProfileProgressFragment_twoPartialStoryProgress_completedStoriesCountIsTwo() {
     storyProgressTestHelper.markCompletedRatiosStory0(
       profileId,
@@ -502,6 +512,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3363): Enable AccessibilityChecks
   fun testProfileProgressFragment_clickFractionsStory_opensTopicActivity() {
     storyProgressTestHelper.markRecentlyPlayedFractionsStory0Exp0(
       profileId,
@@ -524,6 +535,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3363): Enable AccessibilityChecks
   fun testProfileProgressFragment_clickViewAll_opensRecentlyPlayedActivity() {
     storyProgressTestHelper.markRecentlyPlayedFractionsStory0Exp0(
       profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build(),
@@ -592,6 +604,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3251): Enable AccessibilityChecks
   fun testProfileProgressFragment_clickTopicCount_opensOngoingTopicListActivity() {
     storyProgressTestHelper.markCompletedFractionsStory0Exp0(
       profileId = profileId,
@@ -621,6 +634,7 @@ class ProfileProgressFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3251): Enable AccessibilityChecks
   fun testProfileProgressFragment_clickStoryCount_opensCompletedStoryListActivity() {
     storyProgressTestHelper.markCompletedRatiosStory0(
       profileId = profileId,

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -25,6 +25,7 @@ import dagger.Component
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -59,6 +60,7 @@ import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfiguration
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.profile.ProfileTestHelper
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -87,6 +89,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class ProfileEditActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var context: Context

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileListActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileListActivityTest.kt
@@ -41,6 +41,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -63,6 +64,8 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = ProfileListActivityTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class ProfileListActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val activityTestRule: ActivityTestRule<ProfileListActivity> = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileListFragmentTest.kt
@@ -22,6 +22,7 @@ import dagger.Component
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -55,6 +56,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.profile.ProfileTestHelper
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -81,6 +83,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class ProfileListFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var context: Context

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameActivityTest.kt
@@ -65,6 +65,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.espresso.EditTextInputAction
 import org.oppia.android.testing.profile.ProfileTestHelper
@@ -93,6 +94,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class ProfileRenameActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var context: Context

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileResetPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileResetPinActivityTest.kt
@@ -67,6 +67,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.espresso.EditTextInputAction
 import org.oppia.android.testing.profile.ProfileTestHelper
@@ -94,6 +95,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class ProfileResetPinActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val activityTestRule: ActivityTestRule<ProfileResetPinActivity> = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/splash/SplashActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/splash/SplashActivityTest.kt
@@ -57,6 +57,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestCoroutineDispatchers
@@ -88,6 +89,8 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = SplashActivityTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class SplashActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject lateinit var context: Context
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers

--- a/app/src/sharedTest/java/org/oppia/android/app/story/StoryActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/story/StoryActivityTest.kt
@@ -58,6 +58,8 @@ import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.domain.topic.TEST_EXPLORATION_ID_2
 import org.oppia.android.domain.topic.TEST_STORY_ID_0
 import org.oppia.android.domain.topic.TEST_TOPIC_ID_0
+import org.oppia.android.testing.AccessibilityTestRule
+import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -81,6 +83,8 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = StoryActivityTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class StoryActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
@@ -127,6 +131,7 @@ class StoryActivityTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3362): Enable AccessibilityChecks
   fun clickOnStory_intentsToExplorationActivity() {
     launch<StoryActivity>(
       createStoryActivityIntent(

--- a/app/src/sharedTest/java/org/oppia/android/app/story/StoryFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/story/StoryFragmentTest.kt
@@ -88,6 +88,8 @@ import org.oppia.android.domain.topic.FRACTIONS_TOPIC_ID
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.domain.topic.TEST_STORY_ID_0
 import org.oppia.android.domain.topic.TEST_TOPIC_ID_0
+import org.oppia.android.testing.AccessibilityTestRule
+import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.mockito.anyOrNull
 import org.oppia.android.testing.mockito.capture
@@ -117,6 +119,9 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = StoryFragmentTest.TestApplication::class, qualifiers = "port-xxhdpi")
 class StoryFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
+
   @Rule
   @JvmField
   val mockitoRule: MockitoRule = MockitoJUnit.rule()
@@ -165,6 +170,7 @@ class StoryFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3362): Enable AccessibilityChecks
   fun testStoryFragment_clickOnToolbarNavigationButton_closeActivity() {
     activityTestRule.launchActivity(createFractionsStoryActivityIntent())
     testCoroutineDispatchers.runCurrent()
@@ -485,6 +491,7 @@ class StoryFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3362): Enable AccessibilityChecks
   fun testStoryFragment_changeConfiguration_explorationStartCorrectly() {
     launch<StoryActivity>(createFractionsStoryActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/TopicActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/TopicActivityTest.kt
@@ -41,6 +41,7 @@ import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfiguration
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.FRACTIONS_TOPIC_ID
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestDispatcherModule
@@ -66,6 +67,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class TopicActivityTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   var activityTestRule: ActivityTestRule<TopicActivity> = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
@@ -63,6 +63,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.FRACTIONS_STORY_ID_0
 import org.oppia.android.domain.topic.FRACTIONS_TOPIC_ID
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestCoroutineDispatchers
@@ -94,6 +95,8 @@ private const val REVISION_TAB_POSITION = 3
   qualifiers = "port-xxhdpi"
 )
 class TopicFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   var activityTestRule: ActivityTestRule<TopicActivity> = ActivityTestRule(

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentTest.kt
@@ -26,6 +26,7 @@ import org.hamcrest.Matchers.instanceOf
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -58,6 +59,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.RichTextViewMatcher.Companion.containsRichText
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.environment.TestEnvironmentConfig
@@ -88,6 +90,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class ConceptCardFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var context: Context

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/info/TopicInfoFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/info/TopicInfoFragmentTest.kt
@@ -64,6 +64,7 @@ import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfiguration
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.domain.topic.RATIOS_TOPIC_ID
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestImageLoaderModule
@@ -111,6 +112,8 @@ private const val DUMMY_TOPIC_DESCRIPTION_LONG =
   qualifiers = "port-xxhdpi"
 )
 class TopicInfoFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val oppiaTestRule = OppiaTestRule()

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
@@ -30,6 +30,7 @@ import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -73,6 +74,7 @@ import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.domain.topic.RATIOS_EXPLORATION_ID_0
 import org.oppia.android.domain.topic.RATIOS_STORY_ID_0
 import org.oppia.android.domain.topic.RATIOS_TOPIC_ID
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.story.StoryProgressTestHelper
@@ -101,6 +103,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class TopicLessonsFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var testCoroutineDispatchers: TestCoroutineDispatchers

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
@@ -26,6 +26,7 @@ import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -63,6 +64,8 @@ import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfiguration
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.FRACTIONS_TOPIC_ID
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
+import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestCoroutineDispatchers
@@ -89,6 +92,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class TopicPracticeFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   private var skillIdList = ArrayList<String>()
   private val internalProfileId = 0
@@ -156,6 +161,7 @@ class TopicPracticeFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3362): Enable AccessibilityChecks
   fun testTopicPracticeFragment_loadFragment_selectSubtopics_isSuccessful() {
     launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
@@ -179,6 +185,7 @@ class TopicPracticeFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3362): Enable AccessibilityChecks
   fun testTopicPracticeFragment_loadFragment_selectSubtopics_startButtonIsActive() {
     launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
@@ -196,6 +203,7 @@ class TopicPracticeFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3362): Enable AccessibilityChecks
   fun testTopicPracticeFragment_loadFragment_selectSubtopics_thenDeselect_selectsCorrectTopic() {
     launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
@@ -212,6 +220,7 @@ class TopicPracticeFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3362): Enable AccessibilityChecks
   fun testTopicPracticeFragment_loadFragment_selectSubtopics_thenDeselect_startButtonIsInactive() {
     launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
@@ -230,6 +239,7 @@ class TopicPracticeFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3362): Enable AccessibilityChecks
   fun testTopicPracticeFragment_loadFragment_selectSubtopics_clickStartButton_skillListTransferSuccessfully() { // ktlint-disable max-line-length
     launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID)
     clickPracticeTab()
@@ -241,6 +251,7 @@ class TopicPracticeFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3362): Enable AccessibilityChecks
   fun testTopicPracticeFragment_loadFragment_selectSkills_configurationChange_skillsAreSelected() {
     launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
@@ -283,6 +294,7 @@ class TopicPracticeFragmentTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3362): Enable AccessibilityChecks
   fun testTopicPracticeFragment_loadFragment_selectSkills_configChange_startButtonRemainsActive() {
     launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -87,6 +87,8 @@ import org.oppia.android.domain.question.WrongAnswerMasteryPenalty
 import org.oppia.android.domain.question.WrongAnswerScorePenalty
 import org.oppia.android.domain.topic.FRACTIONS_SKILL_ID_0
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
+import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestLogReportingModule
@@ -120,6 +122,9 @@ private val SKILL_ID_LIST = listOf(FRACTIONS_SKILL_ID_0)
 class QuestionPlayerActivityTest {
   // TODO(#503): add tests for QuestionPlayerActivity (use StateFragmentTest for a reference).
   // TODO(#1273): add tests for Hints and Solution in Question Player.
+
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val oppiaTestRule = OppiaTestRule()
@@ -234,6 +239,7 @@ class QuestionPlayerActivityTest {
   }
 
   @Test
+  @DisableAccessibilityChecks // TODO(#3362): Enable AccessibilityChecks
   fun testQuestionPlayer_landscape_forMisconception_clickLinkText_opensConceptCard() {
     launchForSkillList(SKILL_ID_LIST).use {
       rotateToLandscape()

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentTest.kt
@@ -26,6 +26,7 @@ import dagger.Component
 import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.R
@@ -65,6 +66,7 @@ import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfiguration
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.FRACTIONS_TOPIC_ID
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.espresso.ImageViewMatcher.Companion.hasScaleType
@@ -92,6 +94,8 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class TopicRevisionFragmentTest {
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Inject
   lateinit var context: Context

--- a/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughActivityTest.kt
@@ -73,6 +73,8 @@ import javax.inject.Singleton
 )
 class WalkthroughActivityTest {
 
+  // TODO(#3367): Use AccessibilityTestRule
+
   @Test
   fun testWalkthroughActivity_defaultProgressWorksCorrectly() {
     launch(WalkthroughActivity::class.java).use {

--- a/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughFinalFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughFinalFragmentTest.kt
@@ -82,6 +82,8 @@ import javax.inject.Singleton
 )
 class WalkthroughFinalFragmentTest {
 
+  // TODO(#3367): Use AccessibilityTestRule
+
   @Inject
   lateinit var context: Context
 

--- a/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughTopicListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughTopicListFragmentTest.kt
@@ -88,6 +88,8 @@ import javax.inject.Singleton
 )
 class WalkthroughTopicListFragmentTest {
 
+  // TODO(#3367): Use AccessibilityTestRule
+
   @Inject lateinit var context: Context
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
   @Inject lateinit var testEnvironmentConfig: TestEnvironmentConfig

--- a/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughWelcomeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughWelcomeFragmentTest.kt
@@ -79,6 +79,8 @@ import javax.inject.Singleton
 )
 class WalkthroughWelcomeFragmentTest {
 
+  // TODO(#3367): Use AccessibilityTestRule
+
   @Inject
   lateinit var profileTestHelper: ProfileTestHelper
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes part of #3362: Used AccessibilityTestRule for Espresso Tests

While using `AccessibilityTestRule` there were new/old errors identified. For all new errors I have used `DisableAccessibilityChecks` which will be solved in later PRs and for all old PRs I have filed issues mainly #3363 #3364 #3366 #3367

## All Passing Tests

<img width="1561" alt="Screenshot 2021-06-23 at 2 10 39 PM" src="https://user-images.githubusercontent.com/9396084/123106401-3a943700-d456-11eb-95f3-7714b47c3dcb.png">
<img width="1585" alt="Screenshot 2021-06-23 at 2 11 43 PM" src="https://user-images.githubusercontent.com/9396084/123106416-3cf69100-d456-11eb-80d0-630a485b1d70.png">
<img width="1575" alt="Screenshot 2021-06-23 at 2 18 55 PM" src="https://user-images.githubusercontent.com/9396084/123106431-408a1800-d456-11eb-85b2-46b64d6584cd.png">
<img width="1582" alt="Screenshot 2021-06-23 at 2 22 11 PM" src="https://user-images.githubusercontent.com/9396084/123106435-4122ae80-d456-11eb-9d25-367ee926d8ac.png">
<img width="1583" alt="Screenshot 2021-06-23 at 2 24 36 PM" src="https://user-images.githubusercontent.com/9396084/123106437-41bb4500-d456-11eb-8dcf-7d4c8cef7ff6.png">
<img width="1575" alt="Screenshot 2021-06-23 at 2 26 41 PM" src="https://user-images.githubusercontent.com/9396084/123106441-41bb4500-d456-11eb-9d4a-731ea42e736d.png">
<img width="1576" alt="Screenshot 2021-06-23 at 2 29 47 PM" src="https://user-images.githubusercontent.com/9396084/123106442-4253db80-d456-11eb-92a2-8127a591a0bf.png">
<img width="1574" alt="Screenshot 2021-06-23 at 2 37 36 PM" src="https://user-images.githubusercontent.com/9396084/123106444-42ec7200-d456-11eb-8dfc-29fe2bf2978e.png">
<img width="1583" alt="Screenshot 2021-06-23 at 2 39 02 PM" src="https://user-images.githubusercontent.com/9396084/123106446-42ec7200-d456-11eb-8101-db09c285a642.png">
<img width="1567" alt="Screenshot 2021-06-23 at 3 09 29 PM" src="https://user-images.githubusercontent.com/9396084/123106448-43850880-d456-11eb-9e27-55bd6852c22e.png">
<img width="1371" alt="Screenshot 2021-06-23 at 3 13 22 PM" src="https://user-images.githubusercontent.com/9396084/123106454-441d9f00-d456-11eb-9da5-dfa0f865279b.png">



<img width="1498" alt="Screenshot 2021-06-23 at 3 54 29 PM" src="https://user-images.githubusercontent.com/9396084/123106459-44b63580-d456-11eb-9cf3-d023b24814ca.png">
<img width="1551" alt="Screenshot 2021-06-23 at 3 56 00 PM" src="https://user-images.githubusercontent.com/9396084/123106460-454ecc00-d456-11eb-8ad0-ff5774422ae7.png">
<img width="1428" alt="Screenshot 2021-06-23 at 3 57 33 PM" src="https://user-images.githubusercontent.com/9396084/123106462-454ecc00-d456-11eb-9c83-e6312d26ae16.png">


<img width="1537" alt="Screenshot 2021-06-23 at 4 00 11 PM" src="https://user-images.githubusercontent.com/9396084/123106465-45e76280-d456-11eb-83bf-11b691a33b4d.png">
<img width="1562" alt="Screenshot 2021-06-23 at 4 00 52 PM" src="https://user-images.githubusercontent.com/9396084/123106470-467ff900-d456-11eb-99bf-ecda5cfbcee3.png">
<img width="1373" alt="Screenshot 2021-06-23 at 4 04 45 PM" src="https://user-images.githubusercontent.com/9396084/123106472-467ff900-d456-11eb-94e6-c7d48a3697aa.png">


<img width="1466" alt="Screenshot 2021-06-23 at 4 08 41 PM" src="https://user-images.githubusercontent.com/9396084/123106478-47188f80-d456-11eb-8db5-6d94592e3a89.png">
<img width="1531" alt="Screenshot 2021-06-23 at 4 11 27 PM" src="https://user-images.githubusercontent.com/9396084/123106480-47b12600-d456-11eb-99c5-cebe2baf309f.png">
<img width="1489" alt="Screenshot 2021-06-23 at 4 12 36 PM" src="https://user-images.githubusercontent.com/9396084/123106481-47b12600-d456-11eb-8990-7d6aea56e854.png">
<img width="1445" alt="Screenshot 2021-06-23 at 4 14 38 PM" src="https://user-images.githubusercontent.com/9396084/123106484-4849bc80-d456-11eb-8b89-95d0ed489365.png">
<img width="1513" alt="Screenshot 2021-06-23 at 4 17 40 PM" src="https://user-images.githubusercontent.com/9396084/123106486-48e25300-d456-11eb-9fb7-16f9631020a7.png">
<img width="1422" alt="Screenshot 2021-06-23 at 4 19 05 PM" src="https://user-images.githubusercontent.com/9396084/123106488-48e25300-d456-11eb-9032-8206ef9d0821.png">


<img width="1506" alt="Screenshot 2021-06-23 at 4 21 40 PM" src="https://user-images.githubusercontent.com/9396084/123106490-497ae980-d456-11eb-96b7-c31b74af845a.png">
<img width="1350" alt="Screenshot 2021-06-23 at 4 22 57 PM" src="https://user-images.githubusercontent.com/9396084/123106491-4a138000-d456-11eb-93ef-1f6a1ddb59ec.png">

<img width="1403" alt="Screenshot 2021-06-23 at 4 41 16 PM" src="https://user-images.githubusercontent.com/9396084/123106499-4aac1680-d456-11eb-8627-defedcfd88b1.png">
<img width="1313" alt="Screenshot 2021-06-23 at 4 45 36 PM" src="https://user-images.githubusercontent.com/9396084/123106501-4b44ad00-d456-11eb-827c-956831fb02b1.png">
<img width="1497" alt="Screenshot 2021-06-23 at 4 52 37 PM" src="https://user-images.githubusercontent.com/9396084/123106506-4b44ad00-d456-11eb-9a6b-914269df66a1.png">

<img width="1355" alt="Screenshot 2021-06-23 at 4 54 39 PM" src="https://user-images.githubusercontent.com/9396084/123106508-4bdd4380-d456-11eb-9367-e07ff1b27c35.png">
<img width="1518" alt="Screenshot 2021-06-23 at 4 55 03 PM" src="https://user-images.githubusercontent.com/9396084/123106512-4c75da00-d456-11eb-8e94-0a517d2e01d1.png">

<img width="1521" alt="Screenshot 2021-06-23 at 5 31 03 PM" src="https://user-images.githubusercontent.com/9396084/123106517-4d0e7080-d456-11eb-803e-2ab97db63bcc.png">
<img width="1560" alt="Screenshot 2021-06-23 at 5 34 30 PM" src="https://user-images.githubusercontent.com/9396084/123106518-4da70700-d456-11eb-983f-5a06ab417b28.png">
<img width="1381" alt="Screenshot 2021-06-23 at 5 35 54 PM" src="https://user-images.githubusercontent.com/9396084/123106519-4da70700-d456-11eb-8c82-7bd5ff8438b7.png">


<img width="1375" alt="Screenshot 2021-06-23 at 5 38 17 PM" src="https://user-images.githubusercontent.com/9396084/123106521-4e3f9d80-d456-11eb-8858-28983fe569dc.png">
<img width="1303" alt="Screenshot 2021-06-23 at 5 43 33 PM" src="https://user-images.githubusercontent.com/9396084/123106523-4ed83400-d456-11eb-9911-75c6a60a762b.png">
<img width="1552" alt="Screenshot 2021-06-23 at 5 44 38 PM" src="https://user-images.githubusercontent.com/9396084/123106526-4ed83400-d456-11eb-8d56-6f9ad3e3af1b.png">

<img width="1510" alt="Screenshot 2021-06-23 at 5 49 41 PM" src="https://user-images.githubusercontent.com/9396084/123106531-4f70ca80-d456-11eb-9093-e1ee9ca6d083.png">
<img width="1281" alt="Screenshot 2021-06-23 at 5 52 26 PM" src="https://user-images.githubusercontent.com/9396084/123106532-50096100-d456-11eb-88de-78a4e3a7321b.png">
<img width="1501" alt="Screenshot 2021-06-23 at 6 03 41 PM" src="https://user-images.githubusercontent.com/9396084/123106534-50096100-d456-11eb-87ef-09e316b5049f.png">

<img width="1498" alt="Screenshot 2021-06-23 at 6 12 37 PM" src="https://user-images.githubusercontent.com/9396084/123106535-50a1f780-d456-11eb-972a-d7867165d22e.png">
<img width="1356" alt="Screenshot 2021-06-23 at 6 15 19 PM" src="https://user-images.githubusercontent.com/9396084/123106538-50a1f780-d456-11eb-99cc-03862e49aa50.png">
<img width="1524" alt="Screenshot 2021-06-23 at 6 18 23 PM" src="https://user-images.githubusercontent.com/9396084/123106541-513a8e00-d456-11eb-8845-2aa9be7ba813.png">


<img width="1473" alt="Screenshot 2021-06-23 at 6 47 51 PM" src="https://user-images.githubusercontent.com/9396084/123106550-53045180-d456-11eb-9749-6a19f8a7917b.png">
<img width="1297" alt="Screenshot 2021-06-23 at 6 48 22 PM" src="https://user-images.githubusercontent.com/9396084/123106556-53045180-d456-11eb-96ed-ccc6ccaf0124.png">
<img width="1396" alt="Screenshot 2021-06-23 at 6 52 43 PM" src="https://user-images.githubusercontent.com/9396084/123106664-729b7a00-d456-11eb-8832-32f33c7bbd41.png">


## Failing Tests + Explanation

**These tests are failing because these specific tests are meant to be run on Tablet device instead of mobile.**
<img width="1556" alt="Screenshot 2021-06-23 at 3 44 07 PM" src="https://user-images.githubusercontent.com/9396084/123106457-441d9f00-d456-11eb-937c-ff849269cef1.png">


**This test is meant to be run on Tablet device only**
<img width="1366" alt="Screenshot 2021-06-23 at 4 25 24 PM" src="https://user-images.githubusercontent.com/9396084/123106494-4a138000-d456-11eb-8b7b-52289974ea22.png">

**Filed issue #3366**
<img width="1542" alt="Screenshot 2021-06-23 at 6 33 21 PM" src="https://user-images.githubusercontent.com/9396084/123106542-51d32480-d456-11eb-8afa-32f274e0e6f7.png">

**Getting solved in #3250**
<img width="1568" alt="Screenshot 2021-06-23 at 6 44 47 PM" src="https://user-images.githubusercontent.com/9396084/123106547-526bbb00-d456-11eb-9668-b3b54d4ccb3e.png">

**Filed issue #3364**
<img width="1538" alt="Screenshot 2021-06-23 at 5 27 04 PM" src="https://user-images.githubusercontent.com/9396084/123106515-4c75da00-d456-11eb-9dd4-fd4c83b82c35.png">


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
