### PR TITLE
Fix #2032 & #3714: stabilize AndroidX workers

### DIFF
--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -71,6 +71,7 @@ dependencies {
       'com.google.dagger:dagger:2.24',
       'com.google.firebase:firebase-analytics-ktx:17.5.0',
       'com.google.firebase:firebase-crashlytics:17.0.0',
+      'com.google.guava:guava:28.1-android',
       "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
   )
   compileOnly(

--- a/domain/src/main/java/org/oppia/android/domain/oppialogger/loguploader/LogUploadWorker.kt
+++ b/domain/src/main/java/org/oppia/android/domain/oppialogger/loguploader/LogUploadWorker.kt
@@ -1,9 +1,14 @@
 package org.oppia.android.domain.oppialogger.loguploader
 
 import android.content.Context
-import androidx.work.CoroutineWorker
+import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.SettableFuture
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import org.oppia.android.domain.oppialogger.analytics.AnalyticsController
 import org.oppia.android.domain.oppialogger.exceptions.ExceptionsController
@@ -24,7 +29,7 @@ class LogUploadWorker private constructor(
   private val eventLogger: EventLogger,
   private val consoleLogger: ConsoleLogger,
   @BackgroundDispatcher private val backgroundDispatcher: CoroutineDispatcher
-) : CoroutineWorker(context, params) {
+) : ListenableWorker(context, params) {
 
   companion object {
     const val WORKER_CASE_KEY = "worker_case_key"
@@ -33,16 +38,31 @@ class LogUploadWorker private constructor(
     const val EXCEPTION_WORKER = "exception_worker"
   }
 
-  override suspend fun doWork(): Result {
-    return when (inputData.getString(WORKER_CASE_KEY)) {
-      EVENT_WORKER -> {
-        withContext(backgroundDispatcher) { uploadEvents() }
+  @ExperimentalCoroutinesApi
+  override fun startWork(): ListenableFuture<Result> {
+    val backgroundScope = CoroutineScope(backgroundDispatcher)
+    val result = backgroundScope.async {
+      when (inputData.getString(WORKER_CASE_KEY)) {
+        EVENT_WORKER -> {
+          withContext(backgroundDispatcher) { uploadEvents() }
+        }
+        EXCEPTION_WORKER -> {
+          withContext(backgroundDispatcher) { uploadExceptions() }
+        }
+        else -> Result.failure()
       }
-      EXCEPTION_WORKER -> {
-        withContext(backgroundDispatcher) { uploadExceptions() }
-      }
-      else -> Result.failure()
     }
+
+    val future = SettableFuture.create<Result>()
+    result.invokeOnCompletion { failure ->
+      if (failure != null) {
+        future.setException(failure)
+      } else {
+        future.set(result.getCompleted())
+      }
+    }
+    // TODO(#3715): Add withTimeout() to avoid potential hanging.
+    return future
   }
 
   /** Extracts exception logs from the cache store and logs them to the remote service. */
@@ -89,7 +109,7 @@ class LogUploadWorker private constructor(
     @BackgroundDispatcher private val backgroundDispatcher: CoroutineDispatcher
   ) {
 
-    fun create(context: Context, params: WorkerParameters): CoroutineWorker {
+    fun create(context: Context, params: WorkerParameters): ListenableWorker {
       return LogUploadWorker(
         context,
         params,

--- a/domain/src/main/java/org/oppia/android/domain/oppialogger/loguploader/LogUploadWorker.kt
+++ b/domain/src/main/java/org/oppia/android/domain/oppialogger/loguploader/LogUploadWorker.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
-import kotlinx.coroutines.withContext
 import org.oppia.android.domain.oppialogger.analytics.AnalyticsController
 import org.oppia.android.domain.oppialogger.exceptions.ExceptionsController
 import org.oppia.android.domain.oppialogger.exceptions.toException
@@ -43,12 +42,8 @@ class LogUploadWorker private constructor(
     val backgroundScope = CoroutineScope(backgroundDispatcher)
     val result = backgroundScope.async {
       when (inputData.getString(WORKER_CASE_KEY)) {
-        EVENT_WORKER -> {
-          withContext(backgroundDispatcher) { uploadEvents() }
-        }
-        EXCEPTION_WORKER -> {
-          withContext(backgroundDispatcher) { uploadExceptions() }
-        }
+        EVENT_WORKER -> uploadEvents()
+        EXCEPTION_WORKER -> uploadExceptions()
         else -> Result.failure()
       }
     }

--- a/scripts/assets/file_content_validation_checks.textproto
+++ b/scripts/assets/file_content_validation_checks.textproto
@@ -3,3 +3,17 @@ file_content_checks {
   prohibited_content_regex: "^import .+?support.+?$"
   failure_message: "AndroidX should be used instead of the support library"
 }
+file_content_checks {
+  filename_regex: ".+?.kt"
+  prohibited_content_regex: "CoroutineWorker"
+  failure_message: "For stable tests, prefer using ListenableWorker with an Oppia-managed dispatcher."
+  exempted_file_name: "scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt"
+}
+file_content_checks {
+  filename_regex: ".+?.kt"
+  prohibited_content_regex: "SettableFuture"
+  failure_message: "SettableFuture should only be used in pre-approved locations since it's easy to potentially mess up & lead to a hanging ListenableFuture."
+  exempted_file_name: "domain/src/main/java/org/oppia/android/domain/oppialogger/loguploader/LogUploadWorker.kt"
+  exempted_file_name: "domain/src/main/java/org/oppia/android/domain/platformparameter/syncup/PlatformParameterSyncUpWorker.kt"
+  exempted_file_name: "scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt"
+}

--- a/scripts/src/java/org/oppia/android/scripts/regex/RegexPatternValidationCheck.kt
+++ b/scripts/src/java/org/oppia/android/scripts/regex/RegexPatternValidationCheck.kt
@@ -14,7 +14,7 @@ import java.io.FileInputStream
  * codebase.
  *
  * Usage:
- *   bazel run //scripts:pattern_validation_check  -- <path_to_directory_root>
+ *   bazel run //scripts:pattern_validation_check -- <path_to_directory_root>
  *
  * Arguments:
  * - path_to_directory_root: directory path to the root of the Oppia Android repository.
@@ -165,7 +165,7 @@ private fun checkProhibitedContent(
       File(file.toString())
         .bufferedReader()
         .lineSequence().foldIndexed(initial = false) { lineIndex, isFailing, lineContent ->
-          val matches = prohibitedContentRegex.matches(lineContent)
+          val matches = prohibitedContentRegex.containsMatchIn(lineContent)
           if (matches) {
             logProhibitedContentFailure(
               // Since, the line number starts from 1 and index starts from 0, therefore we have


### PR DESCRIPTION
## Explanation
Fix #2032
Fix #3714

Stabilizes both PlatformParameterSyncUpWorker & LogUploadWorker by using a ListenableWorker instead of CoroutineWorker. In order to ensure the tests aren't flaky, we have to fully control the execution pipeline for WorkManager. We get halfway there by using a SynchronousExecutor when setting up the work manager, but CoroutineExecutor has a "hop" using Kotlin's default executor before ``doWork()`` is called. Even though we later use ``withContext`` to hop over to our own background executor, that little hop is on an unmanaged thread that we cannot synchronize against in the test (which results in flakes).

The fix is to use ListenableWorker directly and immediately kick-off a coroutine using our own dispatcher, avoiding any hops. With this setup, the test environment utilizing both SynchronousExecutor and TestCoroutineDispatchers results in a fully managed & deterministic environment. Fortunately, there should be more or less no change to the workers' production behavior since the new implementation added here is close to equivalent to CoroutineWorker (at least for ``doWorker``; there are other aspects of CoroutineWorker that differ which we are ignoring--I think this is fine).

One note on correctness: an issue with both the new implementation of the workers & CoroutineWorker is neither anticipate the  potential of the coroutine task indefinitely hanging. We really ought to introduce a ``withTimeout``, but we can't in a way that won't reintroduce a potential flake in the test until #3715 is resolved. Given this isn't a change in existing prod behavior, I suspect that it's fine.

To verify that this fix works, I ran both workers' test suites 100 times locally and saw no failures (previously, I would see about ~20 failures for PlatformParameterSyncUpWorker and ~12 for LogUploadWorker).

Finally, to prevent this again in the future I introduced a new pattern check to prohibit using CoroutineWorker. I also added one for SettableFuture for good measure since it's challenging to use correctly, though I suspect this will rarely be hit since we prefer using coroutines over ListenableFutures.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR is made from a branch that is up-to-date with "develop".
- [x] The PR's branch is based on "develop" and not on any other branch.
- [x] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
