### PR TITLE
Fix #3937: Ensure ViewEventLogsViewModel builds for alpha builds

### DIFF
--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -648,6 +648,7 @@ kt_android_library(
         "//third_party:androidx_databinding_databinding-runtime",
         "//utility",
         "//utility/src/main/java/org/oppia/android/util/extensions:context_extensions",
+        "//utility/src/main/java/org/oppia/android/util/logging/firebase:debug_event_logger",
         "//utility/src/main/java/org/oppia/android/util/logging/firebase:debug_module",
         # TODO(#59): Remove 'debug_util_module' once we completely migrate to Bazel from Gradle as
         # we can then directly exclude debug files from the build and thus won't be requiring this module.

--- a/utility/src/main/java/org/oppia/android/util/logging/firebase/BUILD.bazel
+++ b/utility/src/main/java/org/oppia/android/util/logging/firebase/BUILD.bazel
@@ -59,7 +59,7 @@ kt_android_library(
         "DebugEventLogger.kt",
     ],
     visibility = [
-        "//app:__pkg__"
+        "//app:__pkg__",
     ],
     deps = [
         "//model:event_logger_java_proto_lite",

--- a/utility/src/main/java/org/oppia/android/util/logging/firebase/BUILD.bazel
+++ b/utility/src/main/java/org/oppia/android/util/logging/firebase/BUILD.bazel
@@ -54,9 +54,12 @@ kt_android_library(
 )
 
 kt_android_library(
-    name = "debug_impl",
+    name = "debug_event_logger",
     srcs = [
         "DebugEventLogger.kt",
+    ],
+    visibility = [
+        "//app:__pkg__"
     ],
     deps = [
         "//model:event_logger_java_proto_lite",
@@ -73,7 +76,7 @@ kt_android_library(
     visibility = ["//:oppia_prod_module_visibility"],
     deps = [
         ":dagger",
-        ":debug_impl",
+        ":debug_event_logger",
         ":firebase_exception_logger",
     ],
 )


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix #3937

This updates DebugEventLogger's Bazel build such that it's still available to depend on for alpha production builds. This is sort of a hacky workaround needed to make ViewEventLogsViewModel compile since view models can't be conditionally excluded in builds yet. Post #59 we'll be able to exclude debug-only view models like ViewEventLogsViewModel in prod builds.

Note that there's not a reasonable way to test this today besides manually building. Also, CI doesn't catch this since our alpha build is still set up to use debug builds (which we can't move away until probably after #1720 is addressed. You can repro this locally by following this excerpt from the release process & then trying to build a debug/alpha version of the app:

- In ApplicationComponent.kt, make the following replacements (which may require imports):
  - Remove modules:
    1. ``DeveloperOptionsStarterModule``
    2. ``DebugLogReportingModule``
    3. ``NetworkConnectionUtilDebugModule``
    4. ``HintsAndSolutionDebugModule``
  - Add modules:
    1. ``LogReportingModule``
    2. ``NetworkConnectionUtilProdModule``
    3. ``HintsAndSolutionProdModule``
  - The above disables the developer options menu and developer-only functionality
- In app/BUILD.bazel
  - In ``view_models``, in: ``//utility/src/main/java/org/oppia/android/util/logging/firebase:debug_module``, replace “debug_module” with ``prod_module``
  - In “app”, in ``//utility/src/main/java/org/oppia/android/util/networking:debug_module``, replace ``debug_module`` with ``prod_module``
  - This sets up the build dependencies correctly for the changes made above in ApplicationComponent.kt

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- not a user-facing change.