### PR TITLE
[RunAllTests] Fix #4512: Upgrade CI to Ubuntu 20.04

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     env:
       ENABLE_CACHING: false
       CACHE_DIRECTORY: ~/.bazel_cache
@@ -165,7 +165,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     env:
       ENABLE_CACHING: false
       CACHE_DIRECTORY: ~/.bazel_cache
@@ -314,7 +314,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     env:
       ENABLE_CACHING: false
       CACHE_DIRECTORY: ~/.bazel_cache
@@ -482,7 +482,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     env:
       ENABLE_CACHING: false
       CACHE_DIRECTORY: ~/.bazel_cache
@@ -612,7 +612,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     env:
       ENABLE_CACHING: false
       CACHE_DIRECTORY: ~/.bazel_cache

--- a/.github/workflows/issue_checks.yml
+++ b/.github/workflows/issue_checks.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   script_check:
     name: Closed TODO Issue Check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -99,7 +99,7 @@ jobs:
 
   run_app_module_test:
     name: Run app module Robolectric test shard
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -145,7 +145,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     steps:
       - name: Check tests passed (for tests that ran)
         if: ${{ needs.run_app_module_test.result != 'success' }}

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   check_codeowners:
     name: Check CODEOWNERS & Repository files
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
@@ -23,7 +23,7 @@ jobs:
 
   check_base_branch:
     name: Check base branch
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'pull_request'
     steps:
       - name: "Branch is not based on develop or release branch"
@@ -44,7 +44,7 @@ jobs:
 
   linters:
     name: Lint Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
@@ -95,7 +95,7 @@ jobs:
 
   script_checks:
     name: Script Checks
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       CACHE_DIRECTORY: ~/.bazel_cache
     steps:
@@ -190,7 +190,7 @@ jobs:
   # ensure the results exactly match the current state of the repository).
   third_party_dependencies_check:
     name: Maven Dependencies Checks
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   bazel_compute_affected_targets:
     name: Compute affected tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.compute-test-matrix.outputs.matrix }}
       have_tests_to_run: ${{ steps.compute-test-matrix.outputs.have_tests_to_run }}
@@ -94,7 +94,7 @@ jobs:
     name: Run Bazel Test
     needs: bazel_compute_affected_targets
     if: ${{ needs.bazel_compute_affected_targets.outputs.have_tests_to_run == 'true' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -319,7 +319,7 @@ jobs:
       name: Check Bazel Test Results
       needs: [bazel_compute_affected_targets, bazel_run_test]
       if: ${{ always() }}
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-20.04
       steps:
         # This step will be skipped if there are no tests to run, so the overall job should pass.
         - name: Check tests passed (for tests that ran)

--- a/.github/workflows/workflow_canceller.yml
+++ b/.github/workflows/workflow_canceller.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   cancel:
     name: Cancel Previous Runs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # See https://github.com/styfle/cancel-workflow-action for details on this workflow.
       - uses: styfle/cancel-workflow-action@0.6.0


### PR DESCRIPTION
## Explanation
Fixes #4512

Per https://github.com/actions/runner-images/issues/6002 this migrates all CI actions over to Ubuntu 20.04 since 18.04 has been deprecated and is being phased out of production.

Due to limited time, I'm planning to fast-track this PR by merging it if CI passes for all tests.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- This only affects the CI runtime environment, not the app or anything user-facing.