### PR TITLE
Disable vacation messaging

### DIFF
--- a/.github/workflows/repository_messaging.yml
+++ b/.github/workflows/repository_messaging.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   holiday_message:
     runs-on: ubuntu-latest
+    if: false
     steps:
       - name: Add holiday comment
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/repository_messaging.yml
+++ b/.github/workflows/repository_messaging.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   holiday_message:
     runs-on: ubuntu-latest
+    # NOTE TO DEVELOPERS: Update the body text and set this to 'true' to enable automatic messaging on all new PRs.
     if: false
     steps:
       - name: Add holiday comment


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Now that the team is back for reviews, the automated PR message is no longer needed. This PR keeps the messaging support, but disables the vacation-specific message used over the last few weeks.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] ~The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)~
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
N/A -- CI workflow change