### PR TITLE
Fix #3410: Merged Switch click with TextViews in ProfileEditActivity

### DIFF
--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditFragmentPresenter.kt
@@ -85,24 +85,24 @@ class ProfileEditFragmentPresenter @Inject constructor(
       }
     )
 
-    binding.profileEditAllowDownloadSwitch.setOnCheckedChangeListener { compoundButton, checked ->
-      if (compoundButton.isPressed) {
-        profileManagementController.updateAllowDownloadAccess(
-          ProfileId.newBuilder().setInternalId(internalProfileId).build(),
-          checked
-        ).toLiveData().observe(
-          activity,
-          Observer {
-            if (it.isFailure()) {
-              oppiaLogger.e(
-                "ProfileEditActivityPresenter",
-                "Failed to updated allow download access",
-                it.getErrorOrNull()!!
-              )
-            }
+    binding.profileEditAllowDownloadContainer.setOnClickListener {
+      binding.profileEditAllowDownloadSwitch.isChecked =
+        !binding.profileEditAllowDownloadSwitch.isChecked
+      profileManagementController.updateAllowDownloadAccess(
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
+        binding.profileEditAllowDownloadSwitch.isChecked
+      ).toLiveData().observe(
+        activity,
+        Observer {
+          if (it.isFailure()) {
+            oppiaLogger.e(
+              "ProfileEditActivityPresenter",
+              "Failed to updated allow download access",
+              it.getErrorOrNull()!!
+            )
           }
-        )
-      }
+        }
+      )
     }
     return binding.root
   }

--- a/app/src/main/res/layout-land/profile_edit_fragment.xml
+++ b/app/src/main/res/layout-land/profile_edit_fragment.xml
@@ -135,61 +135,63 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/profile_reset_button" />
 
-      <View
+      <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/profile_edit_allow_download_container"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:background="@color/white"
-        android:visibility="@{viewModel.profile.isAdmin ? View.GONE : View.VISIBLE}"
-        app:layout_constraintBottom_toBottomOf="@+id/profile_edit_allow_download_sub"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/view4" />
-
-      <TextView
-        android:id="@+id/profile_edit_allow_download_heading"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:fontFamily="sans-serif"
-        android:paddingStart="16dp"
-        android:paddingTop="12dp"
-        android:paddingEnd="24dp"
-        android:text="@string/profile_edit_allow_download_heading"
-        android:textColor="@color/oppiaPrimaryText"
-        android:textSize="16sp"
-        android:visibility="@{viewModel.profile.isAdmin ? View.GONE : View.VISIBLE}"
-        app:layout_constraintEnd_toStartOf="@+id/profile_edit_allow_download_switch"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/view4" />
-
-      <TextView
-        android:id="@+id/profile_edit_allow_download_sub"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:fontFamily="sans-serif"
-        android:paddingStart="16dp"
-        android:paddingEnd="24dp"
-        android:paddingBottom="12dp"
-        android:text="@string/profile_edit_allow_download_sub"
-        android:textColor="@color/accessible_light_grey"
-        android:textSize="14sp"
-        android:visibility="@{viewModel.profile.isAdmin ? View.GONE : View.VISIBLE}"
-        app:layout_constraintEnd_toStartOf="@+id/profile_edit_allow_download_switch"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/profile_edit_allow_download_heading" />
-
-      <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/profile_edit_allow_download_switch"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:minWidth="48dp"
-        android:minHeight="48dp"
-        android:paddingStart="12dp"
-        android:paddingTop="0dp"
-        android:paddingEnd="12dp"
+        android:focusable="true"
+        android:importantForAccessibility="yes"
         android:visibility="@{viewModel.profile.isAdmin ? View.GONE : View.VISIBLE}"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/profile_edit_allow_download_heading" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/view4">
+
+        <TextView
+          android:id="@+id/profile_edit_allow_download_heading"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:fontFamily="sans-serif"
+          android:paddingStart="16dp"
+          android:paddingTop="12dp"
+          android:paddingEnd="24dp"
+          android:text="@string/profile_edit_allow_download_heading"
+          android:textColor="@color/oppiaPrimaryText"
+          android:textSize="16sp"
+          app:layout_constraintEnd_toStartOf="@+id/profile_edit_allow_download_switch"
+          app:layout_constraintHorizontal_bias="0.0"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+          android:id="@+id/profile_edit_allow_download_sub"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:fontFamily="sans-serif"
+          android:paddingStart="16dp"
+          android:paddingEnd="24dp"
+          android:paddingBottom="12dp"
+          android:text="@string/profile_edit_allow_download_sub"
+          android:textColor="@color/accessible_light_grey"
+          android:textSize="14sp"
+          app:layout_constraintEnd_toStartOf="@+id/profile_edit_allow_download_switch"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@+id/profile_edit_allow_download_heading" />
+
+        <androidx.appcompat.widget.SwitchCompat
+          android:id="@+id/profile_edit_allow_download_switch"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:clickable="false"
+          android:focusable="false"
+          android:minWidth="48dp"
+          android:minHeight="48dp"
+          android:paddingStart="12dp"
+          android:paddingTop="0dp"
+          android:paddingEnd="12dp"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toTopOf="@+id/profile_edit_allow_download_heading" />
+      </androidx.constraintlayout.widget.ConstraintLayout>
 
       <View
         android:id="@+id/view6"
@@ -199,7 +201,7 @@
         android:visibility="@{viewModel.profile.isAdmin ? View.GONE : View.VISIBLE}"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/profile_edit_allow_download_sub" />
+        app:layout_constraintTop_toBottomOf="@+id/profile_edit_allow_download_container" />
 
       <View
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/profile_edit_fragment.xml
+++ b/app/src/main/res/layout/profile_edit_fragment.xml
@@ -135,61 +135,63 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/profile_reset_button" />
 
-      <View
+      <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/profile_edit_allow_download_container"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:background="@color/white"
-        android:visibility="@{viewModel.profile.isAdmin ? View.GONE : View.VISIBLE}"
-        app:layout_constraintBottom_toBottomOf="@+id/profile_edit_allow_download_sub"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/view4" />
-
-      <TextView
-        android:id="@+id/profile_edit_allow_download_heading"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:fontFamily="sans-serif"
-        android:paddingStart="16dp"
-        android:paddingTop="12dp"
-        android:paddingEnd="24dp"
-        android:text="@string/profile_edit_allow_download_heading"
-        android:textColor="@color/oppiaPrimaryText"
-        android:textSize="16sp"
-        android:visibility="@{viewModel.profile.isAdmin ? View.GONE : View.VISIBLE}"
-        app:layout_constraintEnd_toStartOf="@+id/profile_edit_allow_download_switch"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/view4" />
-
-      <TextView
-        android:id="@+id/profile_edit_allow_download_sub"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:fontFamily="sans-serif"
-        android:paddingStart="16dp"
-        android:paddingEnd="24dp"
-        android:paddingBottom="12dp"
-        android:text="@string/profile_edit_allow_download_sub"
-        android:textColor="@color/accessible_light_grey"
-        android:textSize="14sp"
-        android:visibility="@{viewModel.profile.isAdmin ? View.GONE : View.VISIBLE}"
-        app:layout_constraintEnd_toStartOf="@+id/profile_edit_allow_download_switch"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/profile_edit_allow_download_heading" />
-
-      <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/profile_edit_allow_download_switch"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:minWidth="48dp"
-        android:minHeight="48dp"
-        android:paddingStart="12dp"
-        android:paddingTop="0dp"
-        android:paddingEnd="12dp"
+        android:focusable="true"
+        android:importantForAccessibility="yes"
         android:visibility="@{viewModel.profile.isAdmin ? View.GONE : View.VISIBLE}"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/profile_edit_allow_download_heading" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/view4">
+
+        <TextView
+          android:id="@+id/profile_edit_allow_download_heading"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:fontFamily="sans-serif"
+          android:paddingStart="16dp"
+          android:paddingTop="12dp"
+          android:paddingEnd="24dp"
+          android:text="@string/profile_edit_allow_download_heading"
+          android:textColor="@color/oppiaPrimaryText"
+          android:textSize="16sp"
+          app:layout_constraintEnd_toStartOf="@+id/profile_edit_allow_download_switch"
+          app:layout_constraintHorizontal_bias="0.0"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+          android:id="@+id/profile_edit_allow_download_sub"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:fontFamily="sans-serif"
+          android:paddingStart="16dp"
+          android:paddingEnd="24dp"
+          android:paddingBottom="12dp"
+          android:text="@string/profile_edit_allow_download_sub"
+          android:textColor="@color/accessible_light_grey"
+          android:textSize="14sp"
+          app:layout_constraintEnd_toStartOf="@+id/profile_edit_allow_download_switch"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@+id/profile_edit_allow_download_heading" />
+
+        <androidx.appcompat.widget.SwitchCompat
+          android:id="@+id/profile_edit_allow_download_switch"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:clickable="false"
+          android:focusable="false"
+          android:minWidth="48dp"
+          android:minHeight="48dp"
+          android:paddingStart="12dp"
+          android:paddingTop="0dp"
+          android:paddingEnd="12dp"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toTopOf="@+id/profile_edit_allow_download_heading" />
+      </androidx.constraintlayout.widget.ConstraintLayout>
 
       <View
         android:layout_width="match_parent"
@@ -198,7 +200,7 @@
         android:visibility="@{viewModel.profile.isAdmin ? View.GONE : View.VISIBLE}"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/profile_edit_allow_download_sub" />
+        app:layout_constraintTop_toBottomOf="@+id/profile_edit_allow_download_container" />
 
       <View
         android:layout_width="match_parent"

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -15,8 +15,10 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
+import androidx.test.espresso.matcher.ViewMatchers.isClickable
 import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isFocusable
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -447,6 +449,82 @@ class ProfileEditActivityTest {
       onView(withId(R.id.profile_edit_allow_download_switch)).check(matches(isChecked()))
       onView(withId(R.id.profile_edit_allow_download_container)).perform(click())
       onView(withId(R.id.profile_edit_allow_download_switch)).check(matches(not(isChecked())))
+    }
+  }
+
+  @Test
+  fun testProfileEdit_startWithUserHasDownloadAccess_switchIsNotClickable() {
+    profileManagementController.addProfile(
+      name = "James",
+      pin = "123",
+      avatarImagePath = null,
+      allowDownloadAccess = true,
+      colorRgb = -10710042,
+      isAdmin = false
+    ).toLiveData()
+    launch<ProfileEditActivity>(
+      ProfileEditActivity.createProfileEditActivity(
+        context = context,
+        profileId = 4
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(withId(R.id.profile_edit_allow_download_switch)).check(matches(not(isClickable())))
+    }
+  }
+
+  @Test
+  fun testProfileEdit_startWithUserHasDownloadAccess_switchContainerIsFocusable() {
+    profileManagementController.addProfile(
+      name = "James",
+      pin = "123",
+      avatarImagePath = null,
+      allowDownloadAccess = true,
+      colorRgb = -10710042,
+      isAdmin = false
+    ).toLiveData()
+    launch<ProfileEditActivity>(
+      ProfileEditActivity.createProfileEditActivity(
+        context = context,
+        profileId = 4
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(withId(R.id.profile_edit_allow_download_container)).check(matches(isFocusable()))
+    }
+  }
+
+  @Test
+  fun testProfileEdit_startWithUserHasDownloadAccess_switchContainerIsDisplayed() {
+    profileManagementController.addProfile(
+      name = "James",
+      pin = "123",
+      avatarImagePath = null,
+      allowDownloadAccess = true,
+      colorRgb = -10710042,
+      isAdmin = false
+    ).toLiveData()
+    launch<ProfileEditActivity>(
+      ProfileEditActivity.createProfileEditActivity(
+        context = context,
+        profileId = 4
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(withId(R.id.profile_edit_allow_download_container)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testProfileEdit_startWithUserDoesNotHaveDownloadAccess_switchContainerIsNotDisplayed() {
+    launch<ProfileEditActivity>(
+      ProfileEditActivity.createProfileEditActivity(
+        context = context,
+        profileId = 0
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(withId(R.id.profile_edit_allow_download_container)).check(matches(not(isDisplayed())))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditActivityTest.kt
@@ -427,6 +427,29 @@ class ProfileEditActivityTest {
     }
   }
 
+  @Test
+  fun testProfileEdit_startWithUserHasDownloadAccess_clickAllowDownloadContainer_checkChanged() {
+    profileManagementController.addProfile(
+      name = "James",
+      pin = "123",
+      avatarImagePath = null,
+      allowDownloadAccess = true,
+      colorRgb = -10710042,
+      isAdmin = false
+    ).toLiveData()
+    launch<ProfileEditActivity>(
+      ProfileEditActivity.createProfileEditActivity(
+        context = context,
+        profileId = 4
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(withId(R.id.profile_edit_allow_download_switch)).check(matches(isChecked()))
+      onView(withId(R.id.profile_edit_allow_download_container)).perform(click())
+      onView(withId(R.id.profile_edit_allow_download_switch)).check(matches(not(isChecked())))
+    }
+  }
+
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.
   @Singleton
   @Component(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fix #3410: Merged Switch click with TextViews in ProfileEditActivity


Similar to https://github.com/oppia/oppia-android/pull/3191 , this PR also merged the textviews with switch to make the entire area clickable. So basically `Switch + 2 Texts` are clickable.

## UI Before vs. After (no change)
<img src="https://user-images.githubusercontent.com/9396084/124488270-49bba300-ddcd-11eb-9b73-bd1882191d27.png" width="250" />  <img src="https://user-images.githubusercontent.com/9396084/124488284-4c1dfd00-ddcd-11eb-93cc-1619472d4863.png" width="250" />

<img src="https://user-images.githubusercontent.com/9396084/124488300-4fb18400-ddcd-11eb-8235-d6bf23337b08.png" width="250" />  <img src="https://user-images.githubusercontent.com/9396084/124488304-504a1a80-ddcd-11eb-9d58-203f70079870.png" width="250" />

<img src="https://user-images.githubusercontent.com/9396084/124488329-563ffb80-ddcd-11eb-9b95-a2a78a8f63f6.png" width="250" />  <img src="https://user-images.githubusercontent.com/9396084/124488331-5809bf00-ddcd-11eb-9618-c4f165d9d416.png" width="250" />

<img src="https://user-images.githubusercontent.com/9396084/124488341-5b04af80-ddcd-11eb-8abc-3dc849778945.png" width="250" />  <img src="https://user-images.githubusercontent.com/9396084/124488344-5c35dc80-ddcd-11eb-9f65-65456e2d8822.png" width="250" />

## Tests
<img width="1506" alt="Screenshot 2021-07-05 at 8 46 24 PM" src="https://user-images.githubusercontent.com/9396084/124492438-162f4780-ddd2-11eb-92a4-8c0ca439bc99.png">


## Accessibility Output

Earlier the screen reader would first read the title, then subtext and then finally the switch, i.e. it took 3 steps.

Now it merges all of that into 1 single step:
<img src="https://user-images.githubusercontent.com/9396084/124493104-df0d6600-ddd2-11eb-9122-1bcbbd8a2e56.png" width="250" />  <img src="https://user-images.githubusercontent.com/9396084/124493110-e0d72980-ddd2-11eb-9ca8-0a8cdc58da80.png" width="250" />

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
