### PR TITLE
Fix #4361: Continue button is not aligned properly when reading text size in extra large 

### DIFF
--- a/app/src/main/res/layout/continue_interaction_item.xml
+++ b/app/src/main/res/layout/continue_interaction_item.xml
@@ -49,7 +49,7 @@
     <Button
       android:id="@+id/continue_button"
       style="@style/StateButtonActive"
-      android:maxWidth="@dimen/continue_submit_button_width"
+      android:layout_width="wrap_content"
       android:onClick="@{(v) -> viewModel.handleButtonClicked()}"
       android:text="@string/state_continue_button"
       app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/continue_navigation_button_item.xml
+++ b/app/src/main/res/layout/continue_navigation_button_item.xml
@@ -49,7 +49,7 @@
     <Button
       android:id="@+id/continue_navigation_button"
       style="@style/StateButtonActive"
-      android:maxWidth="@dimen/continue_submit_button_width"
+      android:layout_width="wrap_content"
       android:onClick="@{(v) -> buttonViewModel.continueNavigationButtonListener.onContinueButtonClicked()}"
       android:text="@string/state_continue_button"
       app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -377,7 +377,6 @@
   <dimen name="general_button_item_split_view_margin_top_left">20dp</dimen>
   <dimen name="general_button_item_split_view_margin_top_right">68dp</dimen>
   <dimen name="general_button_item_margin_top">20dp</dimen>
-  <dimen name="continue_submit_button_width">180dp</dimen>
 
   <!-- General Button Item: Exploration Split View -->
   <dimen name="general_button_item_exploration_split_view_margin_start">44dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -377,7 +377,7 @@
   <dimen name="general_button_item_split_view_margin_top_left">20dp</dimen>
   <dimen name="general_button_item_split_view_margin_top_right">68dp</dimen>
   <dimen name="general_button_item_margin_top">20dp</dimen>
-  <dimen name="continue_submit_button_width">88dp</dimen>
+  <dimen name="continue_submit_button_width">130dp</dimen>
 
   <!-- General Button Item: Exploration Split View -->
   <dimen name="general_button_item_exploration_split_view_margin_start">44dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -377,7 +377,7 @@
   <dimen name="general_button_item_split_view_margin_top_left">20dp</dimen>
   <dimen name="general_button_item_split_view_margin_top_right">68dp</dimen>
   <dimen name="general_button_item_margin_top">20dp</dimen>
-  <dimen name="continue_submit_button_width">130dp</dimen>
+  <dimen name="continue_submit_button_width">180dp</dimen>
 
   <!-- General Button Item: Exploration Split View -->
   <dimen name="general_button_item_exploration_split_view_margin_start">44dp</dimen>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -121,7 +121,7 @@
   </style>
   <!-- STATE BUTTON INACTIVE STYLE -->
   <style name="StateButtonInactive" parent="TextAppearance.AppCompat.Widget.Button">
-    <item name="android:layout_width">160dp</item>
+    <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:padding">8dp</item>
     <item name="android:textAllCaps">true</item>
@@ -415,7 +415,7 @@
   </style>
   <!-- Continue Lesson Button -->
   <style name="ContinueLessonButton" parent="TextAppearance.AppCompat.Widget.Button">
-    <item name="android:layout_width">160dp</item>
+    <item name="android:layout_width">144dp</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:drawablePadding">4dp</item>
     <item name="android:paddingEnd">12dp</item>
@@ -427,7 +427,7 @@
     <item name="android:minHeight">@dimen/clickable_item_min_height</item>
     <item name="android:textAllCaps">true</item>
     <item name="android:textColor">@color/color_def_white</item>
-    <item name="android:textSize">12sp</item>
+    <item name="android:textSize">14sp</item>
   </style>
 
   <style name="BorderlessMaterialButton" parent="Widget.AppCompat.Button.Borderless" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -121,7 +121,7 @@
   </style>
   <!-- STATE BUTTON INACTIVE STYLE -->
   <style name="StateButtonInactive" parent="TextAppearance.AppCompat.Widget.Button">
-    <item name="android:layout_width">wrap_content</item>
+    <item name="android:layout_width">160dp</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:padding">8dp</item>
     <item name="android:textAllCaps">true</item>
@@ -415,7 +415,7 @@
   </style>
   <!-- Continue Lesson Button -->
   <style name="ContinueLessonButton" parent="TextAppearance.AppCompat.Widget.Button">
-    <item name="android:layout_width">144dp</item>
+    <item name="android:layout_width">160dp</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:drawablePadding">4dp</item>
     <item name="android:paddingEnd">12dp</item>
@@ -427,7 +427,7 @@
     <item name="android:minHeight">@dimen/clickable_item_min_height</item>
     <item name="android:textAllCaps">true</item>
     <item name="android:textColor">@color/color_def_white</item>
-    <item name="android:textSize">14sp</item>
+    <item name="android:textSize">12sp</item>
   </style>
 
   <style name="BorderlessMaterialButton" parent="Widget.AppCompat.Button.Borderless" />


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixes #4361 Continue button is not aligned properly when reading text size is extra large

   This pr fixes :-- 
  - Button size for continue button overlapping the text  'continue' and causing a break word on the button while text size is set to extra Large.
  

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference]([https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference]([https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide]([https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide](https://github.com/oppia/oppia-android/wiki/Accessibility-%28A11y%29-Guide)))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing

## Changes made 

| Device Type | Before  | After | Landscape & Potrait |
| --- | --- | --- | --- | 
| Handset | ![before](https://user-images.githubusercontent.com/31986629/178823803-11e13b5d-5ae1-4b6c-b492-1cc60bed57bd.jpg) | ![potrait mobile](https://user-images.githubusercontent.com/31986629/178824127-f053a606-4702-4316-9f4e-811519a06a07.png) |  ![landscape mobile](https://user-images.githubusercontent.com/31986629/178824372-c7a013a3-15bc-4da7-add1-041791d86cc4.png)
| Tablet | ![tablet before](https://user-images.githubusercontent.com/31986629/178847639-c7b968ac-53f0-4fe7-bc0e-6e04a047791c.png) | ![4316](https://user-images.githubusercontent.com/31986629/178848354-eea400dc-cce7-4b4e-909b-2afee1693027.png) | ![potrait tablet](https://user-images.githubusercontent.com/31986629/178848473-c878284b-17c4-454e-a2db-510ffab79166.png)

### Demo Video 
https://user-images.githubusercontent.com/31986629/172633976-ee2bed90-adce-4902-950c-5b594796a07d.mp4



