### PR TITLE
Fix #4494: Hint bulb animation added

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.view.inputmethod.InputMethodManager
 import android.widget.TextView

--- a/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.AnimationUtils
 import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
@@ -338,7 +339,7 @@ class StateFragmentPresenter @Inject constructor(
           oppiaLogger.e("StateFragment", "Failed to retrieve hint/solution", result.error)
         } else {
           // If the hint/solution, was revealed remove dot and radar.
-          viewModel.setHintOpenedAndUnRevealedVisibility(false)
+          setHintOpenedAndUnRevealed(false)
         }
       }
     )
@@ -459,31 +460,45 @@ class StateFragmentPresenter @Inject constructor(
   private fun showHintsAndSolutions(helpIndex: HelpIndex, isCurrentStatePendingState: Boolean) {
     if (!isCurrentStatePendingState) {
       // If current state is not the pending top state, hide the hint bulb.
-      viewModel.setHintOpenedAndUnRevealedVisibility(false)
+      setHintOpenedAndUnRevealed(false)
       viewModel.setHintBulbVisibility(false)
     } else {
       when (helpIndex.indexTypeCase) {
         HelpIndex.IndexTypeCase.NEXT_AVAILABLE_HINT_INDEX -> {
           viewModel.setHintBulbVisibility(true)
-          viewModel.setHintOpenedAndUnRevealedVisibility(true)
+          setHintOpenedAndUnRevealed(true)
         }
         HelpIndex.IndexTypeCase.LATEST_REVEALED_HINT_INDEX -> {
           viewModel.setHintBulbVisibility(true)
-          viewModel.setHintOpenedAndUnRevealedVisibility(false)
+          setHintOpenedAndUnRevealed(false)
         }
         HelpIndex.IndexTypeCase.SHOW_SOLUTION -> {
           viewModel.setHintBulbVisibility(true)
-          viewModel.setHintOpenedAndUnRevealedVisibility(true)
+          setHintOpenedAndUnRevealed(true)
         }
         HelpIndex.IndexTypeCase.EVERYTHING_REVEALED -> {
-          viewModel.setHintOpenedAndUnRevealedVisibility(false)
+          setHintOpenedAndUnRevealed(false)
           viewModel.setHintBulbVisibility(true)
         }
         else -> {
-          viewModel.setHintOpenedAndUnRevealedVisibility(false)
+          setHintOpenedAndUnRevealed(false)
           viewModel.setHintBulbVisibility(false)
         }
       }
+    }
+  }
+
+  private fun setHintOpenedAndUnRevealed(isHintRevealed: Boolean) {
+    viewModel.setHintOpenedAndUnRevealedVisibility(isHintRevealed)
+    if (isHintRevealed) {
+      binding.hintBulb.startAnimation(
+        AnimationUtils.loadAnimation(
+          context,
+          R.anim.hint_bulb_animation
+        )
+      )
+    } else {
+      binding.hintBulb.clearAnimation()
     }
   }
 }

--- a/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
@@ -1,6 +1,5 @@
 package org.oppia.android.app.player.state
 
-import android.animation.Animator
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.View

--- a/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.Transformations
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import javax.inject.Inject
 import nl.dionsegijn.konfetti.KonfettiView
 import org.oppia.android.R
 import org.oppia.android.app.fragment.FragmentScope
@@ -47,6 +46,7 @@ import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.gcsresource.DefaultResourceBucketName
 import org.oppia.android.util.parser.html.ExplorationHtmlParserEntityType
 import org.oppia.android.util.system.OppiaClock
+import javax.inject.Inject
 
 const val STATE_FRAGMENT_PROFILE_ID_ARGUMENT_KEY =
   "StateFragmentPresenter.state_fragment_profile_id"

--- a/app/src/main/res/anim/hint_bulb_animation.xml
+++ b/app/src/main/res/anim/hint_bulb_animation.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+  android:fillAfter="true"
+  android:interpolator="@android:anim/bounce_interpolator">
+  <alpha
+    android:duration="600"
+    android:fromAlpha="0.0"
+    android:interpolator="@android:anim/accelerate_interpolator"
+    android:repeatCount="infinite"
+    android:repeatMode="reverse"
+    android:toAlpha="1.0" />
+</set>

--- a/app/src/main/res/anim/hint_bulb_animation.xml
+++ b/app/src/main/res/anim/hint_bulb_animation.xml
@@ -6,7 +6,7 @@
     android:duration="600"
     android:fromAlpha="0.0"
     android:interpolator="@android:anim/accelerate_interpolator"
-    android:repeatCount="infinite"
+    android:repeatCount="10"
     android:repeatMode="reverse"
     android:toAlpha="1.0" />
 </set>

