### PR TITLE
Fixes #4469: Create a gating parameter for configuration change

### DIFF
--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterAlphaKenyaModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterAlphaKenyaModule.kt
@@ -10,11 +10,13 @@ import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING_DEFAULT_VA
 import org.oppia.android.util.platformparameter.CacheLatexRendering
 import org.oppia.android.util.platformparameter.ENABLE_EDIT_ACCOUNTS_OPTIONS_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EXTRA_TOPIC_TABS_UI_DEFAULT_VALUE
+import org.oppia.android.util.platformparameter.ENABLE_INTERACTION_CONFIG_CHANGE_STATE_RETENTION
 import org.oppia.android.util.platformparameter.ENABLE_LANGUAGE_SELECTION_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.EnableEditAccountsOptionsUi
 import org.oppia.android.util.platformparameter.EnableExtraTopicTabsUi
+import org.oppia.android.util.platformparameter.EnableInteractionConfigChangeStateRetention
 import org.oppia.android.util.platformparameter.EnableLanguageSelectionUi
 import org.oppia.android.util.platformparameter.EnablePerformanceMetricsCollection
 import org.oppia.android.util.platformparameter.LEARNER_STUDY_ANALYTICS
@@ -163,6 +165,14 @@ class PlatformParameterAlphaKenyaModule {
   fun provideEnableExtraTopicTabsUi(): PlatformParameterValue<Boolean> {
     return PlatformParameterValue.createDefaultParameter(
       ENABLE_EXTRA_TOPIC_TABS_UI_DEFAULT_VALUE
+    )
+  }
+
+  @Provides
+  @EnableInteractionConfigChangeStateRetention
+  fun provideEnableInteractionConfigChangeStateRetention(): PlatformParameterValue<Boolean> {
+    return PlatformParameterValue.createDefaultParameter(
+      ENABLE_INTERACTION_CONFIG_CHANGE_STATE_RETENTION
     )
   }
 }

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterModule.kt
@@ -8,12 +8,14 @@ import org.oppia.android.util.platformparameter.AutomaticUpdateTopicSetting
 import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING
 import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.CacheLatexRendering
+import org.oppia.android.util.platformparameter.ENABLE_CONFIGURATION_CHANGE_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EDIT_ACCOUNTS_OPTIONS_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EXTRA_TOPIC_TABS_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_LANGUAGE_SELECTION_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_SPOTLIGHT_UI_DEFAULT_VALUE
+import org.oppia.android.util.platformparameter.EnableConfigurationChange
 import org.oppia.android.util.platformparameter.EnableEditAccountsOptionsUi
 import org.oppia.android.util.platformparameter.EnableExtraTopicTabsUi
 import org.oppia.android.util.platformparameter.EnableLanguageSelectionUi
@@ -169,6 +171,14 @@ class PlatformParameterModule {
   fun provideEnableExtraTopicTabsUi(): PlatformParameterValue<Boolean> {
     return PlatformParameterValue.createDefaultParameter(
       ENABLE_EXTRA_TOPIC_TABS_UI_DEFAULT_VALUE
+    )
+  }
+
+  @Provides
+  @EnableConfigurationChange
+  fun provideEnableConfigurationChange(): PlatformParameterValue<Boolean> {
+    return PlatformParameterValue.createDefaultParameter(
+      ENABLE_CONFIGURATION_CHANGE_DEFAULT_VALUE
     )
   }
 }

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterModule.kt
@@ -15,9 +15,9 @@ import org.oppia.android.util.platformparameter.ENABLE_LANGUAGE_SELECTION_UI_DEF
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_SPOTLIGHT_UI_DEFAULT_VALUE
-import org.oppia.android.util.platformparameter.EnableInteractionConfigChangeStateRetention
 import org.oppia.android.util.platformparameter.EnableEditAccountsOptionsUi
 import org.oppia.android.util.platformparameter.EnableExtraTopicTabsUi
+import org.oppia.android.util.platformparameter.EnableInteractionConfigChangeStateRetention
 import org.oppia.android.util.platformparameter.EnableLanguageSelectionUi
 import org.oppia.android.util.platformparameter.EnablePerformanceMetricsCollection
 import org.oppia.android.util.platformparameter.EnableSpotlightUi

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterModule.kt
@@ -8,14 +8,14 @@ import org.oppia.android.util.platformparameter.AutomaticUpdateTopicSetting
 import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING
 import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.CacheLatexRendering
-import org.oppia.android.util.platformparameter.ENABLE_CONFIGURATION_CHANGE_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EDIT_ACCOUNTS_OPTIONS_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EXTRA_TOPIC_TABS_UI_DEFAULT_VALUE
+import org.oppia.android.util.platformparameter.ENABLE_INTERACTION_CONFIG_CHANGE_STATE_RETENTION
 import org.oppia.android.util.platformparameter.ENABLE_LANGUAGE_SELECTION_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_SPOTLIGHT_UI_DEFAULT_VALUE
