### PR TITLE
Fix #2131: Question Player Progress bar background and margins

### DIFF
--- a/app/src/main/res/drawable/question_player_progress_bar_background_gradient.xml
+++ b/app/src/main/res/drawable/question_player_progress_bar_background_gradient.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+  android:shape="rectangle">
+  <gradient
+    android:angle="270"
+    android:endColor="@color/question_player_progress_bar_gradient_end"
+    android:centerColor="@color/question_player_progress_bar_gradient_center"
+    android:startColor="@color/question_player_progress_bar_gradient_start"
+    android:type="linear" />
+</shape>

--- a/app/src/main/res/layout-land/question_player_fragment.xml
+++ b/app/src/main/res/layout-land/question_player_fragment.xml
@@ -82,14 +82,21 @@
         app:layout_constraintStart_toEndOf="@id/center_guideline"
         app:layout_constraintTop_toBottomOf="@+id/end_session_body_text_view" />
 
+      <FrameLayout
+        android:layout_width="0dp"
+        android:layout_height="72dp"
+        android:background="@drawable/question_player_progress_bar_background_gradient"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
       <ProgressBar
         android:id="@+id/question_progress_bar"
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="30dp"
-        android:layout_marginEnd="30dp"
-        android:layout_marginBottom="5dp"
+        android:layout_height="12dp"
+        android:layout_marginStart="@dimen/question_player_progress_bar_margin_start"
+        android:layout_marginEnd="@dimen/question_player_progress_bar_margin_end"
         android:max="100"
         android:progress="@{viewModel.progressPercentage}"
         android:progressDrawable="@drawable/progress_bar"
@@ -101,9 +108,13 @@
         android:id="@+id/question_progress_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="30dp"
-        android:layout_marginBottom="20dp"
+        android:layout_marginTop="@dimen/question_player_progress_bar_text_margin_top"
+        android:layout_marginEnd="@dimen/question_player_progress_bar_text_margin_end"
+        android:layout_marginBottom="@dimen/question_player_progress_bar_text_margin_bottom"
+        android:fontFamily="sans-serif"
         android:text="@{viewModel.isAtEndOfSession ? @string/question_training_session_progress_finished : @string/question_training_session_progress(viewModel.currentQuestion, viewModel.questionCount)}"
+        android:textColor="@color/oppiaPrimaryText"
+        android:textSize="12sp"
         android:textStyle="italic"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
@@ -124,8 +135,8 @@
 
     <FrameLayout
       android:id="@+id/hints_and_solution_fragment_container"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
+      android:layout_width="@dimen/clickable_item_min_height"
+      android:layout_height="@dimen/clickable_item_min_height"
       android:layout_gravity="bottom|start"
       android:background="@drawable/hints_background"
       android:visibility="@{viewModel.isHintBulbVisible() ? View.VISIBLE : View.GONE}">

--- a/app/src/main/res/layout-sw600dp-land/question_player_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-land/question_player_fragment.xml
@@ -86,14 +86,21 @@
         app:layout_constraintStart_toEndOf="@id/center_guideline"
         app:layout_constraintTop_toBottomOf="@+id/end_session_body_text_view" />
 
+      <FrameLayout
+        android:layout_width="0dp"
+        android:layout_height="72dp"
+        android:background="@drawable/question_player_progress_bar_background_gradient"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
       <ProgressBar
         android:id="@+id/question_progress_bar"
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="0dp"
         android:layout_height="12dp"
-        android:layout_marginStart="96dp"
-        android:layout_marginEnd="96dp"
-        android:layout_marginBottom="12dp"
+        android:layout_marginStart="@dimen/question_player_progress_bar_margin_start"
+        android:layout_marginEnd="@dimen/question_player_progress_bar_margin_end"
         android:max="100"
         android:progress="@{viewModel.progressPercentage}"
         android:progressDrawable="@drawable/progress_bar"
@@ -105,8 +112,9 @@
         android:id="@+id/question_progress_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="96dp"
