### PR TITLE
Fix #4123: Duplicate recently played stories list

### DIFF
--- a/app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedFragmentPresenter.kt
@@ -116,6 +116,7 @@ class RecentlyPlayedFragmentPresenter @Inject constructor(
   private fun addRecentlyPlayedStoryListSection(
     recentlyPlayedStoryList: MutableList<PromotedStory>
   ) {
+    itemList.clear()
     val recentSectionTitleViewModel =
       SectionTitleViewModel(
         resourceHandler.getStringInLocale(R.string.ongoing_story_last_week), false


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fix #4123 

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).


The recently played card list seemed to be duplicated every time the fragment is recreating (or on Activity onResume).
This is because the updated list was getting added to the previous list without clearing it first. So, I added a line to CLEAR the list before adding the updating the items in it by calling `itemList.clear()` before adding new items.
Here is the gif of updated version:
![WhatsApp-Video-2022-02-04-at-11 33 11-AM](https://user-images.githubusercontent.com/71327295/152480677-1e8bfee4-38d6-4ec7-b2a3-9d5fd98cfbdc.gif)



> @ShivanshGoel221B Unfortunately I will need to close this PR.
> 
> > > LGTM.
> > > Just merge your PR with latest develop and it should be ready to merge.
> > 
> > 
> > @rt4914 Done that
> 
> Unfortunately I will have to close this PR.
> 
> There is one force-push commit in this PR and we cannot merge this. Force-push commits actually tampers the commit-history. It has been mentioned in Step 3 in https://github.com/oppia/oppia-android/wiki/making-a-code-change#making-a-code-change-using-the-terminal
> 
> You can create a new PR without force-push and assign it to correct reviewers.

I have created another one, please check that