-import org.oppia.android.util.platformparameter.EnableConfigurationChange
+import org.oppia.android.util.platformparameter.EnableInteractionConfigChangeStateRetention
 import org.oppia.android.util.platformparameter.EnableEditAccountsOptionsUi
 import org.oppia.android.util.platformparameter.EnableExtraTopicTabsUi
 import org.oppia.android.util.platformparameter.EnableLanguageSelectionUi
@@ -175,10 +175,10 @@ class PlatformParameterModule {
   }
 
   @Provides
-  @EnableConfigurationChange
-  fun provideEnableConfigurationChange(): PlatformParameterValue<Boolean> {
+  @EnableInteractionConfigChangeStateRetention
+  fun provideEnableInteractionConfigChangeStateRetention(): PlatformParameterValue<Boolean> {
     return PlatformParameterValue.createDefaultParameter(
-      ENABLE_CONFIGURATION_CHANGE_DEFAULT_VALUE
+      ENABLE_INTERACTION_CONFIG_CHANGE_STATE_RETENTION
     )
   }
 }

--- a/testing/src/main/java/org/oppia/android/testing/platformparameter/TestPlatformParameterModule.kt
+++ b/testing/src/main/java/org/oppia/android/testing/platformparameter/TestPlatformParameterModule.kt
@@ -8,11 +8,13 @@ import org.oppia.android.util.platformparameter.AutomaticUpdateTopicSetting
 import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING
 import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.CacheLatexRendering
+import org.oppia.android.util.platformparameter.ENABLE_CONFIGURATION_CHANGE_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EDIT_ACCOUNTS_OPTIONS_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EXTRA_TOPIC_TABS_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_LANGUAGE_SELECTION_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION_DEFAULT_VALUE
+import org.oppia.android.util.platformparameter.EnableConfigurationChange
 import org.oppia.android.util.platformparameter.EnableEditAccountsOptionsUi
 import org.oppia.android.util.platformparameter.EnableExtraTopicTabsUi
 import org.oppia.android.util.platformparameter.EnableLanguageSelectionUi
@@ -188,12 +190,21 @@ class TestPlatformParameterModule {
     )
   }
 
+  @Provides
+  @EnableConfigurationChange
+  fun provideEnableConfigurationChange(): PlatformParameterValue<Boolean> {
+    return PlatformParameterValue.createDefaultParameter(
+      enableConfigurationChange
+    )
+  }
+
   companion object {
     private var enableAutomaticUpdateTopicSettingUi = AUTOMATIC_UPDATE_TOPIC_SETTING_VALUE
     private var enableLanguageSelectionUi = ENABLE_LANGUAGE_SELECTION_UI_DEFAULT_VALUE
     private var enableEditAccountsOptionsUi = ENABLE_EDIT_ACCOUNTS_OPTIONS_UI_DEFAULT_VALUE
     private var enableLearnerStudyAnalytics = LEARNER_STUDY_ANALYTICS_DEFAULT_VALUE
     private var enableExtraTopicTabsUi = ENABLE_EXTRA_TOPIC_TABS_UI_DEFAULT_VALUE
+    private var enableConfigurationChange = ENABLE_CONFIGURATION_CHANGE_DEFAULT_VALUE
 
     /** Enables forcing [EnableAutomaticUpdateTopicSettingUi] platform parameter flag from tests. */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
@@ -223,6 +234,12 @@ class TestPlatformParameterModule {
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun forceEnableExtraTopicTabsUi(value: Boolean) {
       enableExtraTopicTabsUi = value
+    }
+
+    /** Enables forcing [EnableConfigurationChange] platform parameter flag from tests. */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun forceEnableConfigurationChange(value: Boolean) {
+      enableConfigurationChange = value
     }
   }
 }

--- a/testing/src/main/java/org/oppia/android/testing/platformparameter/TestPlatformParameterModule.kt
+++ b/testing/src/main/java/org/oppia/android/testing/platformparameter/TestPlatformParameterModule.kt
@@ -8,15 +8,15 @@ import org.oppia.android.util.platformparameter.AutomaticUpdateTopicSetting
 import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING
 import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.CacheLatexRendering
-import org.oppia.android.util.platformparameter.ENABLE_CONFIGURATION_CHANGE_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EDIT_ACCOUNTS_OPTIONS_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EXTRA_TOPIC_TABS_UI_DEFAULT_VALUE
+import org.oppia.android.util.platformparameter.ENABLE_INTERACTION_CONFIG_CHANGE_STATE_RETENTION
 import org.oppia.android.util.platformparameter.ENABLE_LANGUAGE_SELECTION_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION_DEFAULT_VALUE
