### PR TITLE
Fix #3833: "Start over" button missing left border in the UI

### DIFF
--- a/app/src/main/res/layout-land/resume_lesson_fragment.xml
+++ b/app/src/main/res/layout-land/resume_lesson_fragment.xml
@@ -58,20 +58,13 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_title_text_view" />
 
-      <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
-        android:layout_marginTop="32dp"
-        android:layout_marginEnd="32dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_description_text_view">
-
         <Button
           android:id="@+id/resume_lesson_start_over_button"
           style="@style/StartOverLessonButton"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_marginStart="32dp"
+          android:layout_marginTop="32dp"
           android:layout_marginEnd="12dp"
           android:text="@string/start_over_lesson_button"
           app:layout_constraintBottom_toBottomOf="parent"
@@ -82,12 +75,15 @@
         <Button
           android:id="@+id/resume_lesson_continue_button"
           style="@style/ContinueLessonButton"
-          android:layout_marginStart="12dp"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_marginStart="32dp"
+          android:layout_marginTop="32dp"
+          android:layout_marginEnd="12dp"
           android:text="@string/resume_lesson_button"
           app:layout_constraintBottom_toBottomOf="parent"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toEndOf="@id/resume_lesson_start_over_button" />
       </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
   </ScrollView>
 </layout>

--- a/app/src/main/res/layout-sw600dp-land/resume_lesson_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-land/resume_lesson_fragment.xml
@@ -14,8 +14,8 @@
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="horizontal"
-    android:baselineAligned="false">
+    android:baselineAligned="false"
+    android:orientation="horizontal">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="0dp"
@@ -89,38 +89,33 @@
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_title_text_view" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-          android:layout_width="match_parent"
+        <Button
+          android:id="@+id/resume_lesson_start_over_button"
+          style="@style/StartOverLessonButton"
+          android:layout_width="0dp"
           android:layout_height="wrap_content"
           android:layout_marginStart="32dp"
           android:layout_marginTop="32dp"
-          android:layout_marginEnd="32dp"
+          android:layout_marginEnd="12dp"
+          android:text="@string/start_over_lesson_button"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toStartOf="@+id/resume_lesson_continue_button"
+          app:layout_constraintHorizontal_chainStyle="spread"
+          app:layout_constraintStart_toStartOf="parent" />
+
+        <Button
+          android:id="@+id/resume_lesson_continue_button"
+          style="@style/ContinueLessonButton"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_marginStart="32dp"
+          android:layout_marginTop="32dp"
+          android:layout_marginEnd="12dp"
+          android:text="@string/resume_lesson_button"
           app:layout_constraintBottom_toBottomOf="parent"
           app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_description_text_view">
-
-          <Button
-            android:id="@+id/resume_lesson_start_over_button"
-            style="@style/StartOverLessonButton"
-            android:layout_marginEnd="12dp"
-            android:text="@string/start_over_lesson_button"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/resume_lesson_continue_button"
-            app:layout_constraintHorizontal_chainStyle="spread"
-            app:layout_constraintStart_toStartOf="parent" />
-
-          <Button
-            android:id="@+id/resume_lesson_continue_button"
-            style="@style/ContinueLessonButton"
-            android:layout_marginStart="12dp"
-            android:text="@string/resume_lesson_button"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/resume_lesson_start_over_button" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+          app:layout_constraintStart_toEndOf="@id/resume_lesson_start_over_button" />
       </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
-
   </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/resume_lesson_fragment.xml
+++ b/app/src/main/res/layout/resume_lesson_fragment.xml
@@ -71,36 +71,34 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_title_text_view" />
 
-      <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
+      <Button
+        android:id="@+id/resume_lesson_start_over_button"
+        style="@style/StartOverLessonButton"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="32dp"
         android:layout_marginTop="32dp"
+        android:layout_marginEnd="12dp"
+        android:text="@string/start_over_lesson_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/resume_lesson_continue_button"
+        app:layout_constraintHorizontal_chainStyle="spread"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/resume_lesson_chapter_description_text_view" />
+
+      <Button
+        android:id="@+id/resume_lesson_continue_button"
+        style="@style/ContinueLessonButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="32dp"
         android:layout_marginEnd="32dp"
+        android:text="@string/resume_lesson_button"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_description_text_view">
-
-        <Button
-          android:id="@+id/resume_lesson_start_over_button"
-          style="@style/StartOverLessonButton"
-          android:layout_marginEnd="12dp"
-          android:text="@string/start_over_lesson_button"
-          app:layout_constraintBottom_toBottomOf="parent"
-          app:layout_constraintEnd_toStartOf="@+id/resume_lesson_continue_button"
-          app:layout_constraintHorizontal_chainStyle="spread"
-          app:layout_constraintStart_toStartOf="parent" />
-
-        <Button
-          android:id="@+id/resume_lesson_continue_button"
-          style="@style/ContinueLessonButton"
-          android:layout_marginStart="12dp"
-          android:text="@string/resume_lesson_button"
-          app:layout_constraintBottom_toBottomOf="parent"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toEndOf="@id/resume_lesson_start_over_button" />
+        app:layout_constraintStart_toEndOf="@id/resume_lesson_start_over_button"
+        app:layout_constraintTop_toBottomOf="@+id/resume_lesson_chapter_description_text_view" />
       </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
   </ScrollView>
 </layout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -329,8 +329,6 @@
   </style>
   <!-- Start Over Lesson Button -->
   <style name="StartOverLessonButton" parent="TextAppearance.AppCompat.Widget.Button">
-    <item name="android:layout_width">144dp</item>
-    <item name="android:layout_height">wrap_content</item>
     <item name="android:paddingEnd">12dp</item>
     <item name="android:paddingStart">12dp</item>
     <item name="android:background">@drawable/start_over_button_background</item>
@@ -344,8 +342,6 @@
   </style>
   <!-- Continue Lesson Button -->
   <style name="ContinueLessonButton" parent="TextAppearance.AppCompat.Widget.Button">
-    <item name="android:layout_width">144dp</item>
-    <item name="android:layout_height">wrap_content</item>
     <item name="android:drawablePadding">4dp</item>
     <item name="android:paddingEnd">12dp</item>
     <item name="android:paddingStart">12dp</item>


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fix #3833 
Width of buttons for small screen size.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing

### Screenshots
![Screenshot_20210927_134207](https://user-images.githubusercontent.com/25057618/134870937-349fd1aa-c7ce-4384-9e55-60e4eb125487.png)
![Screenshot_20210927_134728](https://user-images.githubusercontent.com/25057618/134870962-dca48e92-00d4-419a-b0cb-de4d2bae2f67.png)
![Screenshot_20210927_134807](https://user-images.githubusercontent.com/25057618/134870969-cd0ed2bb-8725-43c2-bc04-7797e5dbda02.png)
![Screenshot_20210927_134855](https://user-images.githubusercontent.com/25057618/134870972-a1f5c702-f983-415b-b181-3892aae028e2.png)
