### PR TITLE
[RunAllTests] Try to fix/workaround rest of #2844: Add retry mechanism when running tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -277,7 +277,7 @@ jobs:
           BAZEL_TEST_TARGETS: ${{ env.BAZEL_TEST_TARGETS }}
         run: |
           # Attempt to build 5 times in case there are flaky builds.
-          # TODO: Remove this once there are no longer app test build failures.
+          # TODO(#3970): Remove this once there are no longer app test build failures.
           i=0
           # Disable exit-on-first-failure.
           set +e
@@ -298,7 +298,7 @@ jobs:
           BAZEL_TEST_TARGETS: ${{ env.BAZEL_TEST_TARGETS }}
         run: |
           # Attempt to build 5 times in case there are flaky builds.
-          # TODO: Remove this once there are no longer app test build failures.
+          # TODO(#3970): Remove this once there are no longer app test build failures.
           i=0
           # Disable exit-on-first-failure.
           set +e

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -276,21 +276,43 @@ jobs:
           BAZEL_REMOTE_CACHE_URL: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
           BAZEL_TEST_TARGETS: ${{ env.BAZEL_TEST_TARGETS }}
         run: |
+          # Attempt to build 5 times in case there are flaky builds.
+          # TODO: Remove this once there are no longer app test build failures.
+          i=0
+          # Disable exit-on-first-failure.
+          set +e
           while [ $i -ne 5 ]; do
             i=$(( $i+1 ))
             echo "Attempt $i/5 to run test targets"
             bazel test --keep_going --remote_http_cache=$BAZEL_REMOTE_CACHE_URL --google_credentials=./config/oppia-dev-workflow-remote-cache-credentials.json -- $BAZEL_TEST_TARGETS
           done
+          # Capture the error code of the final command run (which should be a success if there isn't a real build failure).
+          last_error_code=$?
+          # Reenable exit-on-first-failure.
+          set -e
+          # Exit only if the most recent exit was a failure (by using a subshell).
+          (exit $last_error_code)
       - name: Run Oppia Tests (without caching, or on a fork)
         if: ${{ env.ENABLE_CACHING == 'false' || ((github.ref != 'refs/heads/develop' || github.event_name != 'push') && (github.event.pull_request.head.repo.full_name != 'oppia/oppia-android')) }}
         env:
           BAZEL_TEST_TARGETS: ${{ env.BAZEL_TEST_TARGETS }}
         run: |
+          # Attempt to build 5 times in case there are flaky builds.
+          # TODO: Remove this once there are no longer app test build failures.
+          i=0
+          # Disable exit-on-first-failure.
+          set +e
           while [ $i -ne 5 ]; do
             i=$(( $i+1 ))
             echo "Attempt $i/5 to run test targets"
             bazel test --keep_going -- $BAZEL_TEST_TARGETS
           done
+          # Capture the error code of the final command run (which should be a success if there isn't a real build failure).
+          last_error_code=$?
+          # Reenable exit-on-first-failure.
+          set -e
+          # Exit only if the most recent exit was a failure (by using a subshell).
+          (exit $last_error_code)
 
   # Reference: https://github.community/t/127354/7.
   check_test_results:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -275,13 +275,22 @@ jobs:
         env:
           BAZEL_REMOTE_CACHE_URL: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
           BAZEL_TEST_TARGETS: ${{ env.BAZEL_TEST_TARGETS }}
-        run: bazel test --keep_going --remote_http_cache=$BAZEL_REMOTE_CACHE_URL --google_credentials=./config/oppia-dev-workflow-remote-cache-credentials.json -- $BAZEL_TEST_TARGETS
-
+        run: |
+          while [ $i -ne 5 ]; do
+            i=$(( $i+1 ))
+            echo "Attempt $i/5 to run test targets"
+            bazel test --keep_going --remote_http_cache=$BAZEL_REMOTE_CACHE_URL --google_credentials=./config/oppia-dev-workflow-remote-cache-credentials.json -- $BAZEL_TEST_TARGETS
+          done
       - name: Run Oppia Tests (without caching, or on a fork)
         if: ${{ env.ENABLE_CACHING == 'false' || ((github.ref != 'refs/heads/develop' || github.event_name != 'push') && (github.event.pull_request.head.repo.full_name != 'oppia/oppia-android')) }}
         env:
           BAZEL_TEST_TARGETS: ${{ env.BAZEL_TEST_TARGETS }}
-        run: bazel test --keep_going -- $BAZEL_TEST_TARGETS
+        run: |
+          while [ $i -ne 5 ]; do
+            i=$(( $i+1 ))
+            echo "Attempt $i/5 to run test targets"
+            bazel test --keep_going -- $BAZEL_TEST_TARGETS
+          done
 
   # Reference: https://github.community/t/127354/7.
   check_test_results:

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -1928,7 +1928,7 @@ class StateFragmentLocalTest {
       val positiveButton =
         revealSolutionDialogFragment?.dialog
           ?.findViewById<View>(android.R.id.button1)
-      assertThat(checkNotNull(positiveButton).performClick()).isFalse()
+      assertThat(checkNotNull(positiveButton).performClick()).isTrue()
     }
   }
 

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -1928,7 +1928,7 @@ class StateFragmentLocalTest {
       val positiveButton =
         revealSolutionDialogFragment?.dialog
           ?.findViewById<View>(android.R.id.button1)
-      assertThat(checkNotNull(positiveButton).performClick()).isTrue()
+      assertThat(checkNotNull(positiveButton).performClick()).isFalse()
     }
   }
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Try to workaround the last issue in #2844: a SIGSEGV thrown sometimes when running StateFragmentTest/StateFragmentLocalTest.

While it would be preferable to fix this issue, it will likely be extremely time consuming since it'll require digging into a JVM bug. After some effort to try and find a root cause, I haven't been able to come up with a single dependable way to work around the issue. It mostly went away with previous mitigations, but after adding test sharding it seems to come up a lot.

This solution introduces the same while-loop retry mechanism as we do for builds (which was effective in addressing #3789). Bazel makes this work well since passing tests won't be re-run (their results are cached--see the CI results for this PR). Given that the issue seems to happen less often when StateFragmentTest/StateFragmentLocalTest runs by itself, this is a reasonable outcome (since it'll generally result in running just those tests for runs 2-5).

That being said, I'm not a complete fan of this solution since it will:
- Result in true flakes being discovered less often, though fortunately the same retry mechanism also applies to the develop branch
- False flakes could be missed which could result in them being checked in (but similarly, this also should result in a more stable situation since develop won't fail from them, but it does mean legitimate issues could be missed)
- Result in failures taking longer to be reported since they'll be retried up to 5 times

While the second outcome is definitely worse, it also seems to happen much less often so it seems like a worthwhile trade-off for the stability benefits that we get from this fix.

#3970 was filed to track the long-term fix of the underlying SIGSEGV so that this mechanism isn't needed for CI runs to reliably pass.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- infrastructure change