### PR TITLE
Fix #4583: Deprecated Protobuf Version

### DIFF
--- a/model/build.gradle
+++ b/model/build.gradle
@@ -3,12 +3,13 @@ apply plugin: 'com.google.protobuf'
 
 protobuf {
   protoc {
+    artifact = 'com.google.protobuf:protoc:3.14.0:osx-x86_64'
     // To build protoc in M1 mac. For context, see: #3912.
-    if (project.rootProject.hasProperty('protobuf_platform')) {
-      artifact = "com.google.protobuf:protoc:3.8.0:${project.rootProject.property("protobuf_platform")}"
-    } else {
-      artifact = "com.google.protobuf:protoc:3.8.0"
-    }
+//    if (project.rootProject.hasProperty('protobuf_platform')) {
+//      artifact = "com.google.protobuf:protoc:3.8.0:${project.rootProject.property("protobuf_platform")}"
+//    } else {
+//      artifact = "com.google.protobuf:protoc:3.8.0"
+//    }
   }
   generateProtoTasks {
     all().each { task ->

--- a/third_party/versions.bzl
+++ b/third_party/versions.bzl
@@ -118,7 +118,7 @@ HTTP_DEPENDENCY_VERSIONS = {
         "version": "2.28.1",
     },
     "protobuf_tools": {
-        "version": "3.11.0",
+        "version": "3.14.0",
     },
     "rules_java": {
         "sha": "34b41ec683e67253043ab1a3d1e8b7c61e4e8edefbcad485381328c934d072fe",


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
  - Fixes #4583:

  -  Basically it's like for the older versions of the protobuf there is no executable jars for the mac m1 arm architecture so this PR updates the protobuf version for the project so that we can also support arm based architecture chips.
  - "This PR Fixes #4583:"

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR Protobuf updates the protobuf  version in order to run the app successfully without any gradle and bazel issues.
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is assigned to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).


## For UI-specific PRs only
If your PR includes UI-related changes, then:

- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing