### PR TITLE
Set up vacation bot & enable it for the next two weeks

### DIFF
--- a/.devbots/vacation.yml
+++ b/.devbots/vacation.yml
@@ -1,0 +1,12 @@
+# Reference: https://devbots.xyz/documentation/vacation/.
+enabled: true
+pull-comment: >
+    Thanks for submitting this pull request! Some main reviewers
+    have taken time off for the next few weeks, so it may take a
+    little while before we can look at this PR. We appreciate your
+    patience while some of our team members recharge.
+issue-comment: >
+    Thanks for filing this issue! Please note that some team members
+    are currently taking time off to recharge, so it might be a
+    while before we respond or triage this issue.
+period: 2021-11-19 - 2021-12-06

--- a/.devbots/vacation.yml
+++ b/.devbots/vacation.yml
@@ -8,5 +8,5 @@ pull-comment: >
 issue-comment: >
     Thanks for filing this issue! Please note that some team members
     are currently taking time off to recharge, so it might be a
-    while before we respond or triage this issue.
+    while before we respond to or triage this issue.
 period: 2021-11-19 - 2021-12-06

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,6 +47,9 @@ gradlew.bat @BenHenning
 /.github/workflows/ @BenHenning
 /.github/stale.yml @BenHenning
 
+# Devbots configurations.
+/.devbots/ @BenHenning
+
 # All tests.
 *Test.kt @anandwana001
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
This PR sets up a [vacation bot](https://devbots.xyz/documentation/vacation/) so that at times when we don't have hand-over plans for core team members, we can provide a general notice to the community that there may be delays. Since I'm going to be unavailable for the next two weeks, I'm enabling this until 6 December (#3998 is tracking disabling it).

Note that the validation that this was set up correctly will be done by verifying the message starts showing up tomorrow (I enabled it a day early for this reason).

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] ~The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)~
- [X] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [X] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [X] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [X] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- this is setting up a bot.