### PR TITLE
Fixes Part Of #4194: Added dark mode support to DrawerFragment, ConceptCardFragment and AudioFragment

### DIFF
--- a/app/src/main/res/color/drawer_item.xml
+++ b/app/src/main/res/color/drawer_item.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:color="@color/highlighted_nav_menu_item" android:state_checked="true" />
-  <item android:color="@color/color_def_black" />
+  <item android:color="@color/component_color_drawer_fragment_selected_text_color" android:state_checked="true" />
+  <item android:color="@color/component_color_drawer_fragment_text_color" />
 </selector>

--- a/app/src/main/res/drawable/audio_background.xml
+++ b/app/src/main/res/drawable/audio_background.xml
@@ -4,5 +4,5 @@
   <corners
     android:bottomLeftRadius="@dimen/audio_fragment_corner_radius"
     android:bottomRightRadius="@dimen/audio_fragment_corner_radius" />
-  <solid android:color="@color/audio_component_background" />
+  <solid android:color="@color/component_color_audio_fragment_background_color" />
 </shape>

--- a/app/src/main/res/drawable/seekbar_thumb.xml
+++ b/app/src/main/res/drawable/seekbar_thumb.xml
@@ -17,7 +17,7 @@
     android:left="8dp"
     android:top="4dp">
     <shape android:shape="oval">
-      <solid android:color="@color/color_def_white" />
+      <solid android:color="@color/component_color_audio_fragment_thumb_background_color" />
       <corners android:radius="10dp" />
     </shape>
   </item>

--- a/app/src/main/res/layout/audio_fragment.xml
+++ b/app/src/main/res/layout/audio_fragment.xml
@@ -36,6 +36,7 @@
       android:onClick="@{(v) -> viewModel.togglePlayPause(viewModel.playStatusLiveData)}"
       android:padding="12dp"
       app:srcCompat="@{viewModel.playStatusLiveData == UiAudioPlayStatus.PLAYING ? @drawable/ic_pause_circle_filled_white_24dp : @drawable/ic_play_circle_filled_white_24dp}"
+      app:tint="@color/component_color_audio_fragment_icon_color"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent" />
@@ -70,6 +71,7 @@
       android:onClick="@{(v) -> audioFragment.languageSelectionClicked()}"
       android:padding="12dp"
       app:srcCompat="@drawable/ic_audio_lang_24px"
+      app:tint="@color/component_color_audio_fragment_icon_color"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/concept_card_fragment.xml
+++ b/app/src/main/res/layout/concept_card_fragment.xml
@@ -64,10 +64,10 @@
           <TextView
             android:id="@+id/concept_card_explanation_text"
             style="@style/Body"
-            android:textColor="@color/component_color_concept_card_fragment_text_color"
             android:layout_marginStart="@dimen/concept_card_explanation_text_margin_start"
             android:layout_marginTop="@dimen/concept_card_explanation_text_margin_top"
