### PR TITLE
Fix typos in RetrieveLicenseTexts.kt and the `STRING_TOO_LONG` error for CDDL license text

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/license/MavenDependenciesListCheck.kt
+++ b/scripts/src/java/org/oppia/android/scripts/license/MavenDependenciesListCheck.kt
@@ -2,7 +2,6 @@ package org.oppia.android.scripts.license
 
 import org.oppia.android.scripts.common.CommandExecutor
 import org.oppia.android.scripts.common.CommandExecutorImpl
-import org.oppia.android.scripts.proto.License
 import org.oppia.android.scripts.proto.MavenDependency
 
 /**
@@ -179,44 +178,7 @@ class MavenDependenciesListCheck(
 
   private fun printDependenciesList(dependencyList: List<MavenDependency>) {
     dependencyList.forEach { dep ->
-      println(
-        """
-        artifact_name: "${dep.artifactName}"
-        artifact_version: "${dep.artifactVersion}"
-        """.trimIndent()
-      )
-      dep.licenseList.forEach { license ->
-        printLicense(license)
-      }
-      println()
+      println(dep)
     }
-  }
-
-  private fun printLicense(license: License) {
-    println(
-      """
-      license {
-        license_name: "${license.licenseName}"
-        original_link: "${license.originalLink}"
-      """.trimIndent()
-    )
-    when (license.verifiedLinkCase) {
-      License.VerifiedLinkCase.SCRAPABLE_LINK -> println(
-        """
-          scrapbale_link: "${license.scrapableLink.url}"
-        """.trimIndent()
-      )
-      License.VerifiedLinkCase.EXTRACTED_COPY_LINK -> println(
-        """
-          extracted_copy_link: "${license.extractedCopyLink.url}"
-        """.trimIndent()
-      )
-      License.VerifiedLinkCase.DIRECT_LINK_ONLY -> println(
-        """
-          direct_link_only: "${license.directLinkOnly.url}"
-        """.trimIndent()
-      )
-    }
-    println("}")
   }
 }

--- a/scripts/src/java/org/oppia/android/scripts/license/MavenDependenciesListCheck.kt
+++ b/scripts/src/java/org/oppia/android/scripts/license/MavenDependenciesListCheck.kt
@@ -1,5 +1,6 @@
 package org.oppia.android.scripts.license
 
+import com.google.protobuf.TextFormat
 import org.oppia.android.scripts.common.CommandExecutor
 import org.oppia.android.scripts.common.CommandExecutorImpl
 import org.oppia.android.scripts.proto.MavenDependency
@@ -178,7 +179,8 @@ class MavenDependenciesListCheck(
 
   private fun printDependenciesList(dependencyList: List<MavenDependency>) {
     dependencyList.forEach { dep ->
-      println(dep)
+      TextFormat.printer().print(dep, System.out)
+      println()
     }
   }
 }

--- a/scripts/src/java/org/oppia/android/scripts/maven/RetrieveLicenseTexts.kt
+++ b/scripts/src/java/org/oppia/android/scripts/maven/RetrieveLicenseTexts.kt
@@ -20,7 +20,7 @@ import javax.xml.transform.stream.StreamResult
 
 private const val MAVEN_DEPENDENCY_LIST_NOT_UP_TO_DATE =
   "maven_dependencies.textproto is not up-to-date"
-private const val MAX_CHARS_LIMIT = 16383
+const val MAX_CHARS_LIMIT = 16383
 
 /**
  * Script to extract the licenses for the third-party Maven dependencies (direct and indirect both)

--- a/scripts/src/java/org/oppia/android/scripts/maven/RetrieveLicenseTexts.kt
+++ b/scripts/src/java/org/oppia/android/scripts/maven/RetrieveLicenseTexts.kt
@@ -22,6 +22,7 @@ private const val MAVEN_DEPENDENCY_LIST_NOT_UP_TO_DATE =
   "maven_dependencies.textproto is not up-to-date"
 
 /** Maximum number of chars that can be displayed in a textview. */
