### PR TITLE
Fix #4015 : User name TextView not properly aligned in profile_edit_fragment.xml Screen fix

### DIFF
--- a/app/src/main/res/layout/profile_edit_fragment.xml
+++ b/app/src/main/res/layout/profile_edit_fragment.xml
@@ -47,14 +47,13 @@
 
       <TextView
         android:id="@+id/profile_edit_name"
-        style="@style/Heading2"
+        style="@style/Heading2ViewStart"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
         android:layout_marginEnd="16dp"
         android:importantForAccessibility="no"
         android:text="@{viewModel.profile.name}"
-        android:textDirection="locale"
         app:layout_constraintBottom_toTopOf="@+id/profile_edit_created"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/profile_edit_image"

--- a/app/src/main/res/layout/profile_edit_fragment.xml
+++ b/app/src/main/res/layout/profile_edit_fragment.xml
@@ -54,7 +54,6 @@
         android:layout_marginEnd="16dp"
         android:importantForAccessibility="no"
         android:text="@{viewModel.profile.name}"
-        android:textDirection="locale"
         app:layout_constraintBottom_toTopOf="@+id/profile_edit_created"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/profile_edit_image"

--- a/app/src/main/res/layout/profile_edit_fragment.xml
+++ b/app/src/main/res/layout/profile_edit_fragment.xml
@@ -54,6 +54,7 @@
         android:layout_marginEnd="16dp"
         android:importantForAccessibility="no"
         android:text="@{viewModel.profile.name}"
+        android:textDirection="locale"
         app:layout_constraintBottom_toTopOf="@+id/profile_edit_created"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/profile_edit_image"

--- a/app/src/main/res/layout/profile_edit_fragment.xml
+++ b/app/src/main/res/layout/profile_edit_fragment.xml
@@ -48,12 +48,14 @@
       <TextView
         android:id="@+id/profile_edit_name"
         style="@style/Heading2"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
+        android:layout_marginEnd="16dp"
         android:importantForAccessibility="no"
         android:text="@{viewModel.profile.name}"
         app:layout_constraintBottom_toTopOf="@+id/profile_edit_created"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/profile_edit_image"
         app:layout_constraintTop_toTopOf="@id/profile_edit_image"
         app:layout_constraintVertical_chainStyle="packed" />


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
_Fixes #4015_
**Text View wasn't constrained to the right and was set to wrap_content, which made text to come out of the view.
Setting width to 0dp, And constraining it's right to right of the parent view, with some padding solves the issue.
Adding Text Direction : Locale, fixes the gravity issue**

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes

**Before Portrait** 
![before_portrait](https://user-images.githubusercontent.com/55173065/144497803-18f0d163-ac8b-4571-a95e-a86093731317.png)

**After Portrait**
![after_portrait](https://user-images.githubusercontent.com/55173065/144497797-ed920984-2fb2-42de-9f2a-f5e10a1bbfc4.png)

**Before Landscape**
![before_landscape](https://user-images.githubusercontent.com/55173065/144497800-813343b1-210e-4591-b983-7d32282d31d1.png)

**After Landscape**
![after_landscape](https://user-images.githubusercontent.com/55173065/144497788-daa7a7a4-0055-4ac2-9235-2ac216bcc53e.png)

**RTL Before Portrait**

![before_rtl_portrait](https://user-images.githubusercontent.com/55173065/145155703-ca98ba93-fb42-4273-9365-fee95604ac36.png)

**RTL After Portrait**

![after_rtl_portrait (2)](https://user-images.githubusercontent.com/55173065/145354809-8016f8a7-4929-4d63-bf5d-732544fa49a9.png)


**RTL Before Landscape**

![before_rtl_landscape](https://user-images.githubusercontent.com/55173065/145155734-ff951d71-ba10-4259-a961-e6f2db65d454.png)

**RTL After Landscape**

![after_rtl_landscape](https://user-images.githubusercontent.com/55173065/145155743-8a86112c-4ab9-48b9-85fd-615d9e123e21.png)

- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
