### PR TITLE
Fix #3108: Applied dimens value navigation_drawer_width to layout_width

### DIFF
--- a/app/src/main/res/layout-land/administrator_controls_activity.xml
+++ b/app/src/main/res/layout-land/administrator_controls_activity.xml
@@ -25,7 +25,7 @@
     <fragment
       android:id="@+id/administrator_controls_activity_fragment_navigation_drawer"
       android:name="org.oppia.android.app.drawer.NavigationDrawerFragment"
-      android:layout_width="304dp"
+      android:layout_width="@dimen/navigation_drawer_width"
       android:layout_height="match_parent"
       android:layout_gravity="start"
       app:layout="@layout/drawer_fragment"

--- a/app/src/main/res/layout-land/home_activity.xml
+++ b/app/src/main/res/layout-land/home_activity.xml
@@ -25,7 +25,7 @@
   <fragment
     android:id="@+id/home_activity_fragment_navigation_drawer"
     android:name="org.oppia.android.app.drawer.NavigationDrawerFragment"
-    android:layout_width="304dp"
+    android:layout_width="@dimen/navigation_drawer_width"
     android:layout_height="match_parent"
     android:layout_gravity="start"
     app:layout="@layout/drawer_fragment"

--- a/app/src/main/res/layout-land/option_activity.xml
+++ b/app/src/main/res/layout-land/option_activity.xml
@@ -33,7 +33,7 @@
   <fragment
     android:id="@+id/options_activity_fragment_navigation_drawer"
     android:name="org.oppia.android.app.drawer.NavigationDrawerFragment"
-    android:layout_width="304dp"
+    android:layout_width="@dimen/navigation_drawer_width"
     android:layout_height="match_parent"
     android:layout_gravity="start"
     app:layout="@layout/drawer_fragment"

--- a/app/src/main/res/layout-sw600dp-port/home_activity.xml
+++ b/app/src/main/res/layout-sw600dp-port/home_activity.xml
@@ -25,7 +25,7 @@
   <fragment
     android:id="@+id/home_activity_fragment_navigation_drawer"
     android:name="org.oppia.android.app.drawer.NavigationDrawerFragment"
-    android:layout_width="304dp"
+    android:layout_width="@dimen/navigation_drawer_width"
     android:layout_height="match_parent"
     android:layout_gravity="start"
     app:layout="@layout/drawer_fragment"

--- a/app/src/main/res/layout-sw600dp/administrator_controls_activity.xml
+++ b/app/src/main/res/layout-sw600dp/administrator_controls_activity.xml
@@ -80,7 +80,7 @@
     <fragment
       android:id="@+id/administrator_controls_activity_fragment_navigation_drawer"
       android:name="org.oppia.android.app.drawer.NavigationDrawerFragment"
-      android:layout_width="304dp"
+      android:layout_width="@dimen/navigation_drawer_width"
       android:layout_height="match_parent"
       android:layout_gravity="start"
       app:layout="@layout/drawer_fragment"

--- a/app/src/main/res/layout-sw600dp/help_activity.xml
+++ b/app/src/main/res/layout-sw600dp/help_activity.xml
@@ -96,7 +96,7 @@
   <fragment
     android:id="@+id/help_activity_fragment_navigation_drawer"
     android:name="org.oppia.android.app.drawer.NavigationDrawerFragment"
-    android:layout_width="304dp"
+    android:layout_width="@dimen/navigation_drawer_width"
     android:layout_height="match_parent"
     android:layout_gravity="start"
     app:layout="@layout/drawer_fragment"

--- a/app/src/main/res/layout-sw600dp/option_activity.xml
+++ b/app/src/main/res/layout-sw600dp/option_activity.xml
@@ -81,7 +81,7 @@
   <fragment
     android:id="@+id/options_activity_fragment_navigation_drawer"
     android:name="org.oppia.android.app.drawer.NavigationDrawerFragment"
-    android:layout_width="304dp"
+    android:layout_width="@dimen/navigation_drawer_width"
     android:layout_height="match_parent"
     android:layout_gravity="start"
     app:layout="@layout/drawer_fragment"

