### PR TITLE
Fixes #3435: Added content description for Hints and Solution bulb

### DIFF
--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsAndSolutionDialogFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsAndSolutionDialogFragmentPresenter.kt
@@ -74,6 +74,9 @@ class HintsAndSolutionDialogFragmentPresenter @Inject constructor(
     this.solutionIndex = solutionIndex
     this.isSolutionRevealed = isSolutionRevealed
     binding.hintsAndSolutionToolbar.setNavigationIcon(R.drawable.ic_close_white_24dp)
+    binding.hintsAndSolutionToolbar.setNavigationContentDescription(
+      R.string.hints_andSolution_close_icon_description
+    )
     binding.hintsAndSolutionToolbar.setNavigationOnClickListener {
       (fragment.requireActivity() as? HintsAndSolutionListener)?.dismiss()
     }

--- a/app/src/main/res/layout-land/question_player_fragment.xml
+++ b/app/src/main/res/layout-land/question_player_fragment.xml
@@ -136,6 +136,7 @@
         android:layout_height="6dp"
         android:layout_gravity="top|end"
         android:layout_margin="8dp"
+        android:contentDescription="@string/new_hint_available"
         android:src="@drawable/ic_dot_yellow_24dp"
         android:visibility="@{viewModel.isHintOpenedAndUnRevealed() ? View.VISIBLE : View.GONE}" />
 
@@ -144,6 +145,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="12dp"
+        android:contentDescription="@string/show_hints_and_solution"
         android:src="@drawable/ic_hint_bulb_white_24dp" />
     </FrameLayout>
 

--- a/app/src/main/res/layout-sw600dp-land/question_player_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-land/question_player_fragment.xml
@@ -143,6 +143,7 @@
         android:layout_height="6dp"
         android:layout_gravity="top|end"
         android:layout_margin="8dp"
+        android:contentDescription="@string/new_hint_available"
         android:src="@drawable/ic_dot_yellow_24dp"
         android:visibility="@{viewModel.isHintOpenedAndUnRevealed() ? View.VISIBLE : View.GONE}" />
 
@@ -151,6 +152,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="12dp"
+        android:contentDescription="@string/show_hints_and_solution"
         android:src="@drawable/ic_hint_bulb_white_24dp" />
     </FrameLayout>
 

--- a/app/src/main/res/layout-sw600dp-port/question_player_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-port/question_player_fragment.xml
@@ -143,6 +143,7 @@
         android:layout_height="6dp"
         android:layout_gravity="top|end"
         android:layout_margin="8dp"
+        android:contentDescription="@string/new_hint_available"
         android:src="@drawable/ic_dot_yellow_24dp"
         android:visibility="@{viewModel.isHintOpenedAndUnRevealed() ? View.VISIBLE : View.GONE}" />
 
@@ -151,6 +152,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="12dp"
+        android:contentDescription="@string/show_hints_and_solution"
         android:src="@drawable/ic_hint_bulb_white_24dp" />
     </FrameLayout>
 

--- a/app/src/main/res/layout/question_player_fragment.xml
+++ b/app/src/main/res/layout/question_player_fragment.xml
@@ -120,6 +120,7 @@
           android:layout_height="6dp"
           android:layout_gravity="top|end"
           android:layout_margin="8dp"
+          android:contentDescription="@string/new_hint_available"
           android:src="@drawable/ic_dot_yellow_24dp"
           android:visibility="@{viewModel.isHintOpenedAndUnRevealed() ? View.VISIBLE : View.GONE}" />
 
@@ -128,6 +129,7 @@
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_margin="12dp"
+          android:contentDescription="@string/show_hints_and_solution"
           android:src="@drawable/ic_hint_bulb_white_24dp" />
       </FrameLayout>
 

--- a/app/src/main/res/layout/state_fragment.xml
+++ b/app/src/main/res/layout/state_fragment.xml
@@ -113,6 +113,7 @@
         android:layout_height="6dp"
         android:layout_gravity="top|end"
         android:layout_margin="8dp"
+        android:contentDescription="@string/new_hint_available"
         android:src="@drawable/ic_dot_yellow_24dp"
         android:visibility="@{viewModel.isHintOpenedAndUnRevealed() ? View.VISIBLE : View.GONE}" />
 
@@ -121,6 +122,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="12dp"
+        android:contentDescription="@string/show_hints_and_solution"
         android:src="@drawable/ic_hint_bulb_white_24dp" />
     </FrameLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -377,6 +377,9 @@
   <string name="pick_a_different_topic">Pick a \ndifferent topic.</string>
   <string name="are_you_interested">Are you interested in:\n%s?</string>
   <!-- HintsAndSolutionDialogFragment -->
+  <string name="new_hint_available">New hint available</string>
+  <string name="show_hints_and_solution">Show hints and solution</string>
+  <string name="hints_andSolution_close_icon_description">Navigate up</string>
   <string name="hints_toolbar_title">Hints</string>
   <string name="reveal_solution">Reveal Solution</string>
   <string name="reveal_hint">Reveal Hint</string>

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -1021,24 +1021,6 @@ class StateFragmentTest {
   }
 
   @Test
-  fun testStateFragment_forHintsAndSolution_incorrectInput_hintBulbContainerIsNotVisible() {
-    launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
-      startPlayingExploration()
-      selectMultipleChoiceOption(
-        optionPosition = 3,
-        expectedOptionText = "No, because, in a fraction, the pieces must be the same size."
-      )
-      clickContinueNavigationButton()
-
-      // Entering incorrect answer once.
-      typeFractionText("1/2")
-      clickSubmitAnswerButton()
-
-      onView(withId(R.id.hints_and_solution_fragment_container)).check(matches(not(isDisplayed())))
-    }
-  }
-
-  @Test
   fun testStateFragment_forHintsAndSolution_incorrectInputTwice_hintBulbContainerIsVisible() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
