### PR TITLE
Fix part of #3164: Replace Jan in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -133,9 +133,8 @@ NOTICE @seanlip
 # Parsing functionality needed for interactions.
 /app/src/*/java/org/oppia/android/app/parser/ @rt4914
 
-# TODO(#3164): Restore code ownership to @BenHenning after 2021-05-24.
 # Bazel/data-binding shims.
-/app/src/*/java/org/oppia/android/app/shim/ @fsharpasharp
+/app/src/*/java/org/oppia/android/app/shim/ @BenHenning
 
 # TODO(#3164): Restore code ownership to @BenHenning after 2021-05-24.
 # Splash screen.
@@ -220,10 +219,9 @@ NOTICE @seanlip
 #                                global overrides                                   #
 #####################################################################################
 
-# TODO(#3164): Restore code ownership to @BenHenning after 2021-05-24.
 # Bazel build files. This is added after everything else to ensure Bazel files are always reviewed by the same people.
-WORKSPACE @fsharpasharp
-*.bzl @fsharpasharp
-*.bazel @fsharpasharp
-.bazelrc @fsharpasharp
-/tools/android/ @fsharpasharp
+WORKSPACE @BenHenning
+*.bzl @BenHenning
+*.bazel @BenHenning
+.bazelrc @BenHenning
+/tools/android/ @BenHenning


### PR DESCRIPTION
Fix part of #3164.

## Explanation
Restore codeowners for Bazel-related files. The other files are staying as-is until after GSoC milestone 1 so that existing reviewers don't need to change until after those PRs are merged.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
