### PR TITLE
Fixes part of #4195: Added dark mode support to Exploration and QuestionPlayer

### DIFF
--- a/app/src/main/res/drawable/congratulations_text_background_shadow.xml
+++ b/app/src/main/res/drawable/congratulations_text_background_shadow.xml
@@ -92,9 +92,9 @@
   <item>
     <shape>
       <stroke android:width="3dp"
-        android:color="@color/color_def_green_shade_80"/>
+        android:color="@color/component_color_shared_correct_text_stroke_color"/>
       <corners android:radius="4dp" />
-      <solid android:color="@color/color_def_light_green" />
+      <solid android:color="@color/component_color_shared_correct_text_solid_color" />
     </shape>
   </item>
 </layer-list>

--- a/app/src/main/res/drawable/ic_arrow_back_oppia_dark_blue_24dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_back_oppia_dark_blue_24dp.xml
@@ -2,6 +2,7 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   android:width="24dp"
   android:height="24dp"
+  android:tint="@color/component_color_shared_back_arrow_button_color"
   android:viewportWidth="24.0"
   android:viewportHeight="24.0"
   android:autoMirrored="true">

--- a/app/src/main/res/drawable/previous_next_state_image_view_background.xml
+++ b/app/src/main/res/drawable/previous_next_state_image_view_background.xml
@@ -5,5 +5,5 @@
   <corners
     android:radius="@dimen/state_previous_next_button_radius"/>
   <solid
-    android:color="@color/color_def_oppia_light_yellow"/>
+    android:color="@color/component_color_shared_previous_next_state_image_view_background_color"/>
 </shape>

--- a/app/src/main/res/drawable/progress_bar.xml
+++ b/app/src/main/res/drawable/progress_bar.xml
@@ -3,17 +3,17 @@
   <item android:id="@+id/background">
     <shape>
       <corners android:radius="8dp" />
-      <solid android:color="@color/color_def_white" />
+      <solid android:color="@color/component_color_shared_progress_bar_background_color" />
       <stroke
         android:width="1dp"
-        android:color="@color/oppia_primary" />
+        android:color="@color/component_color_shared_progress_bar_stroke_color" />
     </shape>
   </item>
   <item android:id="@+id/progress">
     <scale android:scaleWidth="100%">
       <shape>
         <corners android:radius="8dp" />
-        <solid android:color="@color/oppia_primary" />
+        <solid android:color="@color/component_color_shared_progress_bar_solid_color" />
       </shape>
     </scale>
   </item>

--- a/app/src/main/res/drawable/question_player_progress_bar_background_gradient.xml
+++ b/app/src/main/res/drawable/question_player_progress_bar_background_gradient.xml
@@ -3,8 +3,8 @@
   android:shape="rectangle">
   <gradient
     android:angle="270"
-    android:endColor="@color/question_player_progress_bar_gradient_end"
-    android:centerColor="@color/question_player_progress_bar_gradient_center"
-    android:startColor="@color/question_player_progress_bar_gradient_start"
+    android:endColor="@color/component_color_shared_question_player_progress_bar_gradient_end_color"
+    android:centerColor="@color/component_color_shared_question_player_progress_bar_gradient_center_color"
+    android:startColor="@color/component_color_shared_question_player_progress_bar_gradient_start_color"
     android:type="linear" />
 </shape>

--- a/app/src/main/res/drawable/state_button_inactive_background.xml
+++ b/app/src/main/res/drawable/state_button_inactive_background.xml
@@ -2,5 +2,8 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
   android:shape="rectangle">
   <corners android:radius="@dimen/state_previous_next_button_radius" />
-  <solid android:color="@color/submit_button_inactive" />
+  <solid android:color="@color/component_color_shared_submit_button_inactive_solid_color" />
+  <stroke
+    android:width="1dp"
+    android:color="@color/component_color_shared_submit_button_inactive_stroke_color" />
 </shape>

--- a/app/src/main/res/drawable/state_button_orange_background.xml
+++ b/app/src/main/res/drawable/state_button_orange_background.xml
@@ -5,5 +5,5 @@
   <corners
     android:radius="@dimen/state_previous_next_button_radius"/>
   <solid
