### PR TITLE
Fixes part of #4195: Added dark mode support to QuestionPlayer and Exploration

### DIFF
--- a/app/src/main/res/drawable/content_blue_background.xml
+++ b/app/src/main/res/drawable/content_blue_background.xml
@@ -4,9 +4,9 @@
   android:shape="rectangle">
   <stroke
     android:width="1dp"
-    android:color="@color/color_def_oppia_stroke_blue"/>
+    android:color="@color/component_color_exploration_activity_content_background_stroke_color"/>
   <corners
     android:radius="4dp"/>
   <solid
-    android:color="@color/color_def_oppia_solid_blue"/>
+    android:color="@color/component_color_exploration_activity_content_background_solid_color"/>
 </shape>

--- a/app/src/main/res/layout-land/question_player_fragment.xml
+++ b/app/src/main/res/layout-land/question_player_fragment.xml
@@ -13,7 +13,7 @@
   <FrameLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/question_player_background">
+    android:background="@color/component_color_question_player_activity_background_color">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
@@ -28,7 +28,7 @@
         android:layout_marginEnd="28dp"
         android:fontFamily="sans-serif"
         android:text="@string/question_training_session_finished_header"
-        android:textColor="@color/oppia_primary_text"
+        android:textColor="@color/component_color_question_player_activity_text_color"
         android:textSize="24sp"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
@@ -43,7 +43,7 @@
         android:layout_marginEnd="28dp"
         android:fontFamily="sans-serif"
         android:text="@string/question_training_session_finished_message"
-        android:textColor="@color/oppia_primary_text"
+        android:textColor="@color/component_color_question_player_activity_text_color"
         android:textSize="16sp"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
@@ -113,7 +113,7 @@
         android:layout_marginBottom="@dimen/question_player_progress_bar_text_margin_bottom"
         android:fontFamily="sans-serif"
         android:text="@{viewModel.questionProgressText}"
-        android:textColor="@color/oppia_primary_text"
+        android:textColor="@color/component_color_question_player_activity_text_color"
         android:textSize="12sp"
         android:textStyle="italic"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout-sw600dp-land/question_player_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-land/question_player_fragment.xml
@@ -15,7 +15,7 @@
   <FrameLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/question_player_background">
+    android:background="@color/component_color_question_player_activity_background_color">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
@@ -30,7 +30,7 @@
         android:layout_marginEnd="192dp"
         android:fontFamily="sans-serif"
         android:text="@string/question_training_session_finished_header"
-        android:textColor="@color/oppia_primary_text"
+        android:textColor="@color/component_color_question_player_activity_text_color"
         android:textSize="24sp"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
@@ -45,7 +45,7 @@
         android:layout_marginEnd="192dp"
         android:fontFamily="sans-serif"
         android:text="@string/question_training_session_finished_message"
-        android:textColor="@color/oppia_primary_text"
+        android:textColor="@color/component_color_question_player_activity_text_color"
         android:textSize="16sp"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
@@ -117,7 +117,7 @@
         android:layout_marginBottom="@dimen/question_player_progress_bar_text_margin_bottom"
         android:fontFamily="sans-serif"
         android:text="@{viewModel.questionProgressText}"
-        android:textColor="@color/oppia_primary_text"
+        android:textColor="@color/component_color_question_player_activity_text_color"
         android:textSize="12sp"
         android:textStyle="italic"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout-sw600dp-port/question_player_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-port/question_player_fragment.xml
@@ -15,7 +15,7 @@
   <FrameLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/question_player_background">
+    android:background="@color/component_color_question_player_activity_background_color">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
@@ -30,7 +30,7 @@
         android:layout_marginEnd="128dp"
         android:fontFamily="sans-serif"
         android:text="@string/question_training_session_finished_header"
-        android:textColor="@color/oppia_primary_text"
+        android:textColor="@color/component_color_question_player_activity_text_color"
         android:textSize="24sp"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
@@ -45,7 +45,7 @@
         android:layout_marginEnd="128dp"
         android:fontFamily="sans-serif"
         android:text="@string/question_training_session_finished_message"
-        android:textColor="@color/oppia_primary_text"
+        android:textColor="@color/component_color_question_player_activity_text_color"
         android:textSize="16sp"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
