### PR TITLE
Fix part of #3245 [A11y] Enabling AccessibilityChecks for PinPasswordActivityTest

### DIFF
--- a/app/src/main/res/layout/pin_password_activity.xml
+++ b/app/src/main/res/layout/pin_password_activity.xml
@@ -113,7 +113,6 @@
               style="@style/TextInputEditText"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
-              android:contentDescription="@string/enter_your_pin"
               android:imeOptions="actionNext"
               android:inputType="numberPassword"
               android:maxLength="@{viewModel.profile.pin.length()}"

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
@@ -73,7 +73,6 @@ import org.oppia.android.domain.platformparameter.PlatformParameterSingletonModu
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
-import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.espresso.EditTextInputAction
@@ -167,50 +166,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  fun testPinPassword_pinView_hasContentDescription() {
-    ActivityScenario.launch<PinPasswordActivity>(
-      PinPasswordActivity.createPinPasswordActivityIntent(
-        context = context,
-        adminPin = adminPin,
-        profileId = adminId
-      )
-    ).use {
-      onView(withId(R.id.pin_password_input_pin_edit_text)).check(
-        matches(
-          withContentDescription(
-            context.resources.getString(
-              R.string.enter_your_pin
-            )
-          )
-        )
-      )
-    }
-  }
-
-  @Test
-  fun testPinPassword_configChange_pinView_hasContentDescription() {
-    ActivityScenario.launch<PinPasswordActivity>(
-      PinPasswordActivity.createPinPasswordActivityIntent(
-        context = context,
-        adminPin = adminPin,
-        profileId = adminId
-      )
-    ).use {
-      onView(isRoot()).perform(orientationLandscape())
-      onView(withId(R.id.pin_password_input_pin_edit_text)).check(
-        matches(
-          withContentDescription(
-            context.resources.getString(
-              R.string.enter_your_pin
-            )
-          )
-        )
-      )
-    }
-  }
-
-  @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withAdmin_inputCorrectPin_opensHomeActivity() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -228,7 +183,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_inputCorrectPin_opensHomeActivity() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -246,7 +200,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withAdmin_inputWrongPin_incorrectPinShows() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -284,7 +237,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_inputWrongPin_incorrectPinShows() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -306,7 +258,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withAdmin_forgot_opensAdminForgotDialog() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -328,7 +279,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_forgot_inputWrongAdminPin_wrongAdminPinError() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -373,7 +323,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_forgot_inputAdminPinAndShortPin_pinLengthError() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -432,7 +381,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_forgot_inputAdminPinAndNewPinAndOldPin_wrongPinError() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -481,7 +429,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_forgot_inputAdminPinAndNewPin_opensHomeActivity() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -528,7 +475,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_forgot_inputAdminPin_configChange_inputPinIsPresent() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -559,7 +505,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_forgot_inputAdminPin_submit_configChange_resetPinDisplayed() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -589,7 +534,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_forgot_inputAdminPin_submit_inputNewPin_pinChanged() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -632,7 +576,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withAdmin_forgot_configChange_opensAdminForgotDialog() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -652,7 +595,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_forgot_inputWrongAdminPin_configChange_wrongAdminPinError() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -696,7 +638,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_forgot_inputAdminPinAndIncorrectPin_errorIsDisplayed() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -739,7 +680,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_forgot_inputAdminPinAndNullPin_errorIsDisplayed() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -773,7 +713,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_forgot_inputAdminPinAndNullPin_configChange_errorIsDisplayed() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -808,7 +747,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_forgot_inputAdminPinAndNullPin_imeAction_errorIsDisplayed() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -839,7 +777,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_user_forgot_adminPinAndNullPin_configChange_imeAction_errorIsDisplayed() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -871,7 +808,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_forgot_inputNullAdminPin_configChange_wrongAdminPinError() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -915,7 +851,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withUser_forgot_inputAdminPinAndInvalidPin_errorIsDisplayed() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -961,7 +896,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withAdmin_inputWrongPin_configChange_incorrectPinIsDisplayed() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -1041,7 +975,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withAdmin_showHidePassword_textChangesToHide() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -1057,7 +990,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withAdmin_clickShowHideIcon_hasPasswordShownContentDescription() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -1081,7 +1013,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withAdmin_showHidePassword_imageChangesToShow() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -1105,7 +1036,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_withAdmin_showHidePassword_configChange_showViewIsShown() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(
@@ -1131,7 +1061,6 @@ class PinPasswordActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testPinPassword_checkInputType_showHidePassword_inputTypeIsSame() {
     ActivityScenario.launch<PinPasswordActivity>(
       PinPasswordActivity.createPinPasswordActivityIntent(


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix part of #3245 : Enable Accessibility Checks
Removed the `@DisableAccessibilityChecks` Annotation from the PinPasswordActivityTest

There were 27 tests with `@DisableAccessibilityChecks` Annotation in PinPasswordActivityTest
So running these tests after removing it caused an Accessibility error and it said to remove `ContentDescription` of `TextInputeditText` in`pin_password_activity.xml`

I have checked this using Accessibility scanner app too and it also showed the same result

<p align="center">
<img src = "https://user-images.githubusercontent.com/78897906/154837806-0e58336c-87bd-4343-aa02-01997df9ac7a.jpeg" width=40% height=40%>
</p>

There were 2 tests `fun testPinPassword_pinView_hasContentDescription()` and 
`fun testPinPassword_configChange_pinView_hasContentDescription()` which check the `ContentDescription` of the `TextinputEditText` . So I have to remove these tests
Screenshots after running the tests

Device: Pixel 3a API 28
![after tests mob](https://user-images.githubusercontent.com/78897906/154838900-b053310e-61ed-4c82-bc2e-8f94f9efe86c.png)

Device: Pixel C API 28
![after test tab](https://user-images.githubusercontent.com/78897906/154838902-0c476c50-8664-4fc8-a7c6-abb42099f0c1.png)

The only test which was failing was 
`fun testPinPassword_withUser_forgot_inputAdminPinAndNullPin_imeAction_errorIsDisplayed()` and it was failing even before removing `ContentDescription` and `@DisableAccessibilityChecks` Annotation and not because of the changes made and the same test passes sometimes while running separately 
![image](https://user-images.githubusercontent.com/78897906/154839590-a1ca05a2-019a-4e1d-925e-01f132d530db.png)


# UI CHANGES
|BEFORE|AFTER|
|---------|-------|
|![pin before mob](https://user-images.githubusercontent.com/78897906/154839090-2e54f844-8f38-45a7-8365-36d5db84657e.png)|![pin after mob](https://user-images.githubusercontent.com/78897906/154839094-3ad85283-0b17-4bdd-b3a6-8e794092043e.png)|
|![pin before mob land](https://user-images.githubusercontent.com/78897906/154839099-0e5bf263-dcf2-4865-b2ce-8bed0e167266.png)|![pin after mob land](https://user-images.githubusercontent.com/78897906/154839135-899639e6-53cf-4f2b-8673-e465f7d5811a.png)|
|![pin before tab](https://user-images.githubusercontent.com/78897906/154839142-b575f516-6562-43ae-bad9-74b47d7e63b1.png)|![pin after tab](https://user-images.githubusercontent.com/78897906/154839154-c593e526-f008-4d82-884e-b9efa4fef222.png)|
|![pin before tab land](https://user-images.githubusercontent.com/78897906/154839169-de4434a1-a47a-4a6c-a1df-72e2cc991246.png)|![pin after tab land](https://user-images.githubusercontent.com/78897906/154839171-f4d470f5-4506-4cf0-ac91-1d749ef8690f.png)|












<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