-    android:color="@color/concept_toolbar_background"/>
+    android:color="@color/component_color_shared_replay_button_color"/>
 </shape>

--- a/app/src/main/res/layout-land/question_player_fragment.xml
+++ b/app/src/main/res/layout-land/question_player_fragment.xml
@@ -180,7 +180,7 @@
         android:lineSpacingExtra="1dp"
         android:text="@string/correct"
         android:textAllCaps="true"
-        android:textColor="@color/color_def_green_shade"
+        android:textColor="@color/component_color_shared_correct_text_color"
         android:textSize="20sp"
         android:visibility="invisible" />
 

--- a/app/src/main/res/layout-sw600dp-land/question_player_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-land/question_player_fragment.xml
@@ -183,7 +183,7 @@
         android:lineSpacingExtra="1dp"
         android:text="@string/correct"
         android:textAllCaps="true"
-        android:textColor="@color/color_def_green_shade"
+        android:textColor="@color/component_color_shared_correct_text_color"
         android:textSize="20sp"
         android:visibility="invisible" />
 

--- a/app/src/main/res/layout-sw600dp-port/question_player_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-port/question_player_fragment.xml
@@ -184,7 +184,7 @@
         android:lineSpacingExtra="1dp"
         android:text="@string/correct"
         android:textAllCaps="true"
-        android:textColor="@color/color_def_green_shade"
+        android:textColor="@color/component_color_shared_correct_text_color"
         android:textSize="20sp"
         android:visibility="invisible" />
 

--- a/app/src/main/res/layout/question_player_fragment.xml
+++ b/app/src/main/res/layout/question_player_fragment.xml
@@ -183,7 +183,7 @@
         android:lineSpacingExtra="1dp"
         android:text="@string/correct"
         android:textAllCaps="true"
-        android:textColor="@color/color_def_green_shade"
+        android:textColor="@color/component_color_shared_correct_text_color"
         android:textSize="20sp"
         android:visibility="invisible" />
 

--- a/app/src/main/res/layout/state_fragment.xml
+++ b/app/src/main/res/layout/state_fragment.xml
@@ -162,7 +162,7 @@
         android:lineSpacingExtra="1dp"
         android:text="@string/correct"
         android:textAllCaps="true"
-        android:textColor="@color/color_def_green_shade"
+        android:textColor="@color/component_color_shared_correct_text_color"
         android:textSize="20sp"
         android:visibility="invisible" />
 

--- a/app/src/main/res/layout/submit_button_item.xml
+++ b/app/src/main/res/layout/submit_button_item.xml
@@ -54,7 +54,7 @@
       android:enabled="@{buttonViewModel.canSubmitAnswer}"
       android:onClick="@{(v) -> buttonViewModel.submitNavigationButtonListener.onSubmitButtonClicked()}"
       android:text="@string/state_submit_button"
-      android:textColor="@{buttonViewModel.canSubmitAnswer ? @color/color_def_white : @color/component_color_shared_submit_text_inactive_color}"
+      android:textColor="@{buttonViewModel.canSubmitAnswer ? @color/component_color_shared_submit_text_active_color : @color/component_color_shared_submit_text_inactive_color}"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintHeight_min="48dp"

--- a/app/src/main/res/layout/submit_button_item.xml
+++ b/app/src/main/res/layout/submit_button_item.xml
@@ -54,6 +54,7 @@
       android:enabled="@{buttonViewModel.canSubmitAnswer}"
       android:onClick="@{(v) -> buttonViewModel.submitNavigationButtonListener.onSubmitButtonClicked()}"
       android:text="@string/state_submit_button"
+      android:textColor="@{buttonViewModel.canSubmitAnswer ? @color/color_def_white : @color/component_color_shared_submit_text_inactive_color}"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintHeight_min="48dp"

--- a/app/src/main/res/values-night/color_palette.xml
+++ b/app/src/main/res/values-night/color_palette.xml
@@ -46,4 +46,18 @@
   <color name="color_palette_show_eye_icon_color">@color/color_def_forest_green</color>
   <color name="color_palette_hide_eye_icon_color">@color/color_def_forest_green</color>
   <color name="color_palette_disabled_button_background_color">@color/color_def_black_grey</color>
