### PR TITLE
Fix #3939 & #3938: Fix KitKat crash & SVG rendering issues

### DIFF
--- a/app/src/main/java/org/oppia/android/app/help/HelpActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/help/HelpActivity.kt
@@ -14,7 +14,6 @@ import org.oppia.android.app.help.thirdparty.ThirdPartyDependencyListActivity
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.util.extensions.getStringFromBundle
 import javax.inject.Inject
-import kotlin.properties.Delegates
 
 const val HELP_OPTIONS_TITLE_SAVED_KEY = "HelpActivity.help_options_title"
 const val SELECTED_FRAGMENT_SAVED_KEY = "HelpActivity.selected_fragment"
@@ -45,8 +44,6 @@ class HelpActivity :
 
   private lateinit var selectedFragment: String
   private lateinit var selectedHelpOptionsTitle: String
-  private var selectedDependencyIndex by Delegates.notNull<Int>()
-  private var selectedLicenseIndex by Delegates.notNull<Int>()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -57,9 +54,9 @@ class HelpActivity :
     )
     selectedFragment =
       savedInstanceState?.getStringFromBundle(SELECTED_FRAGMENT_SAVED_KEY) ?: FAQ_LIST_FRAGMENT_TAG
-    selectedDependencyIndex =
+    val selectedDependencyIndex =
       savedInstanceState?.getInt(THIRD_PARTY_DEPENDENCY_INDEX_SAVED_KEY) ?: 0
