### PR TITLE
Fix #4285 by recreating ExplorationFragment with the newly updated te…

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/audio/AudioFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/audio/AudioFragmentPresenter.kt
@@ -182,7 +182,7 @@ class AudioFragmentPresenter @Inject constructor(
 
   /** Releases audio player resources */
   fun handleOnDestroy() {
-    if (!activity.isChangingConfigurations) {
+    if (!activity.isChangingConfigurations && prepared) {
       viewModel.handleRelease()
     }
   }

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivity.kt
@@ -95,6 +95,7 @@ class ExplorationActivity :
       "ExplorationActivity.backflow_screen"
     const val EXPLORATION_ACTIVITY_IS_CHECKPOINTING_ENABLED_KEY =
       "ExplorationActivity.is_checkpointing_enabled_key"
+    internal var isResumingFromOptions: Boolean = false
 
     fun createExplorationActivityIntent(
       context: Context,
@@ -134,6 +135,9 @@ class ExplorationActivity :
   }
 
   override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    if (item.itemId == R.id.action_preferences) {
+      isResumingFromOptions = true
+    }
     return explorationActivityPresenter.handleOnOptionsItemSelected(item)
   }
 
@@ -201,4 +205,11 @@ class ExplorationActivity :
   }
 
   override fun dismissConceptCard() = explorationActivityPresenter.dismissConceptCard()
+
+  override fun onResume() {
+    super.onResume()
+    if (isResumingFromOptions) {
+      explorationActivityPresenter.handleOnActivityResume()
+    }
+  }
 }

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
@@ -145,6 +145,19 @@ class ExplorationActivityPresenter @Inject constructor(
         ),
         TAG_EXPLORATION_FRAGMENT
       ).commitNow()
+    } else if (getExplorationFragment() != null && ExplorationActivity.isResumingFromOptions) {
+      ExplorationActivity.isResumingFromOptions = false
+      activity.supportFragmentManager.beginTransaction().add(
+        R.id.exploration_fragment_placeholder,
+        ExplorationFragment.newInstance(
+          topicId = topicId,
+          internalProfileId = internalProfileId,
+          storyId = storyId,
+          readingTextSize = readingTextSize.name,
+          explorationId = explorationId
+        ),
+        TAG_EXPLORATION_FRAGMENT
+      ).commitNow()
     }
 
     if (getHintsAndSolutionManagerFragment() == null) {
@@ -179,6 +192,23 @@ class ExplorationActivityPresenter @Inject constructor(
         true
       }
       else -> false
+    }
+  }
+
+  fun handleOnActivityResume() {
+    if (getExplorationManagerFragment() != null && ExplorationActivity.isResumingFromOptions) {
+      val explorationManagerFragment = ExplorationManagerFragment()
+      val args = Bundle()
+      args.putInt(
+        ExplorationActivity.EXPLORATION_ACTIVITY_PROFILE_ID_ARGUMENT_KEY,
+        internalProfileId
+      )
+      explorationManagerFragment.arguments = args
+      activity.supportFragmentManager.beginTransaction().add(
+        R.id.exploration_fragment_placeholder,
+        explorationManagerFragment,
+        TAG_EXPLORATION_MANAGER_FRAGMENT
+      ).commitNow()
     }
   }
 

--- a/domain/src/main/java/org/oppia/android/domain/audio/AudioPlayerController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/audio/AudioPlayerController.kt
@@ -273,14 +273,16 @@ class AudioPlayerController @Inject constructor(
    * MediaPlayer must already be initialized.
    */
   fun releaseMediaPlayer() {
-    audioLock.withLock {
-      check(mediaPlayerActive) { "Media player has not been previously initialized" }
-      mediaPlayerActive = false
-      isReleased = true
-      prepared = false
-      mediaPlayer.release()
-      stopUpdatingSeekBar()
-      playProgress = null
+    if (mediaPlayerActive) {
+      audioLock.withLock {
+        check(mediaPlayerActive) { "Media player has not been previously initialized" }
+        mediaPlayerActive = false
+        isReleased = true
+        prepared = false
+        mediaPlayer.release()
+        stopUpdatingSeekBar()
+        playProgress = null
+      }
     }
   }
 

--- a/domain/src/main/java/org/oppia/android/domain/audio/AudioPlayerController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/audio/AudioPlayerController.kt
@@ -273,16 +273,14 @@ class AudioPlayerController @Inject constructor(
    * MediaPlayer must already be initialized.
    */
   fun releaseMediaPlayer() {
-    if (mediaPlayerActive) {
-      audioLock.withLock {
-        check(mediaPlayerActive) { "Media player has not been previously initialized" }
-        mediaPlayerActive = false
-        isReleased = true
-        prepared = false
-        mediaPlayer.release()
-        stopUpdatingSeekBar()
-        playProgress = null
-      }
+    audioLock.withLock {
+      check(mediaPlayerActive) { "Media player has not been previously initialized" }
+      mediaPlayerActive = false
+      isReleased = true
+      prepared = false
+      mediaPlayer.release()
+      stopUpdatingSeekBar()
+      playProgress = null
     }
   }
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
  Fixes #4285 

  This PR fixes issue whereby changes in text size as described here https://github.com/oppia/oppia-android/issues/4285 are 
  not reflected immediately once the user navigates back to previous page. I have updated ExplorationActivity and ExplorationPresenter to recreate ExplorationFragment when user resumes from OptionsActivity with the newly updated text size.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing

## Before changes demo video
https://user-images.githubusercontent.com/20886444/186862289-c97650e5-a411-41e6-96a7-3894c62fdee4.mp4

## After changes demo video
https://user-images.githubusercontent.com/20886444/186862708-267d8fce-ee96-43bb-b0e1-a45d3f4629d5.mp4




