### PR TITLE
Disable repository messaging

### DIFF
--- a/.github/workflows/repository_messaging.yml
+++ b/.github/workflows/repository_messaging.yml
@@ -10,7 +10,7 @@ jobs:
   holiday_message:
     runs-on: ubuntu-latest
     # NOTE TO DEVELOPERS: Update the body text and set this to 'true' to enable automatic messaging on all new PRs.
-    if: true
+    if: false
     steps:
       - name: Add holiday comment
         uses: peter-evans/create-or-update-comment@v1


### PR DESCRIPTION
## Explanation
Core maintainers are no longer on break.

## Essential Checklist
- [ ] ~The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)~
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- this is an infrastructure-only change.