### PR TITLE
Fix #3140  Shifting Instrumentation tests in Unit test directory for AdministratorControlsFragmentTest

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -11,6 +11,7 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -122,7 +123,7 @@ class AdministratorControlsFragmentTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.edit_profiles_text_view)).perform(click())
-      Intents.intended(hasComponent(ProfileListActivity::class.java.name))
+      intended(hasComponent(ProfileListActivity::class.java.name))
     }
   }
 
@@ -140,7 +141,7 @@ class AdministratorControlsFragmentTest {
         )
       )
       onView(withId(R.id.app_version_text_view)).perform(click())
-      Intents.intended(hasComponent(AppVersionActivity::class.java.name))
+      intended(hasComponent(AppVersionActivity::class.java.name))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -193,3 +193,4 @@ class AdministratorControlsFragmentTest {
     override fun getApplicationInjector(): ApplicationInjector = component
   }
 }
+

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -9,9 +9,9 @@ import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.matcher.IntentMatchers
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Component
@@ -121,9 +121,8 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      onView(withId(R.id.edit_profiles_text_view))
-        .perform(click())
-      Intents.intended(IntentMatchers.hasComponent(ProfileListActivity::class.java.name))
+      onView(withId(R.id.edit_profiles_text_view)).perform(click())
+      Intents.intended(hasComponent(ProfileListActivity::class.java.name))
     }
   }
 
