### PR TITLE
Fix #4200 Add dark mode support to AudioLanguageActivity, ReadingTextSizeActivity, AppLanguageActivity and dialog views.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,12 +6,12 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 31
   buildToolsVersion "29.0.2"
   defaultConfig {
     applicationId "org.oppia.android"
     minSdkVersion 19
-    targetSdkVersion 29
+    targetSdkVersion 31
     versionCode 1
     versionName "1.0"
     multiDexEnabled true
@@ -139,6 +139,8 @@ dependencies {
       'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1',
       'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1',
       'org.mockito:mockito-core:2.7.22',
+      'androidx.cardview:cardview:1.0.0',
+      'com.google.android.material:material:1.5.0'
   )
   compileOnly(
       'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2',

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -88,11 +88,11 @@
     <activity
       android:name=".app.options.AppLanguageActivity"
       android:label="@string/app_language_activity_title"
-      android:theme="@style/OppiaThemeWithoutActionBar" />
+      android:theme="@style/AppTheme.darkMode" />
     <activity
       android:name=".app.options.AudioLanguageActivity"
       android:label="@string/audio_language_activity_title"
-      android:theme="@style/OppiaThemeWithoutActionBar" />
+      android:theme="@style/AppTheme.darkMode" />
     <activity
       android:name=".app.options.OptionsActivity"
       android:label="@string/options_activity_title"
@@ -100,7 +100,7 @@
     <activity
       android:name=".app.options.ReadingTextSizeActivity"
       android:label="@string/reading_text_size_activity_title"
-      android:theme="@style/OppiaThemeWithoutActionBar" />
+      android:theme="@style/AppTheme.darkMode" />
     <activity
       android:name=".app.player.exploration.ExplorationActivity"
       android:label="@string/exploration_activity_title"
@@ -132,7 +132,7 @@
     <activity
       android:name=".app.profileprogress.ProfilePictureActivity"
       android:label="@string/profile_picture_activity_title"
-      android:theme="@style/OppiaThemeWithoutActionBar" />
+      android:theme="@style/AppTheme.darkMode" />
     <activity
       android:name=".app.profileprogress.ProfileProgressActivity"
       android:label="@string/profile_progress_activity_title"

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivity.kt
@@ -19,7 +19,7 @@ class AppVersionActivity : InjectableAppCompatActivity() {
     appVersionActivityPresenter.handleOnCreate()
   }
 
-  override fun onOptionsItemSelected(item: MenuItem?): Boolean {
+  override fun onOptionsItemSelected(item: MenuItem): Boolean {
     if (item?.itemId == android.R.id.home) {
       onBackPressed()
     }

--- a/app/src/main/java/org/oppia/android/app/help/faq/faqsingle/FAQSingleActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/help/faq/faqsingle/FAQSingleActivity.kt
@@ -18,7 +18,11 @@ class FAQSingleActivity : InjectableAppCompatActivity() {
     (activityComponent as ActivityComponentImpl).inject(this)
     val question = intent.getStringExtra(FAQ_SINGLE_ACTIVITY_QUESTION)
     val answer = intent.getStringExtra(FAQ_SINGLE_ACTIVITY_ANSWER)
-    faqSingleActivityPresenter.handleOnCreate(question, answer)
+    if (question != null) {
+      if (answer != null) {
+        faqSingleActivityPresenter.handleOnCreate(question, answer)
+      }
+    }
   }
 
   companion object {

--- a/app/src/main/java/org/oppia/android/app/options/AppLanguageActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AppLanguageActivity.kt
@@ -17,10 +17,10 @@ class AppLanguageActivity : InjectableAppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     (activityComponent as ActivityComponentImpl).inject(this)
-    prefKey = intent.getStringExtra(APP_LANGUAGE_PREFERENCE_TITLE_EXTRA_KEY)
-    prefSummaryValue = if (savedInstanceState == null) {
+    prefKey = intent.getStringExtra(APP_LANGUAGE_PREFERENCE_TITLE_EXTRA_KEY).toString()
+    prefSummaryValue = if (savedInstanceState == null) ({
       intent.getStringExtra(APP_LANGUAGE_PREFERENCE_SUMMARY_VALUE_EXTRA_KEY)
-    } else {
+    }).toString() else {
       savedInstanceState.get(SELECTED_LANGUAGE_EXTRA_KEY) as String
     }
     appLanguageActivityPresenter.handleOnCreate(prefKey, prefSummaryValue)

--- a/app/src/main/java/org/oppia/android/app/options/AudioLanguageActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AudioLanguageActivity.kt
@@ -18,12 +18,12 @@ class AudioLanguageActivity : InjectableAppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     (activityComponent as ActivityComponentImpl).inject(this)
-    prefKey = intent.getStringExtra(AUDIO_LANGUAGE_PREFERENCE_TITLE_EXTRA_KEY)
+    prefKey = intent.getStringExtra(AUDIO_LANGUAGE_PREFERENCE_TITLE_EXTRA_KEY).toString()
     prefSummaryValue = if (savedInstanceState != null) {
       savedInstanceState.get(AUDIO_LANGUAGE_PREFERENCE_SUMMARY_VALUE_EXTRA_KEY) as String
-    } else {
+    } else ({
       intent.getStringExtra(AUDIO_LANGUAGE_PREFERENCE_SUMMARY_VALUE_EXTRA_KEY)
-    }
+    }).toString()
     audioLanguageActivityPresenter.handleOnCreate(prefKey, prefSummaryValue)
   }
 

--- a/app/src/main/java/org/oppia/android/app/options/ReadingTextSizeActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/options/ReadingTextSizeActivity.kt
@@ -18,7 +18,7 @@ class ReadingTextSizeActivity : InjectableAppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     (activityComponent as ActivityComponentImpl).inject(this)
-    prefKey = intent.getStringExtra(KEY_READING_TEXT_SIZE_PREFERENCE_TITLE)
+    prefKey = intent.getStringExtra(KEY_READING_TEXT_SIZE_PREFERENCE_TITLE).toString()
     prefSummaryValue = (
       if (savedInstanceState != null) {
         savedInstanceState.get(KEY_READING_TEXT_SIZE_PREFERENCE_SUMMARY_VALUE)

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivity.kt
@@ -54,9 +54,9 @@ class ExplorationActivity :
     super.onCreate(savedInstanceState)
     (activityComponent as ActivityComponentImpl).inject(this)
     internalProfileId = intent.getIntExtra(EXPLORATION_ACTIVITY_PROFILE_ID_ARGUMENT_KEY, -1)
-    topicId = intent.getStringExtra(EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY)
-    storyId = intent.getStringExtra(EXPLORATION_ACTIVITY_STORY_ID_ARGUMENT_KEY)
-    explorationId = intent.getStringExtra(EXPLORATION_ACTIVITY_EXPLORATION_ID_ARGUMENT_KEY)
+    topicId = intent.getStringExtra(EXPLORATION_ACTIVITY_TOPIC_ID_ARGUMENT_KEY).toString()
+    storyId = intent.getStringExtra(EXPLORATION_ACTIVITY_STORY_ID_ARGUMENT_KEY).toString()
+    explorationId = intent.getStringExtra(EXPLORATION_ACTIVITY_EXPLORATION_ID_ARGUMENT_KEY).toString()
     backflowScreen = intent.getIntExtra(EXPLORATION_ACTIVITY_BACKFLOW_SCREEN_KEY, -1)
     isCheckpointingEnabled =
       intent.getBooleanExtra(EXPLORATION_ACTIVITY_IS_CHECKPOINTING_ENABLED_KEY, false)
@@ -123,7 +123,7 @@ class ExplorationActivity :
     return super.onCreateOptionsMenu(menu)
   }
 
-  override fun onOptionsItemSelected(item: MenuItem?): Boolean {
+  override fun onOptionsItemSelected(item: MenuItem): Boolean {
     return explorationActivityPresenter.handleOnOptionsItemSelected(item)
   }
 

--- a/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivityPresenter.kt
@@ -92,10 +92,12 @@ class AdminAuthActivityPresenter @Inject constructor(
             activity.finish()
           }
         }
-      } else if (inputPin.length == adminPin.length) {
-        authViewModel.errorMessage.set(
-          resourceHandler.getStringInLocale(R.string.admin_auth_incorrect)
-        )
+      } else if (adminPin != null) {
+        if (inputPin.length == adminPin.length) {
+          authViewModel.errorMessage.set(
+            resourceHandler.getStringInLocale(R.string.admin_auth_incorrect)
+          )
+        }
       }
     }
   }

--- a/app/src/main/java/org/oppia/android/app/testing/TestFontScaleConfigurationUtilActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/TestFontScaleConfigurationUtilActivity.kt
@@ -17,7 +17,9 @@ class TestFontScaleConfigurationUtilActivity : InjectableAppCompatActivity() {
     super.onCreate(savedInstanceState)
     (activityComponent as ActivityComponentImpl).inject(this)
     val readingTextSize = intent.getStringExtra(FONT_SCALE_EXTRA_KEY)
-    configUtilActivityPresenter.handleOnCreate(readingTextSize)
+    if (readingTextSize != null) {
+      configUtilActivityPresenter.handleOnCreate(readingTextSize)
+    }
   }
 
   companion object {

--- a/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityPresenter.kt
@@ -92,56 +92,54 @@ class QuestionPlayerActivityPresenter @Inject constructor(
     val skillIds =
       activity.intent.getStringArrayListExtra(QUESTION_PLAYER_ACTIVITY_SKILL_ID_LIST_ARGUMENT_KEY)
     val startDataProvider =
-      questionTrainingController.startQuestionTrainingSession(profileId, skillIds)
-    startDataProvider.toLiveData().observe(
-      activity,
-      {
-        when {
-          it.isPending() -> oppiaLogger.d(
+      skillIds?.let { questionTrainingController.startQuestionTrainingSession(profileId, it) }
+    startDataProvider?.toLiveData()?.observe(
+      activity
+    ) {
+      when {
+        it.isPending() -> oppiaLogger.d(
+          "QuestionPlayerActivity",
+          "Starting training session"
+        )
+        it.isFailure() -> {
+          oppiaLogger.e(
             "QuestionPlayerActivity",
-            "Starting training session"
+            "Failed to start training session",
+            it.getErrorOrNull()!!
           )
-          it.isFailure() -> {
-            oppiaLogger.e(
-              "QuestionPlayerActivity",
-              "Failed to start training session",
-              it.getErrorOrNull()!!
-            )
-            activity.finish() // Can't recover from the session failing to start.
-          }
-          else -> {
-            oppiaLogger.d("QuestionPlayerActivity", "Successfully started training session")
-            callback()
-          }
+          activity.finish() // Can't recover from the session failing to start.
+        }
+        else -> {
+          oppiaLogger.d("QuestionPlayerActivity", "Successfully started training session")
+          callback()
         }
       }
-    )
+    }
   }
 
   private fun stopTrainingSessionWithCallback(callback: () -> Unit) {
     questionTrainingController.stopQuestionTrainingSession().toLiveData().observe(
-      activity,
-      {
-        when {
-          it.isPending() -> oppiaLogger.d(
+      activity
+    ) {
+      when {
+        it.isPending() -> oppiaLogger.d(
+          "QuestionPlayerActivity",
+          "Stopping training session"
+        )
+        it.isFailure() -> {
+          oppiaLogger.e(
             "QuestionPlayerActivity",
-            "Stopping training session"
+            "Failed to stop training session",
+            it.getErrorOrNull()!!
           )
-          it.isFailure() -> {
-            oppiaLogger.e(
-              "QuestionPlayerActivity",
-              "Failed to stop training session",
-              it.getErrorOrNull()!!
-            )
-            activity.finish() // Can't recover from the session failing to stop.
-          }
-          else -> {
-            oppiaLogger.d("QuestionPlayerActivity", "Successfully stopped training session")
-            callback()
-          }
+          activity.finish() // Can't recover from the session failing to stop.
+        }
+        else -> {
+          oppiaLogger.d("QuestionPlayerActivity", "Successfully stopped training session")
+          callback()
         }
       }
-    )
+    }
   }
 
   fun onKeyboardAction(actionCode: Int) {

--- a/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivity.kt
@@ -36,7 +36,7 @@ class RevisionCardActivity :
     return super.onCreateOptionsMenu(menu)
   }
 
-  override fun onOptionsItemSelected(item: MenuItem?): Boolean {
+  override fun onOptionsItemSelected(item: MenuItem): Boolean {
     return revisionCardActivityPresenter.handleOnOptionsItemSelected(item)
   }
 

--- a/app/src/main/res/layout/app_language_activity.xml
+++ b/app/src/main/res/layout/app_language_activity.xml
@@ -2,4 +2,5 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
   android:id="@+id/app_language_fragment_container"
   android:layout_width="match_parent"
-  android:layout_height="match_parent" />
+  android:layout_height="match_parent"
+  android:background="?attr/background_color"/>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
   <!-- Base style for animations.  This style specifies no animations. -->
   <style name="Animation" />
   <!-- Standard animations for a full-screen window or activity. -->
@@ -19,4 +19,5 @@
     <item name="android:progressTint">@color/oppia_primary_light</item>
     <item name="android:colorControlActivated">@color/oppia_primary_light</item>
   </style>
+
 </resources>

--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -40,4 +40,9 @@
     <item name="android:buttonBarNegativeButtonStyle">@style/textAllCaps</item>
     <item name="android:buttonBarPositiveButtonStyle">@style/textAllCaps</item>
   </style>
+
+  <style name="Theme.DarkMode" parent = "Theme.MaterialComponents.DayNight.NoActionBar">
+    <item name="background_color">#000000</item>
+    <item name="text_color">#FFFFFF</item>
+  </style>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,7 +54,7 @@
   <string name="previous_responses_header">Previous Responses (%s)</string>
   <string name="image_interaction_answer_text">Clicks on %s</string>
   <string name="state_learn_again_button">Learn Again</string>
-  <string name="topic_download_text">(%s)</string>
+  <string name="topic_download_text" translatable="false">(%s)</string>
   <string name="see_more">See More</string>
   <string name="see_less">See Less</string>
   <string name="FAQs">FAQs</string>
@@ -73,17 +73,17 @@
   <string name="topic_name">Topic: %s</string>
   <string name="topic">Topic</string>
   <string name="ongoing_topic_list_activity_title">Topics in Progress</string>
-  <string name="topic_story_progress_percentage">%s\%%</string>
-  <string name="topic_play_chapter_index">%s.</string>
-  <string name="chapter_name">Chapter %s: %s</string>
+  <string name="topic_story_progress_percentage" translatable="false">%s\%%</string>
+  <string name="topic_play_chapter_index" translatable="false">%s.</string>
+  <string name="chapter_name">Chapter %s: %s</string>ion in the form x/x.</resources>
+<string name="numeric_input_hint">Enter a number.</string>
+<string name="number_with_units_input_hint_text">Write numbers w
   <string name="chapter_completed">Chapter %s with title %s is completed</string>
   <string name="chapter_in_progress">Chapter %s with title %s is in progress</string>
   <string name="chapter_prerequisite_title_label">Complete Chapter %s: %s to unlock this chapter.</string>
   <string name="text_input_default_content_description">Enter text.</string>
   <string name="fractions_default_hint_text">Enter a fraction in the form x/x, or a mixed number in the form x x/x.</string>
-  <string name="fractions_default_hint_text_no_integer">Enter a fraction in the form x/x.</string>
-  <string name="numeric_input_hint">Enter a number.</string>
-  <string name="number_with_units_input_hint_text">Write numbers with units here.</string>
+  <string name="fractions_default_hint_text_no_integer">Enter a fractith units here.</string>
   <string name="enable_audio_playback_content_description">Enable audio voiceover for this lesson.</string>
   <string name="recently_played_stories">Recently-Played Stories</string>
   <string name="last_played_stories">Last-Played Stories</string>
@@ -140,7 +140,7 @@
   <string name="size_gb">%s GB</string>
   <string name="correct">Correct!</string>
   <string name="topic_prefix">Topic: %s</string>
-  <string name="welcome_profile_name">%s!</string>
+  <string name="welcome_profile_name" translatable="false">%s!</string>
   <string name="chapter_count_with_story_name">%1$s in %2$s</string>
   <plurals name="chapter_count">
     <item quantity="one">
@@ -192,7 +192,7 @@
       %s Topics in Progress
     </item>
   </plurals>
-  <string name="bar_separator">\u0020|\u0020</string>
+  <string name="bar_separator" translatable="false">\u0020|\u0020</string>
   <!-- ProfileChooserFragment -->
   <string name="profile_chooser_activity_label">Profile selection page</string>
   <string name="profile_chooser_admin">Administrator</string>
@@ -261,8 +261,8 @@
   <string name="pin_password_hello">Hi, %s!</string>
   <string name="pin_password_admin_enter">Please enter your Administrator PIN.</string>
   <string name="pin_password_user_enter">Please enter your PIN.</string>
-  <string name="input_pin_password_as_admin">Administrator’s 5-Digit PIN.</string>
-  <string name="input_pin_password_as_user">User’s 3-Digit PIN.</string>
+  <string name="input_pin_password_as_admin" translatable="false">Administrator’s 5-Digit PIN.</string>
+  <string name="input_pin_password_as_user" translatable="false">User’s 3-Digit PIN.</string>
   <string name="pin_password_forgot_pin">I forgot my pin.</string>
   <string name="pin_password_incorrect_pin">Incorrect PIN.</string>
   <string name="pin_password_show">show</string>
@@ -276,7 +276,7 @@
   <string name="password_shown_icon">Password shown icon</string>
   <string name="password_hidden_icon">Password hidden icon</string>
   <string name="enter_your_pin">Enter your PIN</string>
-  <string name="pin_password_toolbar_title">Enter PIN</string>
+  <string name="pin_password_toolbar_title" translatable="false">Enter PIN</string>
   <!-- AdminSettingsDialogFragment -->
   <string name="admin_settings_label">Administrator\'s PIN</string>
   <string name="admin_settings_heading">Access to Administrator Settings</string>
@@ -312,7 +312,7 @@
   <string name="profile_edit_allow_download_heading">Allow Download Access</string>
   <string name="profile_edit_allow_download_sub">User is able to download and delete content without Administrator password</string>
   <!-- ProfilePictureActivity -->
-  <string name="profile_picture_activity_title">Profile Picture</string>
+  <string name="profile_picture_activity_title" translatable="false">Profile Picture</string>
   <!-- ProfileProgressActivity -->
   <string name="profile_progress_edit_dialog_title">Profile Picture</string>
   <string name="profile_picture_edit_alert_dialog_cancel_button">Cancel</string>
@@ -381,7 +381,7 @@
   <!-- CompletedStoryListActivity -->
   <string name="completed_story_list_activity_title">Stories Completed</string>
   <!-- WalkthroughActivity -->
-  <string name="walkthrough_activity_title">App walkthrough</string>
+  <string name="walkthrough_activity_title" translatable="false">App walkthrough</string>
   <string name="walkthrough_welcome_description">Learn new math skills with stories that show you how to use them in your daily life</string>
   <string name="welcome">"Welcome %s!"</string>
   <!-- WalkthroughTopicListFragment -->
@@ -407,7 +407,7 @@
   <string name="reveal">Reveal</string>
   <!-- TextViewBindingAdapters -->
   <string name="just_now">just now</string>
-  <string name="last_logged_in_recently">recently</string>
+  <string name="last_logged_in_recently" translatable="false">recently</string>
   <string name="time_ago">%s ago</string>
   <string name="yesterday">yesterday</string>
   <string name="return_to_topic">Return to topic</string>
@@ -433,9 +433,9 @@
     <item quantity="other">%s days</item>
   </plurals>
   <!-- ViewTags -->
-  <string name="topic_revision_recyclerview_tag">topic_revision_recyclerview_tag</string>
-  <string name="ongoing_recycler_view_tag">ongoing_recycler_view_tag</string>
-  <string name="completed_story_list_recyclerview_tag">completed_story_list_recyclerview_tag</string>
+  <string name="topic_revision_recyclerview_tag" translatable="false">topic_revision_recyclerview_tag</string>
+  <string name="ongoing_recycler_view_tag" translatable="false">ongoing_recycler_view_tag</string>
+  <string name="completed_story_list_recyclerview_tag" translatable="false">completed_story_list_recyclerview_tag</string>
   <string name="item_selection_text">Please select at least one choice.</string>
   <!-- SplashActivity -->
   <string name="unsupported_app_version_dialog_title" description="The title of the dialog shown when a user's pre-release app has expired.">
@@ -464,7 +464,7 @@
   <string name="audio_language_icon_content_description">Change language</string>
   <string name="audio_player_on">Audio, ON</string>
   <string name="audio_player_off">Audio, OFF</string>
-  <string name="hints_android_solution_correct_answer">%s/%s</string>
+  <string name="hints_android_solution_correct_answer" translatable="false">%s/%s</string>
   <string name="correct_submitted_answer">Correct submitted answer</string>
   <string name="correct_submitted_answer_with_append">Correct submitted answer: %s</string>
   <string name="incorrect_submitted_answer">Incorrect submitted answer</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
   <!-- This style specifies the Text Size of the Toolbar Title. -->
   <style name="ToolbarTitle" parent="@style/TextAppearance.Widget.AppCompat.Toolbar.Title">
     <item name="android:textSize">20sp</item>
@@ -463,5 +463,11 @@
 
   <style name="TextViewCenterHorizontal" parent="TextView.Common1">
     <item name="android:gravity">center_horizontal</item>
+  </style>
+  <style name="AppTheme.darkMode" parent = "Theme.AppCompat.Light.DarkActionBar">
+    <iten name = "colorPrimary">@color/colorPrimary</iten>
+    <item name = "colorPrimaryDark">@color/colorPrimaryDark</item>
+    <item name="colorAccent">@color/colorAccent</item>
+    <item name="android:forceDarkAllowed" tools:ignore="NewApi" tools:targetApi="q">true</item>
   </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -43,4 +43,9 @@
   <style name="OppiaActionBarTheme" parent="ThemeOverlay.MaterialComponents.Dark.ActionBar" >
     <item name="android:background">@color/shared_activity_action_bar_color</item>
   </style>
+  
+  <style name="Theme.Light" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <item name="background_color">#FFFFFF</item>
+    <item name="text_color">#000000</item>
+  </style>
 </resources>

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 31
   buildToolsVersion "29.0.2"
 
   defaultConfig {
     minSdkVersion 19
-    targetSdkVersion 29
+    targetSdkVersion 31
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 31
   buildToolsVersion "29.0.2"
 
   defaultConfig {
     minSdkVersion 19
-    targetSdkVersion 29
+    targetSdkVersion 31
     versionCode 1
     versionName "1.0"
     javaCompileOptions {

--- a/domain/src/main/java/org/oppia/android/domain/topic/PrimeTopicAssetsControllerImpl.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/PrimeTopicAssetsControllerImpl.kt
@@ -199,13 +199,13 @@ class PrimeTopicAssetsControllerImpl @Inject constructor(
     // Reference: https://stackoverflow.com/a/37713320.
     val application = context.applicationContext as Application
     application.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
-      override fun onActivityPaused(activity: Activity?) {}
-      override fun onActivityResumed(activity: Activity?) {}
-      override fun onActivityStarted(activity: Activity?) {}
-      override fun onActivityDestroyed(activity: Activity?) {}
-      override fun onActivitySaveInstanceState(activity: Activity?, outState: Bundle?) {}
-      override fun onActivityStopped(activity: Activity?) {}
-      override fun onActivityCreated(activity: Activity?, savedInstanceState: Bundle?) {
+      override fun onActivityPaused(activity: Activity) {}
+      override fun onActivityResumed(activity: Activity) {}
+      override fun onActivityStarted(activity: Activity) {}
+      override fun onActivityDestroyed(activity: Activity) {}
+      override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+      override fun onActivityStopped(activity: Activity) {}
+      override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         if (!dialogDismissed.get()) {
           activity?.let {
             val appCompatActivity = it as AppCompatActivity

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4096m
+org.gradle.jvmargs=-Xmx512m
 # Allows gradle to use build cache
 org.gradle.caching=-true
 # When configured, Gradle will run in incubating parallel mode.

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 31
   buildToolsVersion "29.0.2"
 
   defaultConfig {
     minSdkVersion 19
-    targetSdkVersion 29
+    targetSdkVersion 31
     versionCode 1
     versionName "1.0"
   }

--- a/utility/build.gradle
+++ b/utility/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 31
   buildToolsVersion "29.0.2"
 
   defaultConfig {
     minSdkVersion 19
-    targetSdkVersion 29
+    targetSdkVersion 31
     versionCode 1
     versionName "1.0"
     javaCompileOptions {

--- a/utility/src/main/AndroidManifest.xml
+++ b/utility/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.android.util">
   <uses-sdk android:targetSdkVersion="28" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/utility/src/main/java/org/oppia/android/util/logging/firebase/FirebaseEventLogger.kt
+++ b/utility/src/main/java/org/oppia/android/util/logging/firebase/FirebaseEventLogger.kt
@@ -31,7 +31,7 @@ class FirebaseEventLogger(
     // TODO(#3792): Remove this usage of Locale.
     firebaseAnalytics.setUserProperty(COUNTRY_USER_PROPERTY, Locale.getDefault().displayCountry)
     firebaseAnalytics.setUserProperty(
-      NETWORK_USER_PROPERTY, connectivityManager.activeNetworkInfo.typeName
+      NETWORK_USER_PROPERTY, connectivityManager.activeNetworkInfo?.typeName
     )
   }
 }


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
