### PR TITLE
Fix part of #4300: Add strings for beta/GA notices

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -484,6 +484,17 @@
   <string name="unsupported_app_version_dialog_close_button_text" description="The close button text of the dialog shown when a user's pre-release app has expired.">
     Close app
   </string>
+  <string name="splash_screen_developer_label">Developer Build</string>
+  <string name="splash_screen_alpha_label">Alpha</string>
+  <string name="splash_screen_beta_label">Beta</string>
+  <string name="beta_notice_dialog_title">Beta Notice</string>
+  <string name="beta_notice_dialog_message">Hello! Your app is now being updated to the Beta version. If you experience problems while using the app, or have questions, please contact us at android-feedback@oppia.org.</string>
+  <string name="beta_notice_dialog_do_not_show_again_text">Don\'t show this message again</string>
+  <string name="beta_notice_dialog_close_button_text">OK</string>
+  <string name="general_availability_notice_dialog_title">General Availability Notice</string>
+  <string name="general_availability_notice_dialog_message">Hello! Your app is now being updated to the General Availability version. If you experience problems while using the app, or have questions, please contact us at android-feedback@oppia.org.</string>
+  <string name="general_availability_notice_dialog_do_not_show_again_text">Don\'t show this message again</string>
+  <string name="general_availability_notice_dialog_close_button_text">OK</string>
   <string name="ratio_content_description_separator" description="The separator that would be used to build the text that would be read out for ratio interaction.For e.g if the input is 1:2:3 the read out text would be 1 to 2 to 3">
     \u0020to\u0020
   </string>


### PR DESCRIPTION
## Explanation
Fix part of #4300.

This PR introduces the strings needed in #4417 in isolation so that they can be translated via Translatewiki sooner than #4417 will be merged.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
This PR only introduces strings and otherwise doesn't affect the UI.