-        android:layout_marginBottom="12dp"
+        android:layout_marginTop="@dimen/question_player_progress_bar_text_margin_top"
+        android:layout_marginEnd="@dimen/question_player_progress_bar_text_margin_end"
+        android:layout_marginBottom="@dimen/question_player_progress_bar_text_margin_bottom"
         android:fontFamily="sans-serif"
         android:text="@{viewModel.isAtEndOfSession ? @string/question_training_session_progress_finished : @string/question_training_session_progress(viewModel.currentQuestion, viewModel.questionCount)}"
         android:textColor="@color/oppiaPrimaryText"
@@ -131,8 +139,8 @@
 
     <FrameLayout
       android:id="@+id/hints_and_solution_fragment_container"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
+      android:layout_width="@dimen/clickable_item_min_height"
+      android:layout_height="@dimen/clickable_item_min_height"
       android:layout_gravity="bottom|start"
       android:background="@drawable/hints_background"
       android:visibility="@{viewModel.isHintBulbVisible() ? View.VISIBLE : View.GONE}">

--- a/app/src/main/res/layout-sw600dp-port/question_player_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-port/question_player_fragment.xml
@@ -86,14 +86,21 @@
         app:layout_constraintStart_toEndOf="@id/center_guideline"
         app:layout_constraintTop_toBottomOf="@+id/end_session_body_text_view" />
 
+      <FrameLayout
+        android:layout_width="0dp"
+        android:layout_height="72dp"
+        android:background="@drawable/question_player_progress_bar_background_gradient"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
       <ProgressBar
         android:id="@+id/question_progress_bar"
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="0dp"
         android:layout_height="12dp"
-        android:layout_marginStart="64dp"
-        android:layout_marginEnd="64dp"
-        android:layout_marginBottom="12dp"
+        android:layout_marginStart="@dimen/question_player_progress_bar_margin_start"
+        android:layout_marginEnd="@dimen/question_player_progress_bar_margin_end"
         android:max="100"
         android:progress="@{viewModel.progressPercentage}"
         android:progressDrawable="@drawable/progress_bar"
@@ -105,8 +112,9 @@
         android:id="@+id/question_progress_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="64dp"
-        android:layout_marginBottom="12dp"
+        android:layout_marginTop="@dimen/question_player_progress_bar_text_margin_top"
+        android:layout_marginEnd="@dimen/question_player_progress_bar_text_margin_end"
+        android:layout_marginBottom="@dimen/question_player_progress_bar_text_margin_bottom"
         android:fontFamily="sans-serif"
         android:text="@{viewModel.isAtEndOfSession ? @string/question_training_session_progress_finished : @string/question_training_session_progress(viewModel.currentQuestion, viewModel.questionCount)}"
         android:textColor="@color/oppiaPrimaryText"
@@ -131,8 +139,8 @@
 
     <FrameLayout
       android:id="@+id/hints_and_solution_fragment_container"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
+      android:layout_width="@dimen/clickable_item_min_height"
+      android:layout_height="@dimen/clickable_item_min_height"
       android:layout_gravity="bottom|start"
       android:background="@drawable/hints_background"
       android:visibility="@{viewModel.isHintBulbVisible() ? View.VISIBLE : View.GONE}">

--- a/app/src/main/res/layout/question_player_fragment.xml
+++ b/app/src/main/res/layout/question_player_fragment.xml
@@ -84,14 +84,21 @@
         app:layout_constraintStart_toEndOf="@id/center_guideline"
         app:layout_constraintTop_toBottomOf="@+id/end_session_body_text_view" />
 
+      <FrameLayout
+        android:layout_width="0dp"
+        android:layout_height="72dp"
+        android:background="@drawable/question_player_progress_bar_background_gradient"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
       <ProgressBar
         android:id="@+id/question_progress_bar"
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="0dp"
         android:layout_height="12dp"
