### PR TITLE
Fixes #3808 : Make profile_progress_header RTL compatible

### DIFF
--- a/app/src/main/res/layout-land/profile_progress_header.xml
+++ b/app/src/main/res/layout-land/profile_progress_header.xml
@@ -41,8 +41,7 @@
       android:paddingTop="12dp"
       android:src="@drawable/rounded_white_background_with_shadow"
       app:layout_constraintBottom_toBottomOf="@+id/profile_edit_image"
-      app:layout_constraintEnd_toEndOf="@+id/profile_edit_image"
-      app:layout_constraintRight_toRightOf="@+id/profile_edit_image" />
+      app:layout_constraintEnd_toEndOf="@+id/profile_edit_image" />
 
     <TextView
       android:id="@+id/profile_name_text_view"

--- a/app/src/main/res/layout-sw600dp-land/profile_progress_header.xml
+++ b/app/src/main/res/layout-sw600dp-land/profile_progress_header.xml
@@ -40,8 +40,7 @@
       android:paddingTop="12dp"
       android:src="@drawable/rounded_white_background_with_shadow"
       app:layout_constraintBottom_toBottomOf="@+id/profile_edit_image"
-      app:layout_constraintEnd_toEndOf="@+id/profile_edit_image"
-      app:layout_constraintRight_toRightOf="@+id/profile_edit_image" />
+      app:layout_constraintEnd_toEndOf="@+id/profile_edit_image" />
 
     <TextView
       android:id="@+id/profile_name_text_view"

--- a/app/src/main/res/layout-sw600dp-port/profile_progress_header.xml
+++ b/app/src/main/res/layout-sw600dp-port/profile_progress_header.xml
@@ -40,8 +40,7 @@
       android:paddingTop="12dp"
       android:src="@drawable/rounded_white_background_with_shadow"
       app:layout_constraintBottom_toBottomOf="@+id/profile_edit_image"
-      app:layout_constraintEnd_toEndOf="@+id/profile_edit_image"
-      app:layout_constraintRight_toRightOf="@+id/profile_edit_image" />
+      app:layout_constraintEnd_toEndOf="@+id/profile_edit_image" />
 
     <TextView
       android:id="@+id/profile_name_text_view"

--- a/app/src/main/res/layout/profile_progress_header.xml
+++ b/app/src/main/res/layout/profile_progress_header.xml
@@ -42,8 +42,7 @@
       android:paddingTop="8dp"
       android:src="@drawable/rounded_white_background_with_shadow"
       app:layout_constraintBottom_toBottomOf="@+id/profile_edit_image"
-      app:layout_constraintEnd_toEndOf="@+id/profile_edit_image"
-      app:layout_constraintRight_toRightOf="@+id/profile_edit_image" />
+      app:layout_constraintEnd_toEndOf="@+id/profile_edit_image"/>
 
     <TextView
       android:id="@+id/profile_name_text_view"

--- a/scripts/assets/file_content_validation_checks.textproto
+++ b/scripts/assets/file_content_validation_checks.textproto
@@ -41,10 +41,6 @@ file_content_checks {
   file_path_regex: ".+?.xml"
   prohibited_content_regex: "paddingLeft|paddingRight|drawableLeft|drawableRight|layout_alignLeft|layout_alignRight|layout_marginLeft|layout_marginRight|layout_alignParentLeft|layout_alignParentRight|layout_toLeftOf|layout_toRightOf|layout_constraintLeft_toLeftOf|layout_constraintLeft_toRightOf|layout_constraintRight_toLeftOf|layout_constraintRight_toRightOf|layout_goneMarginLeft|layout_goneMarginRight"
   failure_message: "Use start/end versions of layout properties, instead, for proper RTL support"
-  exempted_file_name: "app/src/main/res/layout/profile_progress_header.xml"
-  exempted_file_name: "app/src/main/res/layout-land/profile_progress_header.xml"
-  exempted_file_name: "app/src/main/res/layout-sw600dp-land/profile_progress_header.xml"
-  exempted_file_name: "app/src/main/res/layout-sw600dp-port/profile_progress_header.xml"
   exempted_file_name: "app/src/main/res/values/styles.xml"
 }
 file_content_checks {


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #3808 made changed to make profile_progress_header RTL compatible
removed the files from exemted files list
## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing

normal screen
![WhatsApp Image 2021-10-02 at 2 47 36 PM](https://user-images.githubusercontent.com/64087572/135710600-9cf55884-b2bb-41ce-844c-3b91f0bdaf4a.jpeg)

after force RTL layout setting
![WhatsApp Image 2021-10-02 at 2 47 36 PM (1)](https://user-images.githubusercontent.com/64087572/135710593-c6dc925c-ca89-4c49-a2a8-9d33e4e13ed3.jpeg)