-import org.oppia.android.util.platformparameter.EnableConfigurationChange
 import org.oppia.android.util.platformparameter.EnableEditAccountsOptionsUi
 import org.oppia.android.util.platformparameter.EnableExtraTopicTabsUi
+import org.oppia.android.util.platformparameter.EnableInteractionConfigChangeStateRetention
 import org.oppia.android.util.platformparameter.EnableLanguageSelectionUi
 import org.oppia.android.util.platformparameter.EnablePerformanceMetricsCollection
 import org.oppia.android.util.platformparameter.LEARNER_STUDY_ANALYTICS_DEFAULT_VALUE
@@ -191,10 +191,10 @@ class TestPlatformParameterModule {
   }
 
   @Provides
-  @EnableConfigurationChange
-  fun provideEnableConfigurationChange(): PlatformParameterValue<Boolean> {
+  @EnableInteractionConfigChangeStateRetention
+  fun provideEnableInteractionConfigChangeStateRetention(): PlatformParameterValue<Boolean> {
     return PlatformParameterValue.createDefaultParameter(
-      enableConfigurationChange
+      enableInteractionConfigChangeStateRetention
     )
   }
 
@@ -204,7 +204,8 @@ class TestPlatformParameterModule {
     private var enableEditAccountsOptionsUi = ENABLE_EDIT_ACCOUNTS_OPTIONS_UI_DEFAULT_VALUE
     private var enableLearnerStudyAnalytics = LEARNER_STUDY_ANALYTICS_DEFAULT_VALUE
     private var enableExtraTopicTabsUi = ENABLE_EXTRA_TOPIC_TABS_UI_DEFAULT_VALUE
-    private var enableConfigurationChange = ENABLE_CONFIGURATION_CHANGE_DEFAULT_VALUE
+    private var enableInteractionConfigChangeStateRetention =
+      ENABLE_INTERACTION_CONFIG_CHANGE_STATE_RETENTION
 
     /** Enables forcing [EnableAutomaticUpdateTopicSettingUi] platform parameter flag from tests. */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
@@ -236,10 +237,10 @@ class TestPlatformParameterModule {
       enableExtraTopicTabsUi = value
     }
 
-    /** Enables forcing [EnableConfigurationChange] platform parameter flag from tests. */
+    /** Enables forcing [EnableInteractionConfigChangeStateRetention] platform parameter flag from tests. */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun forceEnableConfigurationChange(value: Boolean) {
-      enableConfigurationChange = value
+    fun forceEnableInteractionConfigChangeStateRetention(value: Boolean) {
+      enableInteractionConfigChangeStateRetention = value
     }
   }
 }

--- a/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
+++ b/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
@@ -208,11 +208,11 @@ annotation class EnableSpotlightUi
 const val ENABLE_SPOTLIGHT_UI_DEFAULT_VALUE = true
 
 /**
- * Qualifier for the platform parameter that controls whether configuration change for Input
- * Interactions.
+ * Qualifier for the platform parameter that controls controls whether input interaction state is
+ * correctly retained across configuration changes.
  */
 @Qualifier
-annotation class EnableConfigurationChange
+annotation class EnableInteractionConfigChangeStateRetention
 
-/** Default value for feature flag corresponding to [EnableConfigurationChange]. */
-const val ENABLE_CONFIGURATION_CHANGE_DEFAULT_VALUE = false
+/** Default value for feature flag corresponding to [EnableInteractionConfigChangeStateRetention]. */
+const val ENABLE_INTERACTION_CONFIG_CHANGE_STATE_RETENTION = false

--- a/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
+++ b/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
@@ -206,3 +206,13 @@ annotation class EnableSpotlightUi
 
 /** Default value for the feature flag corresponding to [EnableSpotlightUi]. */
 const val ENABLE_SPOTLIGHT_UI_DEFAULT_VALUE = true
+
+/**
+ * Qualifier for the platform parameter that controls whether configuration change for Input
+ * Interactions.
+ */
+@Qualifier
+annotation class EnableConfigurationChange
+
+/** Default value for feature flag corresponding to [EnableConfigurationChange]. */
+const val ENABLE_CONFIGURATION_CHANGE_DEFAULT_VALUE = false


### PR DESCRIPTION
## Explanation
Fixes #4469: Created a platform parameter to enable configuration change. This platform parameter will be used in future PRs related to configuration change. To make data persistent on configuration change, it will required multiple PRs. This platform parameter will be set to false (by default) in production until all PRs related configuration change is merged. 

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