+  <color name="color_palette_back_arrow_button_color">@color/color_def_oppia_turquoise</color>
+  <color name="color_palette_replay_button_color">@color/color_def_dark_pink</color>
+  <color name="color_palette_progress_bar_stroke_color">@color/color_def_light_turquoise</color>
+  <color name="color_palette_progress_bar_solid_color">@color/color_def_oppia_turquoise</color>
+  <color name="color_palette_correct_text_stroke_color">@color/color_def_oppia_turquoise</color>
+  <color name="color_palette_correct_text_solid_color">@color/color_def_oppia_grayish_black</color>
+  <color name="color_palette_correct_text_color">@color/color_def_oppia_turquoise</color>
+  <color name="color_palette_submit_button_inactive_solid_color">@color/color_def_black_grey</color>
+  <color name="color_palette_submit_button_inactive_stroke_color">@color/color_def_bright_turquoise</color>
+  <color name="color_palette_submit_text_inactive_color">@color/color_def_light_grey</color>
+  <color name="color_palette_previous_next_state_image_view_background_color">@color/color_def_oppia_grayish_black</color>
+  <color name="color_palette_progress_bar_gradient_start">@color/color_def_dark_mode_question_player_progress_bar_gradient_start</color>
+  <color name="color_palette_progress_bar_gradient_center">@color/color_def_dark_mode_question_player_progress_bar_gradient_center</color>
+  <color name="color_palette_progress_bar_gradient_end">@color/color_def_dark_mode_question_player_progress_bar_gradient_end</color>
 </resources>

--- a/app/src/main/res/values-night/color_palette.xml
+++ b/app/src/main/res/values-night/color_palette.xml
@@ -60,4 +60,5 @@
   <color name="color_palette_progress_bar_gradient_start">@color/color_def_dark_mode_question_player_progress_bar_gradient_start</color>
   <color name="color_palette_progress_bar_gradient_center">@color/color_def_dark_mode_question_player_progress_bar_gradient_center</color>
   <color name="color_palette_progress_bar_gradient_end">@color/color_def_dark_mode_question_player_progress_bar_gradient_end</color>
+  <color name="color_palette_submit_text_active_color">@color/color_def_white</color>
 </resources>

--- a/app/src/main/res/values-night/color_palette.xml
+++ b/app/src/main/res/values-night/color_palette.xml
@@ -57,8 +57,8 @@
   <color name="color_palette_submit_button_inactive_stroke_color">@color/color_def_bright_turquoise</color>
   <color name="color_palette_submit_text_inactive_color">@color/color_def_light_grey</color>
   <color name="color_palette_previous_next_state_image_view_background_color">@color/color_def_oppia_grayish_black</color>
-  <color name="color_palette_progress_bar_gradient_start">@color/color_def_dark_mode_question_player_progress_bar_gradient_start</color>
-  <color name="color_palette_progress_bar_gradient_center">@color/color_def_dark_mode_question_player_progress_bar_gradient_center</color>
-  <color name="color_palette_progress_bar_gradient_end">@color/color_def_dark_mode_question_player_progress_bar_gradient_end</color>
+  <color name="color_palette_progress_bar_gradient_start_color">@color/color_def_dark_mode_question_player_progress_bar_gradient_start</color>
+  <color name="color_palette_progress_bar_gradient_center_color">@color/color_def_dark_mode_question_player_progress_bar_gradient_center</color>
+  <color name="color_palette_progress_bar_gradient_end_color">@color/color_def_dark_mode_question_player_progress_bar_gradient_end</color>
   <color name="color_palette_submit_text_active_color">@color/color_def_white</color>
 </resources>

--- a/app/src/main/res/values/color_defs.xml
+++ b/app/src/main/res/values/color_defs.xml
@@ -59,4 +59,13 @@
   <color name="color_def_green">#02655c</color>
   <color name="color_def_error_text">#923026</color>
   <color name="color_def_black_grey">#33999999</color>
