### PR TITLE
Fixed #1956: Optimise Profile_chooser_add views

### DIFF
--- a/app/src/main/res/layout-land/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout-land/profile_chooser_add_view.xml
@@ -11,7 +11,7 @@
       type="androidx.databinding.ObservableField&lt;Boolean&gt;" />
   </data>
 
-  <LinearLayout
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal">
@@ -25,6 +25,9 @@
       android:layout_marginBottom="24dp"
       android:gravity="center_horizontal"
       android:orientation="vertical"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
       app:layoutMarginBottom="@{hasProfileEverBeenAddedValue ? @dimen/profile_view_already_added_margin : @dimen/profile_chooser_add_view_margin_bottom_profile_not_added}"
       app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_add_view_margin_top_profile_already_added : @dimen/profile_chooser_add_view_margin_top_profile_not_added}">
 
@@ -40,26 +43,17 @@
 
       <TextView
         android:id="@+id/add_profile_text"
-        style="@style/TextViewCenter"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/AddMultiProfileHeading"
         android:layout_gravity="center"
-        android:fontFamily="sans-serif-medium"
-        android:text="@{hasProfileEverBeenAddedValue ? @string/profile_chooser_add : @string/set_up_multiple_profiles}"
-        android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
-        android:textSize="14sp" />
+        android:text="@{hasProfileEverBeenAddedValue ? @string/profile_chooser_add : @string/set_up_multiple_profiles}" />
 
       <TextView
         android:id="@+id/add_profile_description_text"
-        style="@style/TextViewCenter"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/AddMultiProfileBody"
         android:layout_gravity="center"
-        android:fontFamily="sans-serif"
+        android:textAlignment="center"
         android:text="@string/set_up_multiple_profiles_description"
-        android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
-        android:textSize="12sp"
         android:visibility="@{hasProfileEverBeenAddedValue ? View.GONE : View.VISIBLE}" />
     </LinearLayout>
-  </LinearLayout>
+  </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout-land/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-land/profile_chooser_profile_view.xml
@@ -37,13 +37,9 @@
 
       <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/profile_avatar_img"
-        android:layout_width="72dp"
-        android:layout_height="72dp"
-        android:layout_marginBottom="8dp"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.RoundedShape"
-        app:strokeColor="@color/component_color_profile_chooser_activity_avatar_border_color"
-        app:strokeWidth="1dp"
-        profile:src="@{viewModel.profile.avatar}" />
+        style="@style/ShapeAbleImageView"
+        app:srcCompat="@{@drawable/ic_add_profile}"
+        android:layout_marginBottom="8dp" />
 
       <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout-sw600dp-land/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout-sw600dp-land/profile_chooser_add_view.xml
@@ -43,9 +43,7 @@
         android:layout_height="108dp"
         app:srcCompat="@{@drawable/ic_add_profile}"
         app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_add_view_circular_image_margin_top_profile_already_added : @dimen/space_0dp}"
-        app:strokeColor="@color/component_color_profile_chooser_activity_avatar_border_color"
-        app:strokeWidth="1dp"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.RoundedShape" />
+        style="@style/ShapeAbleImageView" />
 
       <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout-sw600dp-land/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout-sw600dp-land/profile_chooser_add_view.xml
@@ -16,13 +16,14 @@
       type="androidx.databinding.ObservableField&lt;Boolean&gt;" />
   </data>
 
-  <LinearLayout
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="center_horizontal"
+    android:layout_margin="@dimen/profile_chooser_profile_view_margin"
+    android:padding="@dimen/profile_chooser_profile_view_parent_padding"
+    app:layoutMarginBottom="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/space_0dp}"
     android:paddingStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_add_view_parent_margin_start_profile_not_added}"
-    android:paddingEnd="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_add_view_parent_margin_end_profile_not_added}"
-    android:orientation="vertical">
+    android:paddingEnd="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_add_view_parent_margin_end_profile_not_added}">
 
     <LinearLayout
       android:id="@+id/add_profile_item"
@@ -31,8 +32,9 @@
       app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_add_view_margin_top_profile_not_added}"
       android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER}"
       android:orientation="@{hasProfileEverBeenAddedValue ? LinearLayout.VERTICAL : LinearLayout.HORIZONTAL}"
