### PR TITLE
Fixes part of #4178: Added dark mode support to PinPasswordActivity

### DIFF
--- a/app/src/main/res/drawable/ic_hide_eye_icon.xml
+++ b/app/src/main/res/drawable/ic_hide_eye_icon.xml
@@ -1,6 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:tint="@color/component_color_pin_password_activity_hide_eye_icon_color"
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path

--- a/app/src/main/res/drawable/ic_show_eye_icon.xml
+++ b/app/src/main/res/drawable/ic_show_eye_icon.xml
@@ -1,6 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:tint="@color/component_color_pin_password_activity_show_eye_icon_color"
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path

--- a/app/src/main/res/layout/pin_password_activity.xml
+++ b/app/src/main/res/layout/pin_password_activity.xml
@@ -133,7 +133,7 @@
               android:layout_marginTop="2dp"
               android:layout_marginEnd="8dp"
               android:text="@string/pin_password_incorrect_pin"
-              android:textColor="@color/edit_text_error"
+              android:textColor="@color/component_color_pin_password_activity_error_text_color"
               android:textSize="16sp"
               android:visibility="@{viewModel.showError ? View.VISIBLE : View.INVISIBLE}"
               app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/pin_password_activity.xml
+++ b/app/src/main/res/layout/pin_password_activity.xml
@@ -188,7 +188,7 @@
                 android:fontFamily="sans-serif-medium"
                 android:text="@{viewModel.showPassword ? @string/pin_password_hide : @string/pin_password_show}"
                 android:textAllCaps="true"
-                android:textColor="@color/component_color_pin_password_activity_show_color"
+                android:textColor="@color/component_color_pin_password_activity_show_hide_text_color"
                 android:textSize="12sp" />
             </LinearLayout>
           </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/pin_password_activity.xml
+++ b/app/src/main/res/layout/pin_password_activity.xml
@@ -32,7 +32,7 @@
         android:id="@+id/pin_password_toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
+        android:background="@color/component_color_pin_password_activity_toolbar_color"
         android:fontFamily="sans-serif"
         android:minHeight="?attr/actionBarSize"
         app:navigationContentDescription="@string/pin_password_close"
@@ -46,7 +46,7 @@
       android:id="@+id/pin_password_main_frame_layout"
       android:layout_width="@dimen/pin_password_activity_layout_width"
       android:layout_height="0dp"
-      android:background="@color/color_def_oppia_light_yellow"
+      android:background="@color/component_color_pin_password_activity_layout_background_color"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
@@ -76,7 +76,7 @@
             android:layout_marginEnd="@dimen/pin_password_activity_hello_text_view_margin_end"
             android:fontFamily="sans-serif-medium"
             android:text="@{viewModel.helloText}"
-            android:textColor="@color/oppia_primary_text"
+            android:textColor="@color/component_color_pin_password_activity_text_color"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
@@ -89,7 +89,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
             android:text="@{viewModel.profile.isAdmin ? @string/pin_password_admin_enter : @string/pin_password_user_enter}"
-            android:textColor="@color/oppia_primary_text"
+            android:textColor="@color/component_color_pin_password_activity_sub_text_color"
             app:layout_constraintEnd_toEndOf="@+id/hello_text_view"
             app:layout_constraintStart_toStartOf="@+id/hello_text_view"
             app:layout_constraintTop_toBottomOf="@id/hello_text_view" />
@@ -151,7 +151,7 @@
               android:paddingTop="8dp"
               android:text="@string/pin_password_forgot_pin"
               android:textAllCaps="true"
-              android:textColor="@color/oppia_primary"
+              android:textColor="@color/component_color_pin_password_activity_forgot_pin_color"
               app:layout_constraintEnd_toEndOf="parent"
               app:layout_constraintHorizontal_bias="0.0"
               app:layout_constraintStart_toStartOf="@id/pin_password_input_pin"
@@ -188,7 +188,7 @@
                 android:fontFamily="sans-serif-medium"
                 android:text="@{viewModel.showPassword ? @string/pin_password_hide : @string/pin_password_show}"
                 android:textAllCaps="true"
-                android:textColor="@color/oppia_primary_text"
+                android:textColor="@color/component_color_pin_password_activity_show_color"
                 android:textSize="12sp" />
             </LinearLayout>
           </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-night/color_palette.xml
