### PR TITLE
Fix #4438: Add profile login counter

### DIFF
--- a/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
@@ -7,10 +7,6 @@ import android.media.ThumbnailUtils
 import android.net.Uri
 import android.provider.MediaStore
 import androidx.exifinterface.media.ExifInterface
-import java.io.File
-import java.io.FileOutputStream
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlinx.coroutines.Deferred
 import org.oppia.android.app.model.AppLanguage
 import org.oppia.android.app.model.AudioLanguage
@@ -30,12 +26,15 @@ import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders
 import org.oppia.android.util.data.DataProviders.Companion.transform
 import org.oppia.android.util.data.DataProviders.Companion.transformAsync
-import org.oppia.android.util.data.DataProviders.Companion.transformNested
 import org.oppia.android.util.locale.OppiaLocale
 import org.oppia.android.util.platformparameter.LearnerStudyAnalytics
 import org.oppia.android.util.platformparameter.PlatformParameterValue
 import org.oppia.android.util.profile.DirectoryManagementUtil
 import org.oppia.android.util.system.OppiaClock
+import java.io.File
+import java.io.FileOutputStream
+import javax.inject.Inject
+import javax.inject.Singleton
 
 private const val GET_PROFILES_PROVIDER_ID = "get_profiles_provider_id"
 private const val GET_PROFILE_PROVIDER_ID = "get_profile_provider_id"
@@ -641,14 +640,15 @@ class ProfileManagementController @Inject constructor(
     }
   }
 
