### PR TITLE
Fix #3912: Added local property protobuf condition for M1 Mac

### DIFF
--- a/model/build.gradle
+++ b/model/build.gradle
@@ -3,8 +3,7 @@ apply plugin: 'com.google.protobuf'
 
 protobuf {
   protoc {
-    // To build protoc in M1 mac. For Context, see:
-    // https://github.com/grpc/grpc-java/issues/7690.
+    // To build protoc in M1 mac. For context, see: #3912.
     if (project.rootProject.hasProperty('protobuf_platform')) {
       artifact = "com.google.protobuf:protoc:3.8.0:${project.rootProject.property("protobuf_platform")}"
     } else {

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -3,7 +3,11 @@ apply plugin: 'com.google.protobuf'
 
 protobuf {
   protoc {
-    artifact = 'com.google.protobuf:protoc:3.8.0'
+    if (project.rootProject.hasProperty('protobuf_platform')) { // Only for M1 Mac.
+      artifact = "com.google.protobuf:protoc:3.8.0:${project.rootProject.property("protobuf_platform")}"
+    } else {
+      artifact = "com.google.protobuf:protoc:3.8.0"
+    }
   }
   generateProtoTasks {
     all().each { task ->

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -3,7 +3,9 @@ apply plugin: 'com.google.protobuf'
 
 protobuf {
   protoc {
-    if (project.rootProject.hasProperty('protobuf_platform')) { // Only for M1 Mac.
+    // To build protoc in M1 mac. For Context, see:
+    // https://github.com/grpc/grpc-java/issues/7690.
+    if (project.rootProject.hasProperty('protobuf_platform')) {
       artifact = "com.google.protobuf:protoc:3.8.0:${project.rootProject.property("protobuf_platform")}"
     } else {
       artifact = "com.google.protobuf:protoc:3.8.0"


### PR DESCRIPTION
Fixes #3912 

protoc-3.8.0-osx-aarch_64.exe is not available in [3.8.0 release](https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.8.0/) and gives the following error on build
![image](https://user-images.githubusercontent.com/54740946/136200418-9e857861-d3f0-44be-b2b4-6167c1f2cbc9.png)

Here to fix this we the following property to local.properties (Only for M1 Mac) which uses osx release instead for the given condition when built on gradle. 
```
protobuf_platform=osx-x86_64
```


PS: This issue doesn't appear for bazel build