### PR TITLE
Fix time ago plurals

### DIFF
--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.ViewModel
 import org.oppia.android.R
 import org.oppia.android.app.fragment.FragmentScope
 import org.oppia.android.app.translation.AppLanguageResourceHandler
-import org.oppia.android.app.utility.getLastUpdateTime
-import org.oppia.android.app.utility.getVersionName
 import org.oppia.android.app.viewmodel.ObservableViewModel
+import org.oppia.android.util.extensions.getLastUpdateTime
+import org.oppia.android.util.extensions.getVersionName
 import javax.inject.Inject
 
 /** [ViewModel] for [AppVersionFragment]*/
@@ -25,7 +25,8 @@ class AppVersionViewModel @Inject constructor(
 
   fun computeLastUpdatedDateText(): String =
     resourceHandler.getStringInLocaleWithWrapping(
-      R.string.app_last_update_date, getDateTime(lastUpdateDateTime)
+      R.string.app_last_update_date,
+      getDateTime(lastUpdateDateTime)
     )
 
   private fun getDateTime(lastUpdateTime: Long): String =

--- a/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapter.kt
@@ -27,6 +27,7 @@ fun setProfileDataText(textView: TextView, timestamp: Long) {
   )
 }
 
+// TODO: Move this to a common place.
 fun getResourceHandler(view: View): AppLanguageResourceHandler {
   val provider =
     getAttachedActivity(view) as AppLanguageActivityInjectorProvider

--- a/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapter.kt
@@ -1,0 +1,49 @@
+package org.oppia.android.app.databinding
+
+import android.app.Activity
+import android.content.ContextWrapper
+import android.view.View
+import android.widget.TextView
+import androidx.databinding.BindingAdapter
+import org.oppia.android.R
+import org.oppia.android.app.translation.AppLanguageActivityInjectorProvider
+import org.oppia.android.app.translation.AppLanguageResourceHandler
+import org.oppia.android.app.utility.datetime.timeAgo
+
+@BindingAdapter("profile:lastVisited")
+fun TextView.setProfileLastVisitedText(timestamp: Long?) {
+  timestamp?.let {
+    text = it.timeAgo(this)
+  }
+}
+
+@BindingAdapter("profile:created")
+fun setProfileDataText(textView: TextView, timestamp: Long) {
+  val resourceHandler = getResourceHandler(textView)
+  val time = resourceHandler.computeDateString(timestamp)
+  textView.text = resourceHandler.getStringInLocaleWithWrapping(
+    R.string.profile_edit_created,
+    time
+  )
+}
+
+fun getResourceHandler(view: View): AppLanguageResourceHandler {
+  val provider =
+    getAttachedActivity(view) as AppLanguageActivityInjectorProvider
+  return provider.getAppLanguageActivityInjector().getAppLanguageResourceHandler()
+}
+
+private fun getAttachedActivity(view: View): Activity {
+  var context = view.context
+  while (context != null && context !is Activity) {
+    check(context is ContextWrapper) {
+      (
+        "Encountered context in view (" + view + ") that doesn't wrap a parent context: " +
+          context
+        )
+    }
+    context = context.baseContext
+  }
+  checkNotNull(context) { "Failed to find base Activity for view: $view" }
+  return context as Activity
+}

--- a/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapters.java
+++ b/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapters.java
@@ -9,11 +9,11 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.PluralsRes;
 import androidx.databinding.BindingAdapter;
+import java.util.concurrent.TimeUnit;
 import org.oppia.android.R;
 import org.oppia.android.app.translation.AppLanguageActivityInjectorProvider;
 import org.oppia.android.app.translation.AppLanguageResourceHandler;
 import org.oppia.android.util.system.OppiaClock;
-import java.util.concurrent.TimeUnit;
 import org.oppia.android.util.system.OppiaClockInjectorProvider;
 
 /**

--- a/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapters.java
+++ b/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapters.java
@@ -6,20 +6,27 @@ import android.content.ContextWrapper;
 import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.widget.TextView;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.PluralsRes;
 import androidx.databinding.BindingAdapter;
-import java.util.concurrent.TimeUnit;
+
 import org.oppia.android.R;
 import org.oppia.android.app.translation.AppLanguageActivityInjectorProvider;
 import org.oppia.android.app.translation.AppLanguageResourceHandler;
 import org.oppia.android.util.system.OppiaClock;
 import org.oppia.android.util.system.OppiaClockInjectorProvider;
 
-/** Holds all custom binding adapters that bind to [TextView]. */
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Holds all custom binding adapters that bind to [TextView].
+ */
 public final class TextViewBindingAdapters {
 
-  /** Binds date text with relative time. */
+  /**
+   * Binds date text with relative time.
+   */
   @BindingAdapter("profile:created")
   public static void setProfileDataText(@NonNull TextView textView, long timestamp) {
     AppLanguageResourceHandler resourceHandler = getResourceHandler(textView);
@@ -30,10 +37,12 @@ public final class TextViewBindingAdapters {
     ));
   }
 
-  /** Binds last used with relative timestamp. */
-  @BindingAdapter("profile:lastVisited")
+  /**
+   * Binds last used with relative timestamp.
+   */
+  // @BindingAdapter("profile:lastVisited")
   public static void setProfileLastVisitedText(@NonNull TextView textView, long timestamp) {
-    AppLanguageResourceHandler resourceHandler = getResourceHandler(textView);
+    /*AppLanguageResourceHandler resourceHandler = getResourceHandler(textView);
     String profileLastUsed = resourceHandler.getStringInLocale(R.string.profile_last_used);
     String timeAgoTimeStamp = getTimeAgo(textView, timestamp);
     String profileLastVisited = resourceHandler.getStringInLocaleWithWrapping(
@@ -41,11 +50,14 @@ public final class TextViewBindingAdapters {
         profileLastUsed,
         timeAgoTimeStamp
     );
-    textView.setText(profileLastVisited);
+    textView.setText(profileLastVisited);*/
   }
 
   // TODO(#4345): Add test for this method.
-  /** Binds an AndroidX KitKat-compatible drawable top to the specified text view. */
+
+  /**
+   * Binds an AndroidX KitKat-compatible drawable top to the specified text view.
+   */
   @BindingAdapter("app:drawableTopCompat")
   public static void setDrawableTopCompat(
       @NonNull TextView imageView,
@@ -56,7 +68,9 @@ public final class TextViewBindingAdapters {
     );
   }
 
-  /** Binds an AndroidX KitKat-compatible drawable end to the specified text view. */
+  /**
+   * Binds an AndroidX KitKat-compatible drawable end to the specified text view.
+   */
   @BindingAdapter("app:drawableEndCompat")
   public static void setDrawableEndCompat(
       @NonNull TextView imageView,
@@ -82,13 +96,13 @@ public final class TextViewBindingAdapters {
       return resourceHandler.getStringInLocale(R.string.just_now);
     } else if (timeDifferenceMillis < TimeUnit.MINUTES.toMillis(50)) {
       return getPluralString(
-              resourceHandler,
+          resourceHandler,
           R.plurals.minutes,
           (int) TimeUnit.MILLISECONDS.toMinutes(timeDifferenceMillis)
       );
     } else if (timeDifferenceMillis < TimeUnit.DAYS.toMillis(1)) {
       return getPluralString(
-              resourceHandler,
+          resourceHandler,
           R.plurals.hours,
           (int) TimeUnit.MILLISECONDS.toHours(timeDifferenceMillis)
       );
@@ -96,7 +110,7 @@ public final class TextViewBindingAdapters {
       return resourceHandler.getStringInLocale(R.string.yesterday);
     }
     return getPluralString(
-            resourceHandler,
+        resourceHandler,
         R.plurals.days,
         (int) TimeUnit.MILLISECONDS.toDays(timeDifferenceMillis)
     );
@@ -136,8 +150,8 @@ public final class TextViewBindingAdapters {
     while (context != null && !(context instanceof Activity)) {
       if (!(context instanceof ContextWrapper)) {
         throw new IllegalStateException(
-          "Encountered context in view (" + view + ") that doesn't wrap a parent context: "
-            + context
+            "Encountered context in view (" + view + ") that doesn't wrap a parent context: "
+                + context
         );
       }
       context = ((ContextWrapper) context).getBaseContext();

--- a/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapters.java
+++ b/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapters.java
@@ -6,18 +6,15 @@ import android.content.ContextWrapper;
 import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.widget.TextView;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.PluralsRes;
 import androidx.databinding.BindingAdapter;
-
 import org.oppia.android.R;
 import org.oppia.android.app.translation.AppLanguageActivityInjectorProvider;
 import org.oppia.android.app.translation.AppLanguageResourceHandler;
 import org.oppia.android.util.system.OppiaClock;
-import org.oppia.android.util.system.OppiaClockInjectorProvider;
-
 import java.util.concurrent.TimeUnit;
+import org.oppia.android.util.system.OppiaClockInjectorProvider;
 
 /**
  * Holds all custom binding adapters that bind to [TextView].

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditFragmentPresenter.kt
@@ -8,7 +8,6 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
-import javax.inject.Inject
 import org.oppia.android.R
 import org.oppia.android.app.administratorcontrols.AdministratorControlsActivity
 import org.oppia.android.app.administratorcontrols.ProfileEditDeletionDialogListener
@@ -20,6 +19,7 @@ import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.toast
+import javax.inject.Inject
 
 /** Argument key for profile deletion dialog in [ProfileEditFragment]. */
 const val TAG_PROFILE_DELETION_DIALOG = "PROFILE_DELETION_DIALOG"

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditFragmentPresenter.kt
@@ -1,6 +1,5 @@
 package org.oppia.android.app.settings.profile
 
-import android.content.Context
 import android.content.Intent
 import android.view.LayoutInflater
 import android.view.View
@@ -139,7 +138,10 @@ class ProfileEditFragmentPresenter @Inject constructor(
         fragment
       ) {
         if (it is AsyncResult.Success) {
-          fragment.requireContext().toast(fragment.requireContext().getString(R.string.profile_edit_delete_successful_message), Toast.LENGTH_SHORT)
+          fragment.requireContext().toast(
+            fragment.requireContext().getString(R.string.profile_edit_delete_successful_message),
+            Toast.LENGTH_SHORT
+          )
           if (fragment.requireContext().resources.getBoolean(R.bool.isTablet)) {
             val intent =
               Intent(fragment.requireContext(), AdministratorControlsActivity::class.java)

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditFragmentPresenter.kt
@@ -1,12 +1,15 @@
 package org.oppia.android.app.settings.profile
 
+import android.content.Context
 import android.content.Intent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
+import javax.inject.Inject
 import org.oppia.android.R
 import org.oppia.android.app.administratorcontrols.AdministratorControlsActivity
 import org.oppia.android.app.administratorcontrols.ProfileEditDeletionDialogListener
@@ -17,7 +20,7 @@ import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
-import javax.inject.Inject
+import org.oppia.android.util.extensions.toast
 
 /** Argument key for profile deletion dialog in [ProfileEditFragment]. */
 const val TAG_PROFILE_DELETION_DIALOG = "PROFILE_DELETION_DIALOG"
@@ -101,15 +104,16 @@ class ProfileEditFragmentPresenter @Inject constructor(
         ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         binding.profileEditAllowDownloadSwitch.isChecked
       ).toLiveData().observe(
-        activity,
-        Observer {
-          if (it is AsyncResult.Failure) {
-            oppiaLogger.e(
-              "ProfileEditActivityPresenter", "Failed to updated allow download access", it.error
-            )
-          }
+        activity
+      ) {
+        if (it is AsyncResult.Failure) {
+          oppiaLogger.e(
+            "ProfileEditActivityPresenter",
+            "Failed to updated allow download access",
+            it.error
+          )
         }
-      )
+      }
     }
     return binding.root
   }
@@ -132,22 +136,22 @@ class ProfileEditFragmentPresenter @Inject constructor(
     profileManagementController
       .deleteProfile(ProfileId.newBuilder().setInternalId(internalProfileId).build()).toLiveData()
       .observe(
-        fragment,
-        Observer {
-          if (it is AsyncResult.Success) {
-            if (fragment.requireContext().resources.getBoolean(R.bool.isTablet)) {
-              val intent =
-                Intent(fragment.requireContext(), AdministratorControlsActivity::class.java)
-              intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-              fragment.startActivity(intent)
-            } else {
-              val intent = Intent(fragment.requireContext(), ProfileListActivity::class.java)
-              intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-              fragment.startActivity(intent)
-            }
+        fragment
+      ) {
+        if (it is AsyncResult.Success) {
+          fragment.requireContext().toast(fragment.requireContext().getString(R.string.profile_edit_delete_successful_message), Toast.LENGTH_SHORT)
+          if (fragment.requireContext().resources.getBoolean(R.bool.isTablet)) {
+            val intent =
+              Intent(fragment.requireContext(), AdministratorControlsActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            fragment.startActivity(intent)
+          } else {
+            val intent = Intent(fragment.requireContext(), ProfileListActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            fragment.startActivity(intent)
           }
         }
-      )
+      }
   }
 
   /** This loads the dialog whenever requested by the listener in [AdministratorControlsActivity]. */

--- a/app/src/main/java/org/oppia/android/app/utility/datetime/DateTimeUtil.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/datetime/DateTimeUtil.kt
@@ -1,12 +1,12 @@
 package org.oppia.android.app.utility.datetime
 
 import android.view.View
+import java.util.*
+import javax.inject.Inject
 import org.oppia.android.R
 import org.oppia.android.app.databinding.getResourceHandler
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.util.locale.OppiaLocale
-import java.util.*
-import javax.inject.Inject
 
 /** Per-activity utility to manage date and time for user-facing strings. */
 class DateTimeUtil @Inject constructor(
@@ -42,9 +42,7 @@ const val DAY = 24 * HOUR
 const val MONTH = 30 * DAY
 const val YEAR = 12 * MONTH
 
-private fun currentDate(): Long {
-  return Calendar.getInstance().timeInMillis
-}
+private fun currentDate() = Calendar.getInstance().timeInMillis
 
 fun Long.timeAgo(view: View): String {
   val time = this
@@ -58,31 +56,29 @@ fun Long.timeAgo(view: View): String {
     diff < 2 * MINUTE -> resourceHandler.getStringInLocale(R.string.minute_ago)
     diff < 60 * MINUTE -> resourceHandler.getStringInLocaleWithWrapping(
       R.string.minutes_ago,
-      formatDuration(diff, MINUTE).toString()
+      diff.formatDuration(MINUTE).toString()
     )
     diff < 2 * HOUR -> resourceHandler.getStringInLocale(R.string.hour_ago)
     diff < 24 * HOUR -> resourceHandler.getStringInLocaleWithWrapping(
       R.string.hours_ago,
-      formatDuration(diff, HOUR).toString()
+      diff.formatDuration(HOUR).toString()
     )
     diff < 2 * DAY -> resourceHandler.getStringInLocale(R.string.yesterday)
     diff < 30 * DAY -> resourceHandler.getStringInLocaleWithWrapping(
       R.string.days_ago,
-      formatDuration(diff, DAY).toString()
+      diff.formatDuration(DAY).toString()
     )
     diff < 2 * MONTH -> resourceHandler.getStringInLocale(R.string.month_ago)
     diff < 12 * MONTH -> resourceHandler.getStringInLocaleWithWrapping(
       R.string.months_ago,
-      formatDuration(diff, MONTH).toString()
+      diff.formatDuration(MONTH).toString()
     )
     diff < 2 * YEAR -> resourceHandler.getStringInLocale(R.string.year_ago)
     else -> resourceHandler.getStringInLocaleWithWrapping(
       R.string.years_ago,
-      formatDuration(diff, YEAR).toString()
+      diff.formatDuration(YEAR).toString()
     )
   }
 }
 
-private fun formatDuration(diff: Long, duration: Int): Long {
-  return diff.div(duration)
-}
+private fun Long.formatDuration(duration: Int) = div(duration)

--- a/app/src/main/java/org/oppia/android/app/utility/datetime/DateTimeUtil.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/datetime/DateTimeUtil.kt
@@ -5,7 +5,7 @@ import org.oppia.android.R
 import org.oppia.android.app.databinding.getResourceHandler
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.util.locale.OppiaLocale
-import java.util.*
+import java.util.Calendar
 import javax.inject.Inject
 
 /** Per-activity utility to manage date and time for user-facing strings. */

--- a/app/src/main/java/org/oppia/android/app/utility/datetime/DateTimeUtil.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/datetime/DateTimeUtil.kt
@@ -1,12 +1,12 @@
 package org.oppia.android.app.utility.datetime
 
 import android.view.View
-import java.util.*
-import javax.inject.Inject
 import org.oppia.android.R
 import org.oppia.android.app.databinding.getResourceHandler
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.util.locale.OppiaLocale
+import java.util.*
+import javax.inject.Inject
 
 /** Per-activity utility to manage date and time for user-facing strings. */
 class DateTimeUtil @Inject constructor(

--- a/app/src/main/java/org/oppia/android/app/utility/datetime/DateTimeUtil.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/datetime/DateTimeUtil.kt
@@ -1,8 +1,11 @@
 package org.oppia.android.app.utility.datetime
 
+import android.view.View
 import org.oppia.android.R
+import org.oppia.android.app.databinding.getResourceHandler
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.util.locale.OppiaLocale
+import java.util.*
 import javax.inject.Inject
 
 /** Per-activity utility to manage date and time for user-facing strings. */
@@ -30,4 +33,56 @@ class DateTimeUtil @Inject constructor(
     /** Returns [DateTimeUtil] for the current Dagger graph. */
     fun getDateTimeUtil(): DateTimeUtil
   }
+}
+
+const val SECOND = 1
+const val MINUTE = 60 * SECOND
+const val HOUR = 60 * MINUTE
+const val DAY = 24 * HOUR
+const val MONTH = 30 * DAY
+const val YEAR = 12 * MONTH
+
+private fun currentDate(): Long {
+  return Calendar.getInstance().timeInMillis
+}
+
+fun Long.timeAgo(view: View): String {
+  val time = this
+  val now = currentDate()
+  val diff = (now - time) / 1000
+
+  val resourceHandler = getResourceHandler(view)
+
+  return when {
+    diff < MINUTE -> resourceHandler.getStringInLocale(R.string.just_now)
+    diff < 2 * MINUTE -> resourceHandler.getStringInLocale(R.string.minute_ago)
+    diff < 60 * MINUTE -> resourceHandler.getStringInLocaleWithWrapping(
+      R.string.minutes_ago,
+      formatDuration(diff, MINUTE).toString()
+    )
+    diff < 2 * HOUR -> resourceHandler.getStringInLocale(R.string.hour_ago)
+    diff < 24 * HOUR -> resourceHandler.getStringInLocaleWithWrapping(
+      R.string.hours_ago,
+      formatDuration(diff, HOUR).toString()
+    )
+    diff < 2 * DAY -> resourceHandler.getStringInLocale(R.string.yesterday)
+    diff < 30 * DAY -> resourceHandler.getStringInLocaleWithWrapping(
+      R.string.days_ago,
+      formatDuration(diff, DAY).toString()
+    )
+    diff < 2 * MONTH -> resourceHandler.getStringInLocale(R.string.month_ago)
+    diff < 12 * MONTH -> resourceHandler.getStringInLocaleWithWrapping(
+      R.string.months_ago,
+      formatDuration(diff, MONTH).toString()
+    )
+    diff < 2 * YEAR -> resourceHandler.getStringInLocale(R.string.year_ago)
+    else -> resourceHandler.getStringInLocaleWithWrapping(
+      R.string.years_ago,
+      formatDuration(diff, YEAR).toString()
+    )
+  }
+}
+
+private fun formatDuration(diff: Long, duration: Int): Long {
+  return diff.div(duration)
 }

--- a/app/src/main/java/org/oppia/android/app/utility/datetime/DateTimeUtil.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/datetime/DateTimeUtil.kt
@@ -44,6 +44,9 @@ const val YEAR = 12 * MONTH
 
 private fun currentDate() = Calendar.getInstance().timeInMillis
 
+/**
+* Returns the readable string of the duration from the provided time in [Long].
+*/
 fun Long.timeAgo(view: View): String {
   val time = this
   val now = currentDate()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -468,6 +468,16 @@
     <item quantity="one">a day</item>
     <item quantity="other">%s days</item>
   </plurals>
+
+  <string name="minute_ago">a minute ago</string>
+  <string name="minutes_ago">%s minutes ago</string>
+  <string name="hour_ago">an hour ago</string>
+  <string name="hours_ago">%s hours ago</string>
+  <string name="days_ago">%s days ago</string>
+  <string name="month_ago">a month ago</string>
+  <string name="months_ago">%s months ago</string>
+  <string name="year_ago">a year ago</string>
+  <string name="years_ago">%s years ago</string>
   <!-- ViewTags -->
   <string name="topic_revision_recyclerview_tag">topic_revision_recyclerview_tag</string>
   <string name="ongoing_recycler_view_tag">ongoing_recycler_view_tag</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -342,6 +342,7 @@
   <string name="profile_edit_delete_dialog_title">Permanently delete this profile?</string>
   <string name="profile_edit_delete_dialog_message">All progress will be deleted and cannot be recovered.</string>
   <string name="profile_edit_delete_dialog_positive">Delete</string>
+  <string name="profile_edit_delete_successful_message">Profile deleted successfully</string>
   <string name="profile_edit_delete_dialog_negative">Cancel</string>
   <string name="profile_edit_allow_download_heading">Allow Download Access</string>
   <string name="profile_edit_allow_download_sub">User is able to download and delete content without Administrator password</string>

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AppVersionActivityTest.kt
@@ -44,8 +44,8 @@ import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.topic.PracticeTabModule
 import org.oppia.android.app.translation.testing.ActivityRecreatorTestModule
 import org.oppia.android.app.utility.OrientationChangeAction.Companion.orientationLandscape
-import org.oppia.android.app.utility.getLastUpdateTime
-import org.oppia.android.app.utility.getVersionName
+import org.oppia.android.util.extensions.getLastUpdateTime
+import org.oppia.android.util.extensions.getVersionName
 import org.oppia.android.data.backends.gae.NetworkConfigProdModule
 import org.oppia.android.data.backends.gae.NetworkModule
 import org.oppia.android.domain.classify.InteractionsModule

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AppVersionActivityTest.kt
@@ -44,8 +44,6 @@ import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.topic.PracticeTabModule
 import org.oppia.android.app.translation.testing.ActivityRecreatorTestModule
 import org.oppia.android.app.utility.OrientationChangeAction.Companion.orientationLandscape
-import org.oppia.android.util.extensions.getLastUpdateTime
-import org.oppia.android.util.extensions.getVersionName
 import org.oppia.android.data.backends.gae.NetworkConfigProdModule
 import org.oppia.android.data.backends.gae.NetworkModule
 import org.oppia.android.domain.classify.InteractionsModule
@@ -85,6 +83,8 @@ import org.oppia.android.testing.time.FakeOppiaClockModule
 import org.oppia.android.util.accessibility.AccessibilityTestModule
 import org.oppia.android.util.caching.AssetModule
 import org.oppia.android.util.caching.testing.CachingTestModule
+import org.oppia.android.util.extensions.getLastUpdateTime
+import org.oppia.android.util.extensions.getVersionName
 import org.oppia.android.util.gcsresource.GcsResourceModule
 import org.oppia.android.util.locale.LocaleProdModule
 import org.oppia.android.util.logging.LoggerModule
@@ -116,7 +116,9 @@ class AppVersionActivityTest {
 
   @get:Rule
   val activityTestRule: ActivityTestRule<AppVersionActivity> = ActivityTestRule(
-    AppVersionActivity::class.java, /* initialTouchMode= */ true, /* launchActivity= */ false
+    AppVersionActivity::class.java, /* initialTouchMode= */
+    true, /* launchActivity= */
+    false
   )
 
   @Inject

--- a/data/src/main/java/org/oppia/android/data/backends/gae/RemoteAuthNetworkInterceptor.kt
+++ b/data/src/main/java/org/oppia/android/data/backends/gae/RemoteAuthNetworkInterceptor.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
-import org.oppia.android.app.utility.getVersionCode
-import org.oppia.android.app.utility.getVersionName
+import org.oppia.android.util.extensions.getVersionCode
+import org.oppia.android.util.extensions.getVersionName
 import java.io.IOException
 import javax.inject.Inject
 

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/syncup/PlatformParameterSyncUpWorker.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/syncup/PlatformParameterSyncUpWorker.kt
@@ -6,7 +6,6 @@ import androidx.work.WorkerParameters
 import com.google.common.base.Optional
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
-import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,6 +20,7 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.extensions.getVersionName
 import org.oppia.android.util.threading.BackgroundDispatcher
 import retrofit2.Response
+import javax.inject.Inject
 
 /** Worker class that fetches and caches the latest platform parameters from the remote service. */
 class PlatformParameterSyncUpWorker private constructor(

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/syncup/PlatformParameterSyncUpWorker.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/syncup/PlatformParameterSyncUpWorker.kt
@@ -6,23 +6,21 @@ import androidx.work.WorkerParameters
 import com.google.common.base.Optional
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import org.oppia.android.app.model.PlatformParameter
-import org.oppia.android.util.extensions.getVersionName
 import org.oppia.android.data.backends.gae.api.PlatformParameterService
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.oppialogger.exceptions.ExceptionsController
 import org.oppia.android.domain.platformparameter.PlatformParameterController
 import org.oppia.android.domain.util.getStringFromData
 import org.oppia.android.util.data.AsyncResult
+import org.oppia.android.util.extensions.getVersionName
 import org.oppia.android.util.threading.BackgroundDispatcher
 import retrofit2.Response
-import java.lang.IllegalArgumentException
-import java.lang.IllegalStateException
-import javax.inject.Inject
 
 /** Worker class that fetches and caches the latest platform parameters from the remote service. */
 class PlatformParameterSyncUpWorker private constructor(

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/syncup/PlatformParameterSyncUpWorker.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/syncup/PlatformParameterSyncUpWorker.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import org.oppia.android.app.model.PlatformParameter
-import org.oppia.android.app.utility.getVersionName
+import org.oppia.android.util.extensions.getVersionName
 import org.oppia.android.data.backends.gae.api.PlatformParameterService
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.oppialogger.exceptions.ExceptionsController

--- a/utility/src/main/java/org/oppia/android/util/extensions/ContextExtensions.kt
+++ b/utility/src/main/java/org/oppia/android/util/extensions/ContextExtensions.kt
@@ -1,6 +1,7 @@
-package org.oppia.android.app.utility
+package org.oppia.android.util.extensions
 
 import android.content.Context
+import android.widget.Toast
 
 // Extension functions for Context that act as getters for PackageManager.
 
@@ -18,3 +19,9 @@ fun Context.getVersionCode(): Int {
 fun Context.getLastUpdateTime(): Long {
   return this.packageManager.getPackageInfo(this.packageName, /* flags= */ 0).lastUpdateTime
 }
+
+/**
+ * Extension method to show toast for Context.
+ */
+fun Context?.toast(text: CharSequence, duration: Int = Toast.LENGTH_SHORT) =
+  this?.let { Toast.makeText(it, text, duration).show() }


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fixes #3841 

This pull request provides an all kotlin approach to handling timeAgo UI updates.
I have created an extension gets a long timestamp and returns a string e.g just now, a minute ago, an hour ago, 3 days go

Usage: I have also updated BindingAdapter for TextView. This textview simply parses the string result of the extension above

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
