### PR TITLE
Add dependency for "androidx.work:work-testing" on androidTestImpleme…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -208,6 +208,7 @@ dependencies {
       'androidx.test.ext:junit:1.1.1',
       'com.github.bumptech.glide:mocks:4.11.0',
       'com.google.truth:truth:1.1.3',
+      'androidx.work:work-testing:2.4.0',
       'com.google.truth.extensions:truth-liteproto-extension:1.1.3',
       'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.2',
       'org.mockito:mockito-android:2.7.22',


### PR DESCRIPTION
  - Fixes issue whereby UI tests were not running due to missing dependencies.
  - I added the dependency for 'androidx.work:work-testing:2.4.0' on androidTestImplementation which basically fixes the missing dependencies on androidTest package.
 

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Issue stack trace
> Task :app:compileDebugAndroidTestKotlin
e: /Volumes/Kevin/opensource/oppia-android/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/learneranalytics/ProfileAndDeviceIdActivityTest.kt: (12, 22): Unresolved reference: testing
e: /Volumes/Kevin/opensource/oppia-android/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/learneranalytics/ProfileAndDeviceIdActivityTest.kt: (13, 22): Unresolved reference: testing
e: /Volumes/Kevin/opensource/oppia-android/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/learneranalytics/ProfileAndDeviceIdActivityTest.kt: (136, 20): Unresolved reference: SynchronousExecutor
e: /Volumes/Kevin/opensource/oppia-android/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/learneranalytics/ProfileAndDeviceIdActivityTest.kt: (139, 5): Unresolved reference: WorkManagerTestInitHelper
e: /Volumes/Kevin/opensource/oppia-android/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/learneranalytics/ProfileAndDeviceIdFragmentTest.kt: (24, 22): Unresolved reference: testing
e: /Volumes/Kevin/opensource/oppia-android/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/learneranalytics/ProfileAndDeviceIdFragmentTest.kt: (25, 22): Unresolved reference: testing
e: /Volumes/Kevin/opensource/oppia-android/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/learneranalytics/ProfileAndDeviceIdFragmentTest.kt: (170, 20): Unresolved reference: SynchronousExecutor
e: /Volumes/Kevin/opensource/oppia-android/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/learneranalytics/ProfileAndDeviceIdFragmentTest.kt: (173, 5): Unresolved reference: WorkManagerTestInitHelper

> Task :app:compileDebugAndroidTestKotlin FAILED

## Screenshots for affected tests, before and after respectively
<img width="1372" alt="Screenshot 2022-07-08 at 09 46 49" src="https://user-images.githubusercontent.com/20886444/177934224-cdf05ed0-de80-4bcd-9d22-fb91b644cbd4.png">
<img width="1400" alt="Screenshot 2022-07-08 at 09 52 37" src="https://user-images.githubusercontent.com/20886444/177934316-e00b947d-6195-4888-8ebb-d0de370c5ce0.png">


