### PR TITLE
Fix part of #3602: Added label for MyDownloadsActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,6 +75,7 @@
     <activity
       android:name=".app.mydownloads.MyDownloadsActivity"
       android:screenOrientation="portrait"
+      android:label="@string/my_downloads_activity_title"
       android:theme="@style/OppiaThemeWithoutActionBar" />
     <activity
       android:name=".app.onboarding.OnboardingActivity"

--- a/app/src/main/res/layout/my_downloads_fragment.xml
+++ b/app/src/main/res/layout/my_downloads_fragment.xml
@@ -22,7 +22,7 @@
         android:layout_height="?attr/actionBarSize"
         android:background="@color/oppia_primary"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-        app:title="@string/my_downloads"
+        app:title="@string/my_downloads_activity_title"
         app:titleTextAppearance="@style/ToolbarTextAppearance"
         app:titleTextColor="@color/white" />
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -263,7 +263,7 @@
   <string name="admin_settings_incorrect">رقم التعريف الشخصي الخاص بالمشرف غير صحيح. من فضلك حاول مجددًا.</string>
   <string name="admin_settings_enter_user_new_pin">رقم التعريف الشخصي الجديد الخاص ب%1$s.</string>
   <string name="reset_pin_enter">أدخل رقم تعريف شخصي جديد</string>
-  <string name="my_downloads">تنزيلاتي</string>
+  <string name="my_downloads_activity_title">تنزيلاتي</string>
   <string name="tab_downloads">التنزيلات</string>
   <string name="tab_updates">التحديثات (2)</string>
   <string name="home_activity_back_dialog_message">هل تريد الخروج من ملفك الشخصي؟</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -246,7 +246,7 @@
   <string name="admin_settings_incorrect">PIN do administrador incorreto. Por favor, tente novamente.</string>
   <string name="admin_settings_enter_user_new_pin">Novo PIN de %1$s</string>
   <string name="reset_pin_enter">Insira um Novo Pin</string>
-  <string name="my_downloads">Meus Downloads</string>
+  <string name="my_downloads_activity_title">Meus Downloads</string>
   <string name="tab_downloads">Downloads</string>
   <string name="tab_updates">Atualizações (2)</string>
   <string name="home_activity_back_dialog_message">Você gostaria de sair do seu perfil?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -288,7 +288,7 @@
   <!-- ResetPinDialogFragment -->
   <string name="reset_pin_enter">Enter a New Pin</string>
   <!-- MyDownloadsActivity -->
-  <string name="my_downloads">My Downloads</string>
+  <string name="my_downloads_activity_title">My Downloads</string>
   <string name="tab_downloads">Downloads</string>
   <string name="tab_updates">Updates (2)</string>
   <!-- HomeActivityBackDialog -->

--- a/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsActivityTest.kt
@@ -49,7 +49,6 @@ import org.oppia.android.domain.platformparameter.PlatformParameterSingletonModu
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
-import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -71,6 +70,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
+import org.oppia.android.testing.OppiaTestRule
 
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
@@ -84,7 +84,7 @@ class MyDownloadsActivityTest {
   val initializeDefaultLocaleRule = InitializeDefaultLocaleRule()
 
   @get:Rule
-  val accessibilityTestRule = AccessibilityTestRule()
+  val oppiaTestRule = OppiaTestRule()
 
   @Before
   fun setUp() {

--- a/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsActivityTest.kt
@@ -108,6 +108,7 @@ class MyDownloadsActivityTest {
       }
     }
   }