@@ -117,7 +117,7 @@
         android:layout_marginBottom="@dimen/question_player_progress_bar_text_margin_bottom"
         android:fontFamily="sans-serif"
         android:text="@{viewModel.questionProgressText}"
-        android:textColor="@color/oppia_primary_text"
+        android:textColor="@color/component_color_question_player_activity_text_color"
         android:textSize="12sp"
         android:textStyle="italic"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout-sw600dp/revision_card_fragment.xml
+++ b/app/src/main/res/layout-sw600dp/revision_card_fragment.xml
@@ -12,7 +12,7 @@
   <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/component_color_exploration_activity_background_color"
+    android:background="@color/component_color_revision_card_activity_background_color"
     android:overScrollMode="never"
     android:scrollbars="none">
 

--- a/app/src/main/res/layout-sw600dp/revision_card_fragment.xml
+++ b/app/src/main/res/layout-sw600dp/revision_card_fragment.xml
@@ -12,7 +12,7 @@
   <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/color_def_oppia_light_green"
+    android:background="@color/component_color_exploration_activity_background_color"
     android:overScrollMode="never"
     android:scrollbars="none">
 

--- a/app/src/main/res/layout/content_item.xml
+++ b/app/src/main/res/layout/content_item.xml
@@ -48,7 +48,7 @@
       android:breakStrategy="simple"
       android:fontFamily="sans-serif"
       android:text="@{htmlContent}"
-      android:textColor="@color/component_color_exploration_activity_text_color"
+      android:textColor="@color/component_color_shared_content_item_text_view_color"
       android:textSize="16sp"
       android:visibility="@{htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}"
       app:explorationSplitViewPaddingApplicable="@{viewModel.hasConversationView &amp;&amp; viewModel.isSplitView}"

--- a/app/src/main/res/layout/content_item.xml
+++ b/app/src/main/res/layout/content_item.xml
@@ -48,7 +48,7 @@
       android:breakStrategy="simple"
       android:fontFamily="sans-serif"
       android:text="@{htmlContent}"
-      android:textColor="@color/oppia_primary_text"
+      android:textColor="@color/component_color_exploration_activity_text_color"
       android:textSize="16sp"
       android:visibility="@{htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}"
       app:explorationSplitViewPaddingApplicable="@{viewModel.hasConversationView &amp;&amp; viewModel.isSplitView}"

--- a/app/src/main/res/layout/exploration_activity.xml
+++ b/app/src/main/res/layout/exploration_activity.xml
@@ -28,7 +28,7 @@
         android:id="@+id/exploration_toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:background="@color/oppia_primary"
+        android:background="@color/component_color_exploration_activity_toolbar_color"
         android:minHeight="?attr/actionBarSize"
         android:theme="@style/Widget.AppCompat.ActionBar"
         app:navigationIcon="@drawable/ic_close_white_24dp">

--- a/app/src/main/res/layout/feedback_item.xml
+++ b/app/src/main/res/layout/feedback_item.xml
@@ -48,7 +48,7 @@
       android:breakStrategy="simple"
       android:fontFamily="sans-serif"
       android:text="@{htmlContent}"
-      android:textColor="@color/oppia_primary_text"
+      android:textColor="@color/component_color_question_player_activity_text_color"
       android:textSize="16sp"
       android:visibility="@{htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}"
       app:explorationSplitViewPaddingApplicable="@{viewModel.hasConversationView &amp;&amp; viewModel.isSplitView}"

--- a/app/src/main/res/layout/feedback_item.xml
+++ b/app/src/main/res/layout/feedback_item.xml
@@ -48,7 +48,7 @@
       android:breakStrategy="simple"
       android:fontFamily="sans-serif"
       android:text="@{htmlContent}"
-      android:textColor="@color/component_color_question_player_activity_text_color"
+      android:textColor="@color/component_color_shared_feedback_item_text_view_color"
       android:textSize="16sp"
       android:visibility="@{htmlContent.length() > 0 ? View.VISIBLE : View.GONE, default=gone}"
       app:explorationSplitViewPaddingApplicable="@{viewModel.hasConversationView &amp;&amp; viewModel.isSplitView}"