-      android:paddingEnd="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_add_view_margin_end_profile_not_added}"
       android:paddingStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_add_view_margin_start_profile_not_added}"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
       tools:ignore="RtlSymmetry">
 
       <com.google.android.material.imageview.ShapeableImageView
@@ -56,27 +58,19 @@
 
         <TextView
           android:id="@+id/add_profile_text"
-          style="@style/TextViewStart"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:fontFamily="sans-serif-medium"
+          style="@style/AddMultiProfileHeading"
           android:text="@{hasProfileEverBeenAddedValue ? @string/profile_chooser_add : @string/set_up_multiple_profiles}"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
           android:textSize="20sp" />
 
         <TextView
           android:id="@+id/add_profile_description_text"
-          style="@style/TextViewCenter"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
+          style="@style/AddMultiProfileBody"
           android:layout_gravity="center"
           android:layout_marginTop="4dp"
-          android:fontFamily="sans-serif"
           android:text="@string/set_up_multiple_profiles_description"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
           android:textSize="16sp"
           android:visibility="@{hasProfileEverBeenAddedValue ? View.GONE : View.VISIBLE}" />
       </LinearLayout>
     </LinearLayout>
-  </LinearLayout>
+  </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout-sw600dp-port/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout-sw600dp-port/profile_chooser_add_view.xml
@@ -40,11 +40,9 @@
         android:id="@+id/profile_add_button"
         android:layout_width="108dp"
         android:layout_height="108dp"
+        style="@style/ShapeAbleImageView"
         app:srcCompat="@{@drawable/ic_add_profile}"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.RoundedShape"
-        app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_add_view_circular_image_margin_top_profile_already_added : @dimen/space_0dp}"
-        app:strokeColor="@color/component_color_profile_chooser_activity_avatar_border_color"
-        app:strokeWidth="1dp" />
+        app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_add_view_circular_image_margin_top_profile_already_added : @dimen/space_0dp}" />
 
       <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout-sw600dp-port/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout-sw600dp-port/profile_chooser_add_view.xml
@@ -16,14 +16,12 @@
       type="androidx.databinding.ObservableField&lt;Boolean&gt;" />
   </data>
 
-  <LinearLayout
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="center_horizontal"
-    app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_view_already_added_description_parent_margin_top : @dimen/space_0dp}"
-    android:paddingEnd="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_description_margin_end_profile_not_added}"
-    android:paddingStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_description_margin_start_profile_not_added}"
-    android:orientation="vertical">
+    android:layout_margin="@dimen/profile_chooser_profile_view_margin"
+    android:padding="@dimen/profile_chooser_profile_view_parent_padding"
+    android:gravity="center_horizontal">
 
     <LinearLayout
       android:id="@+id/add_profile_item"
@@ -34,6 +32,8 @@
       android:orientation="@{hasProfileEverBeenAddedValue ? LinearLayout.VERTICAL : LinearLayout.HORIZONTAL}"
       android:paddingEnd="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_add_view_margin_end_profile_not_added}"
       android:paddingStart="@{hasProfileEverBeenAddedValue ? @dimen/space_0dp : @dimen/profile_chooser_add_view_margin_start_profile_not_added}"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
       tools:ignore="RtlSymmetry">
 
       <com.google.android.material.imageview.ShapeableImageView
@@ -57,27 +57,19 @@
 
         <TextView
           android:id="@+id/add_profile_text"
-          style="@style/TextViewStart"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:fontFamily="sans-serif-medium"
+          style="@style/AddMultiProfileHeading"
           android:text="@{hasProfileEverBeenAddedValue ? @string/profile_chooser_add : @string/set_up_multiple_profiles}"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
           android:textSize="20sp" />
 
         <TextView
           android:id="@+id/add_profile_description_text"
-          style="@style/TextViewCenter"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
+          style="@style/AddMultiProfileBody"
           android:layout_gravity="center"
           android:layout_marginTop="4dp"
-          android:fontFamily="sans-serif"
           android:text="@string/set_up_multiple_profiles_description"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
           android:textSize="16sp"
           android:visibility="@{hasProfileEverBeenAddedValue ? View.GONE : View.VISIBLE}" />
       </LinearLayout>
     </LinearLayout>
-  </LinearLayout>
+  </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/profile_chooser_add_view.xml
+++ b/app/src/main/res/layout/profile_chooser_add_view.xml
@@ -15,16 +15,17 @@
       type="androidx.databinding.ObservableField&lt;Boolean&gt;" />
   </data>
 