+++ b/app/src/main/res/values-night/color_palette.xml
@@ -30,4 +30,6 @@
   <color name="color_palette_forgot_pin_color">@color/color_def_oppia_turquoise</color>
   <color name="color_palette_show_text_color">@color/color_def_oppia_turquoise</color>
   <color name="color_palette_error_text_color">@color/color_def_oppia_pink</color>
+  <color name="color_palette_show_eye_icon_color">@color/color_def_forest_green</color>
+  <color name="color_palette_hide_eye_icon_color">@color/color_def_forest_green</color>
 </resources>

--- a/app/src/main/res/values-night/color_palette.xml
+++ b/app/src/main/res/values-night/color_palette.xml
@@ -28,5 +28,6 @@
   <color name="color_palette_content_background_solid_color">@color/color_def_oppia_grayish_black</color>
   <color name="color_palette_content_background_stroke_color">@color/color_def_dark_blue</color>
   <color name="color_palette_forgot_pin_color">@color/color_def_oppia_turquoise</color>
-  <color name="color_palette_show_color">@color/color_def_oppia_turquoise</color>
+  <color name="color_palette_show_text_color">@color/color_def_oppia_turquoise</color>
+  <color name="color_palette_error_text_color">@color/color_def_oppia_pink</color>
 </resources>

--- a/app/src/main/res/values-night/color_palette.xml
+++ b/app/src/main/res/values-night/color_palette.xml
@@ -27,4 +27,6 @@
   <color name="color_palette_revision_card_background_color">@color/color_def_oppia_light_black</color>
   <color name="color_palette_content_background_solid_color">@color/color_def_oppia_grayish_black</color>
   <color name="color_palette_content_background_stroke_color">@color/color_def_dark_blue</color>
+  <color name="color_palette_forgot_pin_color">@color/color_def_oppia_turquoise</color>
+  <color name="color_palette_show_color">@color/color_def_oppia_turquoise</color>
 </resources>

--- a/app/src/main/res/values/color_defs.xml
+++ b/app/src/main/res/values/color_defs.xml
@@ -52,4 +52,5 @@
   <color name="color_def_dark_blue">#395FD0</color>
   <color name="color_def_oppia_grey_border">#DDDDDD</color>
   <color name="color_def_dark_silver">#707070</color>
+  <color name="color_def_error_text_color">#923026</color>
 </resources>

--- a/app/src/main/res/values/color_palette.xml
+++ b/app/src/main/res/values/color_palette.xml
@@ -27,4 +27,6 @@
   <color name="color_palette_revision_card_background_color">@color/color_def_oppia_light_green</color>
   <color name="color_palette_content_background_solid_color">@color/color_def_oppia_solid_blue</color>
   <color name="color_palette_content_background_stroke_color">@color/color_def_oppia_stroke_blue</color>
+  <color name="color_palette_forgot_pin_color">@color/color_def_oppia_green</color>
+  <color name="color_palette_show_color">@color/color_def_accessible_grey</color>
 </resources>

--- a/app/src/main/res/values/color_palette.xml
+++ b/app/src/main/res/values/color_palette.xml
@@ -30,4 +30,6 @@
   <color name="color_palette_forgot_pin_color">@color/color_def_oppia_green</color>
   <color name="color_palette_show_text_color">@color/color_def_accessible_grey</color>
   <color name="color_palette_error_text_color">@color/color_def_error_text_color</color>
+  <color name="color_palette_show_eye_icon_color">@color/color_def_accessible_grey</color>
+  <color name="color_palette_hide_eye_icon_color">@color/color_def_accessible_grey</color>
 </resources>

--- a/app/src/main/res/values/color_palette.xml
+++ b/app/src/main/res/values/color_palette.xml
@@ -28,5 +28,6 @@
   <color name="color_palette_content_background_solid_color">@color/color_def_oppia_solid_blue</color>
   <color name="color_palette_content_background_stroke_color">@color/color_def_oppia_stroke_blue</color>
   <color name="color_palette_forgot_pin_color">@color/color_def_oppia_green</color>
-  <color name="color_palette_show_color">@color/color_def_accessible_grey</color>
+  <color name="color_palette_show_text_color">@color/color_def_accessible_grey</color>
+  <color name="color_palette_error_text_color">@color/color_def_error_text_color</color>
 </resources>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -43,6 +43,11 @@
   <color name="component_color_admin_pin_activity_layout_background_color">@color/color_palette_background_color</color>
   <!-- Pin Password Activity -->
   <color name="component_color_pin_password_activity_layout_background_color">@color/color_palette_background_color</color>
