### PR TITLE
Add redundancy for app module ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -105,8 +105,8 @@ config/kitkat_main_dex_class_list.txt @BenHenning
 #####################################################################################
 
 # Global app module code ownership.
-/app/**/*.kt @rt4914
-/app/**/*.java @rt4914
+/app/**/*.kt @rt4914 @BenHenning
+/app/**/*.java @rt4914 @BenHenning
 
 # State players.
 /app/src/*/java/org/oppia/android/app/player/ @BenHenning
@@ -182,13 +182,13 @@ config/kitkat_main_dex_class_list.txt @BenHenning
 /utility/src/test/res/values/strings.xml @BenHenning
 
 # Accessibility utilities.
-/utility/src/*/java/org/oppia/android/util/accessibility/ @rt4914
+/utility/src/*/java/org/oppia/android/util/accessibility/ @rt4914 @BenHenning
 
 # Core logging infrastructure.
 /utility/src/*/java/org/oppia/android/util/logging/ @BenHenning
 
 # Miscellaneous statusbar UI utilities.
-/utility/src/*/java/org/oppia/android/util/statusbar/ @rt4914
+/utility/src/*/java/org/oppia/android/util/statusbar/ @rt4914 @BenHenning
 
 #####################################################################################
 #                                     scripts                                       #


### PR DESCRIPTION
## Explanation
Updates codeowners for non-XML app module files to ensure there's ownership redundancy (to reduce codereview load on @rt4914 & as part of his transition plan).

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] ~The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)~
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- This is nly changing codeowners.