--- a/app/src/main/res/layout/previous_responses_header_item.xml
+++ b/app/src/main/res/layout/previous_responses_header_item.xml
@@ -42,7 +42,7 @@
     <FrameLayout
       android:layout_width="0dp"
       android:layout_height="2dp"
-      android:background="@color/component_color_shared_previous_responses_header_item_container_text_color"
+      android:background="@color/component_color_shared_previous_responses_header_item_container_background_color"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toStartOf="@+id/previous_responses_header_text"
       app:layout_constraintStart_toStartOf="parent"
@@ -59,7 +59,7 @@
       android:paddingEnd="8dp"
       android:text="@{viewModel.computePreviousResponsesHeaderText()}"
       android:textAllCaps="true"
-      android:textColor="@color/component_color_shared_previous_responses_header_item_container_text_color"
+      android:textColor="@color/component_color_shared_previous_responses_header_item_text_color"
       android:textSize="14sp"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
@@ -69,7 +69,7 @@
     <FrameLayout
       android:layout_width="0dp"
       android:layout_height="2dp"
-      android:background="@color/component_color_shared_previous_responses_header_item_container_text_color"
+      android:background="@color/component_color_shared_previous_responses_header_item_container_background_color"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toEndOf="@+id/previous_responses_header_text"

--- a/app/src/main/res/layout/previous_responses_header_item.xml
+++ b/app/src/main/res/layout/previous_responses_header_item.xml
@@ -42,7 +42,7 @@
     <FrameLayout
       android:layout_width="0dp"
       android:layout_height="2dp"
-      android:background="@color/component_color_shared_previous_responses_header_item_container_background_color"
+      android:background="@color/component_color_shared_previous_responses_header_item_container_text_color"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toStartOf="@+id/previous_responses_header_text"
       app:layout_constraintStart_toStartOf="parent"
@@ -59,7 +59,7 @@
       android:paddingEnd="8dp"
       android:text="@{viewModel.computePreviousResponsesHeaderText()}"
       android:textAllCaps="true"
-      android:textColor="@color/component_color_shared_previous_responses_header_item_container_background_color"
+      android:textColor="@color/component_color_shared_previous_responses_header_item_container_text_color"
       android:textSize="14sp"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
@@ -69,7 +69,7 @@
     <FrameLayout
       android:layout_width="0dp"
       android:layout_height="2dp"
-      android:background="@color/component_color_shared_previous_responses_header_item_container_background_color"
+      android:background="@color/component_color_shared_previous_responses_header_item_container_text_color"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toEndOf="@+id/previous_responses_header_text"

--- a/app/src/main/res/layout/previous_responses_header_item.xml
+++ b/app/src/main/res/layout/previous_responses_header_item.xml
@@ -42,7 +42,7 @@
     <FrameLayout
       android:layout_width="0dp"
       android:layout_height="2dp"
-      android:background="@color/color_def_mid_grey"
+      android:background="@color/component_color_question_player_activity_text_color"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toStartOf="@+id/previous_responses_header_text"
       app:layout_constraintStart_toStartOf="parent"
@@ -59,7 +59,7 @@
       android:paddingEnd="8dp"
       android:text="@{viewModel.computePreviousResponsesHeaderText()}"
       android:textAllCaps="true"
-      android:textColor="@color/color_def_mid_grey"
+      android:textColor="@color/component_color_question_player_activity_text_color"
       android:textSize="14sp"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
@@ -69,7 +69,7 @@
     <FrameLayout
       android:layout_width="0dp"
       android:layout_height="2dp"
-      android:background="@color/color_def_mid_grey"
+      android:background="@color/component_color_question_player_activity_text_color"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toEndOf="@+id/previous_responses_header_text"

--- a/app/src/main/res/layout/previous_responses_header_item.xml
+++ b/app/src/main/res/layout/previous_responses_header_item.xml
@@ -42,7 +42,7 @@
     <FrameLayout
       android:layout_width="0dp"
       android:layout_height="2dp"
