### PR TITLE
Add holiday messaging for PRs in CI

### DIFF
--- a/.github/workflows/repository_messaging.yml
+++ b/.github/workflows/repository_messaging.yml
@@ -1,0 +1,21 @@
+# Contains jobs corresponding to repository-wide messaging.
+
+name: Repository Messaging
+
+on:
+  pull_request_target:
+    types: [ opened ]
+
+jobs:
+  holiday_message:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add holiday comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Thanks for submitting this pull request! Some main reviewers
+            have taken time off for the next few weeks, so it may take a
+            little while before we can look at this PR. We appreciate your
+            patience while some of our team members recharge.

--- a/.github/workflows/repository_messaging.yml
+++ b/.github/workflows/repository_messaging.yml
@@ -18,4 +18,5 @@ jobs:
             Thanks for submitting this pull request! Some main reviewers
             have taken time off for the next few weeks, so it may take a
             little while before we can look at this PR. We appreciate your
-            patience while some of our team members recharge.
+            patience while some of our team members recharge. We'll be fully
+            returning on 4 January 2021.


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
A previous attempt to add automatic messaging to PRs didn't work, so manually adding something that will automatically run until the team's multi-person time-off period ends. I'll manually be adding messages to existing PRs since this only operates for new PRs.

Some caveats:
1. I can't test this until the PR is submitted
2. It won't work for first-time contributors since their workflows need to be run by a team member with write access, but everyone else should see the message
3. The workflow will need to be manually disabled once we return (doing a date-based if check is a bit complicated, and I didn't want to have to debug it since this is a temporary thing, anyway)

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] ~The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)~
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
N/A -- CI infrastructure PR.