+
   @Singleton
   @Component(
     modules = [

--- a/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsActivityTest.kt
@@ -49,6 +49,7 @@ import org.oppia.android.domain.platformparameter.PlatformParameterSingletonModu
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
+import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -70,7 +71,6 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
-import org.oppia.android.testing.OppiaTestRule
 
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)

--- a/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/mydownloads/MyDownloadsActivityTest.kt
@@ -1,23 +1,13 @@
 package org.oppia.android.app.mydownloads
 
 import android.app.Application
-import android.widget.TextView
+import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
-import androidx.test.core.app.ActivityScenario.launch
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.action.ViewActions.swipeLeft
-import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withParent
-import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
 import dagger.Component
-import org.hamcrest.CoreMatchers.allOf
-import org.hamcrest.CoreMatchers.instanceOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -35,7 +25,6 @@ import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.topic.PracticeTabModule
 import org.oppia.android.app.translation.testing.ActivityRecreatorTestModule
-import org.oppia.android.app.utility.EspressoTestsMatchers.matchCurrentTabTitle
 import org.oppia.android.data.backends.gae.NetworkConfigProdModule
 import org.oppia.android.data.backends.gae.NetworkModule
 import org.oppia.android.domain.classify.InteractionsModule
@@ -60,7 +49,7 @@ import org.oppia.android.domain.platformparameter.PlatformParameterSingletonModu
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
-import org.oppia.android.testing.OppiaTestRule
+import org.oppia.android.testing.AccessibilityTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -80,126 +69,45 @@ import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
+import javax.inject.Inject
 import javax.inject.Singleton
 
-/** Tests for [MyDownloadsFragment]. */
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
-@Config(application = MyDownloadsFragmentTest.TestApplication::class, qualifiers = "port-xxhdpi")
-class MyDownloadsFragmentTest {
+@Config(
+  application = MyDownloadsActivityTest.TestApplication::class,
+  qualifiers = "port-xxhdpi"
+)
+class MyDownloadsActivityTest {
+
   @get:Rule
   val initializeDefaultLocaleRule = InitializeDefaultLocaleRule()
 
   @get:Rule
-  val oppiaTestRule = OppiaTestRule()
+  val accessibilityTestRule = AccessibilityTestRule()
 
   @Before
   fun setUp() {
     setUpTestApplicationComponent()
   }
 
-  @Test
-  fun testMyDownloadsFragment_toolbarTitle_isDisplayedSuccessfully() {
-    launch(MyDownloadsActivity::class.java).use {
-      onView(
-        allOf(
-          instanceOf(TextView::class.java),
-          withParent(withId(R.id.my_downloads_toolbar))
-        )
-      ).check(
-        matches(
-          withText(R.string.my_downloads_activity_title)
-        )
-      )
-    }
-  }
-
-  @Test
-  fun testMyDownloadsFragment_showsMyDownloadsFragmentWithMultipleTabs() {
-    launch(MyDownloadsActivity::class.java).use {
-      onView(withId(R.id.my_downloads_tabs_container)).perform(click())
-        .check(matches(isDisplayed()))
-    }
-  }
-
-  @Test
-  fun testMyDownloadsFragment_swipePage_hasSwipedPage() {
-    launch(MyDownloadsActivity::class.java).use {
-      onView(withId(R.id.my_downloads_tabs_viewpager)).perform(swipeLeft())
-      onView(withId(R.id.my_downloads_tabs_container)).check(
-        matches(
-          matchCurrentTabTitle(
-            MyDownloadsTab.getTabForPosition(
-              1
-            ).name
-          )
-        )
-      )
-    }
-  }
-
-  @Test
-  fun testMyDownloadsFragment_defaultTabIsDownloads_isSuccessful() {
-    launch(MyDownloadsActivity::class.java).use {
-      onView(withId(R.id.my_downloads_tabs_container)).check(
-        matches(
-          matchCurrentTabTitle(
-            MyDownloadsTab.getTabForPosition(
-              0
-            ).name
-          )
-        )
-      )
-    }
-  }
-
-  @Test
-  fun testMyDownloadsFragment_clickOnDownloadsTab_showsDownloadsTabSelected() {
-    launch(MyDownloadsActivity::class.java).use {
-      onView(
-        allOf(
-          withText(MyDownloadsTab.getTabForPosition(0).name),
-          isDescendantOfA(withId(R.id.my_downloads_tabs_container))
-        )
-      ).perform(click())
-      onView(withId(R.id.my_downloads_tabs_container)).check(
-        matches(
-          matchCurrentTabTitle(
-            MyDownloadsTab.getTabForPosition(
-              0
-            ).name
-          )
-        )
-      )
-    }
-  }
-
-  @Test
-  fun testMyDownloadsFragment_clickOnUpdatesTab_showsUpdatesTabSelected() {
-    launch(MyDownloadsActivity::class.java).use {
-      onView(
-        allOf(
-          withText(R.string.tab_updates),
-          isDescendantOfA(withId(R.id.my_downloads_tabs_container))
-        )
-      ).perform(click())
-      onView(withId(R.id.my_downloads_tabs_container)).check(
-        matches(
-          matchCurrentTabTitle(
-            MyDownloadsTab.getTabForPosition(
-              1
-            ).name
-          )
-        )
-      )
-    }
-  }
-
   private fun setUpTestApplicationComponent() {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
 
-  // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.
+  @Inject
+  lateinit var context: Context
+
+  @Test
+  fun testMyDownloadsActivity_hasCorrectActivityLabel() {
+    ActivityScenario.launch(MyDownloadsActivity::class.java).use { scenario ->
+      scenario.onActivity { activity ->
+        assertThat(activity.title).isEqualTo(
+          context.getString(R.string.my_downloads_activity_title)
+        )
+      }
+    }
+  }
   @Singleton
   @Component(
     modules = [
@@ -228,18 +136,18 @@ class MyDownloadsFragmentTest {
     @Component.Builder
     interface Builder : ApplicationComponent.Builder
 
-    fun inject(myDownloadsFragmentTest: MyDownloadsFragmentTest)
+    fun inject(myDownloadsActivityTest: MyDownloadsActivityTest)
   }
 
   class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
-    private val component: TestApplicationComponent by lazy {
-      DaggerMyDownloadsFragmentTest_TestApplicationComponent.builder()
+    private val component: MyDownloadsActivityTest.TestApplicationComponent by lazy {
+      DaggerMyDownloadsActivityTest_TestApplicationComponent.builder()
         .setApplication(this)
-        .build() as TestApplicationComponent
+        .build() as MyDownloadsActivityTest.TestApplicationComponent
     }
 
-    fun inject(myDownloadsFragmentTest: MyDownloadsFragmentTest) {
-      component.inject(myDownloadsFragmentTest)
+    fun inject(myDownloadsActivityTest: MyDownloadsActivityTest) {
+      component.inject(myDownloadsActivityTest)
     }
 
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {

--- a/scripts/assets/accessibility_label_exemptions.textproto
+++ b/scripts/assets/accessibility_label_exemptions.textproto
@@ -5,7 +5,6 @@ exempted_activity: "app/src/main/java/org/oppia/android/app/devoptions/marktopic
 exempted_activity: "app/src/main/java/org/oppia/android/app/devoptions/vieweventlogs/testing/ViewEventLogsTestActivity"
 exempted_activity: "app/src/main/java/org/oppia/android/app/devoptions/testing/DeveloperOptionsTestActivity"
 exempted_activity: "app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedActivity"
-exempted_activity: "app/src/main/java/org/oppia/android/app/mydownloads/MyDownloadsActivity"
 exempted_activity: "app/src/main/java/org/oppia/android/app/player/state/testing/StateFragmentTestActivity"
 exempted_activity: "app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivity"
 exempted_activity: "app/src/main/java/org/oppia/android/app/testing/AudioFragmentTestActivity"


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixes  #3602 : Added label for MyDownloadsActivity

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
