### PR TITLE
Fix #4255: Add support for sharding app module Gradle tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,12 +97,13 @@ jobs:
           name: testing reports
           path: testing/build/reports
 
-  app_tests:
-    name: App Module Robolectric Tests
-    runs-on: ${{ matrix.os }}
+  run_app_module_test:
+    name: Run app module Robolectric test shard
+    runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        shard: [shard0, shard0, shard0, shard0]
     steps:
       - uses: actions/checkout@v2
 
@@ -136,3 +137,16 @@ jobs:
         with:
           name: app reports
           path: app/build/reports
+
+  app_tests:
+    name: App Module Robolectric Tests
+    needs: run_app_module_test
+    if: ${{ always() }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04]
+    steps:
+      - name: Check tests passed (for tests that ran)
+        if: ${{ needs.run_app_module_test.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [shard0, shard0, shard0, shard0]
+        shard: [shard0, shard1, shard2, shard3]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Robolectric tests - App Module
         # We require 'sudo' to avoid an error of the existing android sdk. See https://github.com/actions/starter-workflows/issues/58
         run: |
-          sudo ./gradlew --full-stacktrace :app:testDebugUnitTest -Dorg.gradle.java.home=$JAVA_HOME
+          sudo ./gradlew --full-stacktrace :app:testDebugUnitTest --${{ matrix.shard }} -Dorg.gradle.java.home=$JAVA_HOME
       - name: Upload App Test Reports
         uses: actions/upload-artifact@v2
         if: ${{ always() }} # IMPORTANT: Upload reports regardless of status

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ always() }} # IMPORTANT: Upload reports regardless of status
         with:
-          name: app reports
+          name: app reports ${{ matrix.shard }}
           path: app/build/reports
 
   app_tests:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,11 +97,48 @@ def filesToExclude = [
     '**/*AppLanguageResourceHandlerTest*.kt',
     '**/*AppLanguageWatcherMixinTest*.kt',
 ]
