### PR TITLE
Changes for making the file RTL compatible

### DIFF
--- a/app/src/main/res/layout/add_profile_activity.xml
+++ b/app/src/main/res/layout/add_profile_activity.xml
@@ -61,8 +61,7 @@
             android:paddingTop="12dp"
             android:src="@drawable/rounded_white_background_with_shadow"
             app:layout_constraintBottom_toBottomOf="@+id/add_profile_activity_user_image_view"
-            app:layout_constraintEnd_toEndOf="@+id/add_profile_activity_user_image_view"
-            app:layout_constraintRight_toRightOf="@+id/add_profile_activity_user_image_view" />
+            app:layout_constraintEnd_toEndOf="@+id/add_profile_activity_user_image_view" />
 
           <TextView
             android:id="@+id/add_profile_activity_required_heading_text_view"

--- a/scripts/assets/file_content_validation_checks.textproto
+++ b/scripts/assets/file_content_validation_checks.textproto
@@ -41,7 +41,6 @@ file_content_checks {
   file_path_regex: ".+?.xml"
   prohibited_content_regex: "paddingLeft|paddingRight|drawableLeft|drawableRight|layout_alignLeft|layout_alignRight|layout_marginLeft|layout_marginRight|layout_alignParentLeft|layout_alignParentRight|layout_toLeftOf|layout_toRightOf|layout_constraintLeft_toLeftOf|layout_constraintLeft_toRightOf|layout_constraintRight_toLeftOf|layout_constraintRight_toRightOf|layout_goneMarginLeft|layout_goneMarginRight"
   failure_message: "Use start/end versions of layout properties, instead, for proper RTL support"
-  exempted_file_name: "app/src/main/res/layout/add_profile_activity.xml"
   exempted_file_name: "app/src/main/res/layout/profile_progress_header.xml"
   exempted_file_name: "app/src/main/res/layout-land/profile_progress_header.xml"
   exempted_file_name: "app/src/main/res/layout-sw600dp-land/profile_progress_header.xml"


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #3807 By removing the right constraints from the xml file 
removed the file name from exempted files list

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passin
![WhatsApp Image 2021-09-27 at 12 21 58 PM (1)](https://user-images.githubusercontent.com/64087572/134861254-903964a3-7e68-46a0-a48b-e1f90b3dd04e.jpeg)

![WhatsApp Image 2021-09-27 at 12 21 58 PM](https://user-images.githubusercontent.com/64087572/134861282-9775608a-bf7e-4c28-8513-e14be14494e0.jpeg)

Added a screenshot for the normal app view and view after selecting force RTL layout. Both were similar to as of before  the changes were made.