-            android:layout_marginEnd="@dimen/concept_card_explanation_text_margin_end" />
+            android:layout_marginEnd="@dimen/concept_card_explanation_text_margin_end"
+            android:textColor="@color/component_color_concept_card_fragment_text_color" />
         </LinearLayout>
         <!-- TODO(#352): Show worked examples in Concept Card. -->
       </ScrollView>

--- a/app/src/main/res/layout/concept_card_fragment.xml
+++ b/app/src/main/res/layout/concept_card_fragment.xml
@@ -13,13 +13,13 @@
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/concept_card_background">
+    android:background="@color/component_color_concept_card_fragment_background_color">
 
     <androidx.appcompat.widget.Toolbar
       android:id="@+id/concept_card_toolbar"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:background="@color/concept_toolbar_background"
+      android:background="@color/component_color_concept_card_fragment_toolbar_color"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
@@ -58,12 +58,13 @@
             android:layout_marginEnd="@dimen/concept_card_heading_text_margin_end"
             android:fontFamily="sans-serif-medium"
             android:text="@{viewModel.conceptCardLiveData.conceptCard.skillDescription}"
-            android:textColor="@color/oppia_primary_text"
+            android:textColor="@color/component_color_concept_card_fragment_text_color"
             android:textSize="20sp" />
 
           <TextView
             android:id="@+id/concept_card_explanation_text"
             style="@style/Body"
+            android:textColor="@color/component_color_concept_card_fragment_text_color"
             android:layout_marginStart="@dimen/concept_card_explanation_text_margin_start"
             android:layout_marginTop="@dimen/concept_card_explanation_text_margin_top"
             android:layout_marginEnd="@dimen/concept_card_explanation_text_margin_end" />

--- a/app/src/main/res/layout/drawer_fragment.xml
+++ b/app/src/main/res/layout/drawer_fragment.xml
@@ -25,6 +25,7 @@
       <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/component_color_drawer_fragment_background_color"
         android:orientation="vertical">
 
         <com.google.android.material.navigation.NavigationView
@@ -35,6 +36,7 @@
           android:fitsSystemWindows="true"
           android:overScrollMode="never"
           android:scrollbars="none"
+          android:background="@color/component_color_drawer_fragment_background_color"
           app:elevation="0dp"
           app:itemBackground="@android:color/transparent"
           app:itemIconTint="@color/drawer_item"
@@ -66,7 +68,7 @@
             android:layout_height="24dp"
             android:layout_gravity="center_vertical"
             app:srcCompat="@drawable/ic_baseline_code_24"
-            android:tint="@{footerViewModel.isDeveloperOptionsSelected ? @color/highlighted_developer_options_nav_menu_item : @color/oppia_primary_text_dark}"/>
+            android:tint="@{footerViewModel.isDeveloperOptionsSelected ? @color/component_color_drawer_fragment_developer_options_selected_image_color : @color/component_color_drawer_fragment_developer_options_image_color}"/>
 
           <TextView
             android:layout_width="match_parent"
@@ -75,7 +77,7 @@
             android:layout_marginStart="12dp"
             android:fontFamily="sans-serif-medium"
             android:text="@string/developer_options"
-            android:textColor="@{footerViewModel.isDeveloperOptionsSelected ? @color/highlighted_developer_options_nav_menu_item : @color/oppia_primary_text_dark}"
+            android:textColor="@{footerViewModel.isDeveloperOptionsSelected ? @color/component_color_drawer_fragment_developer_options_selected_text_color : @color/component_color_drawer_fragment_developer_options_text_color}"
             android:textSize="14sp" />
         </LinearLayout>
 
@@ -97,7 +99,7 @@
             android:layout_height="24dp"
             android:layout_gravity="center_vertical"
             app:srcCompat="@drawable/ic_admin_settings_icon_brown_24dp"
-            android:tint="@{footerViewModel.isAdministratorControlsSelected ? @color/highlighted_nav_menu_item : @color/oppia_primary_text_dark}" />
+            android:tint="@{footerViewModel.isAdministratorControlsSelected ? @color/component_color_drawer_fragment_admin_controls_selected_image_color : @color/component_color_drawer_fragment_admin_controls_image_color}" />
 
           <TextView
             android:layout_width="match_parent"
@@ -106,7 +108,7 @@
             android:layout_marginStart="12dp"
             android:fontFamily="sans-serif-medium"
             android:text="@string/administrator_controls"
-            android:textColor="@{footerViewModel.isAdministratorControlsSelected ? @color/highlighted_nav_menu_item : @color/oppia_primary_text_dark}"
+            android:textColor="@{footerViewModel.isAdministratorControlsSelected ? @color/component_color_drawer_fragment_admin_controls_selected_text_color : @color/component_color_drawer_fragment_admin_controls_text_color}"
             android:textSize="14sp" />
         </LinearLayout>
       </LinearLayout>

--- a/app/src/main/res/values-night/color_palette.xml
+++ b/app/src/main/res/values-night/color_palette.xml
@@ -45,11 +45,11 @@
   <color name="color_palette_error_text_color">@color/color_def_oppia_pink</color>
   <color name="color_palette_show_eye_icon_color">@color/color_def_forest_green</color>
   <color name="color_palette_hide_eye_icon_color">@color/color_def_forest_green</color>
-  <color name="color_palette_icon_background_color_2">@color/color_def_oppia_turquoise</color>
+  <color name="color_palette_icon_background_secondary_color">@color/color_def_oppia_turquoise</color>
   <color name="color_palette_accent_background_color">@color/color_def_oppia_dark_grey</color>
   <color name="color_palette_seekbar_progress_background_color">@color/color_def_maastricht_blue</color>
   <color name="color_palette_toolbar_secondary_color">@color/color_def_forest_green</color>
-  <color name="color_palette_secondary_background_color_2">@color/color_def_oppia_light_black</color>
+  <color name="color_palette_secondary_dark_background_color">@color/color_def_oppia_light_black</color>
   <color name="color_palette_concept_card_toolbar_color">@color/color_def_dark_pink</color>
   <color name="color_palette_menu_selected_text_color">@color/color_def_oppia_pink</color>
   <color name="color_palette_developer_option_menu_selected_color">@color/color_def_persian_blue</color>

--- a/app/src/main/res/values-night/color_palette.xml
+++ b/app/src/main/res/values-night/color_palette.xml
@@ -45,4 +45,16 @@
   <color name="color_palette_error_text_color">@color/color_def_oppia_pink</color>
   <color name="color_palette_show_eye_icon_color">@color/color_def_forest_green</color>
   <color name="color_palette_hide_eye_icon_color">@color/color_def_forest_green</color>
+  <color name="color_palette_icon_background_color_2">@color/color_def_oppia_turquoise</color>
+  <color name="color_palette_accent_background_color">@color/color_def_oppia_dark_grey</color>
+  <color name="color_palette_seekbar_progress_background_color">@color/color_def_maastricht_blue</color>
+  <color name="color_palette_toolbar_secondary_color">@color/color_def_forest_green</color>
+  <color name="color_palette_secondary_background_color_2">@color/color_def_oppia_light_black</color>
+  <color name="color_palette_concept_card_toolbar_color">@color/color_def_dark_pink</color>
+  <color name="color_palette_menu_selected_text_color">@color/color_def_oppia_pink</color>
+  <color name="color_palette_developer_option_menu_selected_color">@color/color_def_persian_blue</color>
+  <color name="color_palette_underline_view_color">@color/color_def_bright_green</color>
+  <color name="color_palette_menu_text_color">@color/color_def_white</color>
+  <color name="color_palette_secondary_container_background_color">@color/color_def_oppia_metallic_blue</color>
+  <color name="color_palette_concept_status_bar_color">@color/color_def_dark_purple</color>
 </resources>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -9,9 +9,9 @@
   </style>
 
   <style name="AudioSeekBar" parent="Widget.AppCompat.SeekBar">
-    <item name="android:progressBackgroundTint">@color/progress_background_tint</item>
-    <item name="android:progressTint">@color/color_def_white</item>
-    <item name="android:colorControlActivated">@color/progress_background_tint</item>
+    <item name="android:progressBackgroundTint">@color/component_color_audio_fragment_seekbar_color</item>
+    <item name="android:progressTint">@color/component_color_audio_fragment_seekbar_progress_color</item>
+    <item name="android:colorControlActivated">@color/component_color_audio_fragment_seekbar_color</item>
   </style>
 
   <style name="ReadingTextSizeSeekBar" parent="Widget.AppCompat.SeekBar">

--- a/app/src/main/res/values/color_defs.xml
+++ b/app/src/main/res/values/color_defs.xml
@@ -58,4 +58,14 @@
   <color name="color_def_chooser_grey">#999999</color>
   <color name="color_def_green">#02655c</color>
   <color name="color_def_error_text_color">#923026</color>
+  <color name="color_def_maastricht_blue">#0e162f</color>
+  <color name="color_def_ocean_blue">#081661</color>
+  <color name="color_def_dark_pink">#8A3D69</color>
+  <color name="color_def_persian_blue">#00609C</color>
+  <color name="color_def_bright_green">#009C8A</color>
+  <color name="color_def_grape_violet">#674172</color>
+  <color name="color_def_bright_violet">#7659B6</color>
+  <color name="color_def_teal_blue">#2F6687</color>
+  <color name="color_def_dark_red">#A6503A</color>
+  <color name="color_def_dark_purple">#441530</color>
 </resources>

--- a/app/src/main/res/values/color_defs.xml
+++ b/app/src/main/res/values/color_defs.xml
@@ -57,7 +57,7 @@
   <color name="color_def_yellow_ivory">#FFFFF0</color>
   <color name="color_def_chooser_grey">#999999</color>
   <color name="color_def_green">#02655c</color>
-  <color name="color_def_error_text_color">#923026</color>
+  <color name="color_def_error">#923026</color>
   <color name="color_def_maastricht_blue">#0e162f</color>
   <color name="color_def_ocean_blue">#081661</color>
   <color name="color_def_dark_pink">#8A3D69</color>

--- a/app/src/main/res/values/color_palette.xml
+++ b/app/src/main/res/values/color_palette.xml
@@ -45,11 +45,11 @@
   <color name="color_palette_error_text_color">@color/color_def_error_text</color>
   <color name="color_palette_show_eye_icon_color">@color/color_def_accessible_grey</color>
   <color name="color_palette_hide_eye_icon_color">@color/color_def_accessible_grey</color>
-  <color name="color_palette_icon_background_color_2">@color/color_def_white</color>
+  <color name="color_palette_icon_background_secondary_color">@color/color_def_white</color>
   <color name="color_palette_accent_background_color">@color/color_def_oppia_dark_blue</color>
   <color name="color_palette_seekbar_progress_background_color">@color/color_def_ocean_blue</color>
   <color name="color_palette_toolbar_secondary_color">@color/color_def_oppia_green</color>
-  <color name="color_palette_secondary_background_color_2">@color/color_def_oppia_light_green</color>
+  <color name="color_palette_secondary_dark_background_color">@color/color_def_oppia_light_green</color>
   <color name="color_palette_concept_card_toolbar_color">@color/color_def_oppia_brown_dark</color>
   <color name="color_palette_menu_selected_text_color">@color/color_def_oppia_brown_dark</color>
   <color name="color_palette_developer_option_menu_selected_color">@color/color_def_persian_blue</color>

--- a/app/src/main/res/values/color_palette.xml
+++ b/app/src/main/res/values/color_palette.xml
@@ -45,4 +45,16 @@
   <color name="color_palette_error_text_color">@color/color_def_error_text_color</color>
   <color name="color_palette_show_eye_icon_color">@color/color_def_accessible_grey</color>
   <color name="color_palette_hide_eye_icon_color">@color/color_def_accessible_grey</color>
+  <color name="color_palette_icon_background_color_2">@color/color_def_white</color>
+  <color name="color_palette_accent_background_color">@color/color_def_oppia_dark_blue</color>
+  <color name="color_palette_seekbar_progress_background_color">@color/color_def_ocean_blue</color>
+  <color name="color_palette_toolbar_secondary_color">@color/color_def_oppia_green</color>
+  <color name="color_palette_secondary_background_color_2">@color/color_def_oppia_light_green</color>
+  <color name="color_palette_concept_card_toolbar_color">@color/color_def_oppia_brown_dark</color>
+  <color name="color_palette_menu_selected_text_color">@color/color_def_oppia_brown_dark</color>
+  <color name="color_palette_developer_option_menu_selected_color">@color/color_def_persian_blue</color>
+  <color name="color_palette_underline_view_color">@color/color_def_oppia_light_brown</color>
+  <color name="color_palette_menu_text_color">@color/color_def_black</color>
+  <color name="color_palette_secondary_container_background_color">@color/color_def_teal_blue</color>
+  <color name="color_palette_concept_status_bar_color">@color/color_def_dark_red</color>
 </resources>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -179,8 +179,8 @@
   <color name="component_color_concept_card_fragment_text_color">@color/color_palette_highlighted_text_color</color>
   <!-- Audio Fragment -->
   <color name="component_color_audio_fragment_background_color">@color/color_palette_accent_background_color</color>
-  <color name="component_color_audio_fragment_icon_color">@color/color_palette_icon_background_color_2</color>
-  <color name="component_color_audio_fragment_thumb_background_color">@color/color_palette_icon_background_color_2</color>
-  <color name="component_color_audio_fragment_seekbar_progress_color">@color/color_palette_icon_background_color_2</color>
+  <color name="component_color_audio_fragment_icon_color">@color/color_palette_icon_background_secondary_color</color>
+  <color name="component_color_audio_fragment_thumb_background_color">@color/color_palette_icon_background_secondary_color</color>
+  <color name="component_color_audio_fragment_seekbar_progress_color">@color/color_palette_icon_background_secondary_color</color>
   <color name="component_color_audio_fragment_seekbar_color">@color/color_palette_seekbar_progress_background_color</color>
 </resources>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -160,4 +160,27 @@
   <color name="component_color_math_expression_parser_activity_radio_buttons_color">@color/color_palette_dark_text_color</color>
   <color name="component_color_math_expression_parser_activity_edit_text_color">@color/color_palette_dark_text_color</color>
   <color name="component_color_math_expression_parser_activity_hint_text_color">@color/color_palette_hint_text_color</color>
+  <!-- Drawer Fragment -->
+  <color name="component_color_drawer_fragment_background_color">@color/color_palette_primary_container_background_color</color>
+  <color name="component_color_drawer_fragment_selected_text_color">@color/color_palette_menu_selected_text_color</color>
+  <color name="component_color_drawer_fragment_text_color">@color/color_palette_menu_text_color</color>
+  <color name="component_color_drawer_fragment_developer_options_text_color">@color/color_palette_dark_text_color</color>
+  <color name="component_color_drawer_fragment_developer_options_selected_text_color">@color/color_palette_developer_option_menu_selected_color</color>
+  <color name="component_color_drawer_fragment_developer_options_image_color">@color/color_palette_dark_text_color</color>
+  <color name="component_color_drawer_fragment_developer_options_selected_image_color">@color/color_palette_developer_option_menu_selected_color</color>
+  <color name="component_color_drawer_fragment_admin_controls_text_color">@color/color_palette_dark_text_color</color>
+  <color name="component_color_drawer_fragment_admin_controls_selected_text_color">@color/color_palette_menu_selected_text_color</color>
+  <color name="component_color_drawer_fragment_admin_controls_image_color">@color/color_palette_dark_text_color</color>
+  <color name="component_color_drawer_fragment_admin_controls_selected_image_color">@color/color_palette_menu_selected_text_color</color>
+  <!-- Concept Card Fragment -->
+  <color name="component_color_concept_card_fragment_toolbar_color">@color/color_palette_concept_card_toolbar_color</color>
+  <color name="component_color_concept_card_fragment_status_bar_color">@color/color_palette_concept_status_bar_color</color>
+  <color name="component_color_concept_card_fragment_background_color">@color/color_palette_background_color</color>
+  <color name="component_color_concept_card_fragment_text_color">@color/color_palette_highlighted_text_color</color>
+  <!-- Audio Fragment -->
+  <color name="component_color_audio_fragment_background_color">@color/color_palette_accent_background_color</color>
+  <color name="component_color_audio_fragment_icon_color">@color/color_palette_icon_background_color_2</color>
+  <color name="component_color_audio_fragment_thumb_background_color">@color/color_palette_icon_background_color_2</color>
+  <color name="component_color_audio_fragment_seekbar_progress_color">@color/color_palette_icon_background_color_2</color>
+  <color name="component_color_audio_fragment_seekbar_color">@color/color_palette_seekbar_progress_background_color</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -21,7 +21,7 @@
 
   <style name="FullScreenDialogStyle" parent="Theme.MaterialComponents.Dialog.Bridge">
     <item name="android:windowNoTitle">true</item>
-    <item name="colorPrimaryDark">@color/concept_toolbar_heading</item>
+    <item name="colorPrimaryDark">@color/component_color_concept_card_fragment_status_bar_color</item>
     <!-- Set this to true if you want Full Screen without status bar -->
     <item name="android:windowFullscreen">false</item>
     <item name="android:windowIsFloating">false</item>


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixes Part Of #4194 

**Drawer Fragment :** https://xd.adobe.com/view/c05e9343-60f6-4c11-84ac-c756b75b940f-950d/screen/eb119ee3-033f-4757-8aee-7ea234d6f126/specs/

**Concept Card Fragment :** https://xd.adobe.com/view/c05e9343-60f6-4c11-84ac-c756b75b940f-950d/screen/2ee531cf-c358-4a7d-b9dd-b772b51c3d3c/specs/

**Audio Fragment :** https://xd.adobe.com/view/c05e9343-60f6-4c11-84ac-c756b75b940f-950d/screen/d67b268b-f6d9-434f-8897-24a2b13ccd84/specs/

**_these 2 needs to be done in following PRs._**

**Revision Card Activity :** https://xd.adobe.com/view/c05e9343-60f6-4c11-84ac-c756b75b940f-950d/screen/5d907b23-a75e-4f8b-8c59-afd3c734c53e/specs/

**Home Activity :** https://xd.adobe.com/view/c05e9343-60f6-4c11-84ac-c756b75b940f-950d/screen/67bfcbac-7b8e-491b-89c3-38937b37e5c2/specs/

- for future suggestion if somebody wants to show the Coming soon activity they can go to their project and can search for **_TopicListController.kt_** and comment out line number 266, 267 and 269. another suggestion is that they can complete all the chapters from developers options and complete recently played activities or they can refer to this document for further details -> https://docs.google.com/document/d/1o7hOz1rP-hJaKn1f5x6LV6ms0bzhyCpsTifJQY5crCc/edit#heading=h.ovlu0iazlug6



| **Default** | **Dark Mode** |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/92685493/170865004-1b3b497c-151b-4e14-95f1-d21c5afeaf4a.png)  | ![image](https://user-images.githubusercontent.com/92685493/174487573-df38bb54-052b-47c2-9573-e78aff706534.png)  |
| ![image](https://user-images.githubusercontent.com/92685493/170865021-7f347441-faa7-47be-9bb9-e86f0e9be64a.png)  | ![image](https://user-images.githubusercontent.com/92685493/174487614-07408c10-96b4-4144-b3a8-a5e8a06863a0.png)  |
| ![image](https://user-images.githubusercontent.com/92685493/170865060-87b6de2a-c80c-4454-ab9f-377c3fd8ce0c.png)  | ![image](https://user-images.githubusercontent.com/92685493/174487635-e68866e0-3ea9-4733-a9ee-2ded8e558c8c.png)  |
| ![image](https://user-images.githubusercontent.com/92685493/170865163-18e88465-bfc8-4885-8f1d-491598ed02c9.png) | ![image](https://user-images.githubusercontent.com/92685493/174487740-ad806440-c14e-4aba-ad49-98c506250201.png)  |
| ![image](https://user-images.githubusercontent.com/92685493/170865258-a96b39cf-f2d0-464b-a65c-74dfb584b418.png)  | ![image](https://user-images.githubusercontent.com/92685493/170865282-600bbe4e-70bf-4b0e-97de-58d85b1f5a0c.png)  |

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
