### PR TITLE
Fix part of #3971: Part2 - Add style for all the TextViews in the Hint summary.

### DIFF
--- a/app/src/main/res/layout-land/hints_summary.xml
+++ b/app/src/main/res/layout-land/hints_summary.xml
@@ -32,8 +32,6 @@
       <TextView
         android:id="@+id/hint_title"
         style="@style/Heading2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_marginTop="12dp"
         android:layout_marginBottom="12dp"

--- a/app/src/main/res/layout-land/hints_summary.xml
+++ b/app/src/main/res/layout-land/hints_summary.xml
@@ -31,14 +31,12 @@
 
       <TextView
         android:id="@+id/hint_title"
+        style="@style/Heading2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_marginTop="12dp"
         android:layout_marginBottom="12dp"
-        android:fontFamily="sans-serif-medium"
-        android:textColor="@color/oppiaPrimaryText"
-        android:textSize="20sp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -103,12 +101,10 @@
 
       <TextView
         android:id="@+id/hints_and_solution_summary"
+        style="@style/Body"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:fontFamily="sans-serif"
-        android:textColor="@color/oppiaPrimaryText"
-        android:textSize="16sp" />
+        android:layout_gravity="start" />
     </LinearLayout>
   </LinearLayout>
 </layout>

--- a/app/src/main/res/layout-sw600dp-land/hints_summary.xml
+++ b/app/src/main/res/layout-sw600dp-land/hints_summary.xml
@@ -31,8 +31,6 @@
       <TextView
         android:id="@+id/hint_title"
         style="@style/Heading2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_marginTop="44dp"
         android:paddingBottom="28dp"

--- a/app/src/main/res/layout-sw600dp-land/hints_summary.xml
+++ b/app/src/main/res/layout-sw600dp-land/hints_summary.xml
@@ -30,14 +30,12 @@
 
       <TextView
         android:id="@+id/hint_title"
+        style="@style/Heading2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_marginTop="44dp"
-        android:fontFamily="sans-serif-medium"
         android:paddingBottom="28dp"
-        android:textColor="@color/oppiaPrimaryText"
-        android:textSize="20sp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -96,12 +94,10 @@
 
       <TextView
         android:id="@+id/hints_and_solution_summary"
+        style="@style/Body"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:fontFamily="sans-serif"
-        android:textColor="@color/oppiaPrimaryText"
-        android:textSize="16sp" />
+        android:layout_gravity="start" />
     </LinearLayout>
   </LinearLayout>
 </layout>

--- a/app/src/main/res/layout-sw600dp-port/hints_summary.xml
+++ b/app/src/main/res/layout-sw600dp-port/hints_summary.xml
@@ -31,8 +31,6 @@
       <TextView
         android:id="@+id/hint_title"
         style="@style/Heading2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_marginTop="44dp"
         android:paddingBottom="28dp"

--- a/app/src/main/res/layout-sw600dp-port/hints_summary.xml
+++ b/app/src/main/res/layout-sw600dp-port/hints_summary.xml
@@ -30,14 +30,12 @@
 
       <TextView
         android:id="@+id/hint_title"
+        style="@style/Heading2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_marginTop="44dp"
-        android:fontFamily="sans-serif-medium"
         android:paddingBottom="28dp"
-        android:textColor="@color/oppiaPrimaryText"
-        android:textSize="20sp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -96,12 +94,10 @@
 
       <TextView
         android:id="@+id/hints_and_solution_summary"
+        style="@style/Body"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:fontFamily="sans-serif"
-        android:textColor="@color/oppiaPrimaryText"
-        android:textSize="16sp" />
+        android:layout_gravity="start"/>
     </LinearLayout>
   </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/hints_summary.xml
+++ b/app/src/main/res/layout/hints_summary.xml
@@ -31,14 +31,10 @@
 
       <TextView
         android:id="@+id/hint_title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/Heading2"
         android:layout_gravity="center"
         android:layout_marginTop="12dp"
         android:layout_marginBottom="12dp"
-        android:fontFamily="sans-serif-medium"
-        android:textColor="@color/oppiaPrimaryText"
-        android:textSize="20sp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -103,12 +99,10 @@
 
       <TextView
         android:id="@+id/hints_and_solution_summary"
+        style="@style/Body"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:fontFamily="sans-serif"
-        android:textColor="@color/oppiaPrimaryText"
-        android:textSize="16sp" />
+        android:layout_gravity="start"/>
     </LinearLayout>
   </LinearLayout>
 </layout>


### PR DESCRIPTION
## Explanation
This PR fixes part of #3971 . This PR  ensures that all the Textviews have style attribute set, to generally manage the text alignment for RTL/LTR where the texts are aligned to  right or left and the texts that are center-aligned.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
