### PR TITLE
Fix part of #2691: Mitigate affected tests script CI hang problem

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/ci/ComputeAffectedTests.kt
+++ b/scripts/src/java/org/oppia/android/scripts/ci/ComputeAffectedTests.kt
@@ -21,7 +21,7 @@ import kotlin.system.exitProcess
  *     Generally, this is 'origin/develop'.
  *
  * Example:
- *   bazel run //scripts:compute_affected_tests -- $(pwd) /tmp/affected_tests.log
+ *   bazel run //scripts:compute_affected_tests -- $(pwd) /tmp/affected_tests.log origin/develop
  */
 fun main(args: Array<String>) {
   if (args.size < 3) {

--- a/scripts/src/java/org/oppia/android/scripts/common/BazelClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/common/BazelClient.kt
@@ -55,6 +55,38 @@ class BazelClient(
     val buildFileList = buildFiles.joinToString(",")
     // Note that this check is needed since rbuildfiles() doesn't like taking an empty list.
     return if (buildFileList.isNotEmpty()) {
+      val referenceFiles =
+        executeBazelCommand(
+          "query",
+          "--noshow_progress",
+          "--universe_scope=//...",
+          "--order_output=no",
+          "rbuildfiles($buildFileList)")
+      println("@@@@@ Reference build files: $referenceFiles")
+      val siblingFiles =
+        executeBazelCommand(
+          "query",
+          "--noshow_progress",
+          "--universe_scope=//...",
+          "--order_output=no",
+          "siblings(rbuildfiles($buildFileList))")
+      println("@@@@@ Sibling files: $siblingFiles")
+      val rdeps =
+        executeBazelCommand(
+          "query",
+          "--noshow_progress",
+          "--universe_scope=//...",
+          "--order_output=no",
+          "allrdeps(siblings(rbuildfiles($buildFileList)))")
+      println("@@@@@ Sibling rdeps: $rdeps")
+      val tests =
+        executeBazelCommand(
+          "query",
+          "--noshow_progress",
+          "--universe_scope=//...",
+          "--order_output=no",
+          "kind(test, allrdeps(siblings(rbuildfiles($buildFileList))))")
+      println("@@@@@ tests: $tests")
       return correctPotentiallyBrokenTargetNames(
         executeBazelCommand(
           "query",
@@ -109,6 +141,7 @@ class BazelClient(
         "\nStandard output:\n${result.output.joinToString("\n")}" +
         "\nError output:\n${result.errorOutput.joinToString("\n")}"
     }
+    println("@@@@@ ${result.command.joinToString(separator = " ")}")
     return result.output
   }
 }

--- a/scripts/src/java/org/oppia/android/scripts/common/BazelClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/common/BazelClient.kt
@@ -61,7 +61,8 @@ class BazelClient(
           "--noshow_progress",
           "--universe_scope=//...",
           "--order_output=no",
-          "rbuildfiles($buildFileList)")
+          "rbuildfiles($buildFileList)"
+        )
       println("@@@@@ Reference build files: $referenceFiles")
       val siblingFiles =
         executeBazelCommand(
@@ -69,7 +70,8 @@ class BazelClient(
           "--noshow_progress",
           "--universe_scope=//...",
           "--order_output=no",
-          "siblings(rbuildfiles($buildFileList))")
+          "siblings(rbuildfiles($buildFileList))"
+        )
       println("@@@@@ Sibling files: $siblingFiles")
       val rdeps =
         executeBazelCommand(
@@ -77,7 +79,8 @@ class BazelClient(
           "--noshow_progress",
           "--universe_scope=//...",
           "--order_output=no",
-          "allrdeps(siblings(rbuildfiles($buildFileList)))")
+          "allrdeps(siblings(rbuildfiles($buildFileList)))"
+        )
       println("@@@@@ Sibling rdeps: $rdeps")
       val tests =
         executeBazelCommand(
@@ -85,7 +88,8 @@ class BazelClient(
           "--noshow_progress",
           "--universe_scope=//...",
           "--order_output=no",
-          "kind(test, allrdeps(siblings(rbuildfiles($buildFileList))))")
+          "kind(test, allrdeps(siblings(rbuildfiles($buildFileList))))"
+        )
       println("@@@@@ tests: $tests")
       return correctPotentiallyBrokenTargetNames(
         executeBazelCommand(

--- a/scripts/src/javatests/org/oppia/android/scripts/common/BazelClientTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/common/BazelClientTest.kt
@@ -2,7 +2,6 @@ package org.oppia.android.scripts.common
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -294,7 +293,6 @@ class BazelClientTest {
   }
 
   @Test
-  @Ignore("Fails in GitHub Actions") // TODO(#2691): Re-enable this test once it can pass in CI.
   fun testRetrieveTransitiveTestTargets_forWorkspace_returnsAllTests() {
     val bazelClient = BazelClient(tempFolder.root)
     testBazelWorkspace.initEmptyWorkspace()


### PR DESCRIPTION
Fix part of #2691.

## Explanation
Introduces a mitigation for the continued issue of certain PRs causing the ComputeAffectedTests target to hang. There's a bunch of context of different situations where this was observed in #2961 and connected PRs, but principally the issue seems to be that sibling queries that return large numbers of results can cause Bazel to hang in CI environments. My theory is that this has something to do with both fewer environment resources & a difference in the filesystem used in CI.

The mitigation tries to reduce the chance the error happens in two ways:
1. By splitting up the query such that we first compute the list of rbuildfile deps, then for *each* dependency we calculate siblings before combining the list together for the final rdeps & test computation (moving from 1 query to 2+N for N related build files).
2. By introducing filtering on the siblings query to only apply to tests and Android libraries.

Note that (1) probably means the query is overall slower in non-CI environments, but it lets us do (2) which is probably the actual fix. For some files, the siblings call alone would expand to >1400 results. With filtering, this goes down to <100 for the same target. There's one important caveat to note here: in special cases where a non-test, non-library target is affected we will not find corresponding tests. This seems fairly unlikely given that this entire mechanism is only the secondary means of finding affected tests, anyway.

Regarding testing, one new test was introduced to verify a scenario where bzl file changes affect tests. This test passed without the fix in CI, but it's still a nice test to have. Further, the WORKSPACE test that previously consistently hung is now passing in CI with this mitigation which provides a fairly strong indication that this fix should work for us at least in the medium term. Finally, #3417 demonstrated the fix works in a real situation where an originating PR's (#3340) tests would not be computed properly in CI.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