@@ -136,12 +135,12 @@ class AdministratorControlsFragmentTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.administrator_controls_list)).perform(
-        RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(
+        scrollToPosition<RecyclerView.ViewHolder>(
           3
         )
       )
       onView(withId(R.id.app_version_text_view)).perform(click())
-      Intents.intended(IntentMatchers.hasComponent(AppVersionActivity::class.java.name))
+      Intents.intended(hasComponent(AppVersionActivity::class.java.name))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -82,6 +82,7 @@ import org.robolectric.annotation.Config
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/** Tests for [AdministratorControlsFragment]. */
 @RunWith(AndroidJUnit4::class)
 @Config(
   application = AdministratorControlsFragmentTest.TestApplication::class,

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -1,33 +1,29 @@
-package org.oppia.android.app.testing.administratorcontrols
+package org.oppia.android.app.administratorcontrols
 
 import android.app.Application
 import android.content.Context
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.core.app.ActivityScenario.launch
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.Intents.intended
-import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.common.truth.Truth.assertThat
+import androidx.test.espresso.intent.matcher.IntentMatchers
+import androidx.test.espresso.matcher.ViewMatchers
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.oppia.android.R
 import org.oppia.android.app.activity.ActivityComponent
 import org.oppia.android.app.activity.ActivityComponentFactory
-import org.oppia.android.app.administratorcontrols.AdministratorControlsActivity
 import org.oppia.android.app.administratorcontrols.appversion.AppVersionActivity
-import org.oppia.android.app.administratorcontrols.appversion.AppVersionFragment
 import org.oppia.android.app.application.ApplicationComponent
 import org.oppia.android.app.application.ApplicationInjector
 import org.oppia.android.app.application.ApplicationInjectorProvider
@@ -36,7 +32,6 @@ import org.oppia.android.app.application.ApplicationStartupListenerModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.settings.profile.ProfileListActivity
-import org.oppia.android.app.settings.profile.ProfileListFragment
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.topic.PracticeTabModule
 import org.oppia.android.app.translation.testing.ActivityRecreatorTestModule
@@ -82,15 +77,7 @@ import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
-import org.robolectric.annotation.Config
-import javax.inject.Inject
-import javax.inject.Singleton
 
-@RunWith(AndroidJUnit4::class)
-@Config(
-  application = AdministratorControlsFragmentTest.TestApplication::class,
-  qualifiers = "port-xxhdpi"
-)
 class AdministratorControlsFragmentTest {
   @get:Rule
   val initializeDefaultLocaleRule = InitializeDefaultLocaleRule()
@@ -117,50 +104,38 @@ class AdministratorControlsFragmentTest {
   private fun setUpTestApplicationComponent() {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
+
   @Test
-  @Config(qualifiers = "sw600dp")
-  fun testAdministratorControlsFragment_clickEditProfile_checkLoadingTheCorrectFragment() {
-    launch<AdministratorControlsActivity>(
+  fun testAdministratorControlsFragment_clickEditProfile_checkSendingTheCorrectIntent() {
+    ActivityScenario.launch<AdministratorControlsActivity>(
       createAdministratorControlsActivityIntent(
         0
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      onView(withId(R.id.edit_profiles_text_view))
-        .perform(click())
-      it.onActivity { activity ->
-        val fragment =
-          activity.supportFragmentManager
-            .findFragmentById(R.id.administrator_controls_fragment_multipane_placeholder)
-        assertThat(fragment is ProfileListFragment).isTrue()
-      }
+      Espresso.onView(ViewMatchers.withId(R.id.edit_profiles_text_view))
+        .perform(ViewActions.click())
+      Intents.intended(IntentMatchers.hasComponent(ProfileListActivity::class.java.name))
     }
   }
 
   @Test
-  @Config(qualifiers = "sw600dp")
-  fun testAdministratorControlsFragment_clickAppVersion_checkLoadingTheCorrectFragment() {
-    launch<AdministratorControlsActivity>(
+  fun testAdministratorControlsFragment_clickAppVersion_checkSendingTheCorrectIntent() {
+    ActivityScenario.launch<AdministratorControlsActivity>(
       createAdministratorControlsActivityIntent(
         0
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      onView(withId(R.id.administrator_controls_list)).perform(
-        scrollToPosition<RecyclerView.ViewHolder>(
+      Espresso.onView(ViewMatchers.withId(R.id.administrator_controls_list)).perform(
+        RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(
           3
         )
       )
-      onView(withId(R.id.app_version_text_view)).perform(click())
-      it.onActivity { activity ->
-        val fragment =
-          activity.supportFragmentManager
-            .findFragmentById(R.id.administrator_controls_fragment_multipane_placeholder)
-        assertThat(fragment is AppVersionFragment).isTrue()
-      }
+      Espresso.onView(ViewMatchers.withId(R.id.app_version_text_view)).perform(ViewActions.click())
+      Intents.intended(IntentMatchers.hasComponent(AppVersionActivity::class.java.name))
     }
   }
-
   private fun createAdministratorControlsActivityIntent(profileId: Int): Intent {
     return AdministratorControlsActivity.createAdministratorControlsActivityIntent(
       context,
@@ -216,4 +191,5 @@ class AdministratorControlsFragmentTest {
 
     override fun getApplicationInjector(): ApplicationInjector = component
   }
+
 }

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -5,9 +5,9 @@ import android.content.Context
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.intent.Intents
@@ -107,13 +107,13 @@ class AdministratorControlsFragmentTest {
 
   @Test
   fun testAdministratorControlsFragment_clickEditProfile_checkSendingTheCorrectIntent() {
-    ActivityScenario.launch<AdministratorControlsActivity>(
+    launch<AdministratorControlsActivity>(
       createAdministratorControlsActivityIntent(
         0
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      Espresso.onView(ViewMatchers.withId(R.id.edit_profiles_text_view))
+      onView(ViewMatchers.withId(R.id.edit_profiles_text_view))
         .perform(ViewActions.click())
       Intents.intended(IntentMatchers.hasComponent(ProfileListActivity::class.java.name))
     }
@@ -121,21 +121,22 @@ class AdministratorControlsFragmentTest {
 
   @Test
   fun testAdministratorControlsFragment_clickAppVersion_checkSendingTheCorrectIntent() {
-    ActivityScenario.launch<AdministratorControlsActivity>(
+    launch<AdministratorControlsActivity>(
       createAdministratorControlsActivityIntent(
         0
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      Espresso.onView(ViewMatchers.withId(R.id.administrator_controls_list)).perform(
+      onView(ViewMatchers.withId(R.id.administrator_controls_list)).perform(
         RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(
           3
         )
       )
-      Espresso.onView(ViewMatchers.withId(R.id.app_version_text_view)).perform(ViewActions.click())
+      onView(ViewMatchers.withId(R.id.app_version_text_view)).perform(ViewActions.click())
       Intents.intended(IntentMatchers.hasComponent(AppVersionActivity::class.java.name))
     }
   }
+
   private fun createAdministratorControlsActivityIntent(profileId: Int): Intent {
     return AdministratorControlsActivity.createAdministratorControlsActivityIntent(
       context,

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -8,16 +8,18 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers
-import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Component
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.oppia.android.R
 import org.oppia.android.app.activity.ActivityComponent
 import org.oppia.android.app.activity.ActivityComponentFactory
@@ -75,9 +77,15 @@ import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
+import org.robolectric.annotation.Config
 import javax.inject.Inject
 import javax.inject.Singleton
 
+@RunWith(AndroidJUnit4::class)
+@Config(
+  application = AdministratorControlsFragmentTest.TestApplication::class,
+  qualifiers = "port-xxhdpi"
+)
 class AdministratorControlsFragmentTest {
   @get:Rule
   val initializeDefaultLocaleRule = InitializeDefaultLocaleRule()
@@ -113,8 +121,8 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      onView(ViewMatchers.withId(R.id.edit_profiles_text_view))
-        .perform(ViewActions.click())
+      onView(withId(R.id.edit_profiles_text_view))
+        .perform(click())
       Intents.intended(IntentMatchers.hasComponent(ProfileListActivity::class.java.name))
     }
   }
@@ -127,12 +135,12 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      onView(ViewMatchers.withId(R.id.administrator_controls_list)).perform(
+      onView(withId(R.id.administrator_controls_list)).perform(
         RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(
           3
         )
       )
-      onView(ViewMatchers.withId(R.id.app_version_text_view)).perform(ViewActions.click())
+      onView(withId(R.id.app_version_text_view)).perform(click())
       Intents.intended(IntentMatchers.hasComponent(AppVersionActivity::class.java.name))
     }
   }

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -14,8 +14,6 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers
 import dagger.Component
-import javax.inject.Inject
-import javax.inject.Singleton
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -77,6 +75,8 @@ import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
+import javax.inject.Inject
+import javax.inject.Singleton
 
 class AdministratorControlsFragmentTest {
   @get:Rule
@@ -193,4 +193,3 @@ class AdministratorControlsFragmentTest {
     override fun getApplicationInjector(): ApplicationInjector = component
   }
 }
-

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -192,5 +192,4 @@ class AdministratorControlsFragmentTest {
 
     override fun getApplicationInjector(): ApplicationInjector = component
   }
-
 }

--- a/app/src/test/java/org/oppia/android/app/testing/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/test/java/org/oppia/android/app/testing/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -11,12 +11,12 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.Intents.intended
-import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.Component
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -26,7 +26,6 @@ import org.oppia.android.R
 import org.oppia.android.app.activity.ActivityComponent
 import org.oppia.android.app.activity.ActivityComponentFactory
 import org.oppia.android.app.administratorcontrols.AdministratorControlsActivity
-import org.oppia.android.app.administratorcontrols.appversion.AppVersionActivity
 import org.oppia.android.app.administratorcontrols.appversion.AppVersionFragment
 import org.oppia.android.app.application.ApplicationComponent
 import org.oppia.android.app.application.ApplicationInjector
@@ -35,7 +34,6 @@ import org.oppia.android.app.application.ApplicationModule
 import org.oppia.android.app.application.ApplicationStartupListenerModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
-import org.oppia.android.app.settings.profile.ProfileListActivity
 import org.oppia.android.app.settings.profile.ProfileListFragment
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.topic.PracticeTabModule
@@ -83,8 +81,6 @@ import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
 import org.robolectric.annotation.Config
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @RunWith(AndroidJUnit4::class)
 @Config(
@@ -117,6 +113,7 @@ class AdministratorControlsFragmentTest {
   private fun setUpTestApplicationComponent() {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
+
   @Test
   @Config(qualifiers = "sw600dp")
   fun testAdministratorControlsFragment_clickEditProfile_checkLoadingTheCorrectFragment() {
@@ -217,3 +214,4 @@ class AdministratorControlsFragmentTest {
     override fun getApplicationInjector(): ApplicationInjector = component
   }
 }
+

--- a/app/src/test/java/org/oppia/android/app/testing/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/test/java/org/oppia/android/app/testing/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -15,8 +15,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import dagger.Component
-import javax.inject.Inject
-import javax.inject.Singleton
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -81,6 +79,8 @@ import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
 import org.robolectric.annotation.Config
+import javax.inject.Inject
+import javax.inject.Singleton
 
 @RunWith(AndroidJUnit4::class)
 @Config(

--- a/app/src/test/java/org/oppia/android/app/testing/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/test/java/org/oppia/android/app/testing/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -214,4 +214,3 @@ class AdministratorControlsFragmentTest {
     override fun getApplicationInjector(): ApplicationInjector = component
   }
 }
-


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix #3140: Shifting tests which were instrumentation tests but written in the Unit test directory in the AdministratorControlsFragmentTest

Shifted tests Screenshot (Device(Emulator): Pixel-3A , API-28)
![Screenshot 2022-01-25 125005](https://user-images.githubusercontent.com/78897906/150930177-516596d2-9672-4b87-acd4-9eb1a6f1551d.png)

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