-      android:background="@color/component_color_question_player_activity_text_color"
+      android:background="@color/component_color_shared_previous_responses_header_item_container_background_color"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toStartOf="@+id/previous_responses_header_text"
       app:layout_constraintStart_toStartOf="parent"
@@ -59,7 +59,7 @@
       android:paddingEnd="8dp"
       android:text="@{viewModel.computePreviousResponsesHeaderText()}"
       android:textAllCaps="true"
-      android:textColor="@color/component_color_question_player_activity_text_color"
+      android:textColor="@color/component_color_shared_previous_responses_header_item_container_background_color"
       android:textSize="14sp"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
@@ -69,7 +69,7 @@
     <FrameLayout
       android:layout_width="0dp"
       android:layout_height="2dp"
-      android:background="@color/component_color_question_player_activity_text_color"
+      android:background="@color/component_color_shared_previous_responses_header_item_container_background_color"
       app:layout_constraintBottom_toBottomOf="@+id/previous_responses_header_text"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toEndOf="@+id/previous_responses_header_text"

--- a/app/src/main/res/layout/question_player_activity.xml
+++ b/app/src/main/res/layout/question_player_activity.xml
@@ -20,7 +20,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="end"
-        android:background="@color/oppia_primary"
+        android:background="@color/component_color_question_player_activity_toolbar_color"
         android:minHeight="?attr/actionBarSize"
         android:theme="@style/Widget.AppCompat.ActionBar"
         app:navigationIcon="@drawable/ic_close_white_24dp"

--- a/app/src/main/res/layout/question_player_fragment.xml
+++ b/app/src/main/res/layout/question_player_fragment.xml
@@ -15,7 +15,7 @@
   <FrameLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/question_player_background">
+    android:background="@color/component_color_question_player_activity_background_color">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
@@ -30,7 +30,7 @@
         android:layout_marginEnd="28dp"
         android:fontFamily="sans-serif"
         android:text="@string/question_training_session_finished_header"
-        android:textColor="@color/oppia_primary_text"
+        android:textColor="@color/component_color_question_player_activity_text_color"
         android:textSize="24sp"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
@@ -45,7 +45,7 @@
         android:layout_marginEnd="28dp"
         android:fontFamily="sans-serif"
         android:text="@string/question_training_session_finished_message"
-        android:textColor="@color/oppia_primary_text"
+        android:textColor="@color/component_color_question_player_activity_text_color"
         android:textSize="16sp"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
@@ -149,7 +149,7 @@
         android:layout_marginBottom="@dimen/question_player_progress_bar_text_margin_bottom"
         android:fontFamily="sans-serif"
         android:text="@{viewModel.questionProgressText}"
-        android:textColor="@color/oppia_primary_text"
+        android:textColor="@color/component_color_question_player_activity_text_color"
         android:textSize="12sp"
         android:textStyle="italic"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/revision_card_activity.xml
+++ b/app/src/main/res/layout/revision_card_activity.xml
@@ -22,7 +22,7 @@
         android:id="@+id/revision_card_toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:background="@color/oppia_primary"
+        android:background="@color/component_color_revision_card_activity_toolbar_color"
         android:gravity="center_vertical"
         android:minHeight="?attr/actionBarSize"
         android:theme="@style/Widget.AppCompat.ActionBar"

--- a/app/src/main/res/layout/revision_card_fragment.xml
+++ b/app/src/main/res/layout/revision_card_fragment.xml
@@ -12,7 +12,7 @@
   <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/component_color_exploration_activity_background_color"
+    android:background="@color/component_color_revision_card_activity_background_color"
     android:overScrollMode="never"
     android:scrollbars="none">
 

--- a/app/src/main/res/layout/revision_card_fragment.xml
+++ b/app/src/main/res/layout/revision_card_fragment.xml
@@ -12,7 +12,7 @@
   <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/color_def_oppia_light_green"
+    android:background="@color/component_color_exploration_activity_background_color"
     android:overScrollMode="never"
     android:scrollbars="none">
 

--- a/app/src/main/res/layout/state_fragment.xml
+++ b/app/src/main/res/layout/state_fragment.xml
@@ -15,7 +15,7 @@
   <FrameLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/component_color_exploration_activity_background_color"
