### PR TITLE
Fix #3864: Debug-sign locally deployed AABs

### DIFF
--- a/oppia_android_application.bzl
+++ b/oppia_android_application.bzl
@@ -45,7 +45,7 @@ def _convert_module_aab_to_structured_zip_impl(ctx):
     mkdir -p $WORKING_DIR/assets $WORKING_DIR/dex $WORKING_DIR/manifest $WORKING_DIR/root
     mv $WORKING_DIR/*.dex $WORKING_DIR/dex/
     mv $WORKING_DIR/AndroidManifest.xml $WORKING_DIR/manifest/
-    ls -d $WORKING_DIR/* | grep -v -w -E "res|assets|dex|manifest|root|resources.pb" | xargs -I{{}} sh -c "mv \\$0 $WORKING_DIR/root/ || exit 255" {{}} 2>&1 || exit $?
+    ls -d $WORKING_DIR/* | grep -v -w -E "res|assets|dex|manifest|root|resources.pb" | xargs -n 1 -I {{}} mv {{}} root/
 
     # Zip up the result--this will be used by bundletool to build a deployable AAB. Note that these
     # strange file path bits are needed because zip will always retain the directory structure


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix #3864
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

I noticed this while working on #3866. When trying to deploy the dev version of the app to certain versions of Android, the installation will fail since the AAB we generate isn't signed. Fortunately, bundletool makes it easy by passing it a keystore & credentials during the installation step (presumably so that it can zipalign & sign the generated APK before installing it on the device). For consistency with android_binary targets, we use Bazel's packaged debug keystore through Starlark.

Automated testing isn't really worth it here since this is a developer-only utility that can easily be mitigated or fixed if it were to break in the future. It can be manually verified by running ``bazel //:install_oppia_dev`` locally on develop vs. this branch when deploying to an Android 11+ emulator or device (I haven't tested it on earlier versions except 8.1 where it isn't an issue).

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A