### PR TITLE
Fix #3946: Fix solution automatically revealing after first hint reveal

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -2603,6 +2603,7 @@ class StateFragmentTest {
     targetTextViewId: Int
   ) {
     scrollToViewType(SELECTION_INTERACTION)
+    // First, check that the option matches what's expected by the test.
     onView(
       atPositionOnView(
         recyclerViewId = R.id.selection_interaction_recyclerview,

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -1146,6 +1146,9 @@ class StateFragmentLocalTest {
     }
   }
 
+  // TODO(#1050): Add a test for verifying that the solution is correct for non-text & non-fraction
+  //  interactions.
+
   @Test
   fun testStateFragment_stateWithNumericSolution_revealHint_reopenDialog_onlyOneHintShown() {
     launchForExploration(TEST_EXPLORATION_ID_2).use {

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -72,6 +72,7 @@ import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewT
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.PREVIOUS_RESPONSES_HEADER
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.SELECTION_INTERACTION
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.SUBMIT_ANSWER_BUTTON
+import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.NUMERIC_INPUT_INTERACTION
 import org.oppia.android.app.player.state.testing.StateFragmentTestActivity
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher
 import org.oppia.android.app.shim.ViewBindingShimModule
@@ -146,6 +147,15 @@ import java.util.Locale
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
+import org.oppia.android.util.caching.LoadLessonProtosFromAssets
+import org.oppia.android.util.caching.CacheAssetsLocally
+import org.oppia.android.util.caching.TopicListToCache
+import org.oppia.android.util.caching.LoadImagesFromAssets
+import org.oppia.android.testing.environment.TestEnvironmentConfig
+import dagger.Module
+import dagger.Provides
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 
 /**
  * Tests for [StateFragment] that can only be run locally, e.g. using Robolectric, and not on an
@@ -251,7 +261,7 @@ class StateFragmentLocalTest {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
 
-      playThroughState1()
+      playThroughFractionsState1()
 
       onView(withId(R.id.hint_bulb)).check(matches(not(isDisplayed())))
     }
@@ -261,7 +271,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_wait10seconds_noHintAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
 
@@ -273,7 +283,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_wait30seconds_noHintAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(30))
 
@@ -285,7 +295,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_wait60seconds_hintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(60))
 
@@ -297,7 +307,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_wait60seconds_canViewOneHint() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(60))
       openHintsAndSolutionsDialog()
@@ -310,7 +320,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_wait120seconds_canViewOneHint() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(120))
       openHintsAndSolutionsDialog()
@@ -324,7 +334,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_portrait_submitCorrectAnswer_correctTextBannerIsDisplayed() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
       onView(withId(R.id.congratulations_text_view))
         .check(matches(isCompletelyDisplayed()))
@@ -336,7 +346,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_landscape_submitCorrectAnswer_correctTextBannerIsDisplayed() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
       onView(withId(R.id.congratulations_text_view))
         .check(matches(isCompletelyDisplayed()))
@@ -348,7 +358,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_portrait_submitCorrectAnswer_confettiIsActive() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
       onView(withId(R.id.congratulations_text_confetti_view)).check(matches(hasActiveConfetti()))
     }
@@ -359,7 +369,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_landscape_submitCorrectAnswer_confettiIsActive() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
       onView(withId(R.id.congratulations_text_confetti_view)).check(matches(hasActiveConfetti()))
     }
@@ -369,10 +379,10 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_wait60seconds_submitTwoWrongAnswers_canViewOneHint() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(60))
-      submitTwoWrongAnswers()
+      submitTwoWrongAnswersForFractionsState2()
       openHintsAndSolutionsDialog()
 
       onView(withText("Hint 1")).inRoot(isDialog()).check(matches(isDisplayed()))
@@ -383,9 +393,9 @@ class StateFragmentLocalTest {
   fun testStateFragment_submitTwoWrongAnswers_checkPreviousHeaderVisible() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
-      submitTwoWrongAnswers()
+      submitTwoWrongAnswersForFractionsState2()
       onView(withId(R.id.state_recycler_view)).perform(scrollToViewType(PREVIOUS_RESPONSES_HEADER))
       testCoroutineDispatchers.runCurrent()
 
@@ -397,9 +407,9 @@ class StateFragmentLocalTest {
   fun testStateFragment_submitTwoWrongAnswers_checkPreviousHeaderCollapsed() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
-      submitTwoWrongAnswers()
+      submitTwoWrongAnswersForFractionsState2()
       onView(withId(R.id.state_recycler_view)).perform(scrollToViewType(PREVIOUS_RESPONSES_HEADER))
       testCoroutineDispatchers.runCurrent()
 
@@ -417,9 +427,9 @@ class StateFragmentLocalTest {
   fun testStateFragment_submitTwoWrongAnswers_expandResponse_checkPreviousHeaderExpanded() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
-      submitTwoWrongAnswers()
+      submitTwoWrongAnswersForFractionsState2()
 
       onView(withId(R.id.state_recycler_view)).perform(scrollToViewType(PREVIOUS_RESPONSES_HEADER))
       testCoroutineDispatchers.runCurrent()
@@ -438,9 +448,9 @@ class StateFragmentLocalTest {
   fun testStateFragment_expandCollapseResponse_checkPreviousHeaderCollapsed() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
-      submitTwoWrongAnswers()
+      submitTwoWrongAnswersForFractionsState2()
 
       onView(withId(R.id.state_recycler_view)).perform(scrollToViewType(PREVIOUS_RESPONSES_HEADER))
       testCoroutineDispatchers.runCurrent()
@@ -475,9 +485,9 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_submitInitialWrongAnswer_noHintAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
 
       // Submitting one wrong answer isn't sufficient to show a hint.
       onView(withId(R.id.hint_bulb)).check(matches(not(isDisplayed())))
@@ -488,9 +498,9 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_submitInitialWrongAnswer_wait10seconds_noHintAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
 
       // Submitting one wrong answer isn't sufficient to show a hint.
@@ -502,9 +512,9 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_submitInitialWrongAnswer_wait30seconds_noHintAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(30))
 
       // Submitting one wrong answer isn't sufficient to show a hint.
@@ -516,9 +526,9 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_submitTwoWrongAnswers_hintAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
-      submitTwoWrongAnswers()
+      submitTwoWrongAnswersForFractionsState2()
 
       // Submitting two wrong answers should make the hint immediately available.
       onView(withId(R.id.hint_bulb)).check(matches(isDisplayed()))
@@ -529,8 +539,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_submitTwoWrongAnswers_hintAvailable_prevState_hintNotAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      submitTwoWrongAnswers()
+      playThroughFractionsState1()
+      submitTwoWrongAnswersForFractionsState2()
       onView(withId(R.id.hint_bulb)).check(matches(isDisplayed()))
       // The previous navigation button is next to a submit answer button in this state.
       onView(withId(R.id.state_recycler_view)).perform(scrollToViewType(SUBMIT_ANSWER_BUTTON))
@@ -545,8 +555,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_submitTwoWrongAnswers_prevState_currentState_checkDotIconVisible() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      submitTwoWrongAnswers()
+      playThroughFractionsState1()
+      submitTwoWrongAnswersForFractionsState2()
       onView(withId(R.id.dot_hint)).check(matches(isDisplayed()))
       moveToPreviousAndBackToCurrentStateWithSubmitButton()
       onView(withId(R.id.dot_hint)).check(matches(isDisplayed()))
@@ -557,8 +567,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_oneUnrevealedHint_prevState_currentState_checkOneUnrevealedHintVisible() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      submitTwoWrongAnswers()
+      playThroughFractionsState1()
+      submitTwoWrongAnswersForFractionsState2()
 
       openHintsAndSolutionsDialog()
       onView(withText("Hint 1")).inRoot(isDialog()).check(matches(isDisplayed()))
@@ -577,9 +587,9 @@ class StateFragmentLocalTest {
   fun testStateFragment_revealFirstHint_prevState_currentState_checkFirstHintRevealed() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
-      produceAndViewFirstHint()
+      produceAndViewFirstHintForFractionState2()
       moveToPreviousAndBackToCurrentStateWithSubmitButton()
       openHintsAndSolutionsDialog()
       onView(withId(R.id.hints_and_solution_recycler_view))
@@ -607,9 +617,9 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_submitTwoWrongAnswersAndWait_canViewOneHint() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
-      submitTwoWrongAnswers()
+      submitTwoWrongAnswersForFractionsState2()
       openHintsAndSolutionsDialog()
 
       onView(withText("Hint 1")).inRoot(isDialog()).check(matches(isDisplayed()))
@@ -620,9 +630,9 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_submitThreeWrongAnswers_canViewOneHint() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
-      submitThreeWrongAnswersAndWait()
+      submitThreeWrongAnswersForFractionsState2AndWait()
       openHintsAndSolutionsDialog()
 
       onView(withText("Hint 1")).inRoot(isDialog()).check(matches(isDisplayed()))
@@ -634,8 +644,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewHint_newHintIsNoLongerAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      submitTwoWrongAnswersAndWait()
+      playThroughFractionsState1()
+      submitTwoWrongAnswersForFractionsState2AndWait()
       openHintsAndSolutionsDialog()
 
       pressRevealHintButton(hintPosition = 0)
@@ -650,8 +660,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewHint_wait10seconds_noNewHintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFirstHint()
+      playThroughFractionsState1()
+      produceAndViewFirstHintForFractionState2()
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
 
@@ -663,8 +673,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewHint_wait30seconds_newHintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFirstHint()
+      playThroughFractionsState1()
+      produceAndViewFirstHintForFractionState2()
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(30))
 
@@ -677,8 +687,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewHint_doNotWait_canViewTwoHints() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFirstHint()
+      playThroughFractionsState1()
+      produceAndViewFirstHintForFractionState2()
 
       openHintsAndSolutionsDialog()
       onView(withText("Hint 1")).inRoot(isDialog()).check(matches(isDisplayed()))
@@ -692,8 +702,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewHint_wait30seconds_canViewTwoHints() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFirstHint()
+      playThroughFractionsState1()
+      produceAndViewFirstHintForFractionState2()
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(30))
       openHintsAndSolutionsDialog()
@@ -708,8 +718,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewHint_wait60seconds_canViewTwoHints() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFirstHint()
+      playThroughFractionsState1()
+      produceAndViewFirstHintForFractionState2()
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(60))
       openHintsAndSolutionsDialog()
@@ -724,11 +734,11 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewHint_wait60seconds_submitWrongAnswer_canViewTwoHints() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFirstHint()
+      playThroughFractionsState1()
+      produceAndViewFirstHintForFractionState2()
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(60))
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
       openHintsAndSolutionsDialog()
 
       // After 60 seconds and one wrong answer submission, only two hints should be available.
@@ -741,10 +751,10 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewHint_submitWrongAnswer_noNewHintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFirstHint()
+      playThroughFractionsState1()
+      produceAndViewFirstHintForFractionState2()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
 
       // Submitting a single wrong answer after the previous hint won't immediately show another.
       onView(withId(R.id.dot_hint)).check(matches(not(isDisplayed())))
@@ -755,10 +765,10 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewHint_submitWrongAnswer_wait10seconds_newHintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFirstHint()
+      playThroughFractionsState1()
+      produceAndViewFirstHintForFractionState2()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
 
       // Waiting 10 seconds after submitting a wrong answer should allow another hint to be shown.
@@ -770,10 +780,10 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewHint_submitWrongAnswer_wait10seconds_canViewTwoHints() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFirstHint()
+      playThroughFractionsState1()
+      produceAndViewFirstHintForFractionState2()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
       openHintsAndSolutionsDialog()
 
@@ -786,10 +796,10 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewHint_submitWrongAnswer_wait30seconds_canViewTwoHints() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFirstHint()
+      playThroughFractionsState1()
+      produceAndViewFirstHintForFractionState2()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(30))
       openHintsAndSolutionsDialog()
 
@@ -803,8 +813,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewFirstHint_configChange_secondHintIsNotAvailableImmediately() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFirstHint()
+      playThroughFractionsState1()
+      produceAndViewFirstHintForFractionState2()
 
       onView(isRoot()).perform(orientationLandscape())
       testCoroutineDispatchers.runCurrent()
@@ -816,8 +826,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewFirstHint_configChange_wait30Seconds_secondHintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFirstHint()
+      playThroughFractionsState1()
+      produceAndViewFirstHintForFractionState2()
 
       onView(isRoot()).perform(orientationLandscape())
       testCoroutineDispatchers.runCurrent()
@@ -832,7 +842,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_newHintAvailable_configChange_newHintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(60))
       onView(withId(R.id.dot_hint)).check(matches(isDisplayed()))
       onView(isRoot()).perform(orientationLandscape())
@@ -845,8 +855,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewFirstHint_prevState_wait30seconds_newHintIsNotAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFirstHint()
+      playThroughFractionsState1()
+      produceAndViewFirstHintForFractionState2()
       clickPreviousStateNavigationButton()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(30))
       onView(withId(R.id.dot_hint)).check(matches(not(isDisplayed())))
@@ -857,8 +867,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewFourHints_wait10seconds_noNewHintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFourHints()
+      playThroughFractionsState1()
+      produceAndViewFourHintsInFractionState2()
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
 
@@ -870,8 +880,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewFourHints_wait30seconds_newHintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFourHints()
+      playThroughFractionsState1()
+      produceAndViewFourHintsInFractionState2()
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(30))
 
@@ -884,8 +894,8 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewFourHints_wait30seconds_canViewSolution() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFourHints()
+      playThroughFractionsState1()
+      produceAndViewFourHintsInFractionState2()
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(30))
       openHintsAndSolutionsDialog()
@@ -907,10 +917,10 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewFourHints_submitWrongAnswer_noNewHintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFourHints()
+      playThroughFractionsState1()
+      produceAndViewFourHintsInFractionState2()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
 
       // Submitting a wrong answer will not immediately reveal the solution.
       onView(withId(R.id.dot_hint)).check(matches(not(isDisplayed())))
@@ -921,10 +931,10 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewFourHints_submitWrongAnswer_wait10s_newHintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFourHints()
+      playThroughFractionsState1()
+      produceAndViewFourHintsInFractionState2()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
 
       // Submitting a wrong answer and waiting will reveal the solution.
@@ -936,10 +946,10 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewFourHints_submitWrongAnswer_wait10s_canViewSolution() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFourHints()
+      playThroughFractionsState1()
+      produceAndViewFourHintsInFractionState2()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
       openHintsAndSolutionsDialog()
 
@@ -960,10 +970,10 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewSolution_clickRevealSolutionButton_showsDialog() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFourHints()
+      playThroughFractionsState1()
+      produceAndViewFourHintsInFractionState2()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
       openHintsAndSolutionsDialog()
 
@@ -989,10 +999,10 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewRevealSolutionDialog_clickReveal_solutionIsRevealed() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use { scenario ->
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFourHints()
+      playThroughFractionsState1()
+      produceAndViewFourHintsInFractionState2()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
 
       openHintsAndSolutionsDialog()
@@ -1009,10 +1019,10 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewRevealSolutionDialog_clickReveal_cannotViewRevealSolution() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use { scenario ->
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFourHints()
+      playThroughFractionsState1()
+      produceAndViewFourHintsInFractionState2()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
 
       openHintsAndSolutionsDialog()
@@ -1029,10 +1039,10 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewRevealSolutionDialog_clickCancel_solutionIsNotRevealed() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use { scenario ->
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFourHints()
+      playThroughFractionsState1()
+      produceAndViewFourHintsInFractionState2()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
 
       openHintsAndSolutionsDialog()
@@ -1049,10 +1059,10 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewRevealSolutionDialog_clickCancel_canViewRevealSolution() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use { scenario ->
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFourHints()
+      playThroughFractionsState1()
+      produceAndViewFourHintsInFractionState2()
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
 
       openHintsAndSolutionsDialog()
@@ -1069,10 +1079,10 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewSolution_noNewHintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use { scenario ->
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFourHints()
+      playThroughFractionsState1()
+      produceAndViewFourHintsInFractionState2()
 
-      produceAndViewSolution(scenario, revealedHintCount = 4)
+      produceAndViewSolutionInFractionsState2(scenario, revealedHintCount = 4)
 
       // No hint should be indicated as available after revealing the solution.
       onView(withId(R.id.dot_hint)).check(matches(not(isDisplayed())))
@@ -1083,9 +1093,9 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewSolution_wait30seconds_noNewHintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use { scenario ->
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFourHints()
-      produceAndViewSolution(scenario, revealedHintCount = 4)
+      playThroughFractionsState1()
+      produceAndViewFourHintsInFractionState2()
+      produceAndViewSolutionInFractionsState2(scenario, revealedHintCount = 4)
 
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(30))
 
@@ -1098,11 +1108,11 @@ class StateFragmentLocalTest {
   fun testStateFragment_nextState_viewSolution_submitWrongAnswer_wait10s_noNewHintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use { scenario ->
       startPlayingExploration()
-      playThroughState1()
-      produceAndViewFourHints()
-      produceAndViewSolution(scenario, revealedHintCount = 4)
+      playThroughFractionsState1()
+      produceAndViewFourHintsInFractionState2()
+      produceAndViewSolutionInFractionsState2(scenario, revealedHintCount = 4)
 
-      submitWrongAnswerToState2()
+      submitWrongAnswerToFractionsState2()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
 
       // Submitting a wrong answer should not change anything since the solution's been revealed.
@@ -1126,14 +1136,62 @@ class StateFragmentLocalTest {
   fun testStateFragment_stateWithoutSolution_viewAllHints_wrongAnswerAndWait_noHintIsAvailable() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playUpToFinalTestSecondTry()
-      produceAndViewThreeHintsInState13()
+      playUpToFractionsFinalTestSecondTry()
+      produceAndViewThreeHintsInFractionsState13()
 
-      submitWrongAnswerToState13()
+      submitWrongAnswerToFractionsState13()
       testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
 
       // No hint indicator should be shown since there is no solution for this state.
       onView(withId(R.id.dot_hint)).check(matches(not(isDisplayed())))
+    }
+  }
+
+  @Test
+  fun testStateFragment_stateWithNumericSolution_revealHint_reopenDialog_onlyOneHintShown() {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
+      startPlayingExploration()
+      playThroughTestState1()
+      playThroughTestState2()
+      playThroughTestState3()
+      playThroughTestState4()
+      playThroughTestState5()
+      // Trigger the first hint to show (via two incorrect answers), then reveal  it.
+      produceAndViewNextHint(hintPosition = 0) {
+        submitNumericInput(text = "1")
+        submitNumericInput(text = "1")
+      }
+
+      // Reopen the dialog after showing the hint.
+      openHintsAndSolutionsDialog()
+
+      // Verify that the first hint is available, but not the solution.
+      onView(withText("Hint 1")).inRoot(isDialog()).check(matches(isDisplayed()))
+      onView(withText("Solution")).inRoot(isDialog()).check(doesNotExist())
+    }
+  }
+
+  @Test
+  fun testStateFragment_stateWithNumericSolution_revealHint_triggerSolution_hintBulbShown() {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
+      startPlayingExploration()
+      playThroughTestState1()
+      playThroughTestState2()
+      playThroughTestState3()
+      playThroughTestState4()
+      playThroughTestState5()
+      // Trigger the first hint to show (via two incorrect answers), then reveal  it.
+      produceAndViewNextHint(hintPosition = 0) {
+        submitNumericInput(text = "1")
+        submitNumericInput(text = "1")
+      }
+
+      // Trigger the solution to show by submitting another incorrect answer & waiting.
+      submitNumericInput(text = "1")
+      testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
+
+      // The new hint indicator should be shown since a solution is now available.
+      onView(withId(R.id.dot_hint)).check(matches(isDisplayed()))
     }
   }
 
@@ -1304,7 +1362,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_mobilePortrait_finishExploration_endOfSessionConfettiIsDisplayed() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughAllStates()
+      playThroughAllFractionsStates()
       clickContinueButton()
 
       onView(withId(R.id.full_screen_confetti_view)).check(matches(hasActiveConfetti()))
@@ -1316,7 +1374,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_mobileLandscape_finishExploration_endOfSessionConfettiIsDisplayed() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughAllStates()
+      playThroughAllFractionsStates()
       clickContinueButton()
 
       onView(withId(R.id.full_screen_confetti_view)).check(matches(hasActiveConfetti()))
@@ -1330,7 +1388,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_tabletPortrait_finishExploration_endOfSessionConfettiIsDisplayed() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughAllStates()
+      playThroughAllFractionsStates()
       clickContinueButton()
 
       onView(withId(R.id.full_screen_confetti_view)).check(matches(hasActiveConfetti()))
@@ -1344,7 +1402,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_tabletLandscape_finishExploration_endOfSessionConfettiIsDisplayed() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughAllStates()
+      playThroughAllFractionsStates()
       clickContinueButton()
 
       onView(withId(R.id.full_screen_confetti_view)).check(matches(hasActiveConfetti()))
@@ -1356,7 +1414,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_finishExploration_changePortToLand_endOfSessionConfettiIsDisplayedAgain() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughAllStates()
+      playThroughAllFractionsStates()
       clickContinueButton()
       onView(withId(R.id.full_screen_confetti_view)).check(
         matches(
@@ -1379,7 +1437,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_finishExploration_changeLandToPort_endOfSessionConfettiIsDisplayedAgain() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughAllStates()
+      playThroughAllFractionsStates()
       clickContinueButton()
       onView(withId(R.id.full_screen_confetti_view)).check(
         matches(
@@ -1401,7 +1459,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_submitCorrectAnswer_endOfSessionConfettiDoesNotStart() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughState1()
+      playThroughFractionsState1()
 
       onView(withId(R.id.full_screen_confetti_view)).check(matches(not(hasActiveConfetti())))
     }
@@ -1412,7 +1470,7 @@ class StateFragmentLocalTest {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
       // Play through all questions but do not reach the last screen of the exploration.
-      playThroughAllStates()
+      playThroughAllFractionsStates()
 
       onView(withId(R.id.full_screen_confetti_view)).check(matches(not(hasActiveConfetti())))
     }
@@ -1422,7 +1480,7 @@ class StateFragmentLocalTest {
   fun testStateFragment_reachEndOfExplorationTwice_endOfSessionConfettiIsDisplayedOnce() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1).use {
       startPlayingExploration()
-      playThroughAllStates()
+      playThroughAllFractionsStates()
       clickContinueButton()
       onView(withId(R.id.full_screen_confetti_view)).check(matches(hasActiveConfetti()))
       onView(withId(R.id.full_screen_confetti_view)).check(
@@ -1477,113 +1535,140 @@ class StateFragmentLocalTest {
     testCoroutineDispatchers.runCurrent()
   }
 
-  private fun playThroughState1() {
+  private fun playThroughFractionsState1() {
     onView(withId(R.id.state_recycler_view)).perform(scrollToViewType(SELECTION_INTERACTION))
     onView(withSubstring("the pieces must be the same size.")).perform(click())
     testCoroutineDispatchers.runCurrent()
     clickContinueNavigationButton()
   }
 
-  private fun playThroughState2() {
+  private fun playThroughFractionsState2() {
     // Correct answer to 'Matthew gets conned'
     submitFractionAnswer(answerText = "3/4")
     clickContinueNavigationButton()
   }
 
-  private fun playThroughState3() {
+  private fun playThroughFractionsState3() {
     // Correct answer to 'Question 1'
     submitFractionAnswer(answerText = "4/9")
     clickContinueNavigationButton()
   }
 
-  private fun playThroughState4() {
+  private fun playThroughFractionsState4() {
     // Correct answer to 'Question 2'
     submitFractionAnswer(answerText = "1/4")
     clickContinueNavigationButton()
   }
 
-  private fun playThroughState5() {
+  private fun playThroughFractionsState5() {
     // Correct answer to 'Question 3'
     submitFractionAnswer(answerText = "1/8")
     clickContinueNavigationButton()
   }
 
-  private fun playThroughState6() {
+  private fun playThroughFractionsState6() {
     // Correct answer to 'Question 4'
     submitFractionAnswer(answerText = "1/2")
     clickContinueNavigationButton()
   }
 
-  private fun playThroughState7() {
+  private fun playThroughFractionsState7() {
     // Correct answer to 'Question 5' which redirects the learner to 'Thinking in fractions Q1'
     submitFractionAnswer(answerText = "2/9")
     clickContinueNavigationButton()
   }
 
-  private fun playThroughState8() {
+  private fun playThroughFractionsState8() {
     // Correct answer to 'Thinking in fractions Q1'
     submitFractionAnswer(answerText = "7/9")
     clickContinueNavigationButton()
   }
 
-  private fun playThroughState9() {
+  private fun playThroughFractionsState9() {
     // Correct answer to 'Thinking in fractions Q2'
     submitFractionAnswer(answerText = "4/9")
     clickContinueNavigationButton()
   }
 
-  private fun playThroughState10() {
+  private fun playThroughFractionsState10() {
     // Correct answer to 'Thinking in fractions Q3'
     submitFractionAnswer(answerText = "5/8")
     clickContinueNavigationButton()
   }
 
-  private fun playThroughState11() {
+  private fun playThroughFractionsState11() {
     // Correct answer to 'Thinking in fractions Q4' which redirects the learner to 'Final Test A'
     submitFractionAnswer(answerText = "3/4")
     clickContinueNavigationButton()
   }
 
-  private fun playThroughState12() {
+  private fun playThroughFractionsState12() {
     // Correct answer to 'Final Test A' redirects learner to 'Happy ending'
     submitFractionAnswer(answerText = "2/4")
     clickContinueNavigationButton()
   }
 
-  private fun playThroughState12WithWrongAnswer() {
+  private fun playThroughFractionsState12WithWrongAnswer() {
     // Incorrect answer to 'Final Test A' redirects the learner to 'Final Test A second try'
     submitFractionAnswer(answerText = "1/9")
     clickContinueNavigationButton()
   }
 
-  private fun playUpToFinalTestSecondTry() {
-    playThroughState1()
-    playThroughState2()
-    playThroughState3()
-    playThroughState4()
-    playThroughState5()
-    playThroughState6()
-    playThroughState7()
-    playThroughState8()
-    playThroughState9()
-    playThroughState10()
-    playThroughState11()
-    playThroughState12WithWrongAnswer()
+  private fun playUpToFractionsFinalTestSecondTry() {
+    playThroughFractionsState1()
+    playThroughFractionsState2()
+    playThroughFractionsState3()
+    playThroughFractionsState4()
+    playThroughFractionsState5()
+    playThroughFractionsState6()
+    playThroughFractionsState7()
+    playThroughFractionsState8()
+    playThroughFractionsState9()
+    playThroughFractionsState10()
+    playThroughFractionsState11()
+    playThroughFractionsState12WithWrongAnswer()
   }
 
-  private fun playThroughAllStates() {
-    playThroughState1()
-    playThroughState2()
-    playThroughState3()
-    playThroughState4()
-    playThroughState5()
-    playThroughState6()
-    playThroughState7()
-    playThroughState8()
-    playThroughState9()
-    playThroughState10()
-    playThroughState11()
-    playThroughState12()
+  private fun playThroughAllFractionsStates() {
+    playThroughFractionsState1()
+    playThroughFractionsState2()
+    playThroughFractionsState3()
+    playThroughFractionsState4()
+    playThroughFractionsState5()
+    playThroughFractionsState6()
+    playThroughFractionsState7()
+    playThroughFractionsState8()
+    playThroughFractionsState9()
+    playThroughFractionsState10()
+    playThroughFractionsState11()
+    playThroughFractionsState12()
+  }
+
+  private fun playThroughTestState1() {
+    clickContinueButton()
+  }
+
+  private fun playThroughTestState2() {
+    submitFractionAnswer(answerText = "1/2")
+    clickContinueNavigationButton()
+  }
+
+  private fun playThroughTestState3() {
+    selectMultipleChoiceOption(optionPosition = 2, expectedOptionText = "Eagle")
+    clickContinueNavigationButton()
+  }
+
+  private fun playThroughTestState4() {
+    selectMultipleChoiceOption(optionPosition = 0, expectedOptionText = "Green")
+    clickContinueNavigationButton()
+  }
+
+  private fun playThroughTestState5() {
+    selectItemSelectionCheckbox(optionPosition = 0, expectedOptionText = "Red")
+    selectItemSelectionCheckbox(optionPosition = 2, expectedOptionText = "Green")
+    selectItemSelectionCheckbox(optionPosition = 3, expectedOptionText = "Blue")
+    clickSubmitAnswerButton()
+    clickContinueNavigationButton()
   }
 
   private fun clickContinueNavigationButton() {
@@ -1597,6 +1682,12 @@ class StateFragmentLocalTest {
     onView(withId(R.id.state_recycler_view)).perform(scrollToViewType(CONTINUE_INTERACTION))
     testCoroutineDispatchers.runCurrent()
     onView(withId(R.id.continue_button)).perform(click())
+    testCoroutineDispatchers.runCurrent()
+  }
+
+  private fun clickSubmitAnswerButton() {
+    onView(withId(R.id.state_recycler_view)).perform(scrollToViewType(SUBMIT_ANSWER_BUTTON))
+    onView(withId(R.id.submit_answer_button)).perform(click())
     testCoroutineDispatchers.runCurrent()
   }
 
@@ -1654,58 +1745,115 @@ class StateFragmentLocalTest {
     testCoroutineDispatchers.runCurrent()
   }
 
-  private fun submitFractionAnswer(answerText: String) {
+  private fun typeFractionAnswer(answerText: String) {
     onView(withId(R.id.state_recycler_view)).perform(scrollToViewType(FRACTION_INPUT_INTERACTION))
-    onView(withId(R.id.fraction_input_interaction_view)).perform(
-      editTextInputAction.appendText(answerText)
-    )
-    testCoroutineDispatchers.runCurrent()
+    typeTextIntoInteraction(answerText, interactionViewId = R.id.fraction_input_interaction_view)
+  }
 
-    onView(withId(R.id.state_recycler_view)).perform(scrollToViewType(SUBMIT_ANSWER_BUTTON))
-    onView(withId(R.id.submit_answer_button)).perform(click())
+  private fun submitFractionAnswer(answerText: String) {
+    typeFractionAnswer(answerText)
+    clickSubmitAnswerButton()
+  }
+
+  private fun selectMultipleChoiceOption(optionPosition: Int, expectedOptionText: String) {
+    clickSelection(
+      optionPosition,
+      targetClickViewId = R.id.multiple_choice_radio_button,
+      expectedText = expectedOptionText,
+      targetTextViewId = R.id.multiple_choice_content_text_view
+    )
+  }
+
+  private fun selectItemSelectionCheckbox(optionPosition: Int, expectedOptionText: String) {
+    clickSelection(
+      optionPosition,
+      targetClickViewId = R.id.item_selection_checkbox,
+      expectedText = expectedOptionText,
+      targetTextViewId = R.id.item_selection_contents_text_view
+    )
+  }
+
+  private fun typeNumericInput(text: String) {
+    onView(withId(R.id.state_recycler_view)).perform(scrollToViewType(NUMERIC_INPUT_INTERACTION))
+    typeTextIntoInteraction(text, interactionViewId = R.id.numeric_input_interaction_view)
+  }
+
+  private fun submitNumericInput(text: String) {
+    typeNumericInput(text)
+    clickSubmitAnswerButton()
+  }
+
+  private fun typeTextIntoInteraction(text: String, interactionViewId: Int) {
+    onView(withId(interactionViewId)).perform(editTextInputAction.appendText(text))
     testCoroutineDispatchers.runCurrent()
   }
 
-  private fun submitWrongAnswerToState2() {
+  private fun clickSelection(
+    optionPosition: Int,
+    targetClickViewId: Int,
+    expectedText: String,
+    targetTextViewId: Int
+  ) {
+    onView(withId(R.id.state_recycler_view)).perform(scrollToViewType(SELECTION_INTERACTION))
+    // First, check that the option matches what's expected by the test.
+    onView(
+      atPositionOnView(
+        recyclerViewId = R.id.selection_interaction_recyclerview,
+        position = optionPosition,
+        targetViewId = targetTextViewId
+      )
+    ).check(matches(withText(containsString(expectedText))))
+    // Then, click on it.
+    onView(
+      atPositionOnView(
+        recyclerViewId = R.id.selection_interaction_recyclerview,
+        position = optionPosition,
+        targetViewId = targetClickViewId
+      )
+    ).perform(click())
+    testCoroutineDispatchers.runCurrent()
+  }
+
+  private fun submitWrongAnswerToFractionsState2() {
     submitFractionAnswer(answerText = "1/2")
   }
 
-  private fun submitWrongAnswerToState2AndWait() {
-    submitWrongAnswerToState2()
+  private fun submitWrongAnswerToFractionsState2AndWait() {
+    submitWrongAnswerToFractionsState2()
     testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
   }
 
-  private fun submitWrongAnswerToState13() {
+  private fun submitWrongAnswerToFractionsState13() {
     submitFractionAnswer(answerText = "1/9")
   }
 
-  private fun submitWrongAnswerToState13AndWait() {
-    submitWrongAnswerToState13()
+  private fun submitWrongAnswerToFractionsState13AndWait() {
+    submitWrongAnswerToFractionsState13()
     testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
   }
 
-  private fun submitTwoWrongAnswers() {
-    submitWrongAnswerToState2()
-    submitWrongAnswerToState2()
+  private fun submitTwoWrongAnswersForFractionsState2() {
+    submitWrongAnswerToFractionsState2()
+    submitWrongAnswerToFractionsState2()
   }
 
-  private fun submitTwoWrongAnswersAndWait() {
-    submitTwoWrongAnswers()
+  private fun submitTwoWrongAnswersForFractionsState2AndWait() {
+    submitTwoWrongAnswersForFractionsState2()
     testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
   }
 
-  private fun submitThreeWrongAnswersAndWait() {
-    submitWrongAnswerToState2()
-    submitWrongAnswerToState2()
-    submitWrongAnswerToState2()
+  private fun submitThreeWrongAnswersForFractionsState2AndWait() {
+    submitWrongAnswerToFractionsState2()
+    submitWrongAnswerToFractionsState2()
+    submitWrongAnswerToFractionsState2()
     testCoroutineDispatchers.advanceTimeBy(TimeUnit.SECONDS.toMillis(10))
   }
 
-  private fun produceAndViewFirstHint() {
+  private fun produceAndViewFirstHintForFractionState2() {
     // Two wrong answers need to be submitted for the first hint to show up, so submit an extra one
     // in advance of the standard show & reveal hint flow.
-    submitWrongAnswerToState2()
-    produceAndViewNextHint(hintPosition = 0, submitAnswer = this::submitWrongAnswerToState2AndWait)
+    submitWrongAnswerToFractionsState2()
+    produceAndViewNextHint(hintPosition = 0, submitAnswer = this::submitWrongAnswerToFractionsState2AndWait)
   }
 
   /**
@@ -1719,27 +1867,39 @@ class StateFragmentLocalTest {
     closeHintsAndSolutionsDialog()
   }
 
-  private fun produceAndViewThreeHintsInState13() {
-    submitWrongAnswerToState13()
-    produceAndViewNextHint(hintPosition = 0, submitAnswer = this::submitWrongAnswerToState13AndWait)
-    produceAndViewNextHint(hintPosition = 1, submitAnswer = this::submitWrongAnswerToState13AndWait)
-    produceAndViewNextHint(hintPosition = 2, submitAnswer = this::submitWrongAnswerToState13AndWait)
+  private fun produceAndViewThreeHintsInFractionsState13() {
+    submitWrongAnswerToFractionsState13()
+    produceAndViewNextHint(
+      hintPosition = 0, submitAnswer = this::submitWrongAnswerToFractionsState13AndWait
+    )
+    produceAndViewNextHint(
+      hintPosition = 1, submitAnswer = this::submitWrongAnswerToFractionsState13AndWait
+    )
+    produceAndViewNextHint(
+      hintPosition = 2, submitAnswer = this::submitWrongAnswerToFractionsState13AndWait
+    )
   }
 
-  private fun produceAndViewFourHints() {
+  private fun produceAndViewFourHintsInFractionState2() {
     // Cause three hints to show, and reveal each of them one at a time (to allow the later hints
     // to be shown).
-    produceAndViewFirstHint()
-    produceAndViewNextHint(hintPosition = 1, submitAnswer = this::submitWrongAnswerToState2AndWait)
-    produceAndViewNextHint(hintPosition = 2, submitAnswer = this::submitWrongAnswerToState2AndWait)
-    produceAndViewNextHint(hintPosition = 3, submitAnswer = this::submitWrongAnswerToState2AndWait)
+    produceAndViewFirstHintForFractionState2()
+    produceAndViewNextHint(
+      hintPosition = 1, submitAnswer = this::submitWrongAnswerToFractionsState2AndWait
+    )
+    produceAndViewNextHint(
+      hintPosition = 2, submitAnswer = this::submitWrongAnswerToFractionsState2AndWait
+    )
+    produceAndViewNextHint(
+      hintPosition = 3, submitAnswer = this::submitWrongAnswerToFractionsState2AndWait
+    )
   }
 
-  private fun produceAndViewSolution(
+  private fun produceAndViewSolutionInFractionsState2(
     activityScenario: ActivityScenario<StateFragmentTestActivity>,
     revealedHintCount: Int
   ) {
-    submitWrongAnswerToState2AndWait()
+    submitWrongAnswerToFractionsState2AndWait()
     openHintsAndSolutionsDialog()
     pressRevealSolutionButton(revealedHintCount)
     clickConfirmRevealSolutionButton(activityScenario)
@@ -1855,19 +2015,40 @@ class StateFragmentLocalTest {
       })
   }
 
+  // TODO(#89): Move this to a common test application component.
+  @Module
+  class TestModule {
+    @Provides
+    @LoadLessonProtosFromAssets
+    fun provideLoadLessonProtosFromAssets(testEnvironmentConfig: TestEnvironmentConfig): Boolean =
+      testEnvironmentConfig.isUsingBazel()
+
+    @Provides
+    @CacheAssetsLocally
+    fun provideCacheAssetsLocally(): Boolean = false
+
+    @Provides
+    @TopicListToCache
+    fun provideTopicListToCache(): List<String> = listOf()
+
+    @Provides
+    @LoadImagesFromAssets
+    fun provideLoadImagesFromAssets(): Boolean = false
+  }
+
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.
   @Singleton
   @Component(
     modules = [
-      TestDispatcherModule::class, ApplicationModule::class, RobolectricModule::class,
-      PlatformParameterModule::class, PlatformParameterSingletonModule::class,
-      LoggerModule::class, ContinueModule::class, FractionInputModule::class,
-      ItemSelectionInputModule::class, MultipleChoiceInputModule::class,
+      TestModule::class, TestDispatcherModule::class, ApplicationModule::class,
+      RobolectricModule::class, PlatformParameterModule::class,
+      PlatformParameterSingletonModule::class, LoggerModule::class, ContinueModule::class,
+      FractionInputModule::class, ItemSelectionInputModule::class, MultipleChoiceInputModule::class,
       NumberWithUnitsRuleModule::class, NumericInputRuleModule::class, TextInputRuleModule::class,
       DragDropSortInputModule::class, ImageClickInputModule::class, InteractionsModule::class,
       GcsResourceModule::class, GlideImageLoaderModule::class, ImageParsingModule::class,
       HtmlParserEntityTypeModule::class, QuestionModule::class, TestLogReportingModule::class,
-      AccessibilityTestModule::class, LogStorageModule::class, CachingTestModule::class,
+      AccessibilityTestModule::class, LogStorageModule::class,
       PrimeTopicAssetsControllerModule::class, ExpirationMetaDataRetrieverModule::class,
       ViewBindingShimModule::class, RatioInputModule::class, WorkManagerConfigurationModule::class,
       ApplicationStartupListenerModule::class, LogUploadWorkerModule::class,

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -17,6 +17,7 @@ import androidx.test.espresso.PerformException
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.ViewAssertion
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToHolder
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
@@ -33,6 +34,8 @@ import com.bumptech.glide.GlideBuilder
 import com.bumptech.glide.load.engine.executor.MockGlideExecutor
 import com.google.common.truth.Truth.assertThat
 import dagger.Component
+import dagger.Module
+import dagger.Provides
 import kotlinx.coroutines.CoroutineDispatcher
 import org.hamcrest.BaseMatcher
 import org.hamcrest.CoreMatchers.allOf
@@ -69,12 +72,13 @@ import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewT
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.CONTINUE_NAVIGATION_BUTTON
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.FRACTION_INPUT_INTERACTION
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.NEXT_NAVIGATION_BUTTON
+import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.NUMERIC_INPUT_INTERACTION
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.PREVIOUS_RESPONSES_HEADER
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.SELECTION_INTERACTION
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.SUBMIT_ANSWER_BUTTON
-import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.NUMERIC_INPUT_INTERACTION
 import org.oppia.android.app.player.state.testing.StateFragmentTestActivity
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.topic.PracticeTabModule
 import org.oppia.android.app.translation.testing.ActivityRecreatorTestModule
@@ -114,6 +118,7 @@ import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.data.DataProviderTestMonitor
+import org.oppia.android.testing.environment.TestEnvironmentConfig
 import org.oppia.android.testing.espresso.EditTextInputAction
 import org.oppia.android.testing.espresso.KonfettiViewMatcher.Companion.hasActiveConfetti
 import org.oppia.android.testing.espresso.KonfettiViewMatcher.Companion.hasExpectedNumberOfActiveSystems
@@ -127,7 +132,10 @@ import org.oppia.android.testing.threading.TestDispatcherModule
 import org.oppia.android.testing.time.FakeOppiaClockModule
 import org.oppia.android.util.accessibility.AccessibilityTestModule
 import org.oppia.android.util.caching.AssetModule
-import org.oppia.android.util.caching.testing.CachingTestModule
+import org.oppia.android.util.caching.CacheAssetsLocally
+import org.oppia.android.util.caching.LoadImagesFromAssets
+import org.oppia.android.util.caching.LoadLessonProtosFromAssets
+import org.oppia.android.util.caching.TopicListToCache
 import org.oppia.android.util.gcsresource.GcsResourceModule
 import org.oppia.android.util.locale.LocaleProdModule
 import org.oppia.android.util.logging.LoggerModule
@@ -147,15 +155,6 @@ import java.util.Locale
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
-import org.oppia.android.util.caching.LoadLessonProtosFromAssets
-import org.oppia.android.util.caching.CacheAssetsLocally
-import org.oppia.android.util.caching.TopicListToCache
-import org.oppia.android.util.caching.LoadImagesFromAssets
-import org.oppia.android.testing.environment.TestEnvironmentConfig
-import dagger.Module
-import dagger.Provides
-import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
-import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 
 /**
  * Tests for [StateFragment] that can only be run locally, e.g. using Robolectric, and not on an
@@ -1853,7 +1852,9 @@ class StateFragmentLocalTest {
     // Two wrong answers need to be submitted for the first hint to show up, so submit an extra one
     // in advance of the standard show & reveal hint flow.
     submitWrongAnswerToFractionsState2()
-    produceAndViewNextHint(hintPosition = 0, submitAnswer = this::submitWrongAnswerToFractionsState2AndWait)
+    produceAndViewNextHint(
+      hintPosition = 0, submitAnswer = this::submitWrongAnswerToFractionsState2AndWait
+    )
   }
 
   /**

--- a/domain/BUILD.bazel
+++ b/domain/BUILD.bazel
@@ -50,6 +50,7 @@ DOMAIN_ASSETS = generate_assets_list_from_text_protos(
         "test_single_interactive_state_exp_with_one_hint_and_solution",
         "test_single_interactive_state_exp_with_one_hint_and_no_solution",
         "test_single_interactive_state_exp_with_only_solution",
+        "test_single_interactive_state_exp_with_solution_missing_answer",
     ],
     skills_file_names = [
         "skills",

--- a/domain/src/main/assets/test_exp_id_2.json
+++ b/domain/src/main/assets/test_exp_id_2.json
@@ -692,8 +692,20 @@
             "refresher_exploration_id": "",
             "missing_prerequisite_skill_id": ""
           },
-          "hints": [],
-          "solution": null
+          "hints": [{
+            "hint_content": {
+              "content_id": "hint_1",
+              "html": "<p>11 * 11 can be rephrased as 11 * 10, then add 11 at the end.</p>"
+            }
+          }],
+          "solution": {
+            "answer_is_exclusive": true,
+            "correct_answer": 121.0,
+            "explanation": {
+              "content_id": "solution",
+              "html": "<p>11 times 11 is 121.</p>"
+            }
+          }
         },
         "classifier_model_id": "",
         "recorded_voiceovers": {

--- a/domain/src/main/assets/test_exp_id_2.json
+++ b/domain/src/main/assets/test_exp_id_2.json
@@ -699,8 +699,8 @@
             }
           }],
           "solution": {
-            "answer_is_exclusive": true,
-            "correct_answer": 121.0,
+            "answer_is_exclusive": false,
+            "correct_answer": "",
             "explanation": {
               "content_id": "solution",
               "html": "<p>11 times 11 is 121.</p>"
@@ -714,11 +714,37 @@
             "feedback_3": {},
             "feedback_1": {},
             "content": {},
-            "default_outcome": {}
+            "default_outcome": {},
+            "hint_1": {},
+            "solution": {}
           }
         },
         "written_translations": {
           "translations_mapping": {
+            "hint_1": {
+              "pt": {
+                "data_format": "html",
+                "translation": {"translation" : "<p> 11 * 11 pode ser reformulado como 11 * 10 e, em seguida, adicione 11 no final. </p>"},
+                "needs_update": false
+              },
+              "ar": {
+                "data_format": "html",
+                "translation": {"translation" : "يمكن إعادة صياغة <p> 11 * 11 على أنها 11 * 10، ثم أضف 11 في النهاية. </p>"},
+                "needs_update": false
+              }
+            },
+            "solution": {
+              "pt": {
+                "data_format": "html",
+                "translation": {"translation" : "<p> 11 vezes 11 é 121. </p>"},
+                "needs_update": false
+              },
+              "ar": {
+                "data_format": "html",
+                "translation": {"translation" : "<p> 11 مرات 11 هو 121. </p>"},
+                "needs_update": false
+              }
+            },
             "feedback_2": {
               "pt": {
                 "data_format": "html",

--- a/domain/src/main/assets/test_exp_id_2.textproto
+++ b/domain/src/main/assets/test_exp_id_2.textproto
@@ -842,11 +842,35 @@ states {
     written_translations {
       key: "hint_1"
       value {
+        translation_mapping {
+          key: "pt"
+          value {
+            html: "<p> 11 * 11 pode ser reformulado como 11 * 10 e, em seguida, adicione 11 no final. </p>"
+          }
+        }
+        translation_mapping {
+          key: "ar"
+          value {
+            html: "\331\212\331\205\331\203\331\206 \330\245\330\271\330\247\330\257\330\251 \330\265\331\212\330\247\330\272\330\251 <p> 11 * 11 \330\271\331\204\331\211 \330\243\331\206\331\207\330\247 11 * 10\330\214 \330\253\331\205 \330\243\330\266\331\201 11 \331\201\331\212 \330\247\331\204\331\206\331\207\330\247\331\212\330\251. </p>"
+          }
+        }
       }
     }
     written_translations {
       key: "solution"
       value {
+        translation_mapping {
+          key: "pt"
+          value {
+            html: "<p> 11 vezes 11 \303\251 121. </p>"
+          }
+        }
+        translation_mapping {
+          key: "ar"
+          value {
+            html: "<p> 11 \331\205\330\261\330\247\330\252 11 \331\207\331\210 121. </p>"
+          }
+        }
       }
     }
     written_translations {

--- a/domain/src/main/assets/test_exp_id_2.textproto
+++ b/domain/src/main/assets/test_exp_id_2.textproto
@@ -825,9 +825,29 @@ states {
       value {
       }
     }
+    recorded_voiceovers {
+      key: "hint_1"
+      value {
+      }
+    }
+    recorded_voiceovers {
+      key: "solution"
+      value {
+      }
+    }
     content {
       html: "<p>What is 11 times 11?</p>"
       content_id: "content"
+    }
+    written_translations {
+      key: "hint_1"
+      value {
+      }
+    }
+    written_translations {
+      key: "solution"
+      value {
+      }
     }
     written_translations {
       key: "feedback_2"
@@ -968,6 +988,19 @@ states {
             }
           }
           rule_type: "IsGreaterThan"
+        }
+      }
+      solution {
+        interaction_id: "NumericInput"
+        explanation {
+          html: "<p>11 times 11 is 121.</p>"
+          content_id: "solution"
+        }
+      }
+      hint {
+        hint_content {
+          html: "<p>11 * 11 can be rephrased as 11 * 10, then add 11 at the end.</p>"
+          content_id: "hint_1"
         }
       }
       default_outcome {

--- a/domain/src/main/assets/test_single_interactive_state_exp_with_solution_missing_answer.json
+++ b/domain/src/main/assets/test_single_interactive_state_exp_with_solution_missing_answer.json
@@ -1,0 +1,112 @@
+{
+  "exploration_id": "test_single_interactive_state_exp_with_solution_missing_answer",
+  "version": 1,
+  "exploration": {
+    "init_state_name": "Text",
+    "states": {
+      "Text": {
+        "content": {
+          "content_id": "content",
+          "html": "<p>In which language does Oppia mean 'to learn'?</p>"
+        },
+        "interaction": {
+          "id": "TextInput",
+          "customization_args": {
+            "rows": {
+              "value": 1.0
+            },
+            "placeholder": {
+              "value": {
+                "content_id": "ca_placeholder_0",
+                "unicode_str": "Enter a language"
+              }
+            }
+          },
+          "answer_groups": [{
+            "rule_specs": [{
+              "rule_type": "Equals",
+              "inputs": {
+                "x": {
+                  "contentId": "<unknown>",
+                  "normalizedStrSet": ["finnish"]
+                }
+              }
+            }],
+            "outcome": {
+              "dest": "End",
+              "feedback": {
+                "content_id": "feedback_1",
+                "html": "<p>Correct!</p>"
+              },
+              "labelled_as_correct": false
+            }
+          }],
+          "default_outcome": {
+            "dest": "Text",
+            "feedback": {
+              "content_id": "default_outcome",
+              "html": "<p>Not quite. Try again (or maybe use a search engine).</p>"
+            },
+            "labelled_as_correct": false
+          },
+          "hints": [],
+          "solution": {
+            "answer_is_exclusive": false,
+            "explanation": {
+              "content_id": "solution",
+              "html": "<p>'Oppia' is translated from Finnish.</p>"
+            }
+          }
+        },
+        "recorded_voiceovers": {
+          "voiceovers_mapping": {
+            "feedback_1": {},
+            "content": {},
+            "default_outcome": {},
+            "solution": {}
+          }
+        },
+        "written_translations": {
+          "translations_mapping": {
+            "feedback_1": {},
+            "content": {},
+            "default_outcome": {},
+            "solution": {}
+          }
+        }
+      },
+      "End": {
+        "content": {
+          "content_id": "content",
+          "html": "Congratulations, you have finished!"
+        },
+        "param_changes": [],
+        "interaction": {
+          "id": "EndExploration",
+          "customization_args": {
+            "recommendedExplorationIds": {
+              "value": []
+            }
+          },
+          "answer_groups": [],
+          "default_outcome": null,
+          "hints": [],
+          "solution": null
+        },
+        "recorded_voiceovers": {
+          "voiceovers_mapping": {
+            "content": {}
+          }
+        },
+        "written_translations": {
+          "translations_mapping": {
+            "content": {}
+          }
+        }
+      }
+    },
+    "objective": "Test exploration.",
+    "language_code": "en",
+    "title": "Prototype exploration with only one solution and no hints"
+  }
+}

--- a/domain/src/main/assets/test_single_interactive_state_exp_with_solution_missing_answer.textproto
+++ b/domain/src/main/assets/test_single_interactive_state_exp_with_solution_missing_answer.textproto
@@ -1,0 +1,140 @@
+id: "test_single_interactive_state_exp_with_solution_missing_answer"
+states {
+  key: "Text"
+  value {
+    name: "Text"
+    recorded_voiceovers {
+      key: "feedback_1"
+      value {
+      }
+    }
+    recorded_voiceovers {
+      key: "content"
+      value {
+      }
+    }
+    recorded_voiceovers {
+      key: "default_outcome"
+      value {
+      }
+    }
+    recorded_voiceovers {
+      key: "solution"
+      value {
+      }
+    }
+    content {
+      html: "<p>In which language does Oppia mean \'to learn\'?</p>"
+      content_id: "content"
+    }
+    written_translations {
+      key: "feedback_1"
+      value {
+      }
+    }
+    written_translations {
+      key: "content"
+      value {
+      }
+    }
+    written_translations {
+      key: "default_outcome"
+      value {
+      }
+    }
+    written_translations {
+      key: "solution"
+      value {
+      }
+    }
+    interaction {
+      id: "TextInput"
+      answer_groups {
+        outcome {
+          dest_state_name: "End"
+          feedback {
+            html: "<p>Correct!</p>"
+            content_id: "feedback_1"
+          }
+        }
+        rule_specs {
+          input {
+            key: "x"
+            value {
+              translatable_set_of_normalized_string {
+                content_id: "<unknown>"
+                normalized_strings: "finnish"
+              }
+            }
+          }
+          rule_type: "Equals"
+        }
+      }
+      solution {
+        interaction_id: "TextInput"
+        explanation {
+          html: "<p>'Oppia' is translated from Finnish.</p>"
+          content_id: "solution"
+        }
+      }
+      default_outcome {
+        dest_state_name: "Text"
+        feedback {
+          html: "<p>Not quite. Try again (or maybe use a search engine).</p>"
+          content_id: "default_outcome"
+        }
+      }
+      customization_args {
+        key: "rows"
+        value {
+          signed_int: 1
+        }
+      }
+      customization_args {
+        key: "placeholder"
+        value {
+          custom_schema_value {
+            subtitled_html {
+              html: "Enter a language"
+              content_id: "ca_placeholder_0"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+states {
+  key: "End"
+  value {
+    name: "End"
+    recorded_voiceovers {
+      key: "content"
+      value {
+      }
+    }
+    content {
+      html: "Congratulations, you have finished!"
+      content_id: "content"
+    }
+    written_translations {
+      key: "content"
+      value {
+      }
+    }
+    interaction {
+      id: "EndExploration"
+      customization_args {
+        key: "recommendedExplorationIds"
+        value {
+          schema_object_list {
+          }
+        }
+      }
+    }
+  }
+}
+init_state_name: "Text"
+objective: "Test exploration."
+title: "Prototype exploration with only one solution and no hints"
+language_code: "en"

--- a/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintHandlerProdImpl.kt
+++ b/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintHandlerProdImpl.kt
@@ -1,5 +1,6 @@
 package org.oppia.android.domain.hintsandsolution
 
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -65,7 +66,7 @@ class HintHandlerProdImpl private constructor(
 
   private var trackedWrongAnswerCount = 0
   private lateinit var pendingState: State
-  private var hintSequenceNumber = 0
+  private var hintSequenceNumber = AtomicInteger(0)
   private var lastRevealedHintIndex = -1
 
   private var latestAvailableHintIndex = -1
@@ -186,7 +187,7 @@ class HintHandlerProdImpl private constructor(
     // Cancel any potential pending hints by advancing the sequence number. Note that this isn't
     // reset to 0 to ensure that all previous hint tasks are cancelled, and new tasks can be
     // scheduled without overlapping with past sequence numbers.
-    hintSequenceNumber++
+    hintSequenceNumber.incrementAndGet()
   }
 
   private fun maybeScheduleShowHint(wrongAnswerCount: Int = trackedWrongAnswerCount) {
@@ -295,17 +296,17 @@ class HintHandlerProdImpl private constructor(
     // Return the index of the first unrevealed hint, or the length of the list if all have been
     // revealed.
     val hintList = pendingState.interaction.hintList
-    val solution = pendingState.interaction.solution
 
     val hasHints = hintList.isNotEmpty()
-    val hasHelp = hasHints || solution.hasCorrectAnswer()
+    val hasSolution = pendingState.hasSolution()
+    val hasHelp = hasHints || hasSolution
     val lastUnrevealedHintIndex = lastRevealedHintIndex + 1
 
     return if (!hasHelp) {
       HelpIndex.getDefaultInstance()
     } else if (hasHints && lastUnrevealedHintIndex < hintList.size) {
       HelpIndex.newBuilder().setNextAvailableHintIndex(lastUnrevealedHintIndex).build()
-    } else if (solution.hasCorrectAnswer() && !solutionIsRevealed) {
+    } else if (hasSolution && !solutionIsRevealed) {
       HelpIndex.newBuilder().setShowSolution(true).build()
     } else {
       HelpIndex.newBuilder().setEverythingRevealed(true).build()
@@ -317,7 +318,7 @@ class HintHandlerProdImpl private constructor(
    * cancelling any previously pending hints initiated by calls to this method.
    */
   private fun scheduleShowHint(delayMs: Long, helpIndexToShow: HelpIndex) {
-    val targetSequenceNumber = ++hintSequenceNumber
+    val targetSequenceNumber = hintSequenceNumber.incrementAndGet()
     backgroundCoroutineScope.launch {
       delay(delayMs)
       handlerLock.withLock {
@@ -331,12 +332,12 @@ class HintHandlerProdImpl private constructor(
    * pending hints initiated by calls to [scheduleShowHint].
    */
   private fun showHintImmediately(helpIndexToShow: HelpIndex) {
-    showHint(++hintSequenceNumber, helpIndexToShow)
+    showHint(hintSequenceNumber.incrementAndGet(), helpIndexToShow)
   }
 
   private fun showHint(targetSequenceNumber: Int, nextHelpIndexToShow: HelpIndex) {
     // Only finish this timer if no other hints were scheduled and no cancellations occurred.
-    if (targetSequenceNumber == hintSequenceNumber) {
+    if (targetSequenceNumber == hintSequenceNumber.get()) {
       val previousHelpIndex = computeCurrentHelpIndex()
 
       when (nextHelpIndexToShow.indexTypeCase) {
@@ -376,7 +377,7 @@ class HintHandlerProdImpl private constructor(
 }
 
 /** Returns whether this state has a solution to show. */
-private fun State.hasSolution(): Boolean = interaction.solution.hasCorrectAnswer()
+private fun State.hasSolution(): Boolean = interaction.hasSolution()
 
 /** Returns whether this state has help that the user can see. */
 internal fun State.offersHelp(): Boolean = interaction.hintList.isNotEmpty() || hasSolution()

--- a/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintHandlerProdImpl.kt
+++ b/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintHandlerProdImpl.kt
@@ -1,6 +1,5 @@
 package org.oppia.android.domain.hintsandsolution
 
-import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -13,6 +12,7 @@ import org.oppia.android.app.model.HelpIndex.IndexTypeCase.NEXT_AVAILABLE_HINT_I
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.SHOW_SOLUTION
 import org.oppia.android.app.model.State
 import org.oppia.android.util.threading.BackgroundDispatcher
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantLock
 import javax.inject.Inject
 import kotlin.concurrent.withLock

--- a/domain/src/main/java/org/oppia/android/domain/util/StateRetriever.kt
+++ b/domain/src/main/java/org/oppia/android/domain/util/StateRetriever.kt
@@ -173,20 +173,20 @@ class StateRetriever @Inject constructor() {
   private fun createCorrectAnswer(containerObject: JSONObject): CorrectAnswer {
     val correctAnswerObject = containerObject.optJSONObject("correct_answer")
     return when {
-        correctAnswerObject != null -> {
-          CorrectAnswer.newBuilder()
-            .setNumerator(correctAnswerObject.getInt("numerator"))
-            .setDenominator(correctAnswerObject.getInt("denominator"))
-            .setWholeNumber(correctAnswerObject.getInt("wholeNumber"))
-            .setIsNegative(correctAnswerObject.getBoolean("isNegative"))
-            .build()
-        }
-        containerObject.optString("correct_answer", /* fallback= */ null) != null -> {
-          CorrectAnswer.newBuilder()
-            .setCorrectAnswer(containerObject.getStringFromObject("correct_answer"))
-            .build()
-        }
-        else -> CorrectAnswer.getDefaultInstance() // For incompatible types.
+      correctAnswerObject != null -> {
+        CorrectAnswer.newBuilder()
+          .setNumerator(correctAnswerObject.getInt("numerator"))
+          .setDenominator(correctAnswerObject.getInt("denominator"))
+          .setWholeNumber(correctAnswerObject.getInt("wholeNumber"))
+          .setIsNegative(correctAnswerObject.getBoolean("isNegative"))
+          .build()
+      }
+      containerObject.optString("correct_answer", /* fallback= */ null) != null -> {
+        CorrectAnswer.newBuilder()
+          .setCorrectAnswer(containerObject.getStringFromObject("correct_answer"))
+          .build()
+      }
+      else -> CorrectAnswer.getDefaultInstance() // For incompatible types.
     }
   }
 

--- a/domain/src/main/java/org/oppia/android/domain/util/StateRetriever.kt
+++ b/domain/src/main/java/org/oppia/android/domain/util/StateRetriever.kt
@@ -60,36 +60,26 @@ class StateRetriever @Inject constructor() {
 
   // Creates an interaction from JSON
   private fun createInteractionFromJson(interactionJson: JSONObject): Interaction {
-    return Interaction.newBuilder()
-      .setId(interactionJson.getStringFromObject("id"))
-      .addAllAnswerGroups(
+    return Interaction.newBuilder().apply {
+      id = interactionJson.getStringFromObject("id")
+      addAllAnswerGroups(
         createAnswerGroupsFromJson(
           interactionJson.getJSONArray("answer_groups"),
           interactionJson.getStringFromObject("id")
         )
       )
-      .setDefaultOutcome(
-        createOutcomeFromJson(
-          interactionJson.optJSONObject("default_outcome")
-        )
-      )
-      .putAllCustomizationArgs(
+      defaultOutcome = createOutcomeFromJson(interactionJson.optJSONObject("default_outcome"))
+      putAllCustomizationArgs(
         createCustomizationArgsMapFromJson(
           interactionJson.getJSONObject("customization_args"),
           interactionJson.getStringFromObject("id")
         )
       )
-      .addAllHint(
-        createListOfHintsFromJson(
-          interactionJson.getJSONArray("hints")
-        )
-      )
-      .setSolution(
-        createSolutionFromJson(
-          interactionJson.optJSONObject("solution")
-        )
-      )
-      .build()
+      addAllHint(createListOfHintsFromJson(interactionJson.getJSONArray("hints")))
+
+      // Only set the solution if one has been defined.
+      createSolutionFromJson(interactionJson.optJSONObject("solution"))?.let { solution = it }
+    }.build()
   }
 
   // Creates the list of answer group objects from JSON
@@ -159,15 +149,14 @@ class StateRetriever @Inject constructor() {
   }
 
   // Creates a solution object from JSON
-  private fun createSolutionFromJson(solutionJson: JSONObject?): Solution {
-    if (solutionJson == null) {
-      return Solution.getDefaultInstance()
+  private fun createSolutionFromJson(optionalSolutionJson: JSONObject?): Solution? {
+    return optionalSolutionJson?.let { solutionJson ->
+      return Solution.newBuilder().apply {
+        correctAnswer = createCorrectAnswer(solutionJson)
+        explanation = parseSubtitledHtml(solutionJson.getJSONObject("explanation"))
+        answerIsExclusive = solutionJson.getBoolean("answer_is_exclusive")
+      }.build()
     }
-    return Solution.newBuilder().apply {
-      correctAnswer = createCorrectAnswer(solutionJson)
-      explanation = parseSubtitledHtml(solutionJson.getJSONObject("explanation"))
-      answerIsExclusive = solutionJson.getBoolean("answer_is_exclusive")
-    }.build()
   }
 
   private fun createCorrectAnswer(containerObject: JSONObject): CorrectAnswer {

--- a/domain/src/main/java/org/oppia/android/domain/util/StateRetriever.kt
+++ b/domain/src/main/java/org/oppia/android/domain/util/StateRetriever.kt
@@ -172,17 +172,21 @@ class StateRetriever @Inject constructor() {
 
   private fun createCorrectAnswer(containerObject: JSONObject): CorrectAnswer {
     val correctAnswerObject = containerObject.optJSONObject("correct_answer")
-    return if (correctAnswerObject != null) {
-      CorrectAnswer.newBuilder()
-        .setNumerator(correctAnswerObject.getInt("numerator"))
-        .setDenominator(correctAnswerObject.getInt("denominator"))
-        .setWholeNumber(correctAnswerObject.getInt("wholeNumber"))
-        .setIsNegative(correctAnswerObject.getBoolean("isNegative"))
-        .build()
-    } else {
-      CorrectAnswer.newBuilder()
-        .setCorrectAnswer(containerObject.getStringFromObject("correct_answer"))
-        .build()
+    return when {
+        correctAnswerObject != null -> {
+          CorrectAnswer.newBuilder()
+            .setNumerator(correctAnswerObject.getInt("numerator"))
+            .setDenominator(correctAnswerObject.getInt("denominator"))
+            .setWholeNumber(correctAnswerObject.getInt("wholeNumber"))
+            .setIsNegative(correctAnswerObject.getBoolean("isNegative"))
+            .build()
+        }
+        containerObject.optString("correct_answer", /* fallback= */ null) != null -> {
+          CorrectAnswer.newBuilder()
+            .setCorrectAnswer(containerObject.getStringFromObject("correct_answer"))
+            .build()
+        }
+        else -> CorrectAnswer.getDefaultInstance() // For incompatible types.
     }
   }
 

--- a/domain/src/test/java/org/oppia/android/domain/hintsandsolution/HintHandlerProdImplTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/hintsandsolution/HintHandlerProdImplTest.kt
@@ -87,6 +87,11 @@ class HintHandlerProdImplTest {
       "test_single_interactive_state_exp_with_hints_and_solution"
     )
   }
+  private val expWithSolutionMissingCorrectAnswer by lazy {
+    explorationRetriever.loadExploration(
+      "test_single_interactive_state_exp_with_solution_missing_answer"
+    )
+  }
 
   @Before
   fun setUp() {
@@ -1895,6 +1900,48 @@ class HintHandlerProdImplTest {
   @Test
   fun testGetCurrentHelpIndex_onlySolution_triggeredAndRevealed_everythingIsRevealed() {
     val state = expWithNoHintsAndOneSolution.getInitialState()
+    hintHandler.startWatchingForHintsInNewState(state)
+    waitFor60Seconds()
+    hintHandler.viewSolution()
+
+    val helpIndex = hintHandler.getCurrentHelpIndex()
+
+    assertThat(helpIndex).isEqualTo(
+      HelpIndex.newBuilder().apply {
+        everythingRevealed = true
+      }.build()
+    )
+  }
+
+  @Test
+  fun testGetCurrentHelpIndex_onlySolution_missingCorrectAnswer_isEmpty() {
+    val state = expWithSolutionMissingCorrectAnswer.getInitialState()
+    hintHandler.startWatchingForHintsInNewState(state)
+
+    val helpIndex = hintHandler.getCurrentHelpIndex()
+
+    assertThat(helpIndex).isEqualToDefaultInstance()
+  }
+
+  @Test
+  fun testGetCurrentHelpIndex_onlySolution_missingCorrectAnswer_twoWrongAnswers_canShowSolution() {
+    val state = expWithSolutionMissingCorrectAnswer.getInitialState()
+    hintHandler.startWatchingForHintsInNewState(state)
+    hintHandler.handleWrongAnswerSubmission(wrongAnswerCount = 1)
+    hintHandler.handleWrongAnswerSubmission(wrongAnswerCount = 2)
+
+    val helpIndex = hintHandler.getCurrentHelpIndex()
+
+    assertThat(helpIndex).isEqualTo(
+      HelpIndex.newBuilder().apply {
+        showSolution = true
+      }.build()
+    )
+  }
+
+  @Test
+  fun testGetCurrentHelpIndex_onlySolution_missingCorrectAnswer_triggeredAndShown_allRevealed() {
+    val state = expWithSolutionMissingCorrectAnswer.getInitialState()
     hintHandler.startWatchingForHintsInNewState(state)
     waitFor60Seconds()
     hintHandler.viewSolution()


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix #3946

Per #3946 there's a bug in some contexts where, after revealing a hint, the solution may automatically be revealed as well when the user reopens the solution dialog.

The root cause of this is that the hint handler decides whether to show solutions based on the presence of a correct answer, not based on the presence of a solution itself. This presents a problem specifically for proto-based lessons because in some cases correct_answer will be absent (if the converter can't properly convert the answer into an app-acceptable format, e.g. text or fraction). This is technically a valid case to introduce a failure, but due to #1050 we can't actually assume that correct_answer is properly defined. Thus, the solution is to change the check to instead check for whether solution is present. This *does* allow for an empty solution object to be added to the proto, but this shouldn't realistically happen in practice so it should be fine.

To repro (on this branch):
- Enable proto loading in CachingModule
- Build & install a dev flavor of the app
- Start a new Prototype Exploration play session
- Play to the numeric expression state
- Enter 2 wrong answers
- Reveal the hint
- Close & reopen the dialog
- (If you want to repro the issue, you'll need to replace the implementation of HintHandlerProdImpl with the current develop copy)
- Without the fix, the solution will automatically be revealed. With the fix, the solution won't yet be available to reveal.

Note that this doesn't affect json since we've taken some measure to ensure that correct_answer is filled with *something* even if that value isn't quite correct.

To ensure this regression is properly caught, tests were added both in StateFragmentLocalTest and HintHandlerProdImplTest. Note that the latter required introducing a new test exploration that specifically tests a missing correct_answer, and the former required changes to the prototype exploration to introduce a hint & solution in the numeric expression state to more easily repro this issue. Test results:
- Failing without the fix (Bazel only since it requires textproto loading): https://app.buildbuddy.io/invocation/da48df48-444c-48d5-870f-dec2c75b68b1
- Passing with the fixes: https://app.buildbuddy.io/invocation/92f3739b-0477-43c1-82df-8170b8fd197a

Other miscellaneous changes:
- StateFragmentLocalTest had some cleaning up since its helpers were a bit confusing referencing states for different explorations (now that the test suite uses at least 2 explorations for testing)
- StateFragmentLocalTest was updated to depend on textproto assets in Bazel for better coverage, and so that the failure case could be triggered per the new regression tests
- StateRetriever was updated to allow a missing correct_answer in solutions (for parity with the textproto variant, but the implementation is a bit more permissive and actually results in passing tests regardless of the fix)
- StateRetriever was also changed so that solutions are not set if they aren't loaded (to avoid an empty solution being included which shouldn't actually ever happen for loaded binary protos). This ensures that the updated check (hasCorrectAnswer -> hasSolution) results in consistent & correct behavior for both JSON & textproto runs of the hint tests/app builds.
- HintHandlerProdImpl was updated to use an AtomicInteger for hint sequencing. This isn't related to the original issue, but there's a likely race condition in the current implementation that I'm fixing at the same time. No regression test is reasonably possible to actually test this, so it needs to be a verify-on-inspection type change.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- this is fixing a UI-affecting issue, but doesn't actually change the UI.