### PR TITLE
Fix #3960: Fix regressed questions tests

### DIFF
--- a/domain/src/main/assets/questions.json
+++ b/domain/src/main/assets/questions.json
@@ -1730,7 +1730,7 @@
             "refresher_exploration_id": "",
             "missing_prerequisite_skill_id": ""
           },
-          "tagged_skill_misconception_id": ""
+          "tagged_skill_misconception_id": "test_skill_id_1-0"
         }],
         "default_outcome": {
           "dest": "",

--- a/domain/src/test/java/org/oppia/android/domain/question/QuestionAssessmentProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/question/QuestionAssessmentProgressControllerTest.kt
@@ -1389,7 +1389,7 @@ class QuestionAssessmentProgressControllerTest {
     submitCorrectAnswerForQuestion0()
 
     val userAssessmentPerformance = getExpectedGrade(TEST_SKILL_ID_LIST_01)
-    val skill0Mastery = 0.2
+    val skill0Mastery = 0.3
     val skill1Mastery = 0.0
     assertThat(userAssessmentPerformance.masteryPerSkillMappingCount).isEqualTo(2)
     assertThat(userAssessmentPerformance.getMasteryPerSkillMappingOrThrow(TEST_SKILL_ID_0))
@@ -1418,7 +1418,7 @@ class QuestionAssessmentProgressControllerTest {
     submitCorrectAnswerForQuestion0()
 
     val userAssessmentPerformance = getExpectedGrade(TEST_SKILL_ID_LIST_01)
-    val skill0Mastery = 0.2
+    val skill0Mastery = 0.25
     val skill1Mastery = 0.0
     assertThat(userAssessmentPerformance.masteryPerSkillMappingCount).isEqualTo(2)
     assertThat(userAssessmentPerformance.getMasteryPerSkillMappingOrThrow(TEST_SKILL_ID_0))


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix #3960

See #3960 for context, but two tests were regressed in #3796 due to an incorrect change in questions.json. This PR reverts the JSON issue, and corrects the two tests so that they match the expected outcomes pre-#3796.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- test-only change