### PR TITLE
[RunAllTests] Fix failing RetreiveLicenseTextsTest on CI

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/license/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/license/BUILD.bazel
@@ -11,6 +11,7 @@ kt_jvm_library(
         "LicenseFetcher.kt",
         "LicenseFetcherImpl.kt",
     ],
+    visibility = ["//scripts:oppia_script_library_visibility"],
 )
 
 kt_jvm_library(

--- a/scripts/src/java/org/oppia/android/scripts/maven/RetrieveLicenseTexts.kt
+++ b/scripts/src/java/org/oppia/android/scripts/maven/RetrieveLicenseTexts.kt
@@ -1,5 +1,7 @@
 package org.oppia.android.scripts.maven
 
+import org.oppia.android.scripts.license.LicenseFetcher
+import org.oppia.android.scripts.license.LicenseFetcherImpl
 import org.oppia.android.scripts.license.model.CopyrightLicense
 import org.oppia.android.scripts.license.model.Dependency
 import org.oppia.android.scripts.proto.License

--- a/scripts/src/javatests/org/oppia/android/scripts/maven/RetrieveLicenseTextsTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/maven/RetrieveLicenseTextsTest.kt
@@ -9,6 +9,7 @@ import org.junit.rules.TemporaryFolder
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.oppia.android.scripts.license.LicenseFetcher
 import org.oppia.android.scripts.proto.DirectLinkOnly
 import org.oppia.android.scripts.proto.ExtractedCopyLink
 import org.oppia.android.scripts.proto.License


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
  
  RetrieveLicenseTextsTest is failing to build in the latest develop. This PR corrects the visibility of `LicenseFetcher` library and add imports at required places.

## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR is made from a branch that is up-to-date with "develop".
- [ ] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
