### PR TITLE
Fix oppia #4532: Multiple tabs are opening on clicking the concept ca…

### DIFF
--- a/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardBackStackManager.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardBackStackManager.kt
@@ -1,0 +1,34 @@
+package org.oppia.android.app.topic.conceptcard
+
+import androidx.lifecycle.MutableLiveData
+
+object ConceptCardBackStackManager {
+
+  const val DEFAULT_STACK_SIZE = -1
+
+  private var conceptCardBackStack: ArrayDeque<String>? = null
+  val stackSize: MutableLiveData<Int> = MutableLiveData(DEFAULT_STACK_SIZE)
+
+  fun initBackStack() {
+    conceptCardBackStack = ArrayDeque()
+  }
+
+  fun addToStack(skillId: String) {
+    conceptCardBackStack?.add(skillId)
+    stackSize.value = conceptCardBackStack?.size
+  }
+
+  fun peek(): String? {
+    return conceptCardBackStack?.last()
+  }
+
+  fun remove() {
+    conceptCardBackStack?.removeLast()
+    stackSize.value = conceptCardBackStack?.size
+  }
+
+  fun destroyBackStack() {
+    conceptCardBackStack = null
+    stackSize.value = DEFAULT_STACK_SIZE
+  }
+}

--- a/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragment.kt
@@ -68,6 +68,16 @@ class ConceptCardFragment : InjectableDialogFragment() {
         "Expected skillId to be passed to ConceptCardFragment"
       }
     val profileId = args.getProto(PROFILE_ID_ARGUMENT_KEY, ProfileId.getDefaultInstance())
+    if (ConceptCardBackStackManager.stackSize.value == ConceptCardBackStackManager.DEFAULT_STACK_SIZE) {
+      ConceptCardBackStackManager.initBackStack()
+      ConceptCardBackStackManager.addToStack(skillId)
+    } else {
+      if (ConceptCardBackStackManager.peek() == skillId) {
+        dismiss()
+      } else {
+        ConceptCardBackStackManager.addToStack(skillId)
+      }
+    }
     return conceptCardFragmentPresenter.handleCreateView(inflater, container, skillId, profileId)
   }
 

--- a/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentPresenter.kt
@@ -55,6 +55,10 @@ class ConceptCardFragmentPresenter @Inject constructor(
       R.string.concept_card_close_icon_description
     )
     binding.conceptCardToolbar.setNavigationOnClickListener {
+      ConceptCardBackStackManager.remove()
+      if (ConceptCardBackStackManager.stackSize.value == 0) {
+        ConceptCardBackStackManager.destroyBackStack()
+      }
       (fragment.requireActivity() as? ConceptCardListener)?.dismissConceptCard()
     }
 


### PR DESCRIPTION
…rds link thrice

<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
