### PR TITLE
Update Oppiabot messaging to match close policy

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -19,7 +19,7 @@ staleLabel: stale
 # by the bot, with the actual author of the pull request.
 markComment: >
   Hi @author, I'm going to mark this PR as stale because it hasn't had any updates for 7 days.
-  If no further activity occurs within **3 days**, it will be automatically closed so that others can take up the issue.
+  If no further activity occurs within **7 days**, it will be automatically closed so that others can take up the issue.
 
   If you are still working on this PR, please make a follow-up commit within **3 days** (and submit it for review, if applicable).
   Please also let us know if you are stuck so we can help you!


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
See https://github.com/oppia/oppia-android/pull/3261#issuecomment-904383857 for an example. The current message indicates PRs are closed after 3 days, but it's actually 7 per the configuration.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A