+    android:background="@color/component_color_shared_state_fragment_background_color"
     android:descendantFocusability="beforeDescendants"
     android:fitsSystemWindows="true"
     android:focusableInTouchMode="true">

--- a/app/src/main/res/layout/state_fragment.xml
+++ b/app/src/main/res/layout/state_fragment.xml
@@ -15,7 +15,7 @@
   <FrameLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/color_def_oppia_light_green"
+    android:background="@color/component_color_exploration_activity_background_color"
     android:descendantFocusability="beforeDescendants"
     android:fitsSystemWindows="true"
     android:focusableInTouchMode="true">

--- a/app/src/main/res/values-night/color_palette.xml
+++ b/app/src/main/res/values-night/color_palette.xml
@@ -23,7 +23,8 @@
   <color name="color_palette_icon_background_color">@color/color_def_white</color>
   <color name="color_palette_button_border_color">@color/color_def_bright_turquoise</color>
   <color name="color_palette_divider_color">@color/color_def_dark_silver</color>
-  <color name="color_palette_exploration_background">@color/color_def_oppia_light_black</color>
+  <color name="color_palette_exploration_background_color">@color/color_def_oppia_light_black</color>
+  <color name="color_palette_revision_card_background_color">@color/color_def_oppia_light_black</color>
   <color name="color_palette_content_background_solid_color">@color/color_def_oppia_grayish_black</color>
   <color name="color_palette_content_background_stroke_color">@color/color_def_dark_blue</color>
 </resources>

--- a/app/src/main/res/values-night/color_palette.xml
+++ b/app/src/main/res/values-night/color_palette.xml
@@ -23,4 +23,7 @@
   <color name="color_palette_icon_background_color">@color/color_def_white</color>
   <color name="color_palette_button_border_color">@color/color_def_bright_turquoise</color>
   <color name="color_palette_divider_color">@color/color_def_dark_silver</color>
+  <color name="color_palette_exploration_background">@color/color_def_oppia_light_black</color>
+  <color name="color_palette_content_background_solid_color">@color/color_def_oppia_grayish_black</color>
+  <color name="color_palette_content_background_stroke_color">@color/color_def_dark_blue</color>
 </resources>

--- a/app/src/main/res/values/color_defs.xml
+++ b/app/src/main/res/values/color_defs.xml
@@ -50,4 +50,6 @@
   <color name="color_def_oppia_dark_grey">#4D4D4D</color>
   <color name="color_def_oppia_pink">#FF938F</color>
   <color name="color_def_oppia_grayish_black">#32363B</color>
+  <color name="color_def_dark_blue">#395FD0</color>
+  <color name="color_def_oppia_grey_border">#DDDDDD</color>
 </resources>

--- a/app/src/main/res/values/color_palette.xml
+++ b/app/src/main/res/values/color_palette.xml
@@ -23,7 +23,8 @@
   <color name="color_palette_icon_background_color">@color/color_def_black</color>
   <color name="color_palette_button_border_color">@color/color_def_oppia_green</color>
   <color name="color_palette_divider_color">@color/color_def_dark_silver</color>
-  <color name="color_palette_exploration_background">@color/color_def_oppia_light_green</color>
+  <color name="color_palette_exploration_background_color">@color/color_def_oppia_light_green</color>
+  <color name="color_palette_revision_card_background_color">@color/color_def_oppia_light_green</color>
   <color name="color_palette_content_background_solid_color">@color/color_def_oppia_solid_blue</color>
   <color name="color_palette_content_background_stroke_color">@color/color_def_oppia_stroke_blue</color>
 </resources>

--- a/app/src/main/res/values/color_palette.xml
+++ b/app/src/main/res/values/color_palette.xml
@@ -23,4 +23,7 @@
   <color name="color_palette_icon_background_color">@color/color_def_black</color>
   <color name="color_palette_button_border_color">@color/color_def_oppia_green</color>
   <color name="color_palette_divider_color">@color/color_def_dark_silver</color>