-  <LinearLayout
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:gravity="center_horizontal"
-    android:orientation="vertical">
+    android:layout_height="wrap_content">
 
     <LinearLayout
       android:id="@+id/add_profile_item"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
       android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
       android:orientation="@{hasProfileEverBeenAddedValue ? LinearLayout.VERTICAL : LinearLayout.HORIZONTAL}"
       app:layoutMarginEnd="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_add_view_margin_end_profile_already_added : @dimen/profile_view_not_added_margin}"
@@ -33,12 +34,8 @@
       
       <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/profile_add_button"
-        android:layout_width="72dp"
-        android:layout_height="72dp"
-        app:srcCompat="@{@drawable/ic_add_profile}"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.RoundedShape"
-        app:strokeColor="@color/component_color_profile_chooser_activity_avatar_border_color"
-        app:strokeWidth="1dp" />
+        style="@style/ShapeAbleImageView"
+        app:srcCompat="@{@drawable/ic_add_profile}" />
 
       <LinearLayout
         android:layout_width="match_parent"
@@ -51,26 +48,16 @@
 
         <TextView
           android:id="@+id/add_profile_text"
-          style="@style/TextViewStart"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:fontFamily="sans-serif-medium"
-          android:text="@{hasProfileEverBeenAddedValue ? @string/profile_chooser_add : @string/set_up_multiple_profiles}"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
-          android:textSize="14sp" />
+          style="@style/AddMultiProfileHeading"
+          android:text="@{hasProfileEverBeenAddedValue ? @string/profile_chooser_add : @string/set_up_multiple_profiles}" />
 
         <TextView
           android:id="@+id/add_profile_description_text"
-          style="@style/TextViewStart"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
+          style="@style/AddMultiProfileBody"
           android:layout_marginTop="4dp"
-          android:fontFamily="sans-serif"
           android:text="@string/set_up_multiple_profiles_description"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
-          android:textSize="12sp"
           android:visibility="@{hasProfileEverBeenAddedValue ? View.GONE : View.VISIBLE}" />
       </LinearLayout>
     </LinearLayout>
-  </LinearLayout>
+  </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout/profile_chooser_profile_view.xml
@@ -39,11 +39,7 @@
 
       <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/profile_avatar_img"
-        android:layout_width="72dp"
-        android:layout_height="72dp"
-        app:strokeColor="@color/component_color_profile_chooser_activity_avatar_border_color"
-        app:strokeWidth="1dp"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.RoundedShape"
+        style="@style/ShapeAbleImageView"
         profile:src="@{viewModel.profile.avatar}" />
 
       <LinearLayout

--- a/app/src/main/res/values-land-hdpi/dimens.xml
+++ b/app/src/main/res/values-land-hdpi/dimens.xml
@@ -4,6 +4,6 @@
   <dimen name="profile_chooser_fragment_profile_select_text_margin_top">20dp</dimen>
   <dimen name="profile_chooser_fragment_profile_recycler_view_margin_top">8dp</dimen>
   <dimen name="profile_chooser_profile_view_view_margin_top">32dp</dimen>
-  <dimen name="profile_chooser_add_view_margin_top_profile_not_added">32dp</dimen>
+  <dimen name="profile_chooser_add_view_margin_top_profile_not_added">24dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -468,6 +468,28 @@
     <item name="android:textAlignment">viewStart</item>
   </style>
 
+  <style name="AddMultiProfileHeading" parent="TextView.Common1">
+    <item name="android:textAlignment">viewStart</item>
+    <item name="fontFamily">sans-serif-medium</item>
+    <item name="android:textColor">@color/color_def_white</item>
+    <item name="android:textSize">14sp</item>
+  </style>
+
+  <style name="AddMultiProfileBody" parent="TextView.Common1">
+    <item name="android:textAlignment">viewStart</item>
+    <item name="fontFamily">sans-serif</item>
+    <item name="android:textColor">@color/color_def_white</item>
+    <item name="android:textSize">12sp</item>
+  </style>
+
+  <style name="ShapeAbleImageView" parent="ShapeAppearanceOverlay.RoundedShape">
+    <item name="strokeWidth">1dp</item>
+    <item name="strokeColor">@color/avatar_border</item>
+    <item name="android:layout_width">72dp</item>
+    <item name="android:layout_height">72dp</item>
+    <item name="shapeAppearanceOverlay">@style/ShapeAppearanceOverlay.RoundedShape</item>
+  </style>
+
   <style name="TextViewCenter" parent="TextView.Common1">
     <item name="android:gravity">center</item>
   </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -484,7 +484,7 @@
 
   <style name="ShapeAbleImageView" parent="ShapeAppearanceOverlay.RoundedShape">
     <item name="strokeWidth">1dp</item>
