### PR TITLE
Fixes #3169: Item selection interaction text change on selection

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
@@ -2,6 +2,7 @@ package org.oppia.android.app.player.state.itemviewmodel
 
 import androidx.databinding.Observable
 import androidx.databinding.ObservableField
+import androidx.databinding.ObservableInt
 import androidx.databinding.ObservableList
 import org.oppia.android.app.model.Interaction
 import org.oppia.android.app.model.InteractionObject
@@ -52,6 +53,8 @@ class SelectionInteractionViewModel private constructor(
       ?: minAllowableSelectionCount
   }
   private val selectedItems: MutableList<Int> = mutableListOf()
+  val selectedItemsCount = ObservableInt()
+  var selectedItemText = ObservableField<String>()
   val choiceItems: ObservableList<SelectionInteractionContentViewModel> =
     computeChoiceItems(choiceSubtitledHtmls, hasConversationView, this)
 
@@ -123,6 +126,12 @@ class SelectionInteractionViewModel private constructor(
     return when {
       isCurrentlySelected -> {
         selectedItems -= itemIndex
+        selectedItemsCount.set(selectedItems.size)
+         when(selectedItemsCount.get()){
+          1 -> selectedItemText.set("You may select more choices")
+          2 -> selectedItemText.set("No more than 4 choices may be selected.")
+          else -> selectedItemText.set("Please select one or more choices")
+        }
         updateIsAnswerAvailable()
         false
       }
@@ -131,6 +140,7 @@ class SelectionInteractionViewModel private constructor(
         choiceItems.forEach { item -> item.isAnswerSelected.set(false) }
         selectedItems.clear()
         selectedItems += itemIndex
+        selectedItemsCount.set(selectedItems.size)
         updateIsAnswerAvailable()
         true
       }
@@ -138,6 +148,7 @@ class SelectionInteractionViewModel private constructor(
         // TODO(#3624): Add warning to user when they exceed the number of allowable selections or are under the minimum
         //  number required.
         selectedItems += itemIndex
+        selectedItemsCount.set(selectedItems.size)
         updateIsAnswerAvailable()
         true
       }

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
@@ -127,7 +127,7 @@ class SelectionInteractionViewModel private constructor(
       isCurrentlySelected -> {
         selectedItems -= itemIndex
         selectedItemsCount.set(selectedItems.size)
-         when(selectedItemsCount.get()){
+        when (selectedItemsCount.get()) {
           1 -> selectedItemText.set("You may select more choices")
           2 -> selectedItemText.set("No more than 4 choices may be selected.")
           else -> selectedItemText.set("Please select one or more choices")

--- a/app/src/main/res/layout/selection_interaction_item.xml
+++ b/app/src/main/res/layout/selection_interaction_item.xml
@@ -42,7 +42,7 @@
       android:layout_marginTop="4dp"
       android:layout_marginBottom="4dp"
       android:fontFamily="sans-serif-light"
-      android:text="@string/item_selection_text"
+      android:text="@{viewModel.selectedItemText}"
       android:textColor="@color/oppia_primary_text"
       android:textSize="14sp"
       android:textStyle="italic"


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixes #3169 

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
