### PR TITLE
Fix #4602 : Fixes Develop branch not building

### DIFF
--- a/app/src/main/res/values/color_defs.xml
+++ b/app/src/main/res/values/color_defs.xml
@@ -84,7 +84,6 @@
   <color name="color_def_maastricht_blue">#0e162f</color>
   <color name="color_def_ocean_blue">#081661</color>
   <color name="color_def_persian_blue">#00609C</color>
-  <color name="color_def_bright_green">#009C8A</color>
   <color name="color_def_grape_violet">#674172</color>
   <color name="color_def_bright_violet">#7659B6</color>
   <color name="color_def_teal_blue">#2F6687</color>


### PR DESCRIPTION
Fix #4602 : Fixes Develop branch not building due to duplicate entry in color defs.

Removes duplicate entry in [color_defs.xml](https://github.com/oppia/oppia-android/blame/develop/app/src/main/res/values/color_defs.xml). 