-        android:layout_marginStart="32dp"
-        android:layout_marginEnd="32dp"
-        android:layout_marginBottom="8dp"
+        android:layout_marginStart="@dimen/question_player_progress_bar_margin_start"
+        android:layout_marginEnd="@dimen/question_player_progress_bar_margin_end"
         android:max="100"
         android:progress="@{viewModel.progressPercentage}"
         android:progressDrawable="@drawable/progress_bar"
@@ -106,8 +113,8 @@
 
       <FrameLayout
         android:id="@+id/hints_and_solution_fragment_container"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="@dimen/clickable_item_min_height"
+        android:layout_height="@dimen/clickable_item_min_height"
         android:layout_gravity="bottom|start"
         android:background="@drawable/hints_background"
         android:visibility="@{viewModel.isHintBulbVisible() ? View.VISIBLE : View.GONE}"
@@ -135,8 +142,9 @@
         android:id="@+id/question_progress_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="32dp"
-        android:layout_marginBottom="12dp"
+        android:layout_marginTop="@dimen/question_player_progress_bar_text_margin_top"
+        android:layout_marginEnd="@dimen/question_player_progress_bar_text_margin_end"
+        android:layout_marginBottom="@dimen/question_player_progress_bar_text_margin_bottom"
         android:fontFamily="sans-serif"
         android:text="@{viewModel.isAtEndOfSession ? @string/question_training_session_progress_finished : @string/question_training_session_progress(viewModel.currentQuestion, viewModel.questionCount)}"
         android:textColor="@color/oppiaPrimaryText"

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -204,6 +204,10 @@
   <dimen name="general_button_item_question_view_padding_start">60dp</dimen>
   <dimen name="general_button_item_question_view_padding_end">60dp</dimen>
 
+  <!-- Question Player ProgressBar -->
+  <dimen name="question_player_progress_bar_margin_start">64dp</dimen>
+  <dimen name="question_player_progress_bar_margin_end">64dp</dimen>
+
   <!-- Congratulations TextView -->
   <dimen name="congratulations_text_view_margin_start">28dp</dimen>
   <dimen name="congratulations_text_view_margin_end">28dp</dimen>

--- a/app/src/main/res/values-sw600dp-land/dimens.xml
+++ b/app/src/main/res/values-sw600dp-land/dimens.xml
@@ -225,6 +225,10 @@
   <dimen name="general_button_item_question_view_padding_start">188dp</dimen>
   <dimen name="general_button_item_question_view_padding_end">188dp</dimen>
 
+  <!-- Question Player ProgressBar -->
+  <dimen name="question_player_progress_bar_margin_start">96dp</dimen>
+  <dimen name="question_player_progress_bar_margin_end">96dp</dimen>
+
   <!-- Congratulations TextView -->
   <dimen name="congratulations_text_view_margin_start">192dp</dimen>
   <dimen name="congratulations_text_view_margin_end">192dp</dimen>

--- a/app/src/main/res/values-sw600dp-port/dimens.xml
+++ b/app/src/main/res/values-sw600dp-port/dimens.xml
@@ -228,6 +228,10 @@
   <dimen name="general_button_item_question_view_padding_start">124dp</dimen>
   <dimen name="general_button_item_question_view_padding_end">124dp</dimen>
 
+  <!-- Question Player ProgressBar -->
+  <dimen name="question_player_progress_bar_margin_start">64dp</dimen>
+  <dimen name="question_player_progress_bar_margin_end">64dp</dimen>
+
   <!-- Congratulations TextView -->
   <dimen name="congratulations_text_view_margin_start">128dp</dimen>
   <dimen name="congratulations_text_view_margin_end">128dp</dimen>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -123,6 +123,9 @@
   <color name="light_green">#D9F3E7</color>
   <!-- QUESTION COMPONENT -->
   <color name="question_player_background">#F0FFFF</color>
