### PR TITLE
Fix #4255: Double number of shards available for app tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [shard0, shard1, shard2, shard3]
+        shard: [shard0, shard1, shard2, shard3, shard4, shard5, shard6, shard7]
     steps:
       - uses: actions/checkout@v2
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,7 +107,7 @@ _excludeTestFiles(filesToExclude)
 // one shard after another without cleaning first (since Gradle doesn't handle file exclusion well,
 // it expects files to be present corresponding to generated code, such as Dagger, from previous
 // runs).
-def appModuleShardCount = 4
+def appModuleShardCount = 8
 def shardIndexes = 0..(appModuleShardCount - 1)
 shardIndexes.each { shardIndex ->
   if (project.gradle.startParameter?.taskRequests?.args[0]?.remove("--shard$shardIndex".toString())) {


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #4255

App module tests are still running into memory issues (specifically shards 2 & 3). This change doubles the number of shards available so that hopefully the tests are better distributes and have a smaller chance of hitting memory limitations.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
N/A -- This is an infrastructure change that doesn't affect app behavior.