### PR TITLE
Update LogStorageModule.kt

### DIFF
--- a/domain/src/main/java/org/oppia/android/domain/oppialogger/LogStorageModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/oppialogger/LogStorageModule.kt
@@ -22,7 +22,7 @@ class LogStorageModule {
    */
   @Provides
   @EventLogStorageCacheSize
-  fun provideEventLogStorageCacheSize(): Int = 50000
+  fun provideEventLogStorageCacheSize(): Int = 50_000
 
   /**
    * Provides the maximum number of exception logs that can be cached on disk.

--- a/domain/src/main/java/org/oppia/android/domain/oppialogger/LogStorageModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/oppialogger/LogStorageModule.kt
@@ -15,18 +15,20 @@ annotation class ExceptionLogStorageCacheSize
 class LogStorageModule {
 
   /**
-   * Provides the number of records that can be stored in EventLog's cache storage.
-   * The current [EventLogStorageCacheSize] is set to be 5000 records.
-   * Taking 70 bytes per record, it is expected to occupy around 350000 bytes of disk space.
+   * Provides the maximum number of event logs that can be cached on disk.
+   *
+   * At a configured cache size of 50k records & estimating 70 bytes per record, it's expected that
+   * no more than 3.33MB will be required for cache disk space.
    */
   @Provides
   @EventLogStorageCacheSize
-  fun provideEventLogStorageCacheSize(): Int = 5000
+  fun provideEventLogStorageCacheSize(): Int = 50000
 
   /**
-   * Provides the number of records that can be stored in ExceptionLog's cache storage.
-   * The current [ExceptionLogStorageCacheSize] is set to be 25 records.
-   * Taking 130 bytes per record, it is expected to occupy around 3250 bytes of disk space.
+   * Provides the maximum number of exception logs that can be cached on disk.
+   *
+   * At a configured cache size of 25 records & estimating 130 bytes per record, it's expected that
+   * no more than 3.17KB will be required for cache disk space.
    */
   @Provides
   @ExceptionLogStorageCacheSize


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix #3949

This increases the event log to 50k total events (from 5k). This results in a 10x change in total event storage, but for an estimated 3.33MB total space now being needed this seems reasonable long-term. We specifically want this for the upcoming alpha MR4 study to ensure that events can be collected for potentially weeks without internet syncing, but that also matches longer-term goals of the app.

Note that no testing changes occur since this is just a configuration knob, and we don't currently have any module tests. They could be trivially added in the future, but this is simple enough to inspect directly so a test doesn't seem urgently needed for this PR.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- configuration-only change with no UI implications\*.

\* Technically, this may result in 50k event logs being viewable from the developer menu, but this realistically will never happen. If, in the event it does, the recycler view that's being used for event logs should be suitable to handle the load.