+  <color name="color_def_dark_pink">#8A3D69</color>
+  <color name="color_def_light_turquoise">#ACFFF8</color>
+  <color name="color_def_submit_button_inactive">#61999999</color>
+  <color name="color_def_question_player_progress_bar_gradient_start">#00E4F2F1</color>
+  <color name="color_def_question_player_progress_bar_gradient_center">#E4F2F1</color>
+  <color name="color_def_question_player_progress_bar_gradient_end">#E4F2F1</color>
+  <color name="color_def_dark_mode_question_player_progress_bar_gradient_start">#23272A00</color>
+  <color name="color_def_dark_mode_question_player_progress_bar_gradient_center">#23272A</color>
+  <color name="color_def_dark_mode_question_player_progress_bar_gradient_end">#00C7B6</color>
 </resources>

--- a/app/src/main/res/values/color_palette.xml
+++ b/app/src/main/res/values/color_palette.xml
@@ -46,4 +46,18 @@
   <color name="color_palette_show_eye_icon_color">@color/color_def_accessible_grey</color>
   <color name="color_palette_hide_eye_icon_color">@color/color_def_accessible_grey</color>
   <color name="color_palette_disabled_button_background_color">@color/color_def_black_grey</color>
+  <color name="color_palette_back_arrow_button_color">@color/color_def_oppia_dark_blue</color>
+  <color name="color_palette_replay_button_color">@color/color_def_oppia_brown_dark</color>
+  <color name="color_palette_progress_bar_stroke_color">@color/color_def_oppia_green</color>
+  <color name="color_palette_progress_bar_solid_color">@color/color_def_oppia_green</color>
+  <color name="color_palette_correct_text_stroke_color">@color/color_def_green_shade_80</color>
+  <color name="color_palette_correct_text_solid_color">@color/color_def_light_green</color>
+  <color name="color_palette_correct_text_color">@color/color_def_green_shade</color>
+  <color name="color_palette_submit_button_inactive_solid_color">@color/color_def_submit_button_inactive</color>
+  <color name="color_palette_submit_button_inactive_stroke_color">@color/color_def_submit_button_inactive</color>
+  <color name="color_palette_submit_text_inactive_color">@color/color_def_white</color>
+  <color name="color_palette_previous_next_state_image_view_background_color">@color/color_def_oppia_light_yellow</color>
+  <color name="color_palette_progress_bar_gradient_start">@color/color_def_question_player_progress_bar_gradient_start</color>
+  <color name="color_palette_progress_bar_gradient_center">@color/color_def_question_player_progress_bar_gradient_center</color>
+  <color name="color_palette_progress_bar_gradient_end">@color/color_def_question_player_progress_bar_gradient_end</color>
 </resources>

--- a/app/src/main/res/values/color_palette.xml
+++ b/app/src/main/res/values/color_palette.xml
@@ -60,4 +60,5 @@
   <color name="color_palette_progress_bar_gradient_start">@color/color_def_question_player_progress_bar_gradient_start</color>
   <color name="color_palette_progress_bar_gradient_center">@color/color_def_question_player_progress_bar_gradient_center</color>
   <color name="color_palette_progress_bar_gradient_end">@color/color_def_question_player_progress_bar_gradient_end</color>
+  <color name="color_palette_submit_text_active_color">@color/color_def_white</color>
 </resources>

--- a/app/src/main/res/values/color_palette.xml
+++ b/app/src/main/res/values/color_palette.xml
@@ -57,8 +57,8 @@
   <color name="color_palette_submit_button_inactive_stroke_color">@color/color_def_submit_button_inactive</color>
   <color name="color_palette_submit_text_inactive_color">@color/color_def_white</color>
   <color name="color_palette_previous_next_state_image_view_background_color">@color/color_def_oppia_light_yellow</color>
