### PR TITLE
Fix #4150: added DrawableBindingAdaptersTestActivity to accessibility_label_exemptions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -174,9 +174,7 @@
     <activity android:name=".app.testing.BindableAdapterTestActivity" />
     <activity android:name=".app.testing.ConceptCardFragmentTestActivity" />
     <activity android:name=".app.testing.DragDropTestActivity" />
-    <activity
-      android:name=".app.testing.DrawableBindingAdaptersTestActivity"
-      android:label="@string/drawable_binding_adapters_test_label" />
+    <activity android:name=".app.testing.DrawableBindingAdaptersTestActivity"/>
     <activity android:name=".app.testing.ExplorationInjectionActivity" />
     <activity android:name=".app.testing.ExplorationTestActivity" />
     <activity

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -452,8 +452,6 @@
   <string name="ratio_default_hint_text" description="The default hint text for the ratio interaction if the placeholder text is not available.">
     Enter a ratio in the form x:y.
   </string>
-  <!-- DrawableBindingAdaptersTestActivity -->
-  <string name="drawable_binding_adapters_test_label">Drawable Binding Adapter Activity</string>
   <string name="smallest_text_size_content_description">Smallest text size</string>
   <string name="largest_text_size_content_description">Largest text size</string>
   <string name="coming_soon">Coming Soon</string>

--- a/scripts/assets/accessibility_label_exemptions.textproto
+++ b/scripts/assets/accessibility_label_exemptions.textproto
@@ -11,6 +11,7 @@ exempted_activity: "app/src/main/java/org/oppia/android/app/testing/AudioFragmen
 exempted_activity: "app/src/main/java/org/oppia/android/app/testing/BindableAdapterTestActivity"
 exempted_activity: "app/src/main/java/org/oppia/android/app/testing/ConceptCardFragmentTestActivity"
 exempted_activity: "app/src/main/java/org/oppia/android/app/testing/DragDropTestActivity"
+exempted_activity: "app/src/main/java/org/oppia/android/app/testing/DrawableBindingAdaptersTestActivity"
 exempted_activity: "app/src/main/java/org/oppia/android/app/testing/ExplorationInjectionActivity"
 exempted_activity: "app/src/main/java/org/oppia/android/app/testing/ExplorationTestActivity"
 exempted_activity: "app/src/main/java/org/oppia/android/app/testing/HomeFragmentTestActivity"


### PR DESCRIPTION
Fix #4150

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).