-    <item name="strokeColor">@color/avatar_border</item>
+    <item name="strokeColor">@color/component_color_profile_chooser_activity_avatar_border_color</item>
     <item name="android:layout_width">72dp</item>
     <item name="android:layout_height">72dp</item>
     <item name="shapeAppearanceOverlay">@style/ShapeAppearanceOverlay.RoundedShape</item>


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix #1956: Optimise Profile_chooser_add views

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing

| Screenshots Before |  After
|:-------------------------:|:-------------------------:|
| Mobile Portrait |
|![mobile_portrait_before](https://user-images.githubusercontent.com/43546652/206875860-745fe9bb-d9e6-4951-961f-89115567c778.png) | ![mobile_portrait_after](https://user-images.githubusercontent.com/43546652/206875863-14733b63-8c09-4626-b89d-ebb55dfe6ba7.png)
| Mobile Landscape |
|![mobile_land_before](https://user-images.githubusercontent.com/43546652/206875865-b14b6106-9d8e-4890-ac67-038c23b2b2e9.png) | ![mobile_land_after](https://user-images.githubusercontent.com/43546652/206876484-0115c672-ddf4-40f5-980d-c0119e318a38.png)
| Tap Portrait |
| ![tap_portrait_before](https://user-images.githubusercontent.com/43546652/206875870-4051acbe-5c46-47c8-8d79-cfc4cd4f4a38.png) | ![tap_portrait_after](https://user-images.githubusercontent.com/43546652/206875871-7f70d5e6-7a8a-4bfa-bc96-cc49ee7a4539.png)
| Tap Landscape |
|![tap_land2_before](https://user-images.githubusercontent.com/43546652/206876590-0386cc8e-a3d5-43f7-bf11-4ea0ad48fb48.png) | ![tap_land2_after](https://user-images.githubusercontent.com/43546652/206875868-58d33fcb-6c67-4300-b887-dd8dd16ca586.png)  
| Tap LTR Portrait |
| ![tap_lrt_portrait_before](https://user-images.githubusercontent.com/43546652/206875874-4b0878a1-3d78-4dfc-8c90-473d1cefe7f7.png) | ![tap_ltr_portrait_after](https://user-images.githubusercontent.com/43546652/206875876-fb42684f-f8b2-41bc-83a7-ea6d58322cb6.png)
| Tap LTR Landscape |
|![tap_ltr_land_before](https://user-images.githubusercontent.com/43546652/206875877-40949643-ac03-4743-a0ae-5a266a67490a.png) | ![tap_ltr_land_after](https://user-images.githubusercontent.com/43546652/206875879-bd9cc1f6-5f4c-48b8-a345-3781f82bab67.png)
| Mobile LTR Portrait |
|![mobile_ltr_before](https://user-images.githubusercontent.com/43546652/206875880-717ab192-ba03-4b88-821d-21e1500bf301.png) | ![mobile_ltr_portrait_after](https://user-images.githubusercontent.com/43546652/206875881-a9fc3334-7960-4401-a681-7e4472fd2f17.png)
| Mobile LTR Landscape |
|![mobile_ltr_land_before](https://user-images.githubusercontent.com/43546652/206875882-c8033397-620d-411f-b3ec-353959320355.png) | ![mobile_ltr_land_after](https://user-images.githubusercontent.com/43546652/206875883-36b9b7bd-ea85-41c9-b74f-e0cf85e6baf3.png)

## Accessibility Guide 
https://user-images.githubusercontent.com/43546652/206877043-0e4221bc-b991-4b4d-8ae7-785eac6d4644.mov


## Unit Test Screenshot
<img width="852" alt="Screenshot 2022-12-09 at 7 52 10 AM" src="https://user-images.githubusercontent.com/43546652/206876749-bda902b6-21b1-4102-8ace-f0fe41bf9877.png">