-  <color name="color_palette_progress_bar_gradient_start">@color/color_def_question_player_progress_bar_gradient_start</color>
-  <color name="color_palette_progress_bar_gradient_center">@color/color_def_question_player_progress_bar_gradient_center</color>
-  <color name="color_palette_progress_bar_gradient_end">@color/color_def_question_player_progress_bar_gradient_end</color>
+  <color name="color_palette_progress_bar_gradient_start_color">@color/color_def_question_player_progress_bar_gradient_start</color>
+  <color name="color_palette_progress_bar_gradient_center_color">@color/color_def_question_player_progress_bar_gradient_center</color>
+  <color name="color_palette_progress_bar_gradient_end_color">@color/color_def_question_player_progress_bar_gradient_end</color>
   <color name="color_palette_submit_text_active_color">@color/color_def_white</color>
 </resources>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -25,6 +25,7 @@
   <color name="component_color_shared_submit_button_inactive_solid_color">@color/color_palette_submit_button_inactive_solid_color</color>
   <color name="component_color_shared_submit_button_inactive_stroke_color">@color/color_palette_submit_button_inactive_stroke_color</color>
   <color name="component_color_shared_submit_text_inactive_color">@color/color_palette_submit_text_inactive_color</color>
+  <color name="component_color_shared_submit_text_active_color">@color/color_palette_submit_text_active_color</color>
   <color name="component_color_shared_previous_next_state_image_view_background_color">@color/color_palette_previous_next_state_image_view_background_color</color>
   <color name="component_color_shared_question_player_progress_bar_gradient_start_color">@color/color_palette_progress_bar_gradient_start</color>
   <color name="component_color_shared_question_player_progress_bar_gradient_center_color">@color/color_palette_progress_bar_gradient_center</color>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -14,6 +14,21 @@
   <color name="component_color_shared_multiple_choice_interaction_selected_text_color">@color/color_palette_multiple_choice_selected_text_color</color>
   <color name="component_color_shared_item_selection_interaction_color">@color/color_palette_item_selection_color</color>
   <color name="component_color_shared_item_selection_interaction_text_color">@color/color_palette_item_selection_text_color</color>
+  <color name="component_color_shared_back_arrow_button_color">@color/color_palette_back_arrow_button_color</color>
+  <color name="component_color_shared_replay_button_color">@color/color_palette_replay_button_color</color>
+  <color name="component_color_shared_progress_bar_solid_color">@color/color_palette_progress_bar_solid_color</color>
+  <color name="component_color_shared_progress_bar_stroke_color">@color/color_palette_progress_bar_stroke_color</color>
+  <color name="component_color_shared_progress_bar_background_color">@color/color_palette_rounded_rect_background_color</color>
+  <color name="component_color_shared_correct_text_stroke_color">@color/color_palette_correct_text_stroke_color</color>
+  <color name="component_color_shared_correct_text_solid_color">@color/color_palette_correct_text_solid_color</color>
+  <color name="component_color_shared_correct_text_color">@color/color_palette_correct_text_color</color>
+  <color name="component_color_shared_submit_button_inactive_solid_color">@color/color_palette_submit_button_inactive_solid_color</color>
+  <color name="component_color_shared_submit_button_inactive_stroke_color">@color/color_palette_submit_button_inactive_stroke_color</color>
+  <color name="component_color_shared_submit_text_inactive_color">@color/color_palette_submit_text_inactive_color</color>
+  <color name="component_color_shared_previous_next_state_image_view_background_color">@color/color_palette_previous_next_state_image_view_background_color</color>
+  <color name="component_color_shared_question_player_progress_bar_gradient_start_color">@color/color_palette_progress_bar_gradient_start</color>
+  <color name="component_color_shared_question_player_progress_bar_gradient_center_color">@color/color_palette_progress_bar_gradient_center</color>
+  <color name="component_color_shared_question_player_progress_bar_gradient_end_color">@color/color_palette_progress_bar_gradient_end</color>
   <!-- Themes.xml -->
   <color name="component_color_shared_activity_status_bar_color">@color/color_palette_status_bar_color</color>
   <color name="component_color_shared_activity_action_bar_color">@color/color_palette_action_bar_color</color>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -27,9 +27,9 @@
   <color name="component_color_shared_submit_text_inactive_color">@color/color_palette_submit_text_inactive_color</color>
   <color name="component_color_shared_submit_text_active_color">@color/color_palette_submit_text_active_color</color>
   <color name="component_color_shared_previous_next_state_image_view_background_color">@color/color_palette_previous_next_state_image_view_background_color</color>
