### PR TITLE
Bump Robolectric to 4.7

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -197,7 +197,7 @@ dependencies {
       'com.google.truth:truth:1.1.3',
       'com.google.truth.extensions:truth-liteproto-extension:1.1.3',
       'org.robolectric:annotations:4.5',
-      'org.robolectric:robolectric:4.5',
+      'org.robolectric:robolectric:4.7',
       'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.2',
       "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version",
       'org.mockito:mockito-core:2.7.22',

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,5 @@ android.enableJetifier=true
 kotlin.code.style=official
 # Needed to enable Android data binding.
 android.databinding.enableV2=true
+# TODO change to android.jetifier.ignorelist=bcprov-jdk15on when we Upgrade AGP to 7.0
 android.jetifier.blacklist=bcprov-jdk15on

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,4 @@ android.enableJetifier=true
 kotlin.code.style=official
 # Needed to enable Android data binding.
 android.databinding.enableV2=true
-
+android.jetifier.blacklist=bcprov-jdk15on

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -79,7 +79,7 @@ dependencies {
       'com.google.truth.extensions:truth-liteproto-extension:1.1.3',
       'nl.dionsegijn:konfetti:1.2.5',
       'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.2',
-      'org.robolectric:robolectric:4.5',
+      'org.robolectric:robolectric:4.7',
       'org.jetbrains.kotlin:kotlin-reflect:$kotlin_version',
       'org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version',
       'org.mockito:mockito-core:2.19.0',


### PR DESCRIPTION
## Explanation
Robolectric 4.7 offers native support for running Robolectric tests on M1 Macs.

To resolve a resulting error:
```
Caused by: org.gradle.api.internal.artifacts.transform.TransformException: 
Failed to transform bcprov-jdk15on-1.68.jar (org.bouncycastle:bcprov-jdk15on:1.68) to match attributes 
{artifactType=android-classes, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
...
Caused by: org.gradle.api.internal.artifacts.transform.TransformException: 
Execution failed for JetifyTransform: ../.gradle/caches/modules-2/files-2.1/org.bouncycastle/bcprov-jdk15on/1.68/46a080368d38b428d237a59458f9bc915222894d/bcprov-jdk15on-1.68.jar.
```

I have added the following to `gradle.properties`:
`android.jetifier.blacklist=bcprov-jdk15on`
The other proposed fix in Robolectric issue [#6521](https://github.com/robolectric/robolectric/issues/6521) is to set `android.enableJetifier=false`, but it seems that we are using jetifier in our project.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).