-tasks.withType(SourceTask.class).configureEach {
-  it.exclude(filesToExclude)
+_excludeTestFiles(filesToExclude)
+
+// Check if sharding is being attempted and, if so, exclude all tests that aren't in the specified
+// shard. The approach to using arguments was inspired by
+// https://prandroid.dev/Parallel-unit-tests-in-android/.
+
+// NOTE TO DEVELOPER: You likely will need to clean before running any of these, and you can't run
+// one shard after another without cleaning first (since Gradle doesn't handle file exclusion well,
+// it expects files to be present corresponding to generated code, such as Dagger, from previous
+// runs).
+def appModuleShardCount = 4
+def shardIndexes = 0..(appModuleShardCount - 1)
+shardIndexes.each { shardIndex ->
+  if (project.gradle.startParameter?.taskRequests?.args[0]?.remove("--shard$shardIndex".toString())) {
+    def filesToExcludeForShard = _computeTestsCorrespondingToShard(appModuleShardCount, shardIndex, true)
+    println("Excluding ${filesToExcludeForShard.size} tests for shard $shardIndex")
+    _excludeTestFiles(filesToExcludeForShard.collect {
+      // Ensure the test paths are properly relative to the app module so that their exclusion
+      // filters match (but keep the unique relative paths to avoid accidentally skipping tests that
+      // share names). Note that the 'org/oppia/android/app' part is specifically included to ensure
+      // that cases where a path relative to org/oppia/android/app is fully overlapping with another
+      // path result in one of the tests being ignored in all shards.
+      def prefixToExclude = "org/oppia/android/app/"
+      "**/${it.substring(it.indexOf(prefixToExclude))}"
+    })
+  }
 }
-android.sourceSets.test.java.exclude(filesToExclude)
-android.sourceSets.test.kotlin.exclude(filesToExclude)
+if (project.gradle.startParameter?.taskRequests?.args[0]?.remove("--list-shards")) {
+  println()
+  println("The app module supports $appModuleShardCount shards")
+  println()
+  shardIndexes.each { shardIndex ->
+    def filesInShard = _computeTestsCorrespondingToShard(appModuleShardCount, shardIndex, false).sort()
+    println("Shard $shardIndex has ${filesInShard.size} tests:")
+    filesInShard.each { filePath ->
+      println("- $filePath")
+    }
+    println()
+  }
+  // This is a hacky way to make an 'information' command.
+  _excludeTestFiles("**/*Test.kt")
+}
 
 dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
@@ -216,4 +253,48 @@ dependencies {
 // The below command stops that from happening: https://github.com/google/tink/issues/282
 configurations {
   all*.exclude module: 'protobuf-java'
+}
+
+def _computeTestsCorrespondingToShard(shardCount, shardIndex, exclude) {
+  def allAppTestDirs = android.sourceSets.test.java.source +
+          android.sourceSets.test.kotlin.source +
+          android.sourceSets.androidTest.java.source +
+          android.sourceSets.androidTest.kotlin.source
+  def allAppTestFiles = []
+  // https://stackoverflow.com/a/38899519/3689782 for file traversal in Groovy.
+  allAppTestDirs.unique().each { testSrcDir ->
+    def testSrcDirFile = testSrcDir instanceof File ? testSrcDir : new File(testSrcDir)
+    if (!testSrcDirFile.isAbsolute()) {
+      testSrcDirFile = new File(projectDir, testSrcDirFile.path).getAbsoluteFile()
+    }
+    if (testSrcDirFile.exists()) {
+      testSrcDirFile.traverse(type: groovy.io.FileType.FILES, nameFilter: ~/^.+?Test\.kt$/) { it ->
+        allAppTestFiles += new File(it.path).getAbsoluteFile()
+      }
+    }
+  }
+  def testFilePaths = allAppTestFiles.collect {
+    projectDir.toPath().relativize(it.toPath()).toFile().path
+  }.unique()
+
+  // Use Random so that the division of tests is relatively even (using just the file path hash
+  // alone can result in some skew which may hamper performance). Since the random class is being
+  // reseeded this should be deterministic. It should also be consistent across different platforms
+  // since only relative paths are used.
+  def random = new Random()
+  return testFilePaths.findAll {
+    random.seed = it.hashCode()
+    def rolledIndex = random.nextInt(shardCount)
+    exclude ? rolledIndex != shardIndex : rolledIndex == shardIndex
+  }.sort()
+}
+
+def _excludeTestFiles(filesToExclude) {
+  tasks.withType(SourceTask.class).configureEach {
+    it.exclude(filesToExclude)
+  }
+  android.sourceSets.test.java.exclude(filesToExclude)
+  android.sourceSets.test.kotlin.exclude(filesToExclude)
+  android.sourceSets.androidTest.java.exclude(filesToExclude)
+  android.sourceSets.androidTest.kotlin.exclude(filesToExclude)
 }

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -1189,7 +1189,7 @@ class StateFragmentTest {
       clickSubmitAnswerButton()
 
       onView(withId(R.id.submitted_answer_text_view))
-        .check(matches(withContentDescription("Correct submitted answer: 4 to 5")))
+        .check(matches(withContentDescription("Correct submitted: 4 to 5")))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -1189,7 +1189,7 @@ class StateFragmentTest {
       clickSubmitAnswerButton()
 
       onView(withId(R.id.submitted_answer_text_view))
-        .check(matches(withContentDescription("Correct submitted: 4 to 5")))
+        .check(matches(withContentDescription("Correct submitted answer: 4 to 5")))
     }
   }
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #4255

This fixes the recent Gradle flakes we've seen by sharding app module tests into 4 separate runners.

### Introduction of Gradle commands to facilitate sharding
Gradle doesn't have sharding built in, so I needed to take a hacky approach by excluding files from other shards when executing a particular shard (leaving only the tests corresponding to that shard). Since Gradle doesn't expect its source sets to change between builds, a clean build must separate running the shards. Running a shard is as simple as:

```bash
./gradlew :app:testDebugUnitTest --shard0
```

The current shards and their respective tests can be listed using:

```bash
./gradlew :app:testDebugUnitTest --list-shards
```

(Note that some of the tests that are excluded for localization are also included in the list but won't actually be executed).

Another requirement is ensuring that test shard bucketing is deterministic and consistent between runs and environments. To this end, it made sense to use the hash of test files' paths relative to the app module project directory. However, simply using the hash to bucket the tests (such as might happen in a hash table) resulted in a less even distribution of tests (probably due to Java's string ``hashCode`` function being fairly weak for uniqueness), so I decided to instead use the index as a seed of a PRNG. This resulted in a better distribution of tests among shards, and determinism.

### CI changes & verifying that it works
The shards are fixed rather than computed like Bazel, so 4 new workflows were added to separately execute each shard. The results are then combined together in the same way as Bazel, and the result of that workflow is what blocks PR submission. I reused the existing app module workflow for the latter part, so we don't need to change the CI checks requirements (which then means no one needs to update their branches for submission).

See [this workflow](https://github.com/oppia/oppia-android/runs/5606675818?check_suite_focus=true) for an example failure, and [this workflow](https://github.com/oppia/oppia-android/runs/5606875428?check_suite_focus=true) to see that it the required check fails due to the shard failing.

Each shard uploads its test results separately (as demonstrated from [this run](https://github.com/oppia/oppia-android/actions/runs/2006558741)).

The sharding also significantly speeds up running the app module tests (to the point where they're now probably faster than their Bazel counterparts), so this should be a nice qualify-of-life improvement beyond just the flake going away.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
N/A -- This is affecting only build infrastructure.