### PR TITLE
Fix #4775: SpotlightFragmentTest is very flaky 

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/spotlight/SpotlightFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/spotlight/SpotlightFragmentTest.kt
@@ -297,6 +297,7 @@ class SpotlightFragmentTest {
         )
 
         checkNotNull(activity.getSpotlightFragment()).requestSpotlight(firstSpotlightTarget)
+        testCoroutineDispatchers.runCurrent()
         checkNotNull(activity.getSpotlightFragment()).requestSpotlight(secondSpotlightTarget)
       }
       testCoroutineDispatchers.runCurrent()
@@ -327,6 +328,7 @@ class SpotlightFragmentTest {
         )
 
         checkNotNull(activity.getSpotlightFragment()).requestSpotlight(firstSpotlightTarget)
+        testCoroutineDispatchers.runCurrent()
         checkNotNull(activity.getSpotlightFragment()).requestSpotlight(secondSpotlightTarget)
       }
       testCoroutineDispatchers.runCurrent()


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
fixes #4775 

This PR was created to investigate why 2 tests mentioned [here](https://github.com/oppia/oppia-android/issues/4775#issuecomment-1331166647) were so flaky and fix these issues. From what I found, it seems that the problem occurs in sequencing while adding spotlight targets: 

>checkNotNull(activity.getSpotlightFragment()).requestSpotlight(firstSpotlightTarget)
checkNotNull(activity.getSpotlightFragment()).requestSpotlight(secondSpotlightTarget)


The addition of targets probably lead to a race condition? I haven't really gotten as deep as to debug it though, but I assumed my speculation was correct, and an easy fix was to add `testCoroutineDispatchers.runCurrent()` between these two lines.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).