-    selectedLicenseIndex = savedInstanceState?.getInt(LICENSE_INDEX_SAVED_KEY) ?: 0
+    val selectedLicenseIndex = savedInstanceState?.getInt(LICENSE_INDEX_SAVED_KEY) ?: 0
     selectedHelpOptionsTitle = savedInstanceState?.getStringFromBundle(HELP_OPTIONS_TITLE_SAVED_KEY)
       ?: resourceHandler.getStringInLocale(R.string.faq_activity_title)
     helpActivityPresenter.handleOnCreate(

--- a/app/src/main/java/org/oppia/android/app/help/HelpActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/help/HelpActivityPresenter.kt
@@ -18,7 +18,6 @@ import org.oppia.android.app.help.thirdparty.LicenseTextViewerFragment
 import org.oppia.android.app.help.thirdparty.ThirdPartyDependencyListFragment
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import javax.inject.Inject
-import kotlin.properties.Delegates
 
 /** The presenter for [HelpActivity]. */
 @ActivityScope
@@ -31,8 +30,8 @@ class HelpActivityPresenter @Inject constructor(
 
   private lateinit var selectedFragmentTag: String
   private lateinit var selectedHelpOptionTitle: String
-  private var selectedDependencyIndex by Delegates.notNull<Int>()
-  private var selectedLicenseIndex by Delegates.notNull<Int>()
+  private var selectedDependencyIndex: Int? = null
+  private var selectedLicenseIndex: Int? = null
 
   fun handleOnCreate(
     helpOptionsTitle: String,
@@ -60,7 +59,7 @@ class HelpActivityPresenter @Inject constructor(
     val titleTextView =
       activity.findViewById<TextView>(R.id.options_activity_selected_options_title)
     if (titleTextView != null) {
-      setMultipaneContainerTitle(helpOptionsTitle!!)
+      setMultipaneContainerTitle(helpOptionsTitle)
     }
     val isMultipane = activity.findViewById<FrameLayout>(R.id.multipane_options_container) != null
     if (isMultipane) {
@@ -140,8 +139,8 @@ class HelpActivityPresenter @Inject constructor(
       outState.putString(HELP_OPTIONS_TITLE_SAVED_KEY, titleTextView.text.toString())
     }
     outState.putString(SELECTED_FRAGMENT_SAVED_KEY, selectedFragmentTag)
-    outState.putInt(THIRD_PARTY_DEPENDENCY_INDEX_SAVED_KEY, selectedDependencyIndex)
-    outState.putInt(LICENSE_INDEX_SAVED_KEY, selectedLicenseIndex)
+    selectedDependencyIndex?.let { outState.putInt(THIRD_PARTY_DEPENDENCY_INDEX_SAVED_KEY, it) }
+    selectedLicenseIndex?.let { outState.putInt(LICENSE_INDEX_SAVED_KEY, it) }
   }
 
   private fun setUpToolbar() {
@@ -156,7 +155,11 @@ class HelpActivityPresenter @Inject constructor(
       val currentFragment = getMultipaneOptionsFragment()
       if (currentFragment != null) {
         when (currentFragment) {
-          is LicenseTextViewerFragment -> handleLoadLicenseListFragment(selectedDependencyIndex)
+          is LicenseTextViewerFragment -> {
+            handleLoadLicenseListFragment(checkNotNull(selectedDependencyIndex) {
+              "Expected dependency index to be selected & defined"
+            })
+          }
           is LicenseListFragment -> handleLoadThirdPartyDependencyListFragment()
         }
       }

--- a/app/src/main/java/org/oppia/android/app/help/HelpActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/help/HelpActivityPresenter.kt
@@ -156,9 +156,11 @@ class HelpActivityPresenter @Inject constructor(
       if (currentFragment != null) {
         when (currentFragment) {
           is LicenseTextViewerFragment -> {
-            handleLoadLicenseListFragment(checkNotNull(selectedDependencyIndex) {
-              "Expected dependency index to be selected & defined"
-            })
+            handleLoadLicenseListFragment(
+              checkNotNull(selectedDependencyIndex) {
+                "Expected dependency index to be selected & defined"
+              }
+            )
           }
           is LicenseListFragment -> handleLoadThirdPartyDependencyListFragment()
         }

--- a/scripts/assets/file_content_validation_checks.textproto
+++ b/scripts/assets/file_content_validation_checks.textproto
@@ -250,3 +250,8 @@ file_content_checks {
   exempted_file_patterns: "scripts/.+?\\.kt"
   exempted_file_patterns: "utility/src/(?:((main)|(test)))/java/org/oppia/android/util/locale/.+?\\.kt"
 }
+file_content_checks {
+  file_path_regex: ".+?.kt"
+  prohibited_content_regex: "kotlin\\.properties\\.Delegates"
+  failure_message: "Don't use Delegates; use a lateinit var or nullable primitive var default-initialized to null, instead. Delegates uses reflection internally, has a non-trivial initialization cost, and can cause breakages on KitKat devices. See #3939 for more context."
+}

--- a/scripts/assets/file_content_validation_checks.textproto
+++ b/scripts/assets/file_content_validation_checks.textproto
@@ -254,4 +254,5 @@ file_content_checks {
   file_path_regex: ".+?.kt"
   prohibited_content_regex: "kotlin\\.properties\\.Delegates"
   failure_message: "Don't use Delegates; use a lateinit var or nullable primitive var default-initialized to null, instead. Delegates uses reflection internally, has a non-trivial initialization cost, and can cause breakages on KitKat devices. See #3939 for more context."
+  exempted_file_name: "scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt"
 }

--- a/scripts/assets/file_content_validation_checks.textproto
+++ b/scripts/assets/file_content_validation_checks.textproto
@@ -253,6 +253,6 @@ file_content_checks {
 file_content_checks {
   file_path_regex: ".+?.kt"
   prohibited_content_regex: "kotlin\\.properties\\.Delegates"
-  failure_message: "Don't use Delegates; use a lateinit var or nullable primitive var default-initialized to null, instead. Delegates uses reflection internally, has a non-trivial initialization cost, and can cause breakages on KitKat devices. See #3939 for more context."
+  failure_message: "Don't use Delegates; use a lateinit var or nullable primitive var default-initialized to null, instead. Delegates uses reflection internally, have a non-trivial initialization cost, and can cause breakages on KitKat devices. See #3939 for more context."
   exempted_file_name: "scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt"
 }

--- a/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
@@ -115,6 +115,10 @@ class RegexPatternValidationCheckTest {
     "Don't perform date/time formatting directly. Instead, use OppiaLocale."
   private val useJavaLocaleErrorMessage =
     "Don't use Locale directly. Instead, use LocaleController, or OppiaLocale & its subclasses."
+  private val doNotUseKotlinDelegatesErrorMessage =
+    "Don't use Delegates; use a lateinit var or nullable primitive var default-initialized to" +
+      " null, instead. Delegates uses reflection internally, has a non-trivial initialization" +
+      " cost, and can cause breakages on KitKat devices. See #3939 for more context."
   private val wikiReferenceNote =
     "Refer to https://github.com/oppia/oppia-android/wiki/Static-Analysis-Checks" +
       "#regexpatternvalidation-check for more details on how to fix this."
@@ -1457,6 +1461,27 @@ class RegexPatternValidationCheckTest {
       .isEqualTo(
         """
         $stringFilePath:1: $useJavaLocaleErrorMessage
+        $wikiReferenceNote
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun testFileContent_kotlinDelegatesImport_fileContentIsNotCorrect() {
+    val prohibitedContent = "kotlin.properties.Delegates"
+    tempFolder.newFolder("testfiles", "domain", "src", "main")
+    val stringFilePath = "domain/src/main/SomeController.kt"
+    tempFolder.newFile("testfiles/$stringFilePath").writeText(prohibitedContent)
+
+    val exception = assertThrows(Exception::class) {
+      runScript()
+    }
+
+    assertThat(exception).hasMessageThat().contains(REGEX_CHECK_FAILED_OUTPUT_INDICATOR)
+    assertThat(outContent.toString().trim())
+      .isEqualTo(
+        """
+        $stringFilePath:1: $doNotUseKotlinDelegatesErrorMessage
         $wikiReferenceNote
         """.trimIndent()
       )

--- a/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
@@ -117,7 +117,7 @@ class RegexPatternValidationCheckTest {
     "Don't use Locale directly. Instead, use LocaleController, or OppiaLocale & its subclasses."
   private val doNotUseKotlinDelegatesErrorMessage =
     "Don't use Delegates; use a lateinit var or nullable primitive var default-initialized to" +
-      " null, instead. Delegates uses reflection internally, has a non-trivial initialization" +
+      " null, instead. Delegates uses reflection internally, have a non-trivial initialization" +
       " cost, and can cause breakages on KitKat devices. See #3939 for more context."
   private val wikiReferenceNote =
     "Refer to https://github.com/oppia/oppia-android/wiki/Static-Analysis-Checks" +


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix #3939
Fix #3938

This PR does two things:
- Fixes a KitKat-specific crash that was indirectly caused by using Kotlin Delegates (see #3939 for the investigation & specifics)
- Fixes SVG rendering issues on KitKat, Lollipop, and Marshmallow devices by forcing conversion to bitmap & rendering bitmaps on these devices rather than relying on native SVG rendering (see #3938 for the investigation & specifics)

Note that, to some extent, both of these are actually just workarounds to underlying problems. The delegates investigation revealed inconsistencies across the app's dex files. While only the help menu was affected, and removing the dependency on delegates fixed the issue (which is also fine since we probably don't want to use delegates per their performance/reflection implications), we did not actually find the root cause. I expect to see more dex inconsistency crashes in the future, but at the moment all tested parts of the app seems to be working well.

The fix for SVG rendering (forcing to bitmap rendering) is a pretty reasonable workaround, but we should eventually figure out why there's a native rendering issue. #3961 was filed to track this longer-term, along with a TODO in code. That being said, this might actually present a performance improvement for older devices and might be a strategy we want to utilize long-term to help with #2975 (though more thought should be put into it since the app should selectively optimize based on need, and ensure the correct resolution is used when rendering to bitmap).

Regarding tests:
- The crash can only be verified manually since this is a dex-specific issue. However, since Delegates seems problematic, a new regex check + test was added to prohibit using them in the future. This seems like a reasonable regression guard for this specific issue.
- The SVG issue unfortunately cannot be tested. We might be able to leverage screenshot testing in the future (i.e. #1815), but it's not an option currently. Also, without a lot of API wrapping with Oppia wrapper/fake classes, there's not a clear way to test that a bitmap is used, either. I think we can rely on manual testing for this change longer-term since failures will be *very* obvious when testing on older API versions.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A. While the SVG issue is definitely UI-impacting, the "fixed" screenshots are just the app looking as expected (and as it does on newer versions of Android). See #3938 for the failure screenshots/video if that context is helpful.