### PR TITLE
Disable workflow cancellation for merged PRs

### DIFF
--- a/.github/workflows/workflow_canceller.yml
+++ b/.github/workflows/workflow_canceller.yml
@@ -3,7 +3,6 @@ name: Automatic Workflow Canceller
 # This workflow should be triggered in one of three situations:
 # 1. Manual workflow dispatch via https://github.com/oppia/oppia-android/actions.
 # 2. Upon creation of a PR & updates to that PR.
-# 3. Whenever the develop branch is changed (e.g. after a PR is merged).
 #
 # Note that the action being used here automatically accounts for the current branch & the commit
 # hash of the tip of the branch to ensure it doesn't cancel previous workflows that aren't related
@@ -11,10 +10,6 @@ name: Automatic Workflow Canceller
 on:
   workflow_dispatch:
   pull_request:
-  push:
-    branches:
-      # Push events on develop branch
-      - develop
 
 jobs:
   cancel:


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
This PR disables workflow cancellation for merged PRs to avoid past workflows failing due to being cancelled (see https://github.com/oppia/oppia-android/commits/develop). While this will slightly increase resources for subsequent PR merges, it's useful since it provides proper CI results for merged PRs (which could help isolate regressions that trigger develop CI failures that aren't caught until post-merging).

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] ~The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)~
- [X] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [X] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [X] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [X] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
N/A -- CI infrastructure change