### PR TITLE
Fix #3906: Incorrect ouput for rich text in hints and solution [Blocked: #3852]

### DIFF
--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsViewModel.kt
@@ -1,5 +1,6 @@
 package org.oppia.android.app.hintsandsolution
 
+import androidx.core.text.HtmlCompat
 import androidx.databinding.ObservableField
 import androidx.lifecycle.ViewModel
 import org.oppia.android.R
@@ -98,7 +99,10 @@ class HintsViewModel @Inject constructor(
   fun computeHintListDropDownIconContentDescription(): String {
     return resourceHandler.getStringInLocaleWithWrapping(
       R.string.show_hide_hint_list,
-      hintsAndSolutionSummary.get() ?: DEFAULT_HINT_AND_SOLUTION_SUMMARY
+      HtmlCompat.fromHtml(
+        hintsAndSolutionSummary.get() ?: DEFAULT_HINT_AND_SOLUTION_SUMMARY,
+        HtmlCompat.FROM_HTML_MODE_LEGACY
+      )
     )
   }
 

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsViewModel.kt
@@ -2,7 +2,6 @@ package org.oppia.android.app.hintsandsolution
 
 import androidx.databinding.ObservableField
 import androidx.lifecycle.ViewModel
-import javax.inject.Inject
 import org.oppia.android.R
 import org.oppia.android.app.fragment.FragmentScope
 import org.oppia.android.app.model.HelpIndex
@@ -16,6 +15,7 @@ import org.oppia.android.domain.translation.TranslationController
 import org.oppia.android.util.gcsresource.DefaultResourceBucketName
 import org.oppia.android.util.parser.html.ExplorationHtmlParserEntityType
 import org.oppia.android.util.parser.html.HtmlParser
+import javax.inject.Inject
 
 /**
  * RecyclerView items are 2 times of (No. of Hints + Solution),

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -1117,6 +1117,7 @@ class StateFragmentTest {
   }
 
   @Test
+  @RunOn(TestPlatform.ESPRESSO)
   fun testStateFragment_showHintsAndSolution_hasCorrectContentDescription() {
     launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
       startPlayingExploration()

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -1118,36 +1118,6 @@ class StateFragmentTest {
   }
 
   @Test
-  fun testStateFragment_showHintsAndSolution_hasCorrectContentDescription() {
-    launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
-      startPlayingExploration()
-      clickContinueInteractionButton()
-
-      typeFractionText("1")
-      clickSubmitAnswerButton()
-      testCoroutineDispatchers.runCurrent()
-      scrollToViewType(FRACTION_INPUT_INTERACTION)
-      typeFractionText("1")
-      clickSubmitAnswerButton()
-      testCoroutineDispatchers.runCurrent()
-
-      // Reveal the hint
-      openHintsAndSolutionsDialog()
-      pressRevealHintButton(0)
-
-      // checking content description of hint
-      onView(withId(R.id.hint_list_drop_down_icon)).check(
-        matches(
-          withContentDescription(
-            "Show/Hide hint list of Remember that two halves," +
-              " when added together, make one whole."
-          )
-        )
-      )
-    }
-  }
-
-  @Test
   fun testStateFragment_forMisconception_showsLinkTextForConceptCard() {
     launchForExploration(FRACTIONS_EXPLORATION_ID_1, shouldSavePartialProgress = false).use {
       startPlayingExploration()

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -47,10 +47,6 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
-import java.io.IOException
-import java.util.concurrent.TimeoutException
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
 import org.hamcrest.BaseMatcher
 import org.hamcrest.CoreMatchers.allOf
@@ -170,6 +166,10 @@ import org.oppia.android.util.parser.image.ImageParsingModule
 import org.oppia.android.util.threading.BackgroundDispatcher
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
+import java.io.IOException
+import java.util.concurrent.TimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /** Tests for [StateFragment]. */
 @RunWith(AndroidJUnit4::class)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -2706,21 +2706,6 @@ class StateFragmentTest {
     return ApplicationProvider.getApplicationContext<TestApplication>().isOnRobolectric()
   }
 
-  private fun openHintsAndSolutionsDialog() {
-    onView(withId(R.id.hints_and_solution_fragment_container)).perform(click())
-    testCoroutineDispatchers.runCurrent()
-  }
-
-  private fun pressRevealHintButton(hintPosition: Int) {
-    onView(withId(R.id.hints_and_solution_recycler_view))
-      .inRoot(isDialog())
-      .perform(RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(hintPosition * 2))
-    onView(allOf(withId(R.id.reveal_hint_button), isDisplayed()))
-      .inRoot(isDialog())
-      .perform(click())
-    testCoroutineDispatchers.runCurrent()
-  }
-
   // TODO(#59): Remove these waits once we can ensure that the production executors are not depended on in tests.
   //  Sleeping is really bad practice in Espresso tests, and can lead to test flakiness. It shouldn't be necessary if we
   //  use a test executor service with a counting idle resource, but right now Gradle mixes dependencies such that both

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -23,6 +23,7 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToHolder
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.matcher.RootMatchers.isDialog
@@ -1117,16 +1118,24 @@ class StateFragmentTest {
   }
 
   @Test
-  @RunOn(TestPlatform.ESPRESSO)
   fun testStateFragment_showHintsAndSolution_hasCorrectContentDescription() {
     launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
       startPlayingExploration()
       clickContinueInteractionButton()
 
-      onView(withId(R.id.hint_bulb)).perform(click())
+      typeFractionText("1")
+      clickSubmitAnswerButton()
       testCoroutineDispatchers.runCurrent()
-      onView(withId(R.id.reveal_hint_button)).perform(click())
+      scrollToViewType(FRACTION_INPUT_INTERACTION)
+      typeFractionText("1")
+      clickSubmitAnswerButton()
       testCoroutineDispatchers.runCurrent()
+
+      //Reveal the hint
+      openHintsAndSolutionsDialog()
+      pressRevealHintButton(0)
+
+      //checking content description of hint
       onView(withId(R.id.hint_list_drop_down_icon)).check(
         matches(
           withContentDescription(
@@ -2725,6 +2734,21 @@ class StateFragmentTest {
 
   private fun isOnRobolectric(): Boolean {
     return ApplicationProvider.getApplicationContext<TestApplication>().isOnRobolectric()
+  }
+
+  private fun openHintsAndSolutionsDialog() {
+    onView(withId(R.id.hints_and_solution_fragment_container)).perform(click())
+    testCoroutineDispatchers.runCurrent()
+  }
+
+  private fun pressRevealHintButton(hintPosition: Int) {
+    onView(withId(R.id.hints_and_solution_recycler_view))
+      .inRoot(isDialog())
+      .perform(RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(hintPosition * 2))
+    onView(allOf(withId(R.id.reveal_hint_button), isDisplayed()))
+      .inRoot(isDialog())
+      .perform(click())
+    testCoroutineDispatchers.runCurrent()
   }
 
   // TODO(#59): Remove these waits once we can ensure that the production executors are not depended on in tests.

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -47,6 +47,10 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
+import java.io.IOException
+import java.util.concurrent.TimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
 import org.hamcrest.BaseMatcher
 import org.hamcrest.CoreMatchers.allOf
@@ -166,10 +170,6 @@ import org.oppia.android.util.parser.image.ImageParsingModule
 import org.oppia.android.util.threading.BackgroundDispatcher
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import java.io.IOException
-import java.util.concurrent.TimeoutException
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /** Tests for [StateFragment]. */
 @RunWith(AndroidJUnit4::class)
@@ -1111,6 +1111,27 @@ class StateFragmentTest {
       onView(withId(R.id.hint_bulb)).check(
         matches(
           withContentDescription(R.string.show_hints_and_solution)
+        )
+      )
+    }
+  }
+
+  @Test
+  fun testStateFragment_showHintsAndSolution_hasCorrectContentDescription() {
+    launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
+      startPlayingExploration()
+      clickContinueInteractionButton()
+
+      onView(withId(R.id.hint_bulb)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+      onView(withId(R.id.reveal_hint_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+      onView(withId(R.id.hint_list_drop_down_icon)).check(
+        matches(
+          withContentDescription(
+            "Show/Hide hint list of Remember that two halves," +
+              " when added together, make one whole."
+          )
         )
       )
     }

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -1131,11 +1131,11 @@ class StateFragmentTest {
       clickSubmitAnswerButton()
       testCoroutineDispatchers.runCurrent()
 
-      //Reveal the hint
+      // Reveal the hint
       openHintsAndSolutionsDialog()
       pressRevealHintButton(0)
 
-      //checking content description of hint
+      // checking content description of hint
       onView(withId(R.id.hint_list_drop_down_icon)).check(
         matches(
           withContentDescription(

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -22,6 +22,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToHolder
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
@@ -1303,6 +1304,31 @@ class StateFragmentLocalTest {
       // done to trigger the
       onView(withId(R.id.hints_and_solution_summary))
         .check(matches(withText(containsString("Remember that two halves"))))
+    }
+  }
+
+  @Test
+  fun testStateFragment_showHintsAndSolution_hasCorrectContentDescription() {
+    launchForExploration(TEST_EXPLORATION_ID_2).use {
+      startPlayingExploration()
+      clickContinueButton()
+      // Submit two incorrect answers.
+      submitFractionAnswer(answerText = "1/3")
+      submitFractionAnswer(answerText = "1/4")
+
+      // Reveal the hint.
+      openHintsAndSolutionsDialog()
+      pressRevealHintButton(hintPosition = 0)
+
+      // checking content description of hint
+      onView(withId(R.id.hint_list_drop_down_icon)).check(
+        matches(
+          ViewMatchers.withContentDescription(
+            "Show/Hide hint list of Remember that two halves," +
+              " when added together, make one whole."
+          )
+        )
+      )
     }
   }
 

--- a/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
@@ -196,22 +196,22 @@ class CustomHtmlContentHandler private constructor(
      */
     fun <T> fromHtml(
       html: String,
-      imageRetriever: T?,
+      imageRetriever: T,
       customTagHandlers: Map<String, CustomTagHandler>
     ): Spannable where T : Html.ImageGetter, T : ImageRetriever {
       // Adjust the HTML to allow the custom content handler to properly initialize custom tag
       // tracking.
-      if (imageRetriever != null) {
-        return HtmlCompat.fromHtml(
-          "<init-custom-handler/>$html",
-          HtmlCompat.FROM_HTML_MODE_LEGACY,
-          imageRetriever,
-          CustomHtmlContentHandler(customTagHandlers, imageRetriever),
-        ) as Spannable
-      }
       return HtmlCompat.fromHtml(
         "<init-custom-handler/>$html",
         HtmlCompat.FROM_HTML_MODE_LEGACY,
+        imageRetriever,
+        CustomHtmlContentHandler(customTagHandlers, imageRetriever),
+      ) as Spannable
+    }
+
+    fun fromHtml(html: String): Spannable {
+      return HtmlCompat.fromHtml(
+        "<init-custom-handler/>$html", HtmlCompat.FROM_HTML_MODE_LEGACY,
       ) as Spannable
     }
   }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
@@ -196,16 +196,22 @@ class CustomHtmlContentHandler private constructor(
      */
     fun <T> fromHtml(
       html: String,
-      imageRetriever: T,
+      imageRetriever: T?,
       customTagHandlers: Map<String, CustomTagHandler>
     ): Spannable where T : Html.ImageGetter, T : ImageRetriever {
       // Adjust the HTML to allow the custom content handler to properly initialize custom tag
       // tracking.
+      if (imageRetriever != null) {
+        return HtmlCompat.fromHtml(
+          "<init-custom-handler/>$html",
+          HtmlCompat.FROM_HTML_MODE_LEGACY,
+          imageRetriever,
+          CustomHtmlContentHandler(customTagHandlers, imageRetriever),
+        ) as Spannable
+      }
       return HtmlCompat.fromHtml(
         "<init-custom-handler/>$html",
         HtmlCompat.FROM_HTML_MODE_LEGACY,
-        imageRetriever,
-        CustomHtmlContentHandler(customTagHandlers, imageRetriever),
       ) as Spannable
     }
   }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParser.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParser.kt
@@ -46,16 +46,24 @@ class HtmlParser private constructor(
    */
   fun parseOppiaHtml(
     rawString: String,
-    htmlContentTextView: TextView? = null,
+    htmlContentTextView: TextView,
     supportsLinks: Boolean = false,
     supportsConceptCards: Boolean = false
   ): Spannable {
 
     // Canvas does not support RTL, it always starts from left to right in RTL due to which compound drawables are
     // not center aligned. To avoid this situation check if RTL is enabled and set the textDirection.
+    when (getLayoutDirection(htmlContentTextView)) {
+      ViewCompat.LAYOUT_DIRECTION_RTL -> {
+        htmlContentTextView.textDirection = View.TEXT_DIRECTION_ANY_RTL
+      }
+      ViewCompat.LAYOUT_DIRECTION_LTR -> {
+        htmlContentTextView.textDirection = View.TEXT_DIRECTION_LTR
+      }
+    }
+    htmlContentTextView.invalidate()
+
     var htmlContent = rawString
-    val htmlSpannable: Spannable
-    val spannableBuilder: SpannableStringBuilder
     if ("\n\t" in htmlContent) {
       htmlContent = htmlContent.replace("\n\t", "")
     }
@@ -66,39 +74,41 @@ class HtmlParser private constructor(
       htmlContent = htmlContent.replace("<li>", "<$CUSTOM_BULLET_LIST_TAG>")
         .replace("</li>", "</$CUSTOM_BULLET_LIST_TAG>")
     }
-    if (htmlContentTextView != null) {
-      when (getLayoutDirection(htmlContentTextView)) {
-        ViewCompat.LAYOUT_DIRECTION_RTL -> {
-          htmlContentTextView.textDirection = View.TEXT_DIRECTION_ANY_RTL
-        }
-        ViewCompat.LAYOUT_DIRECTION_LTR -> {
-          htmlContentTextView.textDirection = View.TEXT_DIRECTION_LTR
-        }
-      }
-      htmlContentTextView.invalidate()
 
-      // https://stackoverflow.com/a/8662457
-      if (supportsLinks) {
-        htmlContentTextView.movementMethod = LinkMovementMethod.getInstance()
-      }
-
-      val imageGetter = urlImageParserFactory.create(
-        htmlContentTextView, gcsResourceName, entityType, entityId, imageCenterAlign
-      )
-      htmlSpannable = CustomHtmlContentHandler.fromHtml(
-        htmlContent, imageGetter, computeCustomTagHandlers(supportsConceptCards)
-      )
-
-      spannableBuilder = CustomBulletSpan.replaceBulletSpan(
-        SpannableStringBuilder(htmlSpannable),
-        htmlContentTextView.context
-      )
-    } else {
-      htmlSpannable = CustomHtmlContentHandler.fromHtml(
-        htmlContent, null, computeCustomTagHandlers(supportsConceptCards)
-      )
-      spannableBuilder = SpannableStringBuilder(htmlSpannable)
+    // https://stackoverflow.com/a/8662457
+    if (supportsLinks) {
+      htmlContentTextView.movementMethod = LinkMovementMethod.getInstance()
     }
+
+    val imageGetter = urlImageParserFactory.create(
+      htmlContentTextView, gcsResourceName, entityType, entityId, imageCenterAlign
+    )
+    val htmlSpannable = CustomHtmlContentHandler.fromHtml(
+      htmlContent, imageGetter, computeCustomTagHandlers(supportsConceptCards)
+    )
+
+    val spannableBuilder = CustomBulletSpan.replaceBulletSpan(
+      SpannableStringBuilder(htmlSpannable),
+      htmlContentTextView.context
+    )
+    return ensureNonEmpty(trimSpannable(spannableBuilder))
+  }
+
+  fun parseOppiaHtml(rawString: String): Spannable {
+    var htmlContent = rawString
+    if ("\n\t" in htmlContent) {
+      htmlContent = htmlContent.replace("\n\t", "")
+    }
+    if ("\n\n" in htmlContent) {
+      htmlContent = htmlContent.replace("\n\n", "")
+    }
+    if ("<li>" in htmlContent) {
+      htmlContent = htmlContent.replace("<li>", "<$CUSTOM_BULLET_LIST_TAG>")
+        .replace("</li>", "</$CUSTOM_BULLET_LIST_TAG>")
+    }
+
+    val htmlSpannable = CustomHtmlContentHandler.fromHtml(htmlContent)
+    val spannableBuilder = SpannableStringBuilder(htmlSpannable)
     return ensureNonEmpty(trimSpannable(spannableBuilder))
   }
 

--- a/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParser.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParser.kt
@@ -6,9 +6,9 @@ import android.text.method.LinkMovementMethod
 import android.view.View
 import android.widget.TextView
 import androidx.core.view.ViewCompat
-import javax.inject.Inject
 import org.oppia.android.util.logging.ConsoleLogger
 import org.oppia.android.util.parser.image.UrlImageParser
+import javax.inject.Inject
 
 /** Html Parser to parse custom Oppia tags with Android-compatible versions. */
 class HtmlParser private constructor(


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix #3906:  Parsed HTML to normal text while setting Content Description for Hints and Solution. 

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

https://user-images.githubusercontent.com/43074241/155514660-2daadc00-a73d-4d51-a702-b52ed341d09a.mp4

