### PR TITLE
Fixes #3895: Rich-text hyperlink text improvement

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentTest.kt
@@ -365,7 +365,7 @@ class RevisionCardFragmentTest {
       testCoroutineDispatchers.runCurrent()
 
       onView(withId(R.id.revision_card_explanation_text)).check(
-        matches(withText(containsString("Learn more")))
+        matches(withText(containsString("Description of subtopic is here.")))
       )
     }
   }
@@ -386,7 +386,7 @@ class RevisionCardFragmentTest {
       testCoroutineDispatchers.runCurrent()
 
       onView(withId(R.id.revision_card_explanation_text)).check(
-        matches(withText(containsString("Learn more")))
+        matches(withText(containsString("Description of subtopic is here.")))
       )
     }
   }
@@ -403,7 +403,8 @@ class RevisionCardFragmentTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
 
-      onView(withId(R.id.revision_card_explanation_text)).perform(openClickableSpan("Learn more"))
+      onView(withId(R.id.revision_card_explanation_text)).perform(
+        openClickableSpan("This concept card demonstrates overall concept card functionality."))
       testCoroutineDispatchers.runCurrent()
 
       onView(withText("Concept Card")).inRoot(isDialog()).check(matches(isDisplayed()))
@@ -427,7 +428,9 @@ class RevisionCardFragmentTest {
       onView(isRoot()).perform(orientationLandscape())
       testCoroutineDispatchers.runCurrent()
 
-      onView(withId(R.id.revision_card_explanation_text)).perform(openClickableSpan("Learn more"))
+      onView(withId(R.id.revision_card_explanation_text)).perform(
+        openClickableSpan("This concept card demonstrates overall concept card functionality.")
+      )
       testCoroutineDispatchers.runCurrent()
 
       onView(withText("Concept Card")).inRoot(isDialog()).check(matches(isDisplayed()))

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentTest.kt
@@ -404,7 +404,8 @@ class RevisionCardFragmentTest {
       testCoroutineDispatchers.runCurrent()
 
       onView(withId(R.id.revision_card_explanation_text)).perform(
-        openClickableSpan("This concept card demonstrates overall concept card functionality."))
+        openClickableSpan("This concept card demonstrates overall concept card functionality.")
+      )
       testCoroutineDispatchers.runCurrent()
 
       onView(withText("Concept Card")).inRoot(isDialog()).check(matches(isDisplayed()))

--- a/domain/src/main/assets/GJ2rLXRKD5hw_2.json
+++ b/domain/src/main/assets/GJ2rLXRKD5hw_2.json
@@ -4,7 +4,7 @@
   "page_contents": {
     "subtitled_html": {
       "content_id": "content",
-      "html": "<p>Description of subtopic is here. <oppia-noninteractive-skillreview skill_id-with-value=\"&amp;quot;5RM9KPfQxobH&amp;quot;\" text-with-value=\"&amp;quot;Learn more&amp;quot;\"></oppia-noninteractive-skillreview></p>"
+      "html": "<p>Description of subtopic is here. <oppia-noninteractive-skillreview skill_id-with-value=\"&amp;quot;5RM9KPfQxobH&amp;quot;\" text-with-value=\"&amp;quot;This concept card demonstrates overall concept card functionality.&amp;quot;\"></oppia-noninteractive-skillreview></p>"
     },
     "recorded_voiceovers": {
       "voiceovers_mapping": {

--- a/domain/src/main/assets/GJ2rLXRKD5hw_2.textproto
+++ b/domain/src/main/assets/GJ2rLXRKD5hw_2.textproto
@@ -1,6 +1,6 @@
 subtopic_title: "Fractions of a group"
 page_contents {
-  html: "<p>Description of subtopic is here. <oppia-noninteractive-skillreview skill_id-with-value=\"&amp;quot;5RM9KPfQxobH&amp;quot;\" text-with-value=\"&amp;quot;Learn more&amp;quot;\"></oppia-noninteractive-skillreview></p>"
+  html: "<p>Description of subtopic is here. <oppia-noninteractive-skillreview skill_id-with-value=\"&amp;quot;5RM9KPfQxobH&amp;quot;\" text-with-value=\"&amp;quot;This concept card demonstrates overall concept card functionality.&amp;quot;\"></oppia-noninteractive-skillreview></p>"
   content_id: "content"
 }
 recorded_voiceover {


### PR DESCRIPTION
## Explanation
Fixes #3895: Rich-text changed for hyperlink such that it can pass accessibility scanner test. 

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).


### Before
<img src="https://user-images.githubusercontent.com/9396084/136244457-9266bfa9-9f1c-425f-879f-5a57fc326214.png" width="300" height="600">

### After
<img src="https://user-images.githubusercontent.com/43074241/182389314-5ea415ad-0f9d-4166-8b4a-6d5578202f50.jpeg" width="300" height="600">