+  <color name="color_palette_exploration_background">@color/color_def_oppia_light_green</color>
+  <color name="color_palette_content_background_solid_color">@color/color_def_oppia_solid_blue</color>
+  <color name="color_palette_content_background_stroke_color">@color/color_def_oppia_stroke_blue</color>
 </resources>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -5,7 +5,7 @@
   <color name="component_color_shared_content_item_text_view_color">@color/color_palette_highlighted_text_color</color>
   <color name="component_color_shared_feedback_item_text_view_color">@color/color_palette_highlighted_text_color</color>
   <color name="component_color_shared_state_fragment_background_color">@color/color_palette_exploration_background_color</color>
-  <color name="component_color_shared_previous_responses_header_item_container_background_color">@color/color_palette_highlighted_text_color</color>
+  <color name="component_color_shared_previous_responses_header_item_container_text_color">@color/color_palette_highlighted_text_color</color>
   <!-- Themes.xml -->
   <color name="component_color_shared_activity_status_bar_color">@color/color_palette_status_bar_color</color>
   <color name="component_color_shared_activity_action_bar_color">@color/color_palette_action_bar_color</color>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -5,7 +5,8 @@
   <color name="component_color_shared_content_item_text_view_color">@color/color_palette_highlighted_text_color</color>
   <color name="component_color_shared_feedback_item_text_view_color">@color/color_palette_highlighted_text_color</color>
   <color name="component_color_shared_state_fragment_background_color">@color/color_palette_exploration_background_color</color>
-  <color name="component_color_shared_previous_responses_header_item_container_text_color">@color/color_palette_highlighted_text_color</color>
+  <color name="component_color_shared_previous_responses_header_item_container_background_color">@color/color_palette_highlighted_text_color</color>
+  <color name="component_color_shared_previous_responses_header_item_text_color">@color/color_palette_highlighted_text_color</color>
   <!-- Themes.xml -->
   <color name="component_color_shared_activity_status_bar_color">@color/color_palette_status_bar_color</color>
   <color name="component_color_shared_activity_action_bar_color">@color/color_palette_action_bar_color</color>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -2,6 +2,10 @@
 <resources>
   <color name="component_color_shared_edit_text_cursor_color">@color/color_palette_primary_text_color</color>
   <color name="component_color_shared_activity_toolbar_color">@color/color_palette_toolbar_color</color>
+  <color name="component_color_shared_content_item_text_view_color">@color/color_palette_highlighted_text_color</color>
+  <color name="component_color_shared_feedback_item_text_view_color">@color/color_palette_highlighted_text_color</color>
+  <color name="component_color_shared_state_fragment_background_color">@color/color_palette_exploration_background_color</color>
+  <color name="component_color_shared_previous_responses_header_item_container_background_color">@color/color_palette_highlighted_text_color</color>
   <!-- Themes.xml -->
   <color name="component_color_shared_activity_status_bar_color">@color/color_palette_status_bar_color</color>
   <color name="component_color_shared_activity_action_bar_color">@color/color_palette_action_bar_color</color>
@@ -87,14 +91,17 @@
   <color name="component_color_start_over_button_drawable_tint_color">@color/color_palette_secondary_toolbar_color</color>
   <!-- Exploration Activity -->
   <color name="component_color_exploration_activity_toolbar_color">@color/color_palette_secondary_toolbar_color</color>
-  <color name="component_color_exploration_activity_background_color">@color/color_palette_exploration_background</color>
+  <color name="component_color_exploration_activity_background_color">@color/color_palette_exploration_background_color</color>
   <color name="component_color_exploration_activity_text_color">@color/color_palette_highlighted_text_color</color>
   <color name="component_color_exploration_activity_content_background_stroke_color">@color/color_palette_content_background_stroke_color</color>
   <color name="component_color_exploration_activity_content_background_solid_color">@color/color_palette_content_background_solid_color</color>
   <!-- Question Player Activity -->
   <color name="component_color_question_player_activity_toolbar_color">@color/color_palette_secondary_toolbar_color</color>
-  <color name="component_color_question_player_activity_background_color">@color/color_palette_exploration_background</color>
+  <color name="component_color_question_player_activity_background_color">@color/color_palette_exploration_background_color</color>
   <color name="component_color_question_player_activity_text_color">@color/color_palette_highlighted_text_color</color>