-  <color name="component_color_shared_question_player_progress_bar_gradient_start_color">@color/color_palette_progress_bar_gradient_start</color>
-  <color name="component_color_shared_question_player_progress_bar_gradient_center_color">@color/color_palette_progress_bar_gradient_center</color>
-  <color name="component_color_shared_question_player_progress_bar_gradient_end_color">@color/color_palette_progress_bar_gradient_end</color>
+  <color name="component_color_shared_question_player_progress_bar_gradient_start_color">@color/color_palette_progress_bar_gradient_start_color</color>
+  <color name="component_color_shared_question_player_progress_bar_gradient_center_color">@color/color_palette_progress_bar_gradient_center_color</color>
+  <color name="component_color_shared_question_player_progress_bar_gradient_end_color">@color/color_palette_progress_bar_gradient_end_color</color>
   <!-- Themes.xml -->
   <color name="component_color_shared_activity_status_bar_color">@color/color_palette_status_bar_color</color>
   <color name="component_color_shared_activity_action_bar_color">@color/color_palette_action_bar_color</color>


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixes part of #4195 

- This PR adds dark mode support to the buttons-- replay button, submit button in inactive state, previous next state image view button.
- To the progress bar 
- To the progress bar background gradient
- To the correct text which appears after submitting the correct answer

**Mocks link:--**

- https://xd.adobe.com/view/c05e9343-60f6-4c11-84ac-c756b75b940f-950d/screen/5ef661fa-8995-45b2-b10d-64c1b5cc7890/specs/
- https://xd.adobe.com/view/c05e9343-60f6-4c11-84ac-c756b75b940f-950d/screen/cf6a4999-56aa-4c3c-802f-7573a0457f9b/specs/
- https://xd.adobe.com/view/c05e9343-60f6-4c11-84ac-c756b75b940f-950d/screen/b8370649-71d2-473e-9b19-ae81616763e1/specs/
- https://xd.adobe.com/view/c05e9343-60f6-4c11-84ac-c756b75b940f-950d/screen/ec286faf-3a4f-4779-984a-17ca470842e6/specs/

**Screenshots**

| Default | Dark mode |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/175898797-2fb06705-7249-4a57-8e1b-2ea127c0fa9c.jpg" width="280" />|<img src="https://user-images.githubusercontent.com/78796264/175898808-f6ac3f40-9839-4943-8799-1b3b278a1f3c.jpg" width="280" />|

| Default | Dark mode |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/175898826-6dc7d751-05ff-46ec-9b59-4d45c12c93ac.jpg" width="280" />|<img src="https://user-images.githubusercontent.com/78796264/175898843-0478451b-f719-41c7-b233-52a2b1588d0f.jpg" width="280" />|

| Default | Dark mode |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/175899196-46780d16-8592-4bc8-a16d-b819dc4789ee.jpg" width="280" />|<img src="https://user-images.githubusercontent.com/78796264/175899218-90761517-6ca9-4639-b61b-3a9d45ee2c17.jpg" width="280" />|

| Default | Dark mode |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/175899231-9a704d55-ae30-4c91-8821-81ba5581e4d9.jpg" width="280" />|<img src="https://user-images.githubusercontent.com/78796264/175899243-612c7933-c76c-4715-8818-23aa875daca6.jpg" width="280" />|

| Default | Dark mode |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/175899324-114a2404-25de-44ae-926a-a26b0e69c568.jpg" width="280" />|<img src="https://user-images.githubusercontent.com/78796264/175899337-093df7ce-2100-495b-aabf-b6a04b86bca9.jpg" width="280" />|

| Default | Dark mode |
|-------|---|
|<img src="https://user-images.githubusercontent.com/78796264/175899360-52c5c330-a46f-40b6-85d3-39ee401dc17e.jpg" width="280" />|<img src="https://user-images.githubusercontent.com/78796264/175899372-4a96a4b2-32dd-4719-b9c9-f2069e1ca89e.jpg" width="280" />|

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