@@ -1101,7 +1083,7 @@ class StateFragmentTest {
       typeFractionText("1/2")
       clickSubmitAnswerButton()
 
-      onView(withId(R.id.dot_hint)).check(
+      onView(withId(R.id.hint_bulb)).check(
         matches(
           withContentDescription(R.string.show_hints_and_solution)
         )

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -1021,6 +1021,95 @@ class StateFragmentTest {
   }
 
   @Test
+  fun testStateFragment_forHintsAndSolution_incorrectInput_hintBulbContainerIsNotVisible() {
+    launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
+      startPlayingExploration()
+      selectMultipleChoiceOption(
+        optionPosition = 3,
+        expectedOptionText = "No, because, in a fraction, the pieces must be the same size."
+      )
+      clickContinueNavigationButton()
+
+      // Entering incorrect answer once.
+      typeFractionText("1/2")
+      clickSubmitAnswerButton()
+
+      onView(withId(R.id.hints_and_solution_fragment_container)).check(matches(not(isDisplayed())))
+    }
+  }
+
+  @Test
+  fun testStateFragment_forHintsAndSolution_incorrectInputTwice_hintBulbContainerIsVisible() {
+    launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
+      startPlayingExploration()
+      selectMultipleChoiceOption(
+        optionPosition = 3,
+        expectedOptionText = "No, because, in a fraction, the pieces must be the same size."
+      )
+      clickContinueNavigationButton()
+
+      // Entering incorrect answer twice.
+      typeFractionText("1/2")
+      clickSubmitAnswerButton()
+      scrollToViewType(FRACTION_INPUT_INTERACTION)
+      typeFractionText("1/2")
+      clickSubmitAnswerButton()
+
+      onView(withId(R.id.hints_and_solution_fragment_container)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testStateFragment_showHintsAndSolutionBulb_dotHasCorrectContentDescription() {
+    launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
+      startPlayingExploration()
+      selectMultipleChoiceOption(
+        optionPosition = 3,
+        expectedOptionText = "No, because, in a fraction, the pieces must be the same size."
+      )
+      clickContinueNavigationButton()
+
+      // Entering incorrect answer twice.
+      typeFractionText("1/2")
+      clickSubmitAnswerButton()
+      scrollToViewType(FRACTION_INPUT_INTERACTION)
+      typeFractionText("1/2")
+      clickSubmitAnswerButton()
+
+      onView(withId(R.id.dot_hint)).check(
+        matches(
+          withContentDescription(R.string.new_hint_available)
+        )
+      )
+    }
+  }
+
+  @Test
+  fun testStateFragment_showHintsAndSolutionBulb_bulbHasCorrectContentDescription() {
+    launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
+      startPlayingExploration()
+      selectMultipleChoiceOption(
+        optionPosition = 3,
+        expectedOptionText = "No, because, in a fraction, the pieces must be the same size."
+      )
+      clickContinueNavigationButton()
+
+      // Entering incorrect answer twice.
+      typeFractionText("1/2")
+      clickSubmitAnswerButton()
+      scrollToViewType(FRACTION_INPUT_INTERACTION)
+      typeFractionText("1/2")
+      clickSubmitAnswerButton()
+
+      onView(withId(R.id.dot_hint)).check(
+        matches(
+          withContentDescription(R.string.show_hints_and_solution)
+        )
+      )
+    }
+  }
+
+  @Test
   fun testStateFragment_forMisconception_showsLinkTextForConceptCard() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #3435: Added content description for Hints and Solution bulb

This PR adds test for this in `StateFragmentTest` file but for `QuestionPlayerTest` we do not have hints correctly and therefore I have added [this comment](https://github.com/oppia/oppia-android/issues/1273#issuecomment-879219798) for future reference.

## Output

https://user-images.githubusercontent.com/9396084/125488684-5211ccab-7674-4e1f-890d-bd5e35475915.mp4

<img width="1281" alt="Screenshot 2021-07-13 at 10 51 16 PM" src="https://user-images.githubusercontent.com/9396084/125497408-81792959-a492-405e-bd6a-dc4cacb65b56.png">


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
