### PR TITLE
Add generates_api = True to compiler_annotation_processor.

### DIFF
--- a/tools/android/BUILD.bazel
+++ b/tools/android/BUILD.bazel
@@ -8,6 +8,7 @@ java_plugin(
     name = "compiler_annotation_processor",
     processor_class = "android.databinding.annotationprocessor.ProcessDataBinding",
     visibility = ["//visibility:public"],
+    generates_api = True,
     deps = [
         "@bazel_tools//src/tools/android/java/com/google/devtools/build/android:all_android_tools",
     ],


### PR DESCRIPTION
So that Java header compilation works with HEAD Bazel.