### PR TITLE
Fix Styles xml Fixes #3809

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -63,7 +63,6 @@
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_marginBottom">4dp</item>
     <item name="android:layout_marginEnd">4dp</item>
-    <item name="android:layout_marginRight">4dp</item>
     <item name="android:layout_marginTop">4dp</item>
     <item name="android:background">@drawable/state_button_primary_background</item>
     <item name="android:fontFamily">sans-serif-medium</item>
@@ -83,7 +82,6 @@
     <item name="android:layout_height">48dp</item>
     <item name="android:layout_marginBottom">4dp</item>
     <item name="android:layout_marginEnd">4dp</item>
-    <item name="android:layout_marginRight">4dp</item>
     <item name="android:layout_marginTop">4dp</item>
     <item name="android:background">@drawable/previous_next_state_image_view_background</item>
     <item name="android:contentDescription">@string/previous_state_description</item>
@@ -96,7 +94,6 @@
     <item name="android:layout_height">48dp</item>
     <item name="android:layout_marginBottom">4dp</item>
     <item name="android:layout_marginEnd">4dp</item>
-    <item name="android:layout_marginRight">4dp</item>
     <item name="android:layout_marginTop">4dp</item>
     <item name="android:background">@drawable/previous_next_state_image_view_background</item>
     <item name="android:contentDescription">@string/next_state_description</item>

--- a/scripts/assets/file_content_validation_checks.textproto
+++ b/scripts/assets/file_content_validation_checks.textproto
@@ -41,7 +41,6 @@ file_content_checks {
   file_path_regex: ".+?.xml"
   prohibited_content_regex: "paddingLeft|paddingRight|drawableLeft|drawableRight|layout_alignLeft|layout_alignRight|layout_marginLeft|layout_marginRight|layout_alignParentLeft|layout_alignParentRight|layout_toLeftOf|layout_toRightOf|layout_constraintLeft_toLeftOf|layout_constraintLeft_toRightOf|layout_constraintRight_toLeftOf|layout_constraintRight_toRightOf|layout_goneMarginLeft|layout_goneMarginRight"
   failure_message: "Use start/end versions of layout properties, instead, for proper RTL support"
-  exempted_file_name: "app/src/main/res/values/styles.xml"
 }
 file_content_checks {
   file_path_regex: ".+?.xml"


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #3809 made styles.xml file RTL compatible and removed it from exempted files list
## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

For UI check 
below is screenshot of add profile xml after change where the StateButtonActive style is being used which I edited in styles.xml
![WhatsApp Image 2021-10-16 at 7 54 41 PM](https://user-images.githubusercontent.com/64087572/137591329-060a3b4a-0c84-40e3-bc32-cc8a640c6a47.jpeg)



