### PR TITLE
Fix #635: Prototype for Handle Multiple clicks throughout the app

### DIFF
--- a/app/src/main/java/org/oppia/android/app/help/HelpFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/help/HelpFragment.kt
@@ -25,4 +25,9 @@ class HelpFragment : InjectableFragment() {
   ): View? {
     return helpFragmentPresenter.handleCreateView(inflater, container)
   }
+
+  override fun onResume() {
+    super.onResume()
+    helpFragmentPresenter.handleOnResume()
+  }
 }

--- a/app/src/main/java/org/oppia/android/app/help/HelpFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/help/HelpFragmentPresenter.kt
@@ -12,6 +12,8 @@ import org.oppia.android.app.viewmodel.ViewModelProvider
 import org.oppia.android.databinding.HelpFragmentBinding
 import org.oppia.android.databinding.HelpItemBinding
 import javax.inject.Inject
+import kotlinx.android.synthetic.main.help_item.*
+import kotlinx.android.synthetic.main.help_item.view.*
 
 /** The presenter for [HelpFragment]. */
 @FragmentScope
@@ -53,5 +55,11 @@ class HelpFragmentPresenter @Inject constructor(
 
   private fun getHelpListViewModel(): HelpListViewModel {
     return viewModelProvider.getForFragment(fragment, HelpListViewModel::class.java)
+  }
+
+  fun handleOnResume(){
+    if(fragment.help_item_text_view != null){
+      fragment.help_item_text_view.isEnabled = true
+    }
   }
 }

--- a/app/src/main/java/org/oppia/android/app/help/HelpItemViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/help/HelpItemViewModel.kt
@@ -1,6 +1,11 @@
 package org.oppia.android.app.help
 
+import android.view.View
+import android.widget.AdapterView
 import androidx.appcompat.app.AppCompatActivity
+import kotlinx.android.synthetic.main.help_fragment.*
+import kotlinx.android.synthetic.main.help_item.*
+import kotlinx.android.synthetic.main.help_item.view.*
 import org.oppia.android.R
 import org.oppia.android.app.viewmodel.ObservableViewModel
 
@@ -13,6 +18,7 @@ class HelpItemViewModel(
     if (title == activity.getString(R.string.frequently_asked_questions_FAQ)) {
       val routeToFAQListener = activity as RouteToFAQListListener
       routeToFAQListener.onRouteToFAQList()
+      activity.help_item_text_view.isEnabled = false
     }
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes part of #635
In this pr, I've added some code that handles the multiple clicks in the help activity FAQ recycler view item. In brief what we were doing when we clicked the 'FAQs' item then it will disable the item from further click so avoiding the cause of multiple clicks. After we resume the activity then it will reenable the recycle view button by overriding the onResume in HelpActivity by the help of HelpFragmentPresenter and the cycle repeats.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
