### PR TITLE
Fix #3978: Removed unused colors from colors.xml

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -13,12 +13,10 @@
   <color name="oppiaPrimaryText">#333333</color>
   <color name="oppiaPrimaryLight">#009688</color>
   <color name="oppiaPrimaryText30">#4D333333</color>
-  <color name="oppiaPrimaryText70">#B3333333</color>
   <color name="oppiaPrimaryTextDark">#DE000000</color>
   <color name="oppiaPrimaryDark">#00645C</color>
   <color name="oppiaSecondaryText">#666666</color>
   <color name="oppiaLightGreen">#F0FFFF</color>
-  <color name="oppiaLightBlue">#4DA5D3EC</color>
   <color name="oppiaLightYellow">#FFFFF0</color>
   <color name="oppiaBrownDark">#BE563C</color>
   <color name="oppiaBrown">#C55F45</color>
@@ -42,29 +40,21 @@
   <color name="oppiaBackgroundYellowIvory">#FFFFF0</color>
   <color name="oppiaFAQDivider">#707070</color>
   <color name="oppiaProfileChooserDivider">#707070</color>
-  <color name="oppiaNavDrawerItemSelected">#D8D8D8</color>
   <color name="oppiaRed">#B92D00</color>
   <!-- BASIC COLORS -->
   <color name="white">#FFFFFF</color>
   <color name="white_80">#CCFFFFFF</color>
-  <color name="white_70">#B3FFFFFF</color>
   <color name="black">#000000</color>
   <color name="transparent">#00000000</color>
   <color name="black_12">#1F000000</color>
-  <color name="black_87">#DE000000</color>
-  <color name="black_20">#33000000</color>
   <color name="black_26">#42000000</color>
-  <color name="black_30">#4D000000</color>
-  <color name="black_38">#61000000</color>
   <color name="black_54">#8A000000</color>
   <color name="whiteLight">#F9F9F9</color>
-  <color name="red">#FF0000</color>
   <color name="accessible_grey">#333333</color>
   <color name="accessible_light_grey">#555555</color>
   <!--  CONFETTI COLORS -->
   <color name="confetti_red">#FF1414</color>
   <color name="confetti_yellow">#FFE558</color>
-  <color name="confetti_evergreen">#00645C</color>
   <color name="confetti_blue">#2D4A9D</color>
   <!-- AUDIO COMPONENT -->
   <color name="audioComponentBackground">@color/oppiaDarkBlue</color>
@@ -72,10 +62,8 @@
   <color name="avatarBorder">#707070</color>
   <color name="addProfileBackground">#FFFFF0</color>
   <color name="hintsAndSolutionBackground">#E4F2F1</color>
-  <color name="pinPasswordBackground">#E4F2F1</color>
   <color name="profileChooserBackground">#212121</color>
   <color name="profileChooserGreyTextColor">#999999</color>
-  <color name="profileImagePlaceHolder">#26A69A</color>
   <color name="profileEditBackground">#E5E5E5</color>
   <color name="generalNavigationBackground">#E5E5E5</color>
   <color name="appVersionBackground">#E5E5E5</color>
@@ -98,29 +86,17 @@
   <color name="mid_grey_05">#0D000000</color>
   <color name="mid_grey_03">#03000000</color>
   <color name="mid_grey_30">#0D000000</color>
-  <color name="blue_shade">#395FD0</color>
-  <color name="blue_shade_80">#80395FD0</color>
-  <color name="blue_shade_60">#60395FD0</color>
-  <color name="blue_shade_40">#40395FD0</color>
-  <color name="blue_shade_10">#10395FD0</color>
   <color name="grey_shade_05">#05395FD0</color>
   <color name="grey_shade_10">#10395FD0</color>
   <color name="grey_shade_20">#D6D6D6</color>
-  <color name="grey_shade_30">#5CBABABA</color>
-  <color name="grey_shade_40">#0000003D</color>
-  <color name="grey_shade_29">#4A000000</color>
   <color name="blue_shade_100">#0F0086FB</color>
   <color name="blue_shade_200">#6B0086FB</color>
   <color name="chapterCardShadow">#AAFFFFFF</color>
   <color name="chapterCardGreyBorder">#666666</color>
-  <color name="chapterCardGreenBorder">#019489</color>
   <color name="divider">#61000000</color>
   <color name="toolbarDropShadow">#3D000000</color>
   <color name="green_shade">#44A85A</color>
   <color name="green_shade_80">#CC44A85A</color>
-  <color name="green_shade_60">#9944A85A</color>
-  <color name="green_shade_40">#6644A85A</color>
-  <color name="green_shade_10">#1A44A85A</color>
   <color name="light_green">#D9F3E7</color>
   <!-- QUESTION COMPONENT -->
   <color name="question_player_background">#F0FFFF</color>
@@ -160,14 +136,11 @@
   <color name="profileStatusBar">#000000</color>
   <color name="hintFullDialogStatusBar">#00236E</color>
   <color name="slideDrawerOpenStatusBar">#001F2A</color>
-  <color name="conceptCardStatusBar">#882814</color>
-  <color name="pinInputStatusBar">#BDCCCC</color>
   <color name="walkthroughStatusBar">#CCCCCC</color>
   <color name="onboarding1StatusBar">#00847A</color>
   <color name="onboarding2StatusBar">#8B2A15</color>
   <color name="onboarding3StatusBar">#AD8500</color>
   <color name="onboarding4StatusBar">#3B5893</color>
-  <color name="registrationStatusBar">#9CB1BE</color>
   <!-- ICON COLORS -->
   <color name="mergeIconEnabled">#FF000000</color>
   <color name="mergeIconDisabled">#999999</color>


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #3978 
Removed unused colors from colors.xml.
Followed approach according to https://stackoverflow.com/a/31669368/14822653

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
