### PR TITLE
Fixes #4615: Increase color contrast ratio between foreground and background in design_menu_item_text

### DIFF
--- a/app/src/main/res/values/color_palette.xml
+++ b/app/src/main/res/values/color_palette.xml
@@ -99,7 +99,7 @@
   <color name="color_palette_toolbar_secondary_color">@color/color_def_oppia_green</color>
   <color name="color_palette_secondary_dark_background_color">@color/color_def_oppia_light_green</color>
   <color name="color_palette_concept_card_toolbar_color">@color/color_def_oppia_brown_dark</color>
-  <color name="color_palette_menu_selected_text_color">@color/color_def_oppia_brown_dark</color>
+  <color name="color_palette_menu_selected_text_color">@color/color_def_oppia_red</color>
   <color name="color_palette_developer_option_menu_selected_color">@color/color_def_persian_blue</color>
   <color name="color_palette_underline_view_color">@color/color_def_oppia_light_brown</color>
   <color name="color_palette_menu_text_color">@color/color_def_black</color>


### PR DESCRIPTION
## Explanation
Fixes #4615: Increase color contrast ratio between foreground and background in design_menu_item_text by replacing color_def_oppia_brown_dark to color_def_oppia_red

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Before
![image](https://user-images.githubusercontent.com/43074241/191899169-17d10ac5-503f-4ae1-95f3-2c389b8fd2fd.png)

## After
![image](https://user-images.githubusercontent.com/43074241/191899517-b6a3ccac-1598-405a-8ab3-9a503d659549.png)

