### PR TITLE
Fixes #4613: Increase color contrast ratio between foreground and background in profile_avatar_img

### DIFF
--- a/app/src/main/res/values/colors_migrating.xml
+++ b/app/src/main/res/values/colors_migrating.xml
@@ -69,12 +69,12 @@
   <color name="question_player_progress_bar_gradient_end">#E4F2F1</color>
   <!-- AVATAR BACKGROUND COLORS -->
   <color name="avatar_background_1">#E65C5C</color>
-  <color name="avatar_background_2">#E6935C</color>
-  <color name="avatar_background_3">#FFDB4E</color>
-  <color name="avatar_background_4">#CAE65C</color>
-  <color name="avatar_background_5">#93E65C</color>
-  <color name="avatar_background_6">#5CE6CA</color>
-  <color name="avatar_background_7">#5CCAE6</color>
+  <color name="avatar_background_2">#EB701D</color>
+  <color name="avatar_background_3">#A48C2D</color>
+  <color name="avatar_background_4">#C1851D</color>
+  <color name="avatar_background_5">#5C9F2F</color>
+  <color name="avatar_background_6">#1A9F84</color>
+  <color name="avatar_background_7">#1F98B7</color>
   <color name="avatar_background_8">#5C93E6</color>
   <color name="avatar_background_9">#5C5CE6</color>
   <color name="avatar_background_10">#935CE6</color>
@@ -82,11 +82,11 @@
   <color name="avatar_background_12">#E65C97</color>
   <color name="avatar_background_13">#CC2929</color>
   <color name="avatar_background_14">#CC6A29</color>
-  <color name="avatar_background_15">#E6C12E</color>
-  <color name="avatar_background_16">#ABCC29</color>
-  <color name="avatar_background_17">#6ACC29</color>
-  <color name="avatar_background_18">#29CCAB</color>
-  <color name="avatar_background_19">#29ABCC</color>
+  <color name="avatar_background_15">#AE8B00</color>
+  <color name="avatar_background_16">#819205</color>
+  <color name="avatar_background_17">#47A00C</color>
+  <color name="avatar_background_18">#0D9176</color>
+  <color name="avatar_background_19">#159DBF</color>
   <color name="avatar_background_20">#296ACC</color>
   <color name="avatar_background_21">#6A29CC</color>
   <color name="avatar_background_22">#AB29CC</color>


### PR DESCRIPTION
## Explanation
Fixes #4613: Increased color contrast ratio between foreground and background in profile_avatar_img by changing profile_avatar_img colors. 

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Before
![image](https://user-images.githubusercontent.com/43074241/191902918-ea298a9a-37de-4d5c-af6d-624d07999344.png)

## After
![image](https://user-images.githubusercontent.com/43074241/191902947-cd64a67d-9231-46cd-8e2a-3239b788fe7b.png)

![Screenshot_2022-09-23-23-03-06-98_943a62cb4c6fb83e010e1c2e82766a17.jpg](https://user-images.githubusercontent.com/43074241/192031141-e0f480bd-f3ba-43b0-a9fa-04023b7c5beb.jpg)