### PR TITLE
Fix part of #3245 : Enabling AccessibilityChecks for StoryActivityTest

### DIFF
--- a/app/src/main/java/org/oppia/android/app/story/StoryFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/story/StoryFragmentPresenter.kt
@@ -5,8 +5,8 @@ import android.text.SpannableString
 import android.text.Spanned
 import android.text.TextPaint
 import android.text.method.LinkMovementMethod
-import android.text.style.ClickableSpan
 import android.text.style.TypefaceSpan
+import android.text.style.URLSpan
 import android.util.DisplayMetrics
 import android.util.TypedValue
 import android.view.LayoutInflater
@@ -183,9 +183,11 @@ class StoryFragmentPresenter @Inject constructor(
               storyItemViewModel.missingPrerequisiteChapter.name
             )
             val chapterLockedSpannable = SpannableString(missingPrerequisiteSummary)
-            val clickableSpan = object : ClickableSpan() {
+            var url = "https://developer.android.com"
+            val urlspan = object : URLSpan(url) {
               override fun onClick(widget: View) {
                 smoothScrollToPosition(storyItemViewModel.index - 1)
+                super.onClick(widget)
               }
 
               override fun updateDrawState(ds: TextPaint) {
@@ -194,7 +196,7 @@ class StoryFragmentPresenter @Inject constructor(
               }
             }
             chapterLockedSpannable.setSpan(
-              clickableSpan,
+              urlspan,
               /* start= */ LOCKED_CARD_PREFIX_LENGTH,
               /* end= */ chapterLockedSpannable.length - LOCKED_CARD_SUFFIX_LENGTH,
               Spanned.SPAN_EXCLUSIVE_EXCLUSIVE

--- a/app/src/main/res/layout-land/story_chapter_view.xml
+++ b/app/src/main/res/layout-land/story_chapter_view.xml
@@ -76,6 +76,8 @@
             android:layout_marginTop="8dp"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
+            android:minWidth="48dp"
+            android:minHeight="48dp"
             android:text="@{htmlContent}"
             android:textColorLink="@color/oppia_primary"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout-sw600dp/story_chapter_view.xml
+++ b/app/src/main/res/layout-sw600dp/story_chapter_view.xml
@@ -146,6 +146,8 @@
               android:layout_marginTop="8dp"
               android:layout_marginEnd="8dp"
               android:layout_marginBottom="4dp"
+              android:minWidth="48dp"
+              android:minHeight="48dp"
               android:text="@{htmlContent}"
               android:textColorLink="@color/oppia_primary"
               app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/story_chapter_view.xml
+++ b/app/src/main/res/layout/story_chapter_view.xml
@@ -108,6 +108,8 @@
             android:layout_marginTop="8dp"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
+            android:minWidth="48dp"
+            android:minHeight="48dp"
             android:text="@{htmlContent}"
             android:textColorLink="@color/oppia_primary"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/sharedTest/java/org/oppia/android/app/story/StoryActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/story/StoryActivityTest.kt
@@ -67,7 +67,6 @@ import org.oppia.android.domain.topic.TEST_EXPLORATION_ID_2
 import org.oppia.android.domain.topic.TEST_STORY_ID_0
 import org.oppia.android.domain.topic.TEST_TOPIC_ID_0
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
-import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
@@ -148,7 +147,6 @@ class StoryActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks // TODO(#3362): Enable AccessibilityChecks
   fun clickOnStory_intentsToExplorationActivity() {
     launch<StoryActivity>(
       createStoryActivityIntent(


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix part of #3245 : Enabling AccessibilityChecks for StoryActivityTest
Removed @DisableAccessibilityChecks from StoryActivityTest

All the tests are passing:--

![Screenshot from 2022-02-24 17-50-34](https://user-images.githubusercontent.com/78796264/155524336-1495d8b3-3e5b-481e-a3fb-8dc7b957a0f0.png)


![Screenshot from 2022-02-24 17-31-32](https://user-images.githubusercontent.com/78796264/155524345-1afefeaf-0ff4-4486-8678-65c22e5ddc92.png)




## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
