### PR TITLE
Separate domain asset handling for better build management

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,6 @@
 # TODO(#1532): Rename file to 'BUILD' post-Gradle.
 
-load("//:build_flavors.bzl", "AVAILABLE_FLAVORS", "define_oppia_aab_binary_flavor", "transform_android_manifest")
-load("//:version.bzl", "MAJOR_VERSION", "MINOR_VERSION", "OPPIA_DEV_KITKAT_VERSION_CODE", "OPPIA_DEV_VERSION_CODE")
+load("//:build_flavors.bzl", "AVAILABLE_APK_FLAVORS", "AVAILABLE_BUNDLE_FLAVORS", "define_oppia_aab_binary_flavor", "define_oppia_apk_binary_flavor")
 
 # This is exported here since config/ isn't a Bazel package.
 exports_files(["config/kitkat_main_dex_class_list.txt"])
@@ -71,61 +70,10 @@ package_group(
     ],
 )
 
-# TODO(#1640): Move binary manifest to top-level package post-Gradle.
+# TODO: Add docs.
 [
-    transform_android_manifest(
-        name = "oppia_apk_%s_transformed_manifest" % apk_flavor_metadata["flavor"],
-        build_flavor = apk_flavor_metadata["flavor"],
-        input_file = "//app:src/main/AndroidManifest.xml",
-        major_version = MAJOR_VERSION,
-        minor_version = MINOR_VERSION,
-        output_file = "AndroidManifest_transformed_%s.xml" % apk_flavor_metadata["flavor"],
-        version_code = apk_flavor_metadata["version_code"],
-    )
-    for apk_flavor_metadata in [
-        {
-            "flavor": "oppia",
-            "version_code": OPPIA_DEV_VERSION_CODE,
-        },
-        {
-            "flavor": "oppia_kitkat",
-            "version_code": OPPIA_DEV_KITKAT_VERSION_CODE,
-        },
-    ]
-]
-
-[
-    android_binary(
-        name = apk_flavor_metadata["flavor"],
-        custom_package = "org.oppia.android",
-        enable_data_binding = True,
-        main_dex_list = apk_flavor_metadata.get("main_dex_list"),
-        manifest = "oppia_apk_%s_transformed_manifest" % apk_flavor_metadata["flavor"],
-        manifest_values = {
-            "applicationId": "org.oppia.android",
-            "minSdkVersion": "%d" % apk_flavor_metadata["min_sdk_version"],
-            "targetSdkVersion": "%d" % apk_flavor_metadata["target_sdk_version"],
-        },
-        multidex = apk_flavor_metadata["multidex"],
-        deps = [
-            "//app",
-        ],
-    )
-    for apk_flavor_metadata in [
-        {
-            "flavor": "oppia",
-            "min_sdk_version": 21,
-            "multidex": "native",
-            "target_sdk_version": 30,
-        },
-        {
-            "flavor": "oppia_kitkat",
-            "main_dex_list": "//:config/kitkat_main_dex_class_list.txt",
-            "min_sdk_version": 19,
-            "multidex": "manual_main_dex",
-            "target_sdk_version": 30,
-        },
-    ]
+    define_oppia_apk_binary_flavor(flavor = flavor)
+    for flavor in AVAILABLE_APK_FLAVORS
 ]
 
 # Define all binary flavors that can be built. Note that these are AABs, not APKs, and can be
@@ -133,5 +81,5 @@ package_group(
 #  bazel run //:install_oppia_dev
 [
     define_oppia_aab_binary_flavor(flavor = flavor)
-    for flavor in AVAILABLE_FLAVORS
+    for flavor in AVAILABLE_BUNDLE_FLAVORS
 ]

--- a/data/data_test.bzl
+++ b/data/data_test.bzl
@@ -21,7 +21,7 @@ def data_test(name, filtered_tests, deps, **kwargs):
         deps = deps,
         custom_package = "org.oppia.android.data",
         test_manifest = "src/test/AndroidManifest.xml",
-        assets = native.glob(["src/test/assets/**"]),
-        assets_dir = "src/test/assets/",
+        test_assets = native.glob(["src/test/assets/**"]),
+        test_asset_dir = "data/src/test/assets/",
         **kwargs
     )

--- a/domain/BUILD.bazel
+++ b/domain/BUILD.bazel
@@ -84,19 +84,26 @@ DOMAIN_ASSETS = generate_assets_list_from_text_protos(
     ],
 )
 
