### PR TITLE
Fix #2546: Renamed OngoingStory to PromotedStory at required places.

### DIFF
--- a/app/src/main/java/org/oppia/android/app/home/recentlyplayed/OngoingListAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/recentlyplayed/OngoingListAdapter.kt
@@ -57,7 +57,7 @@ class OngoingListAdapter(
       }
       VIEW_TYPE_SECTION_STORY_ITEM -> {
         storyGridPosition = position - titleIndex
-        (holder as OngoingStoryViewHolder).bind(itemList[position] as OngoingStoryViewModel)
+        (holder as OngoingStoryViewHolder).bind(itemList[position] as PromotedStoryViewModel)
       }
       else -> throw IllegalArgumentException("Invalid item view type: ${holder.itemViewType}")
     }
@@ -67,7 +67,7 @@ class OngoingListAdapter(
       is SectionTitleViewModel -> {
         VIEW_TYPE_SECTION_TITLE_TEXT
       }
-      is OngoingStoryViewModel -> {
+      is PromotedStoryViewModel -> {
         VIEW_TYPE_SECTION_STORY_ITEM
       }
       else -> throw IllegalArgumentException(
@@ -95,8 +95,8 @@ class OngoingListAdapter(
   private class OngoingStoryViewHolder(
     val binding: OngoingStoryCardBinding
   ) : RecyclerView.ViewHolder(binding.root) {
-    internal fun bind(ongoingStoryViewModel: OngoingStoryViewModel) {
-      binding.viewModel = ongoingStoryViewModel
+    internal fun bind(promotedStoryViewModel: PromotedStoryViewModel) {
+      binding.viewModel = promotedStoryViewModel
     }
   }
 }

--- a/app/src/main/java/org/oppia/android/app/home/recentlyplayed/PromotedStoryViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/home/recentlyplayed/PromotedStoryViewModel.kt
@@ -10,7 +10,7 @@ import org.oppia.android.app.translation.AppLanguageResourceHandler
 // TODO(#297): Add download status information to promoted-story-card.
 
 /** [ViewModel] for displaying a promoted story. */
-class OngoingStoryViewModel(
+class PromotedStoryViewModel(
   private val activity: AppCompatActivity,
   val ongoingStory: PromotedStory,
   val entityType: String,

--- a/app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedFragmentPresenter.kt
@@ -68,11 +68,11 @@ class RecentlyPlayedFragmentPresenter @Inject constructor(
     }
     binding.lifecycleOwner = fragment
 
-    subscribeToOngoingStoryList()
+    subscribeToPromotedStoryList()
     return binding.root
   }
 
-  private val ongoingStoryListSummaryResultLiveData:
+  private val promotedStoryListSummaryResultLiveData:
     LiveData<AsyncResult<PromotedActivityList>>
     by lazy {
       topicListController.getPromotedActivityList(
@@ -80,7 +80,7 @@ class RecentlyPlayedFragmentPresenter @Inject constructor(
       ).toLiveData()
     }
 
-  private fun subscribeToOngoingStoryList() {
+  private fun subscribeToPromotedStoryList() {
     getAssumedSuccessfulPromotedActivityList().observe(
       fragment,
       {
@@ -131,7 +131,7 @@ class RecentlyPlayedFragmentPresenter @Inject constructor(
     promotedStory: PromotedStory,
     index: Int
   ): RecentlyPlayedItemViewModel {
-    return OngoingStoryViewModel(
+    return PromotedStoryViewModel(
       activity,
       promotedStory,
       entityType,
@@ -171,7 +171,7 @@ class RecentlyPlayedFragmentPresenter @Inject constructor(
 
   private fun getAssumedSuccessfulPromotedActivityList(): LiveData<PromotedActivityList> {
     // If there's an error loading the data, assume the default.
-    return Transformations.map(ongoingStoryListSummaryResultLiveData) {
+    return Transformations.map(promotedStoryListSummaryResultLiveData) {
       it.getOrDefault(
         PromotedActivityList.getDefaultInstance()
       )

--- a/app/src/main/res/layout/ongoing_story_card.xml
+++ b/app/src/main/res/layout/ongoing_story_card.xml
@@ -8,7 +8,7 @@
 
     <variable
       name="viewModel"
-      type="org.oppia.android.app.home.recentlyplayed.OngoingStoryViewModel" />
+      type="org.oppia.android.app.home.recentlyplayed.PromotedStoryViewModel" />
   </data>
 
   <com.google.android.material.card.MaterialCardView


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->

- [✓] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)

- [✓] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [✓] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [✓] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [✓] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [✓] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
