### PR TITLE
Fix #4644: Set custom protobuf artifact for macOS

### DIFF
--- a/model/build.gradle
+++ b/model/build.gradle
@@ -4,8 +4,11 @@ apply plugin: 'com.google.protobuf'
 protobuf {
   protoc {
     // To build protoc in M1 mac. For context, see: #3912.
-    if (project.rootProject.hasProperty('protobuf_platform')) {
-      artifact = "com.google.protobuf:protoc:3.8.0:${project.rootProject.property("protobuf_platform")}"
+    if (osdetector.os == "osx") {
+      Properties properties = new Properties()
+      properties.load(project.rootProject.file("local.properties").newDataInputStream())
+      def protobufPlatform = properties.getProperty("protobuf_platform", "")
+      artifact = "com.google.protobuf:protoc:3.8.0:${protobufPlatform}"
     } else {
       artifact = "com.google.protobuf:protoc:3.8.0"
     }

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -6,7 +6,9 @@ protobuf {
     // To build protoc in M1 mac. For context, see: #3912.
     if (osdetector.os == "osx") {
       Properties properties = new Properties()
-      properties.load(project.rootProject.file("local.properties").newDataInputStream())
+      DataInputStream input = project.rootProject.file("local.properties").newDataInputStream()
+      properties.load(input)
+      input.close()
       def protobufPlatform = properties.getProperty("protobuf_platform", "")
       artifact = "com.google.protobuf:protoc:3.8.0:${protobufPlatform}"
     } else {


### PR DESCRIPTION
## Explanation
Fix #4644: 

> `Execution failed for task ':model:generateProto'.`
> 
> Could not resolve all files for configuration ':model:protobufToolsLocator_protoc'.
> Could not find protoc-3.8.0-osx-aarch_64.exe (com.google.protobuf:protoc:3.8.0).
> Searched in the following locations:
> [https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/3.8.0/protoc-3.8.0-osx-aarch_64.exe`](https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/3.8.0/protoc-3.8.0-osx-aarch_64.exe%60)

Changed the conditional check for the `protobuf_platform` property from checking for property presence to checking for the current os. This is because `project.rootProject.hasProperty('protobuf_platform')` does not actually read the properties file as it is meant to, therefore the if condition was never met and the artifact was never set correctly.

I tested the existing implementaion by adding in build.gradle:
`println project.rootProject.property('protobuf_platform') `
This throws an error: 
`Caused by: groovy.lang.MissingPropertyException: Could not get unknown property 'protobuf_platform' for root project 'oppia-android' of type org.gradle.api.Project. `
Which shows that the current solution for reading the property from l`ocal.properties` file does not work correctly.

This solution changes how the property is read by loading the local.properties file with inputstream.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
