### PR TITLE
 Fix #4446: Add placeholders for text based interactions

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/MathExpressionInteractionsViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/MathExpressionInteractionsViewModel.kt
@@ -87,7 +87,7 @@ class MathExpressionInteractionsViewModel private constructor(
   var errorMessage = ObservableField("")
 
   /** Specifies the text to show in the answer box when no text is entered. */
-  val hintText: CharSequence = deriveHintText(interaction)
+  val hintText: CharSequence = foldPlaceholderText(deriveHintText(interaction))
 
   private val allowedVariables = retrieveAllowedVariables(interaction)
   private val useFractionsForDivision =
@@ -177,6 +177,42 @@ class MathExpressionInteractionsViewModel private constructor(
       override fun afterTextChanged(s: Editable) {
       }
     }
+  }
+
+  private fun foldPlaceholderText(placeholder: CharSequence): String {
+    val numberOfLettersInOneLine = 40
+    val length = placeholder.length
+    return if (length <= numberOfLettersInOneLine) placeholder.toString()
+    else {
+      val newPlaceholder = StringBuilder()
+      var start = 0
+      var end = numberOfLettersInOneLine
+      while (end <= length) {
+        newPlaceholder.append(placeholder.subSequence(start, end))
+        if (placeholder[end - 1] == ' ') {
+          newPlaceholder.append("\n")
+          start = end
+          end = findMin((start + numberOfLettersInOneLine), length)
+          continue
+        }
+        start = end
+        val index = (placeholder.subSequence(start, length)).indexOfFirst {
+          it == ' '
+        }
+        if (index == -1) {
+          return newPlaceholder.append("\n" + placeholder.subSequence(start, length)).toString()
+        }
+        end = start + index
+        newPlaceholder.appendLine(placeholder.subSequence(start, end))
+        start = end + 1
+        end = findMin((start + numberOfLettersInOneLine), length)
+      }
+      newPlaceholder.toString()
+    }
+  }
+
+  private fun findMin(a: Int, b: Int): Int {
+    return if (a < b) a else b
   }
 
   private fun deriveHintText(interaction: Interaction): CharSequence {

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/MathExpressionInteractionsViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/MathExpressionInteractionsViewModel.kt
@@ -87,7 +87,7 @@ class MathExpressionInteractionsViewModel private constructor(
   var errorMessage = ObservableField("")
 
   /** Specifies the text to show in the answer box when no text is entered. */
-  val hintText: CharSequence = foldPlaceholderText(deriveHintText(interaction))
+  val hintText: CharSequence = deriveHintText(interaction)
 
   private val allowedVariables = retrieveAllowedVariables(interaction)
   private val useFractionsForDivision =
@@ -177,42 +177,6 @@ class MathExpressionInteractionsViewModel private constructor(
       override fun afterTextChanged(s: Editable) {
       }
     }
-  }
-
-  private fun foldPlaceholderText(placeholder: CharSequence): String {
-    val numberOfLettersInOneLine = 50
-    val length = placeholder.length
-    return if (length <= numberOfLettersInOneLine) placeholder.toString()
-    else {
-      val newPlaceholder = StringBuilder()
-      var start = 0
-      var end = numberOfLettersInOneLine
-      while (end <= length) {
-        newPlaceholder.append(placeholder.subSequence(start, end))
-        if (placeholder[end - 1] == ' ') {
-          newPlaceholder.append("\n")
-          start = end
-          end = findMin((start + numberOfLettersInOneLine), length)
-          continue
-        }
-        start = end
-        val index = (placeholder.subSequence(start, length)).indexOfFirst {
-          it == ' '
-        }
-        if (index == -1) {
-          return newPlaceholder.append("\n" + placeholder.subSequence(start, length)).toString()
-        }
-        end = start + index
-        newPlaceholder.appendLine(placeholder.subSequence(start, end))
-        start = end + 1
-        end = findMin((start + numberOfLettersInOneLine), length)
-      }
-      newPlaceholder.toString()
-    }
-  }
-
-  private fun findMin(a: Int, b: Int): Int {
-    return if (a < b) a else b
   }
 
   private fun deriveHintText(interaction: Interaction): CharSequence {

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/MathExpressionInteractionsViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/MathExpressionInteractionsViewModel.kt
@@ -180,7 +180,7 @@ class MathExpressionInteractionsViewModel private constructor(
   }
 
   private fun foldPlaceholderText(placeholder: CharSequence): String {
-    val numberOfLettersInOneLine = 40
+    val numberOfLettersInOneLine = 50
     val length = placeholder.length
     return if (length <= numberOfLettersInOneLine) placeholder.toString()
     else {

--- a/app/src/main/res/layout/math_expression_interactions_item.xml
+++ b/app/src/main/res/layout/math_expression_interactions_item.xml
@@ -24,7 +24,7 @@
       android:id="@+id/math_expression_input_interaction_view"
       style="@style/InputInteractionEditText"
       app:placeholder="@{viewModel.hintText}"
-      android:inputType="text"
+      android:inputType="textMultiLine"
       android:text="@={viewModel.answerText}"
       app:textChangedListener="@{viewModel.answerTextWatcher}"
       app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Additional note: At the time of PR creation it was observed that the placeholder texts are displayed everywhere and match with the ones on the website.

This PR fixes #4446 by adding a function that folds the placeholders texts (while also making sure that the lines are folded at a word break). These placeholder texts are "TextView hints"  -- which can't fold the hint text as an out of the box feature in android. 

In the function created called "foldPlaceholderText", there is an adjustable variable called `numberOfLettersInOneLine`. On tweaking this, the function can handle changing lines after the adjusted number of letters, or after few more letters depending on where is the immediate next word break.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing

Before:
Portrait
![Screenshot from 2022-08-17 23-03-44](https://user-images.githubusercontent.com/64526117/185205058-8a9ae391-a0fb-4b47-9a01-dd2490f8513b.png)


Landscape
![Screenshot from 2022-08-17 23-02-29](https://user-images.githubusercontent.com/64526117/185204824-2ec9e1a3-677f-4e09-a15c-9a9766eaad53.png)



After:
Portrait
![Screenshot from 2022-08-17 00-20-37](https://user-images.githubusercontent.com/64526117/184957636-d472a662-61a4-480d-8bef-1a00b3ed8280.png)

Landscape
![Screenshot from 2022-08-17 23-00-40](https://user-images.githubusercontent.com/64526117/185204650-d0696306-83c2-49b1-bf96-437eabd64e45.png)