-  private fun updateLastLoggedInAsyncAndNumberOfLogins(profileId: ProfileId): Deferred<ProfileActionStatus> {
+  private fun updateLastLoggedInAsyncAndNumberOfLogins(profileId: ProfileId):
+    Deferred<ProfileActionStatus> {
     return profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
       val profile = it.profilesMap[profileId.internalId]
         ?: return@storeDataWithCustomChannelAsync Pair(it, ProfileActionStatus.PROFILE_NOT_FOUND)
       val updatedProfile = profile.toBuilder()
-          .setLastLoggedInTimestampMs(oppiaClock.getCurrentTimeMs())
-          .setNumberOfLogins(profile.numberOfLogins + 1)
-          .build()
+        .setLastLoggedInTimestampMs(oppiaClock.getCurrentTimeMs())
+        .setNumberOfLogins(profile.numberOfLogins + 1)
+        .build()
       val profileDatabaseBuilder = it.toBuilder().putProfiles(
         profileId.internalId,
         updatedProfile

--- a/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
@@ -642,20 +642,20 @@ class ProfileManagementController @Inject constructor(
 
   private fun updateLastLoggedInAsyncAndNumberOfLogins(profileId: ProfileId):
     Deferred<ProfileActionStatus> {
-    return profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
-      val profile = it.profilesMap[profileId.internalId]
-        ?: return@storeDataWithCustomChannelAsync Pair(it, ProfileActionStatus.PROFILE_NOT_FOUND)
-      val updatedProfile = profile.toBuilder()
-        .setLastLoggedInTimestampMs(oppiaClock.getCurrentTimeMs())
-        .setNumberOfLogins(profile.numberOfLogins + 1)
-        .build()
-      val profileDatabaseBuilder = it.toBuilder().putProfiles(
-        profileId.internalId,
-        updatedProfile
-      )
-      Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
+      return profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
+        val profile = it.profilesMap[profileId.internalId]
+          ?: return@storeDataWithCustomChannelAsync Pair(it, ProfileActionStatus.PROFILE_NOT_FOUND)
+        val updatedProfile = profile.toBuilder()
+          .setLastLoggedInTimestampMs(oppiaClock.getCurrentTimeMs())
+          .setNumberOfLogins(profile.numberOfLogins + 1)
+          .build()
+        val profileDatabaseBuilder = it.toBuilder().putProfiles(
+          profileId.internalId,
+          updatedProfile
+        )
+        Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
+      }
     }
-  }
 
   /**
    * Deletes an existing profile.

--- a/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
@@ -232,6 +232,7 @@ class ProfileManagementController @Inject constructor(
         readingTextSize = ReadingTextSize.MEDIUM_TEXT_SIZE
         appLanguage = AppLanguage.ENGLISH_APP_LANGUAGE
         audioLanguage = AudioLanguage.ENGLISH_AUDIO_LANGUAGE
+        numberOfLogins = 0
 
         if (learnerStudyAnalytics.value) {
           // Only set a learner ID if there's an ongoing user study.

--- a/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
@@ -59,7 +59,6 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.io.File
 import java.io.FileInputStream
-import java.lang.IllegalStateException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -121,6 +120,7 @@ class ProfileManagementControllerTest {
     assertThat(profile.readingTextSize).isEqualTo(MEDIUM_TEXT_SIZE)
     assertThat(profile.appLanguage).isEqualTo(AppLanguage.ENGLISH_APP_LANGUAGE)
     assertThat(profile.audioLanguage).isEqualTo(AudioLanguage.ENGLISH_AUDIO_LANGUAGE)
+    assertThat(profile.numberOfLogins).isEqualTo(0)
     assertThat(File(getAbsoluteDirPath("0")).isDirectory).isTrue()
   }
 
@@ -521,7 +521,7 @@ class ProfileManagementControllerTest {
   }
 
   @Test
-  fun testLoginToProfile_addProfiles_loginToProfile_checkGetProfileIdAndLoginTimestampIsCorrect() {
+  fun testLoginToProfile_addProfiles_loginToProfile_checkGetProfileIdAndLoginTimestampAndNumberOfLoginsIsCorrect() {
     setUpTestApplicationComponent()
     addTestProfiles()
 
@@ -532,6 +532,32 @@ class ProfileManagementControllerTest {
     val profile = monitorFactory.waitForNextSuccessfulResult(profileProvider)
     assertThat(profileManagementController.getCurrentProfileId().internalId).isEqualTo(2)
     assertThat(profile.lastLoggedInTimestampMs).isNotEqualTo(0)
+    assertThat(profile.numberOfLogins).isNotEqualTo(0)
+  }
+
+  @Test
+  fun testLoginToProfile_addProfile_loginToProfile_logoutProfile_checkNumberOfLoginsIsCorrect() {
+    setUpTestApplicationComponent()
+    addTestProfiles()
+
+    var profileProvider = profileManagementController.getProfile(PROFILE_ID_2)
+    var profile = monitorFactory.waitForNextSuccessfulResult(profileProvider)
+    assertThat(profile.numberOfLogins).isEqualTo(0)
+
+    var loginProvider = profileManagementController.loginToProfile(PROFILE_ID_2)
+    monitorFactory.waitForNextSuccessfulResult(loginProvider)
+    profileProvider = profileManagementController.getProfile(PROFILE_ID_2)
+    profile = monitorFactory.waitForNextSuccessfulResult(profileProvider)
+    assertThat(profile.numberOfLogins).isEqualTo(1)
+
+    loginProvider = profileManagementController.loginToProfile(PROFILE_ID_3)
+    monitorFactory.waitForNextSuccessfulResult(loginProvider)
+
+    loginProvider = profileManagementController.loginToProfile(PROFILE_ID_2)
+    monitorFactory.waitForNextSuccessfulResult(loginProvider)
+    profileProvider = profileManagementController.getProfile(PROFILE_ID_2)
+    profile = monitorFactory.waitForNextSuccessfulResult(profileProvider)
+    assertThat(profile.numberOfLogins).isEqualTo(2)
   }
 
   @Test

--- a/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
@@ -521,7 +521,7 @@ class ProfileManagementControllerTest {
   }
 
   @Test
-  fun testLoginProfile_addedProfile_profileIdTimestampAndNumberOfLoginsCorrectlyDefaulted() {
+  fun testLoginProfile_addedProfile_profileIdTimestampAndNumberOfLoginsIsCorrectlyUpdated() {
     setUpTestApplicationComponent()
     addTestProfiles()
 

--- a/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
@@ -521,7 +521,7 @@ class ProfileManagementControllerTest {
   }
 
   @Test
-  fun testLoginProfile_addProfiles_loginProfile_checkProfileId_Timestamp_NumberOfLoginsCorrect() {
+  fun testLoginProfile_addedProfile_profileIdTimestampAndNumberOfLoginsCorrectlyDefaulted() {
     setUpTestApplicationComponent()
     addTestProfiles()
 
@@ -532,7 +532,7 @@ class ProfileManagementControllerTest {
     val profile = monitorFactory.waitForNextSuccessfulResult(profileProvider)
     assertThat(profileManagementController.getCurrentProfileId().internalId).isEqualTo(2)
     assertThat(profile.lastLoggedInTimestampMs).isNotEqualTo(0)
-    assertThat(profile.numberOfLogins).isNotEqualTo(0)
+    assertThat(profile.numberOfLogins).isEqualTo(1)
   }
 
   @Test

--- a/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
@@ -536,27 +536,20 @@ class ProfileManagementControllerTest {
   }
 
   @Test
-  fun testLoginToProfile_addProfile_loginToProfile_logoutProfile_checkNumberOfLoginsIsCorrect() {
+  fun testLoginToProfile_addProfile_loginToProfileTwice_checkNumberOfLoginsIsTwo() {
     setUpTestApplicationComponent()
     addTestProfiles()
-
-    var profileProvider = profileManagementController.getProfile(PROFILE_ID_2)
-    var profile = monitorFactory.waitForNextSuccessfulResult(profileProvider)
-    assertThat(profile.numberOfLogins).isEqualTo(0)
-
     var loginProvider = profileManagementController.loginToProfile(PROFILE_ID_2)
     monitorFactory.waitForNextSuccessfulResult(loginProvider)
-    profileProvider = profileManagementController.getProfile(PROFILE_ID_2)
-    profile = monitorFactory.waitForNextSuccessfulResult(profileProvider)
-    assertThat(profile.numberOfLogins).isEqualTo(1)
 
+    // log out of profile 2
     loginProvider = profileManagementController.loginToProfile(PROFILE_ID_3)
     monitorFactory.waitForNextSuccessfulResult(loginProvider)
 
     loginProvider = profileManagementController.loginToProfile(PROFILE_ID_2)
     monitorFactory.waitForNextSuccessfulResult(loginProvider)
-    profileProvider = profileManagementController.getProfile(PROFILE_ID_2)
-    profile = monitorFactory.waitForNextSuccessfulResult(profileProvider)
+    val profileProvider = profileManagementController.getProfile(PROFILE_ID_2)
+    val profile = monitorFactory.waitForNextSuccessfulResult(profileProvider)
     assertThat(profile.numberOfLogins).isEqualTo(2)
   }
 

--- a/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
@@ -521,7 +521,7 @@ class ProfileManagementControllerTest {
   }
 
   @Test
-  fun testLoginToProfile_addProfiles_loginToProfile_checkProfileId_Timestamp_NumberOfLoginsCorrect() {
+  fun testLoginProfile_addProfiles_loginProfile_checkProfileId_Timestamp_NumberOfLoginsCorrect() {
     setUpTestApplicationComponent()
     addTestProfiles()
 

--- a/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
@@ -521,7 +521,7 @@ class ProfileManagementControllerTest {
   }
 
   @Test
-  fun testLoginToProfile_addProfiles_loginToProfile_checkGetProfileIdAndLoginTimestampAndNumberOfLoginsIsCorrect() {
+  fun testLoginToProfile_addProfiles_loginToProfile_checkProfileId_Timestamp_NumberOfLoginsCorrect() {
     setUpTestApplicationComponent()
     addTestProfiles()
 

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -70,6 +70,9 @@ message Profile {
   // are enabled as part of a user study. In non-user study cases this is expected to either be
   // empty or a meaningless value.
   string learner_id = 13;
+
+  // Represents the number of times a user has logged into their profile
+  int32 number_of_logins = 14;
 }
 
 // Represents a profile avatar image.

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -71,7 +71,7 @@ message Profile {
   // empty or a meaningless value.
   string learner_id = 13;
 
-  // Represents the number of times a user has successfully logged into their profile
+  // Represents the number of times a user has successfully logged into their profile.
   int32 number_of_logins = 14;
 }
 

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -71,7 +71,7 @@ message Profile {
   // empty or a meaningless value.
   string learner_id = 13;
 
-  // Represents the number of times a user has logged into their profile
+  // Represents the number of times a user has successfully logged into their profile
   int32 number_of_logins = 14;
 }
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fixes #4438

This PR is a part of the GSoC project: Interactive Onboarding Flow which introduces a new field into the profile proto called number_of_logins. This is a variable which will be used to count the number of logins made by a user, based on which specific UI elements and spotlights could be shown to them.

The PR affects the ProfileManagementController -- we introduce a method called incrementLoginCount which is called when the user logs into their profile.

All the new changes are backed up by appropriate tests which check that the functionality works as expected.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).