--- a/app/src/main/res/anim/hint_bulb_animation.xml
+++ b/app/src/main/res/anim/hint_bulb_animation.xml
@@ -1,12 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android"
-  android:fillAfter="true"
-  android:interpolator="@android:anim/bounce_interpolator">
-  <alpha
-    android:duration="600"
-    android:fromAlpha="0.0"
-    android:interpolator="@android:anim/accelerate_interpolator"
-    android:repeatCount="10"
-    android:repeatMode="reverse"
-    android:toAlpha="1.0" />
+<?xml version="1.0" encoding="utf-8"?><!-- NOTE: This animation must be used in conjunction with the
+app's custom BounceUpAndDownInterpolator in order to animate correctly. -->
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+  <translate
+    android:duration="2000"
+    android:fromYDelta="-50%"
+    android:repeatCount="2"
+    android:toYDelta="0" />
 </set>

--- a/app/src/main/res/layout/state_fragment.xml
+++ b/app/src/main/res/layout/state_fragment.xml
@@ -99,49 +99,57 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent" />
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:id="@+id/hints_and_solution_fragment_container"
+    <FrameLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:paddingTop="24dp"
       android:layout_gravity="bottom|start"
-      android:background="@color/audio_component_background"
-      android:visibility="@{viewModel.isHintBulbVisible() ? View.VISIBLE : View.GONE}">
-
-      <ImageView
-        android:id="@+id/hint_bulb"
-        android:layout_width="wrap_content"
+      android:clipChildren="false"
+      android:clipToPadding="false">
+      <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/hints_and_solution_fragment_container"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:contentDescription="@{viewModel.isHintOpenedAndUnRevealed() ? @string/new_hint_available : @string/no_new_hint_available}"
-        app:srcCompat="@{viewModel.isHintOpenedAndUnRevealed() ? @drawable/ic_hint_bulb_filled_yellow_48dp : @drawable/ic_hint_bulb_white_48dp}"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        android:background="@color/audio_component_background"
+        android:visibility="@{viewModel.isHintBulbVisible() ? View.VISIBLE : View.GONE}"
+        android:clipChildren="false">
 
-      <TextView
-        android:id="@+id/hint_bar_title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:text="@string/hints_toolbar_title"
-        android:textSize="24sp"
-        android:textColor="@color/color_def_white"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/hint_bulb" />
+        <ImageView
+          android:id="@+id/hint_bulb"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_margin="8dp"
+          android:contentDescription="@{viewModel.isHintOpenedAndUnRevealed() ? @string/new_hint_available : @string/no_new_hint_available}"
+          app:srcCompat="@{viewModel.isHintOpenedAndUnRevealed() ? @drawable/ic_hint_bulb_filled_yellow_48dp : @drawable/ic_hint_bulb_white_48dp}"
+          app:layout_constraintTop_toTopOf="parent"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintStart_toStartOf="parent" />
 
-      <ImageView
-        android:id="@+id/open_hint_dialog_arrow"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:contentDescription="@string/show_hints_and_solution"
-        app:srcCompat="@{viewModel.isHintOpenedAndUnRevealed() ? @drawable/ic_keyboard_arrow_down_white_48dp : @drawable/ic_keyboard_arrow_right_white_48}"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        <TextView
+          android:id="@+id/hint_bar_title"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginStart="16dp"
+          android:text="@string/hints_toolbar_title"
+          android:textSize="24sp"
+          android:textColor="@color/color_def_white"
+          app:layout_constraintTop_toTopOf="parent"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintStart_toEndOf="@+id/hint_bulb" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        <ImageView
+          android:id="@+id/open_hint_dialog_arrow"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_margin="8dp"
+          android:contentDescription="@string/show_hints_and_solution"
+          app:srcCompat="@{viewModel.isHintOpenedAndUnRevealed() ? @drawable/ic_keyboard_arrow_down_white_48dp : @drawable/ic_keyboard_arrow_right_white_48}"
+          app:layout_constraintTop_toTopOf="parent"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toEndOf="parent" />
+
+      </androidx.constraintlayout.widget.ConstraintLayout>
+    </FrameLayout>
 
     <FrameLayout
       android:layout_width="match_parent"


### PR DESCRIPTION
## Explanation
Fixes #4494

This PR introduces a bouncing animation for the light bulb to make it easier to notice. It has an animation delay of 5 seconds and will repeat every 30 seconds. The animation itself lasts about 6 seconds (see the video below). The animation will continue until the user reveals the hint or moves on to the next card.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
Demonstration video:

https://user-images.githubusercontent.com/12983742/185574373-27abd959-a377-49b5-a677-56a799d9ee1b.mp4