+  <color name="component_color_pin_password_activity_toolbar_color">@color/color_palette_toolbar_color</color>
+  <color name="component_color_pin_password_activity_text_color">@color/color_palette_highlighted_text_color</color>
+  <color name="component_color_pin_password_activity_sub_text_color">@color/color_palette_primary_text_color</color>
+  <color name="component_color_pin_password_activity_forgot_pin_color">@color/color_palette_forgot_pin_color</color>
+  <color name="component_color_pin_password_activity_show_color">@color/color_palette_show_color</color>
   <!-- Help Activity -->
   <color name="component_color_help_activity_background_color">@color/color_palette_dark_background_color</color>
   <color name="component_color_help_activity_container_color">@color/color_palette_container_background_color</color>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -49,6 +49,8 @@
   <color name="component_color_pin_password_activity_forgot_pin_color">@color/color_palette_forgot_pin_color</color>
   <color name="component_color_pin_password_activity_show_hide_text_color">@color/color_palette_show_text_color</color>
   <color name="component_color_pin_password_activity_error_text_color">@color/color_palette_error_text_color</color>
+  <color name="component_color_pin_password_activity_show_eye_icon_color">@color/color_palette_show_eye_icon_color</color>
+  <color name="component_color_pin_password_activity_hide_eye_icon_color">@color/color_palette_hide_eye_icon_color</color>
   <!-- Help Activity -->
   <color name="component_color_help_activity_background_color">@color/color_palette_dark_background_color</color>
   <color name="component_color_help_activity_container_color">@color/color_palette_container_background_color</color>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -47,7 +47,8 @@
   <color name="component_color_pin_password_activity_text_color">@color/color_palette_highlighted_text_color</color>
   <color name="component_color_pin_password_activity_sub_text_color">@color/color_palette_primary_text_color</color>
   <color name="component_color_pin_password_activity_forgot_pin_color">@color/color_palette_forgot_pin_color</color>
-  <color name="component_color_pin_password_activity_show_hide_text_color">@color/color_palette_show_color</color>
+  <color name="component_color_pin_password_activity_show_hide_text_color">@color/color_palette_show_text_color</color>
+  <color name="component_color_pin_password_activity_error_text_color">@color/color_palette_error_text_color</color>
   <!-- Help Activity -->
   <color name="component_color_help_activity_background_color">@color/color_palette_dark_background_color</color>
   <color name="component_color_help_activity_container_color">@color/color_palette_container_background_color</color>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -47,7 +47,7 @@
   <color name="component_color_pin_password_activity_text_color">@color/color_palette_highlighted_text_color</color>
   <color name="component_color_pin_password_activity_sub_text_color">@color/color_palette_primary_text_color</color>
   <color name="component_color_pin_password_activity_forgot_pin_color">@color/color_palette_forgot_pin_color</color>
-  <color name="component_color_pin_password_activity_show_color">@color/color_palette_show_color</color>
+  <color name="component_color_pin_password_activity_show_hide_text_color">@color/color_palette_show_color</color>
   <!-- Help Activity -->
   <color name="component_color_help_activity_background_color">@color/color_palette_dark_background_color</color>
   <color name="component_color_help_activity_container_color">@color/color_palette_container_background_color</color>


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixes part of #4178 : Added dark mode support to PinPasswordActivity.

**Mock link** : https://xd.adobe.com/view/c05e9343-60f6-4c11-84ac-c756b75b940f-950d/screen/81c45a9d-5c70-46f0-8b02-b57a3df3ff50/specs/

**Screenshots**

| Default  | Dark mode |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/171486711-5433d3b4-cad6-48c0-9269-52c9073dcaa6.jpg" width="280" />|<img src="https://user-images.githubusercontent.com/78796264/171986374-aa7e3189-a5b6-495b-8816-c45a06bb8191.jpg" width="280" />|

| Default  | Dark mode |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/171550270-f825b552-9ac9-41d0-9652-20a422a94ef6.jpg" width="280" />|<img src="https://user-images.githubusercontent.com/78796264/171986376-ed49f141-df76-46c8-8dab-2424ddb3f635.jpg" width="280" />|

## Essential Checklist

<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
