### PR TITLE
Fix #3901 : [A11Y] Terminal state question player recyclerview fix

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
@@ -1,7 +1,6 @@
 package org.oppia.android.app.player.state
 
 import android.content.Context
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.animation.AccelerateInterpolator
@@ -204,7 +203,6 @@ class StatePlayerRecyclerViewAssembler private constructor(
     val extraInteractionPendingItemList = mutableListOf<StateItemViewModel>()
     if (playerFeatureSet.contentSupport) {
       addContentItem(conversationPendingItemList, ephemeralState, gcsEntityId)
-      Log.d("TAG", "addContentItem: " + conversationPendingItemList.size)
     }
     val interaction = ephemeralState.state.interaction
 

--- a/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
@@ -1,6 +1,7 @@
 package org.oppia.android.app.player.state
 
 import android.content.Context
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.animation.AccelerateInterpolator
@@ -203,6 +204,7 @@ class StatePlayerRecyclerViewAssembler private constructor(
     val extraInteractionPendingItemList = mutableListOf<StateItemViewModel>()
     if (playerFeatureSet.contentSupport) {
       addContentItem(conversationPendingItemList, ephemeralState, gcsEntityId)
+      Log.d("TAG", "addContentItem: " + conversationPendingItemList.size)
     }
     val interaction = ephemeralState.state.interaction
 
@@ -328,13 +330,15 @@ class StatePlayerRecyclerViewAssembler private constructor(
       translationController.extractString(
         ephemeralState.state.content, ephemeralState.writtenTranslationContext
       )
-    pendingItemList += ContentViewModel(
-      contentSubtitledHtml,
-      gcsEntityId,
-      hasConversationView,
-      isSplitView.get()!!,
-      playerFeatureSet.conceptCardSupport
-    )
+    if (contentSubtitledHtml.isNotEmpty()) {
+      pendingItemList += ContentViewModel(
+        contentSubtitledHtml,
+        gcsEntityId,
+        hasConversationView,
+        isSplitView.get()!!,
+        playerFeatureSet.conceptCardSupport
+      )
+    }
   }
 
   private fun addPreviousAnswers(

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -15,6 +15,7 @@ import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToHolder
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
@@ -451,6 +452,25 @@ class QuestionPlayerActivityTest {
     }
   }
 
+   @Test
+   @DisableAccessibilityChecks // TODO(#3927): Feedback item should be min 48dp in height.
+   fun testQuestionPlayer_terminalState_recyclerView_contentItem_isNotEmpty(){
+     updateContentLanguage(profileId, OppiaLanguage.ENGLISH)
+     launchForSkillList(SKILL_ID_LIST).use {
+       selectMultipleChoiceOption(optionPosition = 2)
+       clickContinueNavigationButton()
+
+       typeTextInput("1/4")
+       clickSubmitAnswerButton()
+       clickContinueNavigationButton()
+
+       typeTextInput("3/4")
+       clickSubmitAnswerButton()
+       clickContinueNavigationButton()
+
+       onView(withId(R.id.content_text_view)).check(doesNotExist())
+     }
+   }
   private fun setUpTestApplicationComponent() {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -452,25 +452,25 @@ class QuestionPlayerActivityTest {
     }
   }
 
-   @Test
-   @DisableAccessibilityChecks // TODO(#3927): Feedback item should be min 48dp in height.
-   fun testQuestionPlayer_terminalState_recyclerView_contentItem_isNotEmpty(){
-     updateContentLanguage(profileId, OppiaLanguage.ENGLISH)
-     launchForSkillList(SKILL_ID_LIST).use {
-       selectMultipleChoiceOption(optionPosition = 2)
-       clickContinueNavigationButton()
+  @Test
+  @DisableAccessibilityChecks // TODO(#3927): Feedback item should be min 48dp in height.
+  fun testQuestionPlayer_terminalState_recyclerView_contentItem_isNotEmpty() {
+    updateContentLanguage(profileId, OppiaLanguage.ENGLISH)
+    launchForSkillList(SKILL_ID_LIST).use {
+      selectMultipleChoiceOption(optionPosition = 2)
+      clickContinueNavigationButton()
 
-       typeTextInput("1/4")
-       clickSubmitAnswerButton()
-       clickContinueNavigationButton()
+      typeTextInput("1/4")
+      clickSubmitAnswerButton()
+      clickContinueNavigationButton()
 
-       typeTextInput("3/4")
-       clickSubmitAnswerButton()
-       clickContinueNavigationButton()
+      typeTextInput("3/4")
+      clickSubmitAnswerButton()
+      clickContinueNavigationButton()
 
-       onView(withId(R.id.content_text_view)).check(doesNotExist())
-     }
-   }
+      onView(withId(R.id.content_text_view)).check(doesNotExist())
+    }
+  }
 
   private fun setUpTestApplicationComponent() {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -109,8 +109,8 @@ import org.oppia.android.domain.translation.TranslationController
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.BuildEnvironment
-import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.DisableAccessibilityChecks
+import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.TestPlatform

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -60,11 +60,13 @@ import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.WrittenTranslationLanguageSelection
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.CONTENT
+import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.CONTINUE_NAVIGATION_BUTTON
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.FEEDBACK
-import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.TEXT_INPUT_INTERACTION
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.SELECTION_INTERACTION
 import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.SUBMIT_ANSWER_BUTTON
+import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.TEXT_INPUT_INTERACTION
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.hasItemCount
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.topic.PracticeTabModule
 import org.oppia.android.app.translation.testing.ActivityRecreatorTestModule
@@ -108,10 +110,12 @@ import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.BuildEnvironment
 import org.oppia.android.testing.OppiaTestRule
+import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.TestPlatform
 import org.oppia.android.testing.data.DataProviderTestMonitor
+import org.oppia.android.testing.espresso.EditTextInputAction
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.profile.ProfileTestHelper
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -136,10 +140,6 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
-import org.oppia.android.app.player.state.itemviewmodel.StateItemViewModel.ViewType.CONTINUE_NAVIGATION_BUTTON
-import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.hasItemCount
-import org.oppia.android.testing.DisableAccessibilityChecks
-import org.oppia.android.testing.espresso.EditTextInputAction
 
 private val SKILL_ID_LIST = listOf(FRACTIONS_SKILL_ID_0)
 

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -471,6 +471,7 @@ class QuestionPlayerActivityTest {
        onView(withId(R.id.content_text_view)).check(doesNotExist())
      }
    }
+
   private fun setUpTestApplicationComponent() {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #3901 ( its a remake of PR #3928 )
## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing

 Espresso test results 

<img width="1914" alt="test2" src="https://user-images.githubusercontent.com/64087572/143086537-c56de042-321b-4858-9ef2-a92570430b26.png">
<img width="1914" alt="test1" src="https://user-images.githubusercontent.com/64087572/143086668-c5b8c890-faca-4435-932c-c28733871c93.png">







A11Y output 



https://user-images.githubusercontent.com/64087572/142926641-9f85e501-6a8a-45b6-b0a2-cdb2ed33c4e1.mp4