+# TODO: Remove.
+filegroup(
+    name = "domain_assets",
+    srcs = glob(
+        ["src/main/assets/**"],
+        exclude = ["src/main/assets/**/*.textproto"],
+    ) + DOMAIN_ASSETS,
+    visibility = [
+        "//:oppia_binary_visibility",
+        "//:oppia_testing_visibility",
+    ],
+)
+
 kt_android_library(
     name = "domain",
     srcs = glob(
         ["src/main/java/org/oppia/android/domain/**/*.kt"],
         exclude = MIGRATED_PROD_FILES + ["src/main/java/org/oppia/android/domain/testing/**/*.kt"],
     ),
-    assets = glob(
-        ["src/main/assets/**"],
-        exclude = ["src/main/assets/**/*.textproto"],
-    ) + DOMAIN_ASSETS,
-    assets_dir = "src/main/assets/",
     custom_package = "org.oppia.android.domain",
-    manifest = "src/main/AndroidManifest.xml",
     visibility = ["//visibility:public"],
     deps = [
         ":dagger",
@@ -216,7 +223,6 @@ TEST_DEPS = [
     "//third_party:androidx_work_work-testing",
     "//third_party:com_google_truth_extensions_truth-liteproto-extension",
     "//third_party:com_google_truth_truth",
-    "//third_party:org_jetbrains_kotlin_kotlin-reflect",
     "//third_party:org_jetbrains_kotlin_kotlin-test-junit",
     "//third_party:robolectric_android-all",
     "//utility/src/main/java/org/oppia/android/util/caching:asset_prod_module",

--- a/domain/domain_assets.bzl
+++ b/domain/domain_assets.bzl
@@ -4,6 +4,57 @@ Macros for preparing & creating assets to include in the domain module.
 
 load("//model:text_proto_assets.bzl", "generate_proto_binary_assets")
 
+def _compute_stripped_path(input_file, base_path):
+    short_path = input_file.short_path
+    if not short_path.startswith(base_path):
+        fail("Expected %s input file to have base path: %s", input_file, base_path)
+    return short_path[len(base_path):]
+
+# TODO: Add TODO to remove this once Gradle goes away since the assets can just become top-level.
+def _copy_files_impl(ctx):
+    input_files = ctx.files.input_files
+    input_base_path = ctx.attr.input_base_path
+    output_file_path = ctx.attr.output_file_path
+
+    output_files = [
+        ctx.actions.declare_file(
+            "%s/%s" % (output_file_path, _compute_stripped_path(input_file, input_base_path)),
+        )
+        for input_file in input_files
+    ]
+
+    # Use a symlink to avoid an actual filesystem copy (for compatible systems).
+    for (input_file, output_file) in zip(input_files, output_files):
+        ctx.actions.symlink(output = output_file, target_file = input_file)
+
+    return DefaultInfo(
+        files = depset(output_files),
+        runfiles = ctx.runfiles(files = output_files),
+    )
+
+_copy_files = rule(
+    attrs = {
+        "input_files": attr.label_list(
+            allow_empty = False,
+            allow_files = True,
+            mandatory = True,
+        ),
+        "input_base_path": attr.string(mandatory = True),
+        "output_file_path": attr.string(mandatory = True),
+    },
+    implementation = _copy_files_impl,
+)
+
+# TODO: Mention in documentation that input_base_path needs to end with '/'.
+def copy_files(name, input_files, input_base_path, output_file_path):
+    _copy_files(
+        name = name,
+        input_files = input_files,
+        input_base_path = input_base_path,
+        output_file_path = output_file_path,
+    )
+    return [":%s" % name]
+
 def generate_assets_list_from_text_protos(
         name,
         topic_list_file_names,
@@ -81,4 +132,13 @@ def generate_assets_list_from_text_protos(
         asset_dir = "src/main/assets",
         proto_dep_bazel_target_prefix = "//model/src/main/proto",
         proto_package = "model",
+    )
+
+# TODO: Revert related changes.
+def retrieve_domain_assets(name, dest_assets_dir):
+    return copy_files(
+        name = "copy_domain_assets_%s" % name,
+        input_files = ["//domain:domain_assets"],
+        input_base_path = "domain/src/main/assets/",
+        output_file_path = dest_assets_dir,
     )


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
TODO: description

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
