### PR TITLE
[RunAllTests] Add missing build flag to bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,8 @@ build --android_databinding_use_v3_4_args \
     --experimental_android_databinding_v2 \
     --java_header_compilation=false \
     --noincremental_dexing \
-    --define=android_standalone_dexing_tool=d8_compat_dx
+    --define=android_standalone_dexing_tool=d8_compat_dx \
+    --android_databinding_use_androidx
 
 # Show all test output by default (for better debugging).
 test --test_output=all

--- a/.github/actions/set-up-android-bazel-build-environment/action.yml
+++ b/.github/actions/set-up-android-bazel-build-environment/action.yml
@@ -99,5 +99,4 @@ runs:
         cd $HOME/opensource
         git clone https://github.com/oppia/oppia-bazel-tools
         echo build --override_repository=android_tools="$(cd "$(dirname "$HOME/opensource/oppia-bazel-tools")"; pwd)/$(basename "$HOME/opensource/oppia-bazel-tools")" >> $HOME/.bazelrc
-        echo build --android_databinding_use_androidx >> $HOME/.bazelrc
       shell: bash


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
This was an oversight on my part, but the androidx flag is necessary for building.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A