+// Reference: https://stackoverflow.com/a/51733275
 const val MAX_CHARS_LIMIT = 16383
 
 /**

--- a/scripts/src/java/org/oppia/android/scripts/maven/RetrieveLicenseTexts.kt
+++ b/scripts/src/java/org/oppia/android/scripts/maven/RetrieveLicenseTexts.kt
@@ -20,6 +20,8 @@ import javax.xml.transform.stream.StreamResult
 
 private const val MAVEN_DEPENDENCY_LIST_NOT_UP_TO_DATE =
   "maven_dependencies.textproto is not up-to-date"
+
+/** Maximum number of chars that can be displayed in a textview. */
 const val MAX_CHARS_LIMIT = 16383
 
 /**

--- a/scripts/src/java/org/oppia/android/scripts/maven/RetrieveLicenseTexts.kt
+++ b/scripts/src/java/org/oppia/android/scripts/maven/RetrieveLicenseTexts.kt
@@ -20,6 +20,7 @@ import javax.xml.transform.stream.StreamResult
 
 private const val MAVEN_DEPENDENCY_LIST_NOT_UP_TO_DATE =
   "maven_dependencies.textproto is not up-to-date"
+private const val MAX_CHARS_LIMIT = 16383
 
 /**
  * Script to extract the licenses for the third-party Maven dependencies (direct and indirect both)
@@ -147,16 +148,22 @@ class RetrieveLicenseTexts(
   }
 
   private fun retrieveCopyrightLicense(license: License): CopyrightLicense {
-    val licenseText: String
+    var licenseText: String
     val licenseLink: String
     when (license.verifiedLinkCase) {
       License.VerifiedLinkCase.SCRAPABLE_LINK -> {
         licenseText = fetchLicenseText(license.scrapableLink.url)
         licenseLink = license.scrapableLink.url
+        if (licenseText.length > MAX_CHARS_LIMIT) {
+          licenseText = licenseLink
+        }
       }
       License.VerifiedLinkCase.EXTRACTED_COPY_LINK -> {
         licenseText = fetchLicenseText(license.extractedCopyLink.url)
         licenseLink = license.extractedCopyLink.url
+        if (licenseText.length > MAX_CHARS_LIMIT) {
+          licenseText = licenseLink
+        }
       }
       License.VerifiedLinkCase.DIRECT_LINK_ONLY -> {
         licenseText = license.directLinkOnly.url

--- a/scripts/src/java/org/oppia/android/scripts/maven/RetrieveLicenseTexts.kt
+++ b/scripts/src/java/org/oppia/android/scripts/maven/RetrieveLicenseTexts.kt
@@ -329,7 +329,7 @@ class RetrieveLicenseTexts(
 
     val arrayOfLicenseNamesArrays = createArray(
       arrayTag = "array",
-      arrayName = "third_party_dependency_license_names_arrays",
+      arrayName = "third_party_dependency_license_names_array",
       itemListSize = dependenciesList.size,
       textNodePrefix = "@array/third_party_dependency_license_names_",
       doc = doc
@@ -339,7 +339,7 @@ class RetrieveLicenseTexts(
 
     val arrayOfLicenseTextsArrays = createArray(
       arrayTag = "array",
-      arrayName = "third_party_dependency_license_texts_arrays",
+      arrayName = "third_party_dependency_license_texts_array",
       itemListSize = dependenciesList.size,
       textNodePrefix = "@array/third_party_dependency_license_texts_",
       doc = doc

--- a/scripts/src/java/org/oppia/android/scripts/maven/RetrieveLicenseTexts.kt
+++ b/scripts/src/java/org/oppia/android/scripts/maven/RetrieveLicenseTexts.kt
@@ -156,6 +156,8 @@ class RetrieveLicenseTexts(
       License.VerifiedLinkCase.SCRAPABLE_LINK -> {
         licenseText = fetchLicenseText(license.scrapableLink.url)
         licenseLink = license.scrapableLink.url
+
+        // TODO(#3738): Ensure entire license text is displayed for all the copyright licenses
         if (licenseText.length > MAX_CHARS_LIMIT) {
           licenseText = licenseLink
         }
@@ -163,6 +165,8 @@ class RetrieveLicenseTexts(
       License.VerifiedLinkCase.EXTRACTED_COPY_LINK -> {
         licenseText = fetchLicenseText(license.extractedCopyLink.url)
         licenseLink = license.extractedCopyLink.url
+
+        // TODO(#3738): Ensure entire license text is displayed for all the copyright licenses
         if (licenseText.length > MAX_CHARS_LIMIT) {
           licenseText = licenseLink
         }

--- a/scripts/src/javatests/org/oppia/android/scripts/license/MavenDependenciesListCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/license/MavenDependenciesListCheckTest.kt
@@ -292,8 +292,12 @@ class MavenDependenciesListCheckTest {
   fun testMavenDepsListCheck_singleDepRemoved_failsAndCallsOutRedundantDep() {
     val pbFile = tempFolder.newFile("scripts/assets/maven_dependencies.pb")
     val license1 = License.newBuilder().apply {
-      this.licenseName = "The Apache License, Version 2.0"
-      this.originalLink = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+      this.licenseName = "Terms of Service for Firebase Services"
+      this.originalLink = "https://fabric.io/terms"
+      this.directLinkOnly = DirectLinkOnly.newBuilder().apply {
+        url = "https://firebase.google.com/terms"
+      }.build()
+      this.isOriginalLinkInvalid = true
     }.build()
     val license2 = License.newBuilder().apply {
       this.licenseName = "Simplified BSD License"
@@ -306,8 +310,8 @@ class MavenDependenciesListCheckTest {
       this.addAllMavenDependency(
         listOf(
           MavenDependency.newBuilder().apply {
-            this.artifactName = DATA_BINDING_DEP
-            this.artifactVersion = DATA_BINDING_VERSION
+            this.artifactName = IO_FABRIC_DEP
+            this.artifactVersion = IO_FABRIC_VERSION
             this.addLicense(license1)
           }.build(),
           MavenDependency.newBuilder().apply {
@@ -341,11 +345,15 @@ class MavenDependenciesListCheckTest {
 
       Redundant dependencies that need to be removed:
 
-      artifact_name: "$DATA_BINDING_DEP"
-      artifact_version: "$DATA_BINDING_VERSION"
+      artifact_name: "$IO_FABRIC_DEP"
+      artifact_version: "$IO_FABRIC_VERSION"
       license {
-        license_name: "The Apache License, Version 2.0"
-        original_link: "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        license_name: "Terms of Service for Firebase Services"
+        original_link: "https://fabric.io/terms"
+        direct_link_only {
+          url: "https://firebase.google.com/terms"
+        }
+        is_original_link_invalid: true
       }
 
       Refer to https://github.com/oppia/oppia-android/wiki/Updating-Maven-Dependencies for more details.

--- a/scripts/src/javatests/org/oppia/android/scripts/maven/RetrieveLicenseTextsTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/maven/RetrieveLicenseTextsTest.kt
@@ -320,12 +320,12 @@ class RetrieveLicenseTextsTest {
     )
     val arrayOfLicenseNamesArrays = retrieveArray(
       xmlContent = xmlContent,
-      attributeName = "third_party_dependency_license_names_arrays",
+      attributeName = "third_party_dependency_license_names_array",
       arrayTag = "array"
     )
     val arrayOfLicenseTextsArrays = retrieveArray(
       xmlContent = xmlContent,
-      attributeName = "third_party_dependency_license_texts_arrays",
+      attributeName = "third_party_dependency_license_texts_array",
       arrayTag = "array"
     )
     verifyArray(

--- a/scripts/src/javatests/org/oppia/android/scripts/maven/RetrieveLicenseTextsTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/maven/RetrieveLicenseTextsTest.kt
@@ -30,7 +30,7 @@ class RetrieveLicenseTextsTest {
   private val MAVEN_DEPENDENCY_LIST_NOT_UP_TO_DATE_FAILURE =
     "maven_dependencies.textproto is not up-to-date"
   private val SCRIPT_PASSED_INDICATOR = "Script execution completed successfully."
-  private val LONG_LICENSE_TEXT_LENGTH = 16384
+  private val LONG_LICENSE_TEXT_LENGTH = MAX_CHARS_LIMIT + 1
 
   private val SCRAPABLE_LINK = "https://www.apache.org/licenses/LICENSE-2.0.txt"
   private val DIRECT_LINK_ONLY = "https://developer.android.com/studio/terms.html"
@@ -550,7 +550,7 @@ class RetrieveLicenseTextsTest {
   }
 
   private fun retrieveLongLicenseText(): String {
-    val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9') + ' '
+    val charPool: List<Char> = (' '..'z').toList() // Inlcude all chars from ASCII value 32 to 122.
     return (1..LONG_LICENSE_TEXT_LENGTH)
       .map { kotlin.random.Random.nextInt(0, charPool.size) }
       .map(charPool::get)

--- a/scripts/src/javatests/org/oppia/android/scripts/maven/RetrieveLicenseTextsTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/maven/RetrieveLicenseTextsTest.kt
@@ -23,6 +23,7 @@ import org.xml.sax.InputSource
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.random.Random
 
 /** Tests for [RetrieveLicenseTexts]. */
 class RetrieveLicenseTextsTest {
@@ -30,15 +31,14 @@ class RetrieveLicenseTextsTest {
   private val MAVEN_DEPENDENCY_LIST_NOT_UP_TO_DATE_FAILURE =
     "maven_dependencies.textproto is not up-to-date"
   private val SCRIPT_PASSED_INDICATOR = "Script execution completed successfully."
-  private val LONG_LICENSE_TEXT_LENGTH = MAX_CHARS_LIMIT + 1
+  private val LONG_LICENSE_TEXT_LENGTH = MAX_LICENSE_LENGTH + 1
 
   private val SCRAPABLE_LINK = "https://www.apache.org/licenses/LICENSE-2.0.txt"
   private val DIRECT_LINK_ONLY = "https://developer.android.com/studio/terms.html"
   private val EXTRACTED_COPY_ORIGINAL_LINK = "https://www.opensource.org/licenses/bsd-license"
   private val EXTRACTED_COPY_LINK = "https://raw.githubusercontent.com/oppia/oppia-android-" +
     "licenses/develop/simplified-bsd-license.txt"
-  private val LONG_LICENSE_TEXT_LINK = "https://raw.githubusercontent.com/javaee/javax." +
-    "annotation/83417807ad402ee1022c0307208d4510c80c68b6/LICENSE"
+  private val LONG_LICENSE_TEXT_LINK = "https://verylonglicense.txt"
 
   private val mockLicenseFetcher by lazy { initializeLicenseFetcher() }
 
@@ -552,7 +552,7 @@ class RetrieveLicenseTextsTest {
   private fun retrieveLongLicenseText(): String {
     val charPool: List<Char> = (' '..'z').toList() // Inlcude all chars from ASCII value 32 to 122.
     return (1..LONG_LICENSE_TEXT_LENGTH)
-      .map { kotlin.random.Random.nextInt(0, charPool.size) }
+      .map { Random.nextInt(0, charPool.size) }
       .map(charPool::get)
       .joinToString("")
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged. 
  -->

The PR fixes the STRING_TOO_LONG error that occurs when the license text is too long to be displayed and some typos in RetrieveLicenseTexts.kt script.
<img src = "https://user-images.githubusercontent.com/54636525/130578732-939cfb4d-814a-4c1b-83e6-72144bd2cfbf.jpg" width=300>

Tests passing locally - 
![Screenshot from 2021-08-24 13-26-24](https://user-images.githubusercontent.com/54636525/130579213-e240d182-b972-4ac5-8905-d98054887f79.png)
![Screenshot from 2021-08-24 13-34-00](https://user-images.githubusercontent.com/54636525/130580188-52283f91-44cb-44b2-8426-78a4eb8496b3.png)


## Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary auto-generated code from Android Studio.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR is made from a branch that is up-to-date with "develop".
- [ ] The PR's branch is based on "develop" and not on any other branch.
- [ ] The PR is **assigned** to an appropriate reviewer in both the **Assignees** and the **Reviewers** sections.
