### PR TITLE
Fix #3248: A11y checks for Nav Drawer Tests

### DIFF
--- a/app/src/main/java/org/oppia/android/app/testing/NavigationDrawerTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/NavigationDrawerTestActivity.kt
@@ -7,11 +7,18 @@ import org.oppia.android.R
 import org.oppia.android.app.activity.InjectableAppCompatActivity
 import org.oppia.android.app.drawer.NAVIGATION_PROFILE_ID_ARGUMENT_KEY
 import org.oppia.android.app.home.HomeActivityPresenter
+import org.oppia.android.app.home.RouteToRecentlyPlayedListener
 import org.oppia.android.app.home.RouteToTopicListener
+import org.oppia.android.app.home.RouteToTopicPlayStoryListener
+import org.oppia.android.app.home.recentlyplayed.RecentlyPlayedActivity
 import org.oppia.android.app.topic.TopicActivity
 import javax.inject.Inject
 
-class NavigationDrawerTestActivity : InjectableAppCompatActivity(), RouteToTopicListener {
+class NavigationDrawerTestActivity :
+  InjectableAppCompatActivity(),
+  RouteToTopicListener,
+  RouteToTopicPlayStoryListener,
+  RouteToRecentlyPlayedListener {
   @Inject
   lateinit var homeActivityPresenter: HomeActivityPresenter
   private var internalProfileId: Int = -1
@@ -39,5 +46,25 @@ class NavigationDrawerTestActivity : InjectableAppCompatActivity(), RouteToTopic
 
   override fun routeToTopic(internalProfileId: Int, topicId: String) {
     startActivity(TopicActivity.createTopicActivityIntent(this, internalProfileId, topicId))
+  }
+
+  override fun routeToTopicPlayStory(internalProfileId: Int, topicId: String, storyId: String) {
+    startActivity(
+      TopicActivity.createTopicPlayStoryActivityIntent(
+        this,
+        internalProfileId,
+        topicId,
+        storyId
+      )
+    )
+  }
+
+  override fun routeToRecentlyPlayed() {
+    startActivity(
+      RecentlyPlayedActivity.createRecentlyPlayedActivityIntent(
+        this,
+        internalProfileId
+      )
+    )
   }
 }

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/NavigationDrawerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/NavigationDrawerActivityTest.kt
@@ -87,6 +87,7 @@ import org.oppia.android.domain.oppialogger.loguploader.LogUploadWorkerModule
 import org.oppia.android.domain.oppialogger.loguploader.WorkManagerConfigurationModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestLogReportingModule
@@ -119,6 +120,9 @@ import javax.inject.Singleton
   qualifiers = "port-xxhdpi"
 )
 class NavigationDrawerActivityTest {
+
+  @get:Rule
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @get:Rule
   val oppiaTestRule = OppiaTestRule()
@@ -175,7 +179,9 @@ class NavigationDrawerActivityTest {
 
   @Test
   fun testNavDrawer_openNavDrawer_navDrawerIsOpened() {
-    launch(NavigationDrawerTestActivity::class.java).use {
+    launch<NavigationDrawerTestActivity>(
+      createNavigationDrawerActivityIntent(internalProfileId)
+    ).use {
       it.openNavigationDrawer()
       onView(withId(R.id.home_fragment_placeholder)).check(matches(isCompletelyDisplayed()))
       onView(withId(R.id.home_activity_drawer_layout)).check(matches(isOpen()))
@@ -184,7 +190,9 @@ class NavigationDrawerActivityTest {
 
   @Test
   fun testNavDrawer_openNavDrawer_configChange_navDrawerIsDisplayed() {
-    launch(NavigationDrawerTestActivity::class.java).use {
+    launch<NavigationDrawerTestActivity>(
+      createNavigationDrawerActivityIntent(internalProfileId)
+    ).use {
       it.openNavigationDrawer()
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.home_activity_drawer_layout)).check(matches(isOpen()))
@@ -737,7 +745,9 @@ class NavigationDrawerActivityTest {
   @Test
   @Ignore("My Downloads is removed until we have full download support.")
   fun testNavDrawer_myDownloadsMenu_myDownloadsFragmentIsDisplayed() {
-    launch(NavigationDrawerTestActivity::class.java).use {
+    launch<NavigationDrawerTestActivity>(
+      createNavigationDrawerActivityIntent(internalProfileId)
+    ).use {
       it.openNavigationDrawer()
       onView(withText(R.string.menu_my_downloads)).perform(click())
       intended(hasComponent(MyDownloadsActivity::class.java.name))
@@ -746,7 +756,9 @@ class NavigationDrawerActivityTest {
 
   @Test
   fun testNavDrawer_switchProfileMenu_exitToProfileChooserDialogIsDisplayed() {
-    launch(NavigationDrawerTestActivity::class.java).use {
+    launch<NavigationDrawerTestActivity>(
+      createNavigationDrawerActivityIntent(internalProfileId)
+    ).use {
       it.openNavigationDrawer()
       onView(withText(R.string.menu_switch_profile)).perform(click())
       onView(withText(R.string.home_activity_back_dialog_message))
@@ -757,7 +769,9 @@ class NavigationDrawerActivityTest {
 
   @Test
   fun testNavDrawer_switchProfileMenu_clickExit_opensProfileChooserActivity() {
-    launch(NavigationDrawerTestActivity::class.java).use {
+    launch<NavigationDrawerTestActivity>(
+      createNavigationDrawerActivityIntent(internalProfileId)
+    ).use {
       it.openNavigationDrawer()
       onView(withText(R.string.menu_switch_profile)).perform(click())
       onView(withText(R.string.home_activity_back_dialog_message))
@@ -773,7 +787,9 @@ class NavigationDrawerActivityTest {
   @RunOn(TestPlatform.ESPRESSO)
   @Test
   fun testNavDrawer_openNavDrawerAndClose_navDrawerIsClosed() {
-    launch(NavigationDrawerTestActivity::class.java).use {
+    launch<NavigationDrawerTestActivity>(
+      createNavigationDrawerActivityIntent(internalProfileId)
+    ).use {
       testCoroutineDispatchers.runCurrent()
       it.openNavigationDrawer()
       onView(withId(R.id.home_activity_drawer_layout)).perform(close())
@@ -784,7 +800,9 @@ class NavigationDrawerActivityTest {
   @RunOn(TestPlatform.ESPRESSO)
   @Test
   fun testNavDrawer_selectSwitchProfileMenu_clickCancel_navDrawerIsClosed() {
-    launch(NavigationDrawerTestActivity::class.java).use {
+    launch<NavigationDrawerTestActivity>(
+      createNavigationDrawerActivityIntent(internalProfileId)
+    ).use {
       it.openNavigationDrawer()
       onView(withText(R.string.menu_switch_profile)).perform(click())
       onView(withText(R.string.home_activity_back_dialog_message))
@@ -800,7 +818,9 @@ class NavigationDrawerActivityTest {
 
   @Test
   fun testNavDrawer_selectSwitchProfile_configChange_dialogIsVisible() {
-    launch(NavigationDrawerTestActivity::class.java).use {
+    launch<NavigationDrawerTestActivity>(
+      createNavigationDrawerActivityIntent(internalProfileId)
+    ).use {
       it.openNavigationDrawer()
       onView(withText(R.string.menu_switch_profile)).perform(click())
       onView(withText(R.string.home_activity_back_dialog_message))
@@ -813,7 +833,9 @@ class NavigationDrawerActivityTest {
 
   @Test
   fun testNavDrawer_openNavDrawer_selectHelpMenu_opensHelpActivity() {
-    launch(NavigationDrawerTestActivity::class.java).use {
+    launch<NavigationDrawerTestActivity>(
+      createNavigationDrawerActivityIntent(internalProfileId)
+    ).use {
       it.openNavigationDrawer()
       onView(withText(R.string.menu_help)).perform(click())
       intended(hasComponent(HelpActivity::class.java.name))


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fix #3248: A11y checks for Nav Drawer Tests

This PR first enables the `AccessibilityTestRule` in `NavigationDrawerTestActivityTest` file where tests are failing because the `HomeRecyclerView` is empty.

On further inspection it was identified that it was failing because we were not using all the listeners similar to `HomeActivity` inside `NavigationDrawerTestActivityTest`. On making it similar all tests are passing now.

##Output
<img width="1433" alt="Screenshot 2021-06-29 at 4 21 25 PM" src="https://user-images.githubusercontent.com/9396084/123796542-db756d00-d902-11eb-8c97-fdc0cb917e01.png">


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
