### PR TITLE
Fix #3413: Fix espresso test failing in topic practice fragment test

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -91,6 +92,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
+import org.oppia.android.app.devoptions.DeveloperOptionsActivity
 
 /** Tests for [TopicPracticeFragment]. */
 @RunWith(AndroidJUnit4::class)
@@ -244,14 +246,49 @@ class TopicPracticeFragmentTest {
 
   @Test
   fun testTopicPracticeFragment_loadFragment_selectSubtopics_clickStartButton_skillListTransferSuccessfully() { // ktlint-disable max-line-length
-    testCoroutineDispatchers.unregisterIdlingResource()
-    launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID)
-    clickPracticeTab()
-    clickPracticeItem(position = 1, targetViewId = R.id.subtopic_check_box)
-    scrollToPosition(position = 5)
-    clickPracticeItem(position = 5, targetViewId = R.id.topic_practice_start_button)
-    intended(hasComponent(QuestionPlayerActivity::class.java.name))
-    intended(hasExtra(QuestionPlayerActivity.getIntentKey(), skillIdList))
+//    testCoroutineDispatchers.unregisterIdlingResource()
+    launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
+//      testCoroutineDispatchers.runCurrent()
+      onView(
+        allOf(
+          withText(TopicTab.getTabForPosition(position = 2, enablePracticeTab).name),
+          isDescendantOfA(withId(R.id.topic_tabs_container))
+        )
+      ).perform(click())
+      onView(
+      atPositionOnView(
+        recyclerViewId = R.id.topic_practice_skill_list,
+        position = 1,
+        targetViewId = R.id.subtopic_check_box
+      )
+    ).perform(click())
+      onView(withId(R.id.topic_practice_skill_list)).perform(
+        scrollToPosition<RecyclerView.ViewHolder>(
+          5
+        )
+      )
+      onView(
+      atPositionOnView(
+        recyclerViewId = R.id.topic_practice_skill_list,
+        position = 5,
+        targetViewId = R.id.topic_practice_start_button
+      )
+    ).perform(click())
+      testCoroutineDispatchers.runCurrent()
+      intended(hasComponent(QuestionPlayerActivity::class.java.name))
+      intended(hasExtra(QuestionPlayerActivity.getIntentKey(), skillIdList))
+
+      /*clickPracticeTab()
+      testCoroutineDispatchers.runCurrent()
+      clickPracticeItem(position = 1, targetViewId = R.id.subtopic_check_box)
+      testCoroutineDispatchers.runCurrent()
+      scrollToPosition(position = 5)
+      testCoroutineDispatchers.runCurrent()
+      clickPracticeItem(position = 5, targetViewId = R.id.topic_practice_start_button)
+      testCoroutineDispatchers.runCurrent()
+      intended(hasComponent(QuestionPlayerActivity::class.java.name))
+      intended(hasExtra(QuestionPlayerActivity.getIntentKey(), skillIdList))*/
+    }
   }
 
   @Test

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
@@ -256,24 +256,24 @@ class TopicPracticeFragmentTest {
         )
       ).perform(click())
       onView(
-      atPositionOnView(
-        recyclerViewId = R.id.topic_practice_skill_list,
-        position = 1,
-        targetViewId = R.id.subtopic_check_box
-      )
-    ).perform(click())
+        atPositionOnView(
+          recyclerViewId = R.id.topic_practice_skill_list,
+          position = 1,
+          targetViewId = R.id.subtopic_check_box
+        )
+      ).perform(click())
       onView(withId(R.id.topic_practice_skill_list)).perform(
         scrollToPosition<RecyclerView.ViewHolder>(
           5
         )
       )
       onView(
-      atPositionOnView(
-        recyclerViewId = R.id.topic_practice_skill_list,
-        position = 5,
-        targetViewId = R.id.topic_practice_start_button
-      )
-    ).perform(click())
+        atPositionOnView(
+          recyclerViewId = R.id.topic_practice_skill_list,
+          position = 5,
+          targetViewId = R.id.topic_practice_start_button
+        )
+      ).perform(click())
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(QuestionPlayerActivity::class.java.name))
       intended(hasExtra(QuestionPlayerActivity.getIntentKey(), skillIdList))

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
@@ -245,48 +245,14 @@ class TopicPracticeFragmentTest {
 
   @Test
   fun testTopicPracticeFragment_loadFragment_selectSubtopics_clickStartButton_skillListTransferSuccessfully() { // ktlint-disable max-line-length
-//    testCoroutineDispatchers.unregisterIdlingResource()
+    testCoroutineDispatchers.unregisterIdlingResource()
     launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID).use {
-//      testCoroutineDispatchers.runCurrent()
-      onView(
-        allOf(
-          withText(TopicTab.getTabForPosition(position = 2, enablePracticeTab).name),
-          isDescendantOfA(withId(R.id.topic_tabs_container))
-        )
-      ).perform(click())
-      onView(
-        atPositionOnView(
-          recyclerViewId = R.id.topic_practice_skill_list,
-          position = 1,
-          targetViewId = R.id.subtopic_check_box
-        )
-      ).perform(click())
-      onView(withId(R.id.topic_practice_skill_list)).perform(
-        scrollToPosition<RecyclerView.ViewHolder>(
-          5
-        )
-      )
-      onView(
-        atPositionOnView(
-          recyclerViewId = R.id.topic_practice_skill_list,
-          position = 5,
-          targetViewId = R.id.topic_practice_start_button
-        )
-      ).perform(click())
-      testCoroutineDispatchers.runCurrent()
+      clickPracticeTab()
+      clickPracticeItem(position = 1, targetViewId = R.id.subtopic_check_box)
+      scrollToPosition(position = 5)
+      clickPracticeItem(position = 5, targetViewId = R.id.topic_practice_start_button)
       intended(hasComponent(QuestionPlayerActivity::class.java.name))
       intended(hasExtra(QuestionPlayerActivity.getIntentKey(), skillIdList))
-
-      /*clickPracticeTab()
-      testCoroutineDispatchers.runCurrent()
-      clickPracticeItem(position = 1, targetViewId = R.id.subtopic_check_box)
-      testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 5)
-      testCoroutineDispatchers.runCurrent()
-      clickPracticeItem(position = 5, targetViewId = R.id.topic_practice_start_button)
-      testCoroutineDispatchers.runCurrent()
-      intended(hasComponent(QuestionPlayerActivity::class.java.name))
-      intended(hasExtra(QuestionPlayerActivity.getIntentKey(), skillIdList))*/
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
@@ -92,7 +92,6 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
-import org.oppia.android.app.devoptions.DeveloperOptionsActivity
 
 /** Tests for [TopicPracticeFragment]. */
 @RunWith(AndroidJUnit4::class)

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
@@ -244,8 +244,8 @@ class TopicPracticeFragmentTest {
   }
 
   @Test
-  @Ignore("Flaky test") // TODO(#3413): Test is failing unexpectedly.
   fun testTopicPracticeFragment_loadFragment_selectSubtopics_clickStartButton_skillListTransferSuccessfully() { // ktlint-disable max-line-length
+    testCoroutineDispatchers.unregisterIdlingResource()
     launchTopicActivityIntent(internalProfileId, FRACTIONS_TOPIC_ID)
     clickPracticeTab()
     clickPracticeItem(position = 1, targetViewId = R.id.subtopic_check_box)

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
@@ -26,7 +26,6 @@ import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #3413 
unregistered the idling resource for the specific test as it was not need it was creating IdlingResouceTImedOutException
## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
