### PR TITLE
Fix part of #3245 : Enabling AccessibilityChecks for WalkthroughActivityTest

### DIFF
--- a/app/src/main/res/layout/walkthrough_activity.xml
+++ b/app/src/main/res/layout/walkthrough_activity.xml
@@ -30,8 +30,8 @@
 
     <ImageView
       android:id="@+id/back_button"
-      android:layout_width="32dp"
-      android:layout_height="32dp"
+      android:layout_width="48dp"
+      android:layout_height="48dp"
       android:layout_margin="16dp"
       android:clickable="true"
       android:contentDescription="@string/back_button"

--- a/app/src/main/res/layout/walkthrough_activity.xml
+++ b/app/src/main/res/layout/walkthrough_activity.xml
@@ -32,7 +32,7 @@
       android:id="@+id/back_button"
       android:layout_width="48dp"
       android:layout_height="48dp"
-      android:layout_margin="16dp"
+      android:padding="16dp"
       android:clickable="true"
       android:contentDescription="@string/back_button"
       android:focusable="true"

--- a/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughActivityTest.kt
@@ -62,7 +62,6 @@ import org.oppia.android.domain.platformparameter.PlatformParameterSingletonModu
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
-import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
@@ -142,7 +141,6 @@ class WalkthroughActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughActivity_incProgress_progressWorksCorrectly() {
     launch(WalkthroughActivity::class.java).use {
       onView(withId(R.id.walkthrough_welcome_next_button)).perform(scrollTo(), click())
@@ -151,7 +149,6 @@ class WalkthroughActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughActivity_incProgress_configChange_progressWorksCorrectly() {
     launch(WalkthroughActivity::class.java).use {
       onView(withId(R.id.walkthrough_welcome_next_button)).perform(scrollTo(), click())
@@ -162,7 +159,6 @@ class WalkthroughActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughActivity_pressNextBtn_configChange_pressBackBtn_backBtnWorksCorrectly() {
     launch(WalkthroughActivity::class.java).use {
       onView(withId(R.id.walkthrough_welcome_next_button)).perform(scrollTo(), click())
@@ -178,7 +174,6 @@ class WalkthroughActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughActivity_incProgress_onBackPress_decProgress_progressWorksCorrectly() {
     launch(WalkthroughActivity::class.java).use {
       onView(withId(R.id.walkthrough_welcome_next_button)).perform(scrollTo(), click())
@@ -189,7 +184,6 @@ class WalkthroughActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughActivity_incProgress_pressBackBtn_decProgress_progressWorksCorrectly() {
     launch(WalkthroughActivity::class.java).use {
       onView(withId(R.id.walkthrough_welcome_next_button)).perform(scrollTo(), click())

--- a/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughFinalFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughFinalFragmentTest.kt
@@ -65,7 +65,6 @@ import org.oppia.android.domain.platformparameter.PlatformParameterSingletonModu
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
-import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
@@ -131,7 +130,6 @@ class WalkthroughFinalFragmentTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughFinalFragment_topicSelected_firstTestTopicIsDisplayed() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
       testCoroutineDispatchers.runCurrent()
@@ -157,7 +155,6 @@ class WalkthroughFinalFragmentTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughFinalFragment_topicSelected_secondTestTopicIsDisplayed() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
       testCoroutineDispatchers.runCurrent()
@@ -183,7 +180,6 @@ class WalkthroughFinalFragmentTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughFinalFragment_topicSelected_configChange_secondTestTopicIsDisplayed() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
       testCoroutineDispatchers.runCurrent()
@@ -216,7 +212,6 @@ class WalkthroughFinalFragmentTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughFinalFragment_topicSelected_yesNoBtnIsDisplayed() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
       testCoroutineDispatchers.runCurrent()
@@ -240,7 +235,6 @@ class WalkthroughFinalFragmentTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughFinalFragment_topicSelected_clickNoBtn_noBtnWorksCorrectly() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
       testCoroutineDispatchers.runCurrent()

--- a/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughTopicListFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/walkthrough/WalkthroughTopicListFragmentTest.kt
@@ -66,7 +66,6 @@ import org.oppia.android.domain.platformparameter.PlatformParameterSingletonModu
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.topic.PrimeTopicAssetsControllerModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
-import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
@@ -138,7 +137,6 @@ class WalkthroughTopicListFragmentTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughTopicListFragment_topicHeader_whatDoYouWantToLearnIsDisplayed() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
       testCoroutineDispatchers.runCurrent()
@@ -159,7 +157,6 @@ class WalkthroughTopicListFragmentTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughTopicListFragment_topicCard_topicNameIsCorrect() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
       testCoroutineDispatchers.runCurrent()
@@ -186,7 +183,6 @@ class WalkthroughTopicListFragmentTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughTopicListFragment_topicCard_configChange_topicNameIsCorrect() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
       testCoroutineDispatchers.runCurrent()
@@ -214,7 +210,6 @@ class WalkthroughTopicListFragmentTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughTopicListFragment_topicCard_lessonThumbnailIsCorrect() {
     // TODO(#59): Remove if-check & disable test.
     if (!testEnvironmentConfig.isUsingBazel()) {
@@ -247,7 +242,6 @@ class WalkthroughTopicListFragmentTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testWalkthroughTopicListFragment_topicCard_lessonBackgroundColorIsCorrect() {
     launch<WalkthroughActivity>(createWalkthroughActivityIntent(0)).use {
       testCoroutineDispatchers.runCurrent()


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fix part of #3245  : Enable AccessibilityChecks for WalkthroughActivityTest
Removed the @DisableAccessibilityChecks Annotation from the WalkthroughActivityTest

Out of 10 tests , 5 were failing after removing @DisableAccessibilityChecks:--

1. testWalkthroughActivity_incProgress_onBackPress_decProgress_progressWorksCorrectly
2. testWalkthroughActivity_pressNextBtn_configChange_pressBackBtn_backBtnWorksCorrectly
3. testWalkthroughActivity_incProgress_pressBackBtn_decProgress_progressWorksCorrectly
4. testWalkthroughActivity_incProgress_configChange_progressWorksCorrectly
5. testWalkthroughActivity_incProgress_progressWorksCorrectly

Now all the 5 are passing:--
**1.** 
 ![Screenshot from 2022-02-24 19-13-10](https://user-images.githubusercontent.com/78796264/155537970-112c543a-2cf6-4235-9c32-1b47a23cd527.png)

**2.**
![Screenshot from 2022-02-24 19-14-42](https://user-images.githubusercontent.com/78796264/155538080-14ec5a28-2668-4e14-ba0d-2fe327607250.png)

**3.**
![Screenshot from 2022-02-24 19-15-28](https://user-images.githubusercontent.com/78796264/155538145-1c593cf3-015e-4bb0-9bec-93cd6886de0d.png)

**4.**
 ![Screenshot from 2022-02-24 19-16-24](https://user-images.githubusercontent.com/78796264/155538275-5dcf05b6-118d-425b-8532-377dcd0a40e3.png)

**5.**
![Screenshot from 2022-02-24 19-17-08](https://user-images.githubusercontent.com/78796264/155538331-093faf34-d72c-4519-8f7b-19b16eb183fa.png)
## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
