### PR TITLE
Fixes #4759: App crashes intermittently while trying to Switch profile

### DIFF
--- a/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
@@ -216,11 +216,10 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
 
   private fun subscribeToOngoingTopicListLiveData() {
     getOngoingTopicListCount().observe(
-      fragment,
-      {
-        getHeaderViewModel().setOngoingTopicProgress(it.topicCount)
-      }
-    )
+      fragment
+    ) {
+      getHeaderViewModel().setOngoingTopicProgress(it.topicCount)
+    }
   }
 
   private fun processGetOngoingTopicListResult(
@@ -417,7 +416,6 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
       ) {
         override fun onDrawerOpened(drawerView: View) {
           super.onDrawerOpened(drawerView)
-          fragment.activity!!.invalidateOptionsMenu()
           StatusBarColor.statusBarColorUpdate(
             R.color.slide_drawer_open_status_bar,
             activity,
@@ -427,7 +425,6 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
 
         override fun onDrawerClosed(drawerView: View) {
           super.onDrawerClosed(drawerView)
-          fragment.activity!!.invalidateOptionsMenu()
           StatusBarColor.statusBarColorUpdate(
             R.color.oppia_primary_dark,
             activity,
@@ -454,7 +451,6 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
       ) {
         override fun onDrawerOpened(drawerView: View) {
           super.onDrawerOpened(drawerView)
-          fragment.activity!!.invalidateOptionsMenu()
           StatusBarColor.statusBarColorUpdate(
             R.color.slide_drawer_open_status_bar,
             activity,
@@ -464,7 +460,6 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
 
         override fun onDrawerClosed(drawerView: View) {
           super.onDrawerClosed(drawerView)
-          fragment.activity!!.invalidateOptionsMenu()
           StatusBarColor.statusBarColorUpdate(
             R.color.oppia_primary_dark,
             activity,

--- a/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
@@ -416,6 +416,7 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
       ) {
         override fun onDrawerOpened(drawerView: View) {
           super.onDrawerOpened(drawerView)
+         fragment.activity?.invalidateOptionsMenu()
           StatusBarColor.statusBarColorUpdate(
             R.color.slide_drawer_open_status_bar,
             activity,
@@ -425,6 +426,14 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
 
         override fun onDrawerClosed(drawerView: View) {
           super.onDrawerClosed(drawerView)
+          /* When we switch profile we should check if the fragment is still attached
+          *  because the order of lifecycle callbacks are not certain, meaning.
+          *  OnDetach() can be called before onDrawerClosed() which results in crash
+          */
+          if(!fragment.isDetached)
+          {
+            fragment.activity?.invalidateOptionsMenu()
+          }
           StatusBarColor.statusBarColorUpdate(
             R.color.oppia_primary_dark,
             activity,
@@ -451,6 +460,7 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
       ) {
         override fun onDrawerOpened(drawerView: View) {
           super.onDrawerOpened(drawerView)
+          fragment.activity?.invalidateOptionsMenu()
           StatusBarColor.statusBarColorUpdate(
             R.color.slide_drawer_open_status_bar,
             activity,
@@ -460,6 +470,10 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
 
         override fun onDrawerClosed(drawerView: View) {
           super.onDrawerClosed(drawerView)
+          if(!fragment.isDetached)
+          {
+            fragment.activity?.invalidateOptionsMenu()
+          }
           StatusBarColor.statusBarColorUpdate(
             R.color.oppia_primary_dark,
             activity,


### PR DESCRIPTION
Fixes https://github.com/oppia/oppia-android/issues/4759

<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
