### PR TITLE
Fixes #3673: Concept card bottom padding

### DIFF
--- a/app/src/main/res/layout/concept_card_fragment.xml
+++ b/app/src/main/res/layout/concept_card_fragment.xml
@@ -38,6 +38,7 @@
       <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:clipToPadding="false"
         android:overScrollMode="never"
         android:paddingBottom="@dimen/general_screen_padding_bottom"
         android:scrollbars="none">


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #3673: Concept card bottom padding

Earlier the text was getting cropped as shown in issue image. This has been fixed now

![device-2021-08-16-211825](https://user-images.githubusercontent.com/9396084/129592182-90451480-6329-4d2f-bf84-94a5a8dccc70.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
