### PR TITLE
Fixes #2116: misalignment in profile_chooser_add_view

### DIFF
--- a/app/src/main/res/layout-sw600dp-land/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout-sw600dp-land/profile_chooser_add_view.xml
@@ -22,6 +22,7 @@
     android:gravity="center_horizontal"
     android:paddingStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_add_view_parent_margin_start_profile_not_added}"
     android:paddingEnd="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_add_view_parent_margin_end_profile_not_added}"
+    app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_view_already_added_description_parent_margin_top : @dimen/space_0dp}"
     android:orientation="vertical">
 
     <LinearLayout

--- a/app/src/main/res/layout-sw600dp-land/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout-sw600dp-land/profile_chooser_add_view.xml
@@ -51,7 +51,7 @@
         android:layout_height="wrap_content"
         android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
         android:orientation="vertical"
-        app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_view_already_added_description_parent_margin_top : @dimen/space_0dp}"
+        app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_view_already_added_description_textview_parent_margin_top : @dimen/space_0dp}"
         android:paddingEnd="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_description_margin_end_profile_not_added}"
         android:paddingStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_description_margin_start_profile_not_added}">
 

--- a/app/src/main/res/layout-sw600dp-port/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout-sw600dp-port/profile_chooser_add_view.xml
@@ -51,7 +51,7 @@
         android:layout_height="wrap_content"
         android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
         android:orientation="vertical"
-        app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_view_already_added_description_parent_margin_top : @dimen/space_0dp}"
+        app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_view_already_added_description_textview_parent_margin_top : @dimen/space_0dp}"
         android:paddingEnd="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_description_margin_end_profile_not_added}"
         android:paddingStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_description_margin_start_profile_not_added}">
 

--- a/app/src/main/res/values-sw600dp-land/dimens.xml
+++ b/app/src/main/res/values-sw600dp-land/dimens.xml
@@ -508,5 +508,6 @@
   <dimen name="topic_fragment_tab_layout_margin_end">192dp</dimen>
   <dimen name="topic_fragment_tab_layout_tab_indicator_height">4dp</dimen>
 
-  <dimen name="profile_view_already_added_description_parent_margin_top">16dp</dimen>
+  <dimen name="profile_view_already_added_description_parent_margin_top">20dp</dimen>
+  <dimen name="profile_view_already_added_description_textview_parent_margin_top">10dp</dimen>
 </resources>

--- a/app/src/main/res/values-sw600dp-land/dimens.xml
+++ b/app/src/main/res/values-sw600dp-land/dimens.xml
@@ -507,4 +507,6 @@
   <dimen name="topic_fragment_tab_layout_margin_start">192dp</dimen>
   <dimen name="topic_fragment_tab_layout_margin_end">192dp</dimen>
   <dimen name="topic_fragment_tab_layout_tab_indicator_height">4dp</dimen>
+
+  <dimen name="profile_view_already_added_description_parent_margin_top">16dp</dimen>
 </resources>

--- a/app/src/main/res/values-sw600dp-port/dimens.xml
+++ b/app/src/main/res/values-sw600dp-port/dimens.xml
@@ -507,5 +507,6 @@
   <dimen name="topic_fragment_tab_layout_margin_end">64dp</dimen>
   <dimen name="topic_fragment_tab_layout_tab_indicator_height">4dp</dimen>
 
-  <dimen name="profile_view_already_added_description_parent_margin_top">16dp</dimen>
+  <dimen name="profile_view_already_added_description_parent_margin_top">20dp</dimen>
+  <dimen name="profile_view_already_added_description_textview_parent_margin_top">10dp</dimen>
 </resources>

--- a/app/src/main/res/values-sw600dp-port/dimens.xml
+++ b/app/src/main/res/values-sw600dp-port/dimens.xml
@@ -506,4 +506,6 @@
   <dimen name="topic_fragment_tab_layout_margin_start">64dp</dimen>
   <dimen name="topic_fragment_tab_layout_margin_end">64dp</dimen>
   <dimen name="topic_fragment_tab_layout_tab_indicator_height">4dp</dimen>
+
+  <dimen name="profile_view_already_added_description_parent_margin_top">16dp</dimen>
 </resources>


### PR DESCRIPTION
"Add profile" is misaligned compared to the other profiles.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Before
### Land
<img width="640" alt="Screenshot 2022-11-19 at 11 30 29" src="https://user-images.githubusercontent.com/4971463/202846359-dbfe1ed9-947c-4026-abea-13bd289d891c.png">

### Port
<img width="453" alt="Screenshot 2022-11-19 at 11 30 50" src="https://user-images.githubusercontent.com/4971463/202846373-dd885751-784c-4a8e-8128-f20de1cd47de.png">


## After
### Land
<img width="651" alt="Screenshot 2022-11-19 at 13 55 19" src="https://user-images.githubusercontent.com/4971463/202851910-bb7c5231-6dbc-4324-91ef-bf6a136791de.png">


### Port
<img width="564" alt="Screenshot 2022-11-19 at 13 55 09" src="https://user-images.githubusercontent.com/4971463/202851900-7b1704c7-9dc6-4a67-8f94-ed55c0cbdf61.png">


