### PR TITLE
Fixes #3169: Item selection interaction text change on selection

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
@@ -124,6 +124,7 @@ class SelectionInteractionViewModel private constructor(
       isCurrentlySelected -> {
         selectedItems -= itemIndex
         updateIsAnswerAvailable()
+        updateSelectionText()
         false
       }
       !areCheckboxesBound() -> {
@@ -140,24 +141,25 @@ class SelectionInteractionViewModel private constructor(
         selectedItems += itemIndex
         selectedItemText.set("You may select more choices")
         updateIsAnswerAvailable()
-        true
-      }
-      selectedItems.size == 0 -> {
-        selectedItems += itemIndex
-        selectedItemText.set("Please select one or more choices.")
-        updateIsAnswerAvailable()
-        true
-      }
-      selectedItems.size == maxAllowableSelectionCount -> {
-        selectedItems += itemIndex
-        selectedItemText.set("No more than $maxAllowableSelectionCount choices may be selected.")
-        updateIsAnswerAvailable()
+        updateSelectionText()
         true
       }
       else -> {
         // Do not change the current status if it isn't valid to do so.
         isCurrentlySelected
       }
+    }
+  }
+
+  private fun updateSelectionText(){
+    if (selectedItems.size < maxAllowableSelectionCount)  {
+      selectedItemText.set("You may select more choices")
+    }
+    if(selectedItems.size == 0) {
+      selectedItemText.set("Please select one or more choices.")
+    }
+    if (selectedItems.size == maxAllowableSelectionCount) {
+      selectedItemText.set("No more than $maxAllowableSelectionCount choices may be selected.")
     }
   }
 

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
@@ -56,7 +56,7 @@ class SelectionInteractionViewModel private constructor(
     computeChoiceItems(choiceSubtitledHtmls, hasConversationView, this)
 
   private val isAnswerAvailable = ObservableField(false)
-
+  val selectedItemText = ObservableField("Please select atleast one choice.")
   init {
     val callback: Observable.OnPropertyChangedCallback =
       object : Observable.OnPropertyChangedCallback() {
@@ -138,6 +138,19 @@ class SelectionInteractionViewModel private constructor(
         // TODO(#3624): Add warning to user when they exceed the number of allowable selections or are under the minimum
         //  number required.
         selectedItems += itemIndex
+        selectedItemText.set("You may select more choices")
+        updateIsAnswerAvailable()
+        true
+      }
+      selectedItems.size == 0 -> {
+        selectedItems += itemIndex
+        selectedItemText.set("Please select one or more choices.")
+        updateIsAnswerAvailable()
+        true
+      }
+      selectedItems.size == maxAllowableSelectionCount -> {
+        selectedItems += itemIndex
+        selectedItemText.set("No more than $maxAllowableSelectionCount choices may be selected.")
         updateIsAnswerAvailable()
         true
       }

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
@@ -57,6 +57,7 @@ class SelectionInteractionViewModel private constructor(
 
   private val isAnswerAvailable = ObservableField(false)
   val selectedItemText = ObservableField("Please select atleast one choice.")
+
   init {
     val callback: Observable.OnPropertyChangedCallback =
       object : Observable.OnPropertyChangedCallback() {
@@ -151,11 +152,11 @@ class SelectionInteractionViewModel private constructor(
     }
   }
 
-  private fun updateSelectionText(){
-    if (selectedItems.size < maxAllowableSelectionCount)  {
+  private fun updateSelectionText() {
+    if (selectedItems.size < maxAllowableSelectionCount) {
       selectedItemText.set("You may select more choices")
     }
-    if(selectedItems.size == 0) {
+    if (selectedItems.size == 0) {
       selectedItemText.set("Please select one or more choices.")
     }
     if (selectedItems.size == maxAllowableSelectionCount) {

--- a/app/src/main/res/layout/selection_interaction_item.xml
+++ b/app/src/main/res/layout/selection_interaction_item.xml
@@ -42,7 +42,7 @@
       android:layout_marginTop="4dp"
       android:layout_marginBottom="4dp"
       android:fontFamily="sans-serif-light"
-      android:text="@string/item_selection_text"
+      android:text="@{viewModel.selectedItemText}"
       android:textColor="@color/oppia_primary_text"
       android:textSize="14sp"
       android:textStyle="italic"


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixes: #3169 
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