--- a/app/src/main/res/layout/administrator_controls_activity.xml
+++ b/app/src/main/res/layout/administrator_controls_activity.xml
@@ -25,7 +25,7 @@
     <fragment
       android:id="@+id/administrator_controls_activity_fragment_navigation_drawer"
       android:name="org.oppia.android.app.drawer.NavigationDrawerFragment"
-      android:layout_width="match_parent"
+      android:layout_width="@dimen/navigation_drawer_width"
       android:layout_height="match_parent"
       android:layout_gravity="start"
       app:layout="@layout/drawer_fragment"

--- a/app/src/main/res/layout/developer_options_activity.xml
+++ b/app/src/main/res/layout/developer_options_activity.xml
@@ -36,7 +36,7 @@
     <fragment
       android:id="@+id/developer_options_activity_fragment_navigation_drawer"
       android:name="org.oppia.android.app.drawer.NavigationDrawerFragment"
-      android:layout_width="match_parent"
+      android:layout_width="@dimen/navigation_drawer_width"
       android:layout_height="match_parent"
       android:layout_gravity="start"
       app:layout="@layout/drawer_fragment"

--- a/app/src/main/res/layout/home_activity.xml
+++ b/app/src/main/res/layout/home_activity.xml
@@ -25,7 +25,7 @@
   <fragment
     android:id="@+id/home_activity_fragment_navigation_drawer"
     android:name="org.oppia.android.app.drawer.NavigationDrawerFragment"
-    android:layout_width="match_parent"
+    android:layout_width="@dimen/navigation_drawer_width"
     android:layout_height="match_parent"
     android:layout_gravity="start"
     app:layout="@layout/drawer_fragment"

--- a/app/src/main/res/layout/option_activity.xml
+++ b/app/src/main/res/layout/option_activity.xml
@@ -33,7 +33,7 @@
   <fragment
     android:id="@+id/options_activity_fragment_navigation_drawer"
     android:name="org.oppia.android.app.drawer.NavigationDrawerFragment"
-    android:layout_width="match_parent"
+    android:layout_width="@dimen/navigation_drawer_width"
     android:layout_height="match_parent"
     android:layout_gravity="start"
     app:layout="@layout/drawer_fragment"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix #3108 

Changed `layout_width` values to `navigation_drawer_width` value from the dimens.xml. Earlier there was UI inconsistency in the `Developer Options` . The layout_width was set to `match_parent`, which has been now changed through this PR.

Before and after screenshots:

|Before      |After      |
|-----------|----------|
| ![image](https://user-images.githubusercontent.com/75847993/129974498-4f210bd8-0b26-4702-96e6-6dff1ec8ce50.png) | ![image](https://user-images.githubusercontent.com/75847993/129974517-0c9a3186-97c1-416b-96c4-5d8ed5bd9431.png)|
| ![image](https://user-images.githubusercontent.com/75847993/129974555-6478765d-85ea-46b6-a306-3c3f0d383fdc.png) | ![image](https://user-images.githubusercontent.com/75847993/129974568-948363d2-156d-4798-9276-760acdfc4a64.png) |
| ![image](https://user-images.githubusercontent.com/75847993/129974614-b9017833-2ef5-427a-ace1-2c50560ef39e.png) | ![image](https://user-images.githubusercontent.com/75847993/129974625-e2beb838-ddf6-437e-ad95-61c9edb7ca90.png) |
| ![image](https://user-images.githubusercontent.com/75847993/129974689-74bf2eeb-377e-417f-8f0c-7853f435cf27.png) | ![image](https://user-images.githubusercontent.com/75847993/129974717-1fe4ba0f-9444-4f04-aaae-f8c2b1abc057.png) |
| ![image](https://user-images.githubusercontent.com/75847993/129974753-58fad614-9e9b-4bc0-8589-7fcd3083eada.png) | ![image](https://user-images.githubusercontent.com/75847993/129974772-a9b256dd-1d56-4e04-90a8-1d30236133a3.png) |

@rt4914 PTAL


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
