### PR TITLE
Fix #3904:  [A11Y] Optimised Add Profile Flow

### DIFF
--- a/app/src/main/java/org/oppia/android/app/profile/AddProfileActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AddProfileActivityPresenter.kt
@@ -7,9 +7,7 @@ import android.graphics.PorterDuff
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.provider.MediaStore
-import android.view.KeyEvent
 import android.view.View
-import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
 import androidx.appcompat.app.AlertDialog
@@ -162,15 +160,6 @@ class AddProfileActivityPresenter @Inject constructor(
           setValidPin(binding)
         }
       }
-    }
-
-    binding.addProfileActivityConfirmPinEditText.setOnEditorActionListener { _, actionId, event ->
-      if (actionId == EditorInfo.IME_ACTION_DONE ||
-        (event != null && (event.keyCode == KeyEvent.KEYCODE_ENTER))
-      ) {
-        binding.addProfileActivityCreateButton.callOnClick()
-      }
-      false
     }
 
     if (profileViewModel.showInfoAlertPopup.get()!!) {

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
@@ -17,6 +17,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
+import androidx.test.espresso.action.ViewActions.pressImeActionButton
 import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
@@ -989,6 +990,35 @@ class AddProfileActivityTest {
       )
       onView(withId(R.id.add_profile_activity_confirm_pin))
         .check(matches(hasNoErrorText()))
+    }
+  }
+
+  @Test
+  fun testAddProfileActivity_inputCorrectPinAndConfirmPin_actionDone_buttonIsVisible() {
+    launch(AddProfileActivity::class.java).use {
+      onView(isRoot()).perform(orientationLandscape())
+      onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
+      onView(withId(R.id.add_profile_activity_pin_check_box)).perform(click())
+      onView(
+        allOf(
+          withId(R.id.add_profile_activity_pin_edit_text),
+          isDescendantOfA(withId(R.id.add_profile_activity_pin))
+        )
+      ).perform(scrollTo()).perform(
+        editTextInputAction.appendText("123"),
+        closeSoftKeyboard()
+      )
+      onView(
+        allOf(
+          withId(R.id.add_profile_activity_confirm_pin_edit_text),
+          isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
+        )
+      ).perform(scrollTo()).perform(
+        editTextInputAction.appendText("123"),
+        pressImeActionButton()
+      )
+      onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
+      onView(withId(R.id.add_profile_activity_create_button)).check(matches(isDisplayed()))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
@@ -996,7 +996,14 @@ class AddProfileActivityTest {
   @Test
   fun testAddProfileActivity_inputCorrectPinAndConfirmPin_actionDone_buttonIsVisible() {
     launch(AddProfileActivity::class.java).use {
-      onView(isRoot()).perform(orientationLandscape())
+      onView(
+        allOf(
+          withId(R.id.add_profile_activity_user_name_edit_text),
+          isDescendantOfA(withId(R.id.add_profile_activity_user_name))
+        )
+      ).perform(scrollTo()).perform(
+        editTextInputAction.appendText("test"), closeSoftKeyboard()
+      )
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(click())
       onView(


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fix #3904:  [A11Y] Optimised Add Profile Flow

Earlier after typing pin inside `Confirm Pin` when user clicks/selects the `Done` action button inside keyboard the profile was getting created without giving a chance to select/deselect the `Allow Downloads` option.

To fix this on `Done` action I have removed the `createProfile` function call.

## Output
Now the A11Y user can navigate to all views easily.

https://user-images.githubusercontent.com/9396084/137358210-78a8c453-019e-4bc7-b796-36e466b60035.mp4

## Espresso Test Output

<img width="800" alt="Screenshot 2021-10-14 at 10 08 36 PM" src="https://user-images.githubusercontent.com/9396084/137360201-6b53267a-7371-456f-970e-49282453b195.png">

### Without the solution (new test fails)
<img width="800" alt="Screenshot 2021-10-21 at 1 30 17 PM" src="https://user-images.githubusercontent.com/9396084/138237611-ae9f1420-e60a-4d72-9a13-c0770985983c.png">


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
