### PR TITLE
Fixes #3892: Locked chapter item selection change is incorrect

### DIFF
--- a/app/src/main/java/org/oppia/android/app/story/StoryFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/story/StoryFragmentPresenter.kt
@@ -185,7 +185,7 @@ class StoryFragmentPresenter @Inject constructor(
               storyItemViewModel.missingPrerequisiteChapterTitle
             )
             val chapterLockedSpannable = SpannableString(missingPrerequisiteSummary)
-            if(!accessibilityService.isScreenReaderEnabled()) {
+            if (!accessibilityService.isScreenReaderEnabled()) {
               val clickableSpan = object : ClickableSpan() {
                 override fun onClick(widget: View) {
                   smoothScrollToPosition(storyItemViewModel.index - 1)

--- a/app/src/sharedTest/java/org/oppia/android/app/story/StoryFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/story/StoryFragmentTest.kt
@@ -126,6 +126,7 @@ import org.oppia.android.testing.threading.TestDispatcherModule
 import org.oppia.android.testing.time.FakeOppiaClock
 import org.oppia.android.testing.time.FakeOppiaClockModule
 import org.oppia.android.util.accessibility.AccessibilityTestModule
+import org.oppia.android.util.accessibility.FakeAccessibilityService
 import org.oppia.android.util.caching.AssetModule
 import org.oppia.android.util.caching.testing.CachingTestModule
 import org.oppia.android.util.gcsresource.GcsResourceModule
@@ -174,6 +175,9 @@ class StoryFragmentTest {
 
   @Inject
   lateinit var fakeOppiaClock: FakeOppiaClock
+
+  @Inject
+  lateinit var accessibilityService: FakeAccessibilityService
 
   @Captor
   lateinit var listCaptor: ArgumentCaptor<List<ImageTransformation>>
@@ -553,6 +557,52 @@ class StoryFragmentTest {
         matches(
           withText("Complete Chapter 1: What is a Fraction? to unlock this chapter.")
         )
+      )
+    }
+  }
+
+  @Test
+  fun testStoryFragment_checkClickableSpanWithoutScreenReader_isClickable() {
+    launch<StoryActivity>(createFractionsStoryActivityIntent()).use {
+      accessibilityService.setScreenReaderEnabled(false)
+      testCoroutineDispatchers.runCurrent()
+      onView(isRoot()).perform(orientationLandscape())
+      onView(allOf(withId(R.id.story_chapter_list))).perform(
+        scrollToPosition<RecyclerView.ViewHolder>(
+          2
+        )
+      )
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.story_chapter_list,
+          position = 2,
+          targetViewId = R.id.chapter_summary
+        )
+      ).check(
+        matches(hasClickableSpanWithText("Chapter 1: What is a Fraction?"))
+      )
+    }
+  }
+
+  @Test
+  fun testStoryFragment_checkClickableSpanWithScreenReader_isNotClickable() {
+    launch<StoryActivity>(createFractionsStoryActivityIntent()).use {
+      accessibilityService.setScreenReaderEnabled(true)
+      testCoroutineDispatchers.runCurrent()
+      onView(isRoot()).perform(orientationLandscape())
+      onView(allOf(withId(R.id.story_chapter_list))).perform(
+        scrollToPosition<RecyclerView.ViewHolder>(
+          2
+        )
+      )
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.story_chapter_list,
+          position = 2,
+          targetViewId = R.id.chapter_summary
+        )
+      ).check(
+        matches(not(hasClickableSpanWithText("Chapter 1: What is a Fraction?")))
       )
     }
   }


### PR DESCRIPTION
## Explanation
Fixes #3892: Changes UX for users with visual imparity such that if screen reader is turned on, link will be disabled. 

- Link will be disabled when screen reader is turned on so that when someone clicks on locked chapter summary, it won't redirect user to previous unlocked chapter (when screen reader is turned on)

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## UI after changes

https://user-images.githubusercontent.com/43074241/189179339-e5d47566-be39-49e9-9bb2-7b7655e2da37.mp4




