### PR TITLE
Remove Vinita from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -157,10 +157,10 @@ config/kitkat_main_dex_class_list.txt @BenHenning
 /domain/src/test/res/values/strings.xml @BenHenning
 
 # Questions support.
-/domain/src/*/java/org/oppia/android/domain/question/ @vinitamurthi
+/domain/src/*/java/org/oppia/android/domain/question/ @BenHenning
 
 # Oppia logging support.
-/domain/src/main/java/org/oppia/android/domain/oppialogger/ @vinitamurthi
+/domain/src/main/java/org/oppia/android/domain/oppialogger/ @BenHenning
 
 #####################################################################################
 #                                  testing module                                   #
@@ -188,7 +188,7 @@ config/kitkat_main_dex_class_list.txt @BenHenning
 /utility/src/*/java/org/oppia/android/util/accessibility/ @rt4914
 
 # Core logging infrastructure.
-/utility/src/*/java/org/oppia/android/util/logging/ @vinitamurthi
+/utility/src/*/java/org/oppia/android/util/logging/ @BenHenning
 
 # Miscellaneous statusbar UI utilities.
 /utility/src/*/java/org/oppia/android/util/statusbar/ @rt4914
@@ -214,10 +214,10 @@ config/kitkat_main_dex_class_list.txt @BenHenning
 #####################################################################################
 
 # Global proto file ownership for model/.
-/model/**/*.proto @vinitamurthi @BenHenning
+/model/**/*.proto @BenHenning
 
 # Global model ownership.
-/model/ @vinitamurthi @BenHenning
+/model/ @BenHenning
 
 
 #####################################################################################


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Since Vinita is taking a step back from Oppia work, removing her from the codeowners list so that she doesn't have any code reviewer expectations.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] ~The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)~ (N/A)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- This is a codeowner-only change.