### PR TITLE
Fixes #3841: 'time_ago' & quantity plurals should be combined

### DIFF
--- a/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapters.java
+++ b/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapters.java
@@ -68,15 +68,14 @@ public final class TextViewBindingAdapters {
   }
 
   private static String getTimeAgo(View view, long lastVisitedTimestamp) {
-    long timeStampMillis = ensureTimestampIsInMilliseconds(lastVisitedTimestamp);
     long currentTimeMillis = getOppiaClock(view).getCurrentTimeMs();
     AppLanguageResourceHandler resourceHandler = getResourceHandler(view);
 
-    if (timeStampMillis > currentTimeMillis || timeStampMillis <= 0) {
+    if (lastVisitedTimestamp > currentTimeMillis || lastVisitedTimestamp <= 0) {
       return resourceHandler.getStringInLocale(R.string.last_logged_in_recently);
     }
 
-    long timeDifferenceMillis = currentTimeMillis - timeStampMillis;
+    long timeDifferenceMillis = currentTimeMillis - lastVisitedTimestamp;
 
     if (timeDifferenceMillis < (int) TimeUnit.MINUTES.toMillis(1)) {
       return resourceHandler.getStringInLocale(R.string.just_now);
@@ -107,22 +106,9 @@ public final class TextViewBindingAdapters {
       @PluralsRes int pluralsResId,
       int count
   ) {
-    // TODO(#3841): Combine these strings together.
-    return resourceHandler.getStringInLocaleWithWrapping(
-        R.string.time_ago,
-        resourceHandler.getQuantityStringInLocaleWithWrapping(
-            pluralsResId, count, String.valueOf(count)
-        )
+    return resourceHandler.getQuantityStringInLocaleWithWrapping(
+        pluralsResId, count, String.valueOf(count)
     );
-  }
-
-  private static long ensureTimestampIsInMilliseconds(long lastVisitedTimestamp) {
-    // TODO(#3842): Investigate & remove this check.
-    if (lastVisitedTimestamp < 1000000000000L) {
-      // If timestamp is given in seconds, convert that to milliseconds.
-      return TimeUnit.SECONDS.toMillis(lastVisitedTimestamp);
-    }
-    return lastVisitedTimestamp;
   }
 
   private static AppLanguageResourceHandler getResourceHandler(View view) {


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #3841
Fixes #3842
This PR includes the required update to combine strings together

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