+  <color name="question_player_progress_bar_gradient_start">#00E4F2F1</color>
+  <color name="question_player_progress_bar_gradient_center">#E4F2F1</color>
+  <color name="question_player_progress_bar_gradient_end">#E4F2F1</color>
   <!-- AVATAR BACKGROUND COLORS -->
   <color name="avatar_background_1">#E65C5C</color>
   <color name="avatar_background_2">#E6935C</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -380,6 +380,14 @@
   <!-- Replay Button: Question View -->
   <dimen name="replay_button_item_question_view_margin_top">44dp</dimen>
 
+  <!-- Question Player ProgressBar -->
+  <dimen name="question_player_progress_bar_margin_start">32dp</dimen>
+  <dimen name="question_player_progress_bar_margin_end">32dp</dimen>
+
+  <dimen name="question_player_progress_bar_text_margin_bottom">12dp</dimen>
+  <dimen name="question_player_progress_bar_text_margin_end">32dp</dimen>
+  <dimen name="question_player_progress_bar_text_margin_top">8dp</dimen>
+
   <!-- Congratulations TextView -->
   <dimen name="congratulations_text_view_margin_start">28dp</dimen>
   <dimen name="congratulations_text_view_margin_end">28dp</dimen>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fix #2131: Question Player Progress bar background and margins

## Resources
[Mobile](https://xd.adobe.com/view/dfe8ccd4-39eb-414d-a0b2-b5674357f966-8abb/screen/2fe1d26d-3ee7-4907-982b-a2fab9fc622c/specs/)
[Tablet](https://xd.adobe.com/view/dfe8ccd4-39eb-414d-a0b2-b5674357f966-8abb/screen/723e0e8e-0da5-4613-88c3-4e155b31e289/specs/)

**Notes**
- In `Mobile-Portrait` the external margins is `32dp`, which matches with the `content-item-external-margins`. Therefore from this logic and consistency factor I have kept external margins as `64dp` for mobile landscape mode.
- In `Tablet-Portrait` the external margins is `64dp` which is `1/2` of `128dp` which again matches with the `content-item-external-margins`. Applying this same logic I have kept external margins for `Tablet-Landscape` as `96dp`.

## Output
I have sharing screenshots focusing on following points:
1. Default view of progress bar
2. Progress bar with hint bulb
3. Progress bar with content behind it - gradient visible

<img src="https://user-images.githubusercontent.com/9396084/125524246-c2195300-3826-4f13-bfce-8d0bbdc4378e.png" width="250" />  <img src="https://user-images.githubusercontent.com/9396084/125524257-526588be-24a3-4721-b097-2b093e42d01c.png" width="250" />  <img src="https://user-images.githubusercontent.com/9396084/125524265-9bc1fbe7-b251-450f-b9b1-df0a984fb60e.png" width="250" />

<img src="https://user-images.githubusercontent.com/9396084/125524310-cd5e3e07-51ef-45a9-9ae7-3009ceeadf71.png" width="250" />  <img src="https://user-images.githubusercontent.com/9396084/125524323-d49ef294-d9ba-4788-ac2f-7bdfc95f69bf.png" width="250" />  <img src="https://user-images.githubusercontent.com/9396084/125524327-38d1b995-ffda-4443-90d9-e20ec79baaf8.png" width="250" />

<img src="https://user-images.githubusercontent.com/9396084/125524163-74455488-8e73-47d3-a696-4e49158f9c58.png" width="250" />  <img src="https://user-images.githubusercontent.com/9396084/125524171-0f7977b2-33fd-4666-86de-16ba5a47f09e.png" width="250" />  <img src="https://user-images.githubusercontent.com/9396084/125524175-367b876e-726b-436b-a876-ea04fc0c1604.png" width="250" />

<img src="https://user-images.githubusercontent.com/9396084/125524178-8971138e-aba4-44ad-8f61-f191f42dff46.png" width="250" />  <img src="https://user-images.githubusercontent.com/9396084/125524179-9f32db0d-d3bd-4da7-9c6b-cc929747b720.png" width="250" />  <img src="https://user-images.githubusercontent.com/9396084/125524185-5a687d6f-044f-40e7-9f7c-8a0a9030ad4a.png" width="250" />


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