+  <!-- Revision Card Activity -->
+  <color name="component_color_revision_card_activity_background_color">@color/color_palette_revision_card_background_color</color>
+  <color name="component_color_revision_card_activity_toolbar_color">@color/color_palette_secondary_toolbar_color</color>
   <!-- Third Party Dependency List Activity -->
   <color name="component_color_third_party_dependency_list_activity_background_color">@color/color_palette_dark_background_color</color>
   <color name="component_color_third_party_dependency_list_activity_dependency_name_text_view_color">@color/color_palette_dark_text_color</color>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -68,4 +68,14 @@
   <color name="component_color_start_over_button_text_color">@color/color_palette_secondary_toolbar_color</color>
   <color name="component_color_start_over_button_stroke_color">@color/color_palette_secondary_toolbar_color</color>
   <color name="component_color_start_over_button_drawable_tint_color">@color/color_palette_secondary_toolbar_color</color>
+  <!-- Exploration Activity -->
+  <color name="component_color_exploration_activity_toolbar_color">@color/color_palette_secondary_toolbar_color</color>
+  <color name="component_color_exploration_activity_background_color">@color/color_palette_exploration_background</color>
+  <color name="component_color_exploration_activity_text_color">@color/color_palette_highlighted_text_color</color>
+  <color name="component_color_exploration_activity_content_background_stroke_color">@color/color_palette_content_background_stroke_color</color>
+  <color name="component_color_exploration_activity_content_background_solid_color">@color/color_palette_content_background_solid_color</color>
+  <!-- Question Player Activity -->
+  <color name="component_color_question_player_activity_toolbar_color">@color/color_palette_secondary_toolbar_color</color>
+  <color name="component_color_question_player_activity_background_color">@color/color_palette_exploration_background</color>
+  <color name="component_color_question_player_activity_text_color">@color/color_palette_highlighted_text_color</color>
 </resources>


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fixes part of #4195 : Added dark mode support to QuestionPlayerActivity and ExplorationActivity
- This PR focusses on adding dark mode mainly for content part

**ScreenShots**

| Default  | Dark Mode  |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/170878737-35e69431-15b7-440d-ae5d-710c41303ada.jpeg" width="300" />|<img src="https://user-images.githubusercontent.com/78796264/170878750-62d4db23-cb45-43d7-bebd-5bb598dae189.jpeg" width="300" />|

| Default  | Dark Mode  |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/170878758-d4800c07-8281-47fc-977f-fb817a6f5881.jpeg" width="300" />|<img src="https://user-images.githubusercontent.com/78796264/170878767-915792ea-ce5a-4c34-af92-9d7056da61f1.jpeg" width="300" />|

| Default  | Dark Mode  |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/170879161-8ff3b37b-9e1d-4ab7-a07f-019b6f53de97.jpeg" width="300" />|<img src="https://user-images.githubusercontent.com/78796264/170879175-f99fe7a1-e845-49be-a714-e5412b11f556.jpeg" width="300" />|

| Default  | Dark Mode  |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/170879194-ef89ad69-49f8-496c-94e4-3f3903d8a5e0.jpeg" width="300" />|<img src="https://user-images.githubusercontent.com/78796264/170879199-53964b27-60f9-4c3a-8dd2-bfe5c2dbf6a8.jpeg" width="300" />|

| Default  | Dark Mode  |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/170878885-6ac541a1-0539-4013-931a-d55b99f956ab.jpeg" width="300" />|<img src="https://user-images.githubusercontent.com/78796264/170878894-f3a57b15-0b68-4276-916f-0a819d8324a6.jpeg" width="300" />|

| Default  | Dark Mode  |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/170878901-0f1ddd49-2275-4ce3-9e66-9cf1c676fdbc.jpeg" width="300" />|<img src="https://user-images.githubusercontent.com/78796264/170878910-7033d009-7d50-43c1-b06f-103f51218455.jpeg" width="300" />|

| Default  | Dark Mode  |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/170878917-90c48071-b137-43bc-8947-a775855f1f42.jpeg" width="300" />|<img src="https://user-images.githubusercontent.com/78796264/170878919-7f75edc8-5e97-4335-b70a-4677daa8fa13.jpeg" width="300" />|

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
