### PR TITLE
Fix part of #3660: Introduce string descriptions

### DIFF
--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file contains the English descriptions for what each corresponding string from
+values/strings.xml represents. Note that these messages will be shown to Translators to give them
+context when translating strings. It's suggested to include screenshot links in the descriptions
+to provide a visual context in addition to the written context. -->
+<resources>
+  <string name="menu_home">The title of both the home screen (screenshot: shorturl.at/qKW05) and the option to open the home screen from the side menu (screenshot: shorturl.at/frU19).</string>
+  <string name="menu_options">The title of both the options screen (screenshot: shorturl.at/hoxHW) and the option to open the options screen from the side menu (screenshot: shorturl.at/frU19).</string>
+  <string name="menu_help">The title of both the help screen (screenshot: shorturl.at/lJOX1) and the option to open the help screen from the side menu (screenshot: shorturl.at/frU19).</string>
+  <string name="exploration_activity_title">The title that is read out when a user navigates to the exploration player (shorturl.at/xMT29) with a screenreader.</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="app_name">Oppia</string>
+  <string name="app_name" translatable="false">Oppia</string>
   <string name="nav_header_desc">Navigation header</string>
   <string name="menu_home">Home</string>
   <string name="menu_options">Options</string>


### PR DESCRIPTION
Fix part of #3660.

## Explanation
Introduce initial translation descriptions for a few strings.

The language code 'qq' is used to represent descriptions for strings that will then be exported to Translatewiki for translation. These descriptions help provide context to translators that they may not be able to easily get from the raw untranslated text. This PR introduces an initial set of descriptions. The rest of the app's strings will need to be backfilled.

Further, this PR also marks app_name as not translatable (something I noticed in passing).

Regarding tests, there's an ongoing design plan being written for introducing several CI checks to ensure translations don't have detectable errors, that translations are mostly consistent across different languages (with regards to things like string variables), and that strings have descriptions. We can't add the latter until all existing strings have their descriptions backfilled (for which this PR unblocks that work from being able to start).

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
