### PR TITLE
Dark mode implementation - Fixed Post PR Changes Part 2

### DIFF
--- a/app/src/main/res/drawable/radio_checked.xml
+++ b/app/src/main/res/drawable/radio_checked.xml
@@ -4,7 +4,7 @@
     <shape android:shape="oval">
       <stroke
         android:width="2dp"
-        android:color="@color/audio_language_activity_radio_button" />
+        android:color="@color/component_color_shared_radio_button_checked_color" />
       <size
         android:width="20dp"
         android:height="20dp" />
@@ -16,7 +16,7 @@
     android:right="5dp"
     android:top="5dp">
     <shape android:shape="oval">
-      <solid android:color="@color/audio_language_activity_radio_button" />
+      <solid android:color="@color/component_color_shared_radio_button_checked_color" />
       <size
         android:width="10dp"
         android:height="10dp" />

--- a/app/src/main/res/drawable/radio_unchecked.xml
+++ b/app/src/main/res/drawable/radio_unchecked.xml
@@ -3,7 +3,7 @@
   android:shape="oval">
   <stroke
     android:width="2dp"
-    android:color="@color/color_def_black_54" />
+    android:color="@color/component_color_shared_radio_button_unchecked_color" />
   <size
     android:width="20dp"
     android:height="20dp" />

--- a/app/src/main/res/layout-land/profile_chooser_fragment.xml
+++ b/app/src/main/res/layout-land/profile_chooser_fragment.xml
@@ -55,7 +55,7 @@
           android:layout_marginTop="@dimen/profile_chooser_fragment_profile_select_text_margin_top"
           android:layout_marginEnd="36dp"
           android:text="@string/profile_chooser_select"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
+          android:textColor="@color/component_color_shared_secondary_4_text_color"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout-land/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-land/profile_chooser_profile_view.xml
@@ -60,14 +60,14 @@
           android:maxLines="2"
           android:singleLine="false"
           android:text="@{viewModel.profile.name}"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color" />
+          android:textColor="@color/component_color_shared_secondary_4_text_color" />
 
         <TextView
           android:id="@+id/profile_last_visited"
           style="@style/SubtitleLight1Center"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
+          android:textColor="@color/component_color_shared_secondary_4_text_color"
           android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
           profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
 
@@ -77,7 +77,7 @@
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:text="@string/profile_chooser_admin"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
+          android:textColor="@color/component_color_shared_secondary_4_text_color"
           android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}" />
       </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout-sw600dp-land/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-sw600dp-land/profile_chooser_profile_view.xml
@@ -68,7 +68,7 @@
           android:maxLines="2"
           android:singleLine="false"
           android:text="@{viewModel.profile.name}"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
+          android:textColor="@color/component_color_shared_secondary_4_text_color"
           app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_name_margin_top_profile_already_added : @dimen/space_0dp}" />
         <!-- Note: The style set here is without the Gravity property, as the gravity set for this TextView is conditional and its not doable through styles. -->
         <TextView
@@ -78,7 +78,7 @@
           android:layout_height="wrap_content"
           android:layout_marginTop="4dp"
           android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
+          android:textColor="@color/component_color_shared_secondary_4_text_color"
           android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
           app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_last_visited_margin_top_profile_already_added : @dimen/profile_chooser_profile_view_last_visited_margin_top_profile_not_added}"
           profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
@@ -91,7 +91,7 @@
           android:layout_marginTop="4dp"
           android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
           android:text="@string/profile_chooser_admin"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
+          android:textColor="@color/component_color_shared_secondary_4_text_color"
           android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}"
           app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_is_admin_margin_top_profile_already_added : @dimen/space_0dp}" />
       </LinearLayout>

--- a/app/src/main/res/layout-sw600dp-land/topic_lessons_story_summary.xml
+++ b/app/src/main/res/layout-sw600dp-land/topic_lessons_story_summary.xml
@@ -146,7 +146,7 @@
                 app:isRotationAnimationClockwise="@{isListExpanded}"
                 app:rotationAnimationAngle="@{180f}"
                 app:srcCompat="@drawable/ic_arrow_drop_down_black_24dp"
-                app:tint="@color/component_color_lessons_tab_activity_lesson_card_drop_down_arrow_color" />
+                app:tint="@color/component_color_shared_multipane_icon_color" />
             </FrameLayout>
           </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/layout-sw600dp-port/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout-sw600dp-port/profile_chooser_profile_view.xml
@@ -68,7 +68,7 @@
           android:maxLines="2"
           android:singleLine="false"
           android:text="@{viewModel.profile.name}"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
+          android:textColor="@color/component_color_shared_secondary_4_text_color"
           app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_name_margin_top_profile_already_added : @dimen/space_0dp}" />
 
         <!-- Note: The style set here is without the Gravity property, as the gravity set for this TextView is conditional and its not doable through styles. -->
@@ -79,7 +79,7 @@
           android:layout_height="wrap_content"
           android:layout_marginTop="4dp"
           android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
+          android:textColor="@color/component_color_shared_secondary_4_text_color"
           android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
           profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
 
@@ -91,7 +91,7 @@
           android:layout_marginTop="4dp"
           android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
           android:text="@string/profile_chooser_admin"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
+          android:textColor="@color/component_color_shared_secondary_4_text_color"
           android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}" />
       </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout-sw600dp/profile_chooser_fragment.xml
+++ b/app/src/main/res/layout-sw600dp/profile_chooser_fragment.xml
@@ -60,7 +60,7 @@
           android:layout_marginTop="80dp"
           android:fontFamily="sans-serif"
           android:text="@string/profile_chooser_select"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
+          android:textColor="@color/component_color_shared_secondary_4_text_color"
           android:textSize="36sp"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/profile_chooser_fragment.xml
+++ b/app/src/main/res/layout/profile_chooser_fragment.xml
@@ -55,7 +55,7 @@
           android:layout_marginTop="@dimen/profile_chooser_fragment_profile_select_text_margin_top"
           android:layout_marginEnd="36dp"
           android:text="@string/profile_chooser_select"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
+          android:textColor="@color/component_color_shared_secondary_4_text_color"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/profile_chooser_profile_view.xml
+++ b/app/src/main/res/layout/profile_chooser_profile_view.xml
@@ -63,7 +63,7 @@
           android:maxLines="2"
           android:singleLine="false"
           android:text="@{viewModel.profile.name}"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
+          android:textColor="@color/component_color_shared_secondary_4_text_color"
           app:layoutMarginTop="@{hasProfileEverBeenAddedValue ? @dimen/profile_chooser_profile_view_name_margin_top_profile_already_added : @dimen/space_0dp}" />
         <!-- Note: The style set here is without the Gravity property, as the gravity set for this TextView is conditional and its not doable through styles. -->
         <TextView
@@ -73,7 +73,7 @@
           android:layout_height="wrap_content"
           android:layout_marginTop="4dp"
           android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
+          android:textColor="@color/component_color_shared_secondary_4_text_color"
           android:visibility="@{viewModel.profile.lastLoggedInTimestampMs > 0 ? View.VISIBLE : View.GONE}"
           profile:lastVisited="@{viewModel.profile.lastLoggedInTimestampMs}" />
         <!-- Note: The style set here is without the Gravity property, as the gravity set for this TextView is conditional and its not doable through styles. -->
@@ -85,7 +85,7 @@
           android:layout_marginTop="@dimen/profile_chooser_profile_view_is_admin_margin_top"
           android:gravity="@{hasProfileEverBeenAddedValue ? Gravity.CENTER_HORIZONTAL : Gravity.CENTER_VERTICAL}"
           android:text="@string/profile_chooser_admin"
-          android:textColor="@color/component_color_profile_chooser_activity_white_text_color"
+          android:textColor="@color/component_color_shared_secondary_4_text_color"
           android:visibility="@{viewModel.profile.isAdmin ? View.VISIBLE : View.GONE}" />
       </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/topic_lessons_story_summary.xml
+++ b/app/src/main/res/layout/topic_lessons_story_summary.xml
@@ -143,7 +143,7 @@
               app:isRotationAnimationClockwise="@{isListExpanded}"
               app:rotationAnimationAngle="@{180f}"
               app:srcCompat="@drawable/ic_arrow_drop_down_black_24dp"
-              app:tint="@color/component_color_lessons_tab_activity_lesson_card_drop_down_arrow_color" />
+              app:tint="@color/component_color_shared_multipane_icon_color" />
           </FrameLayout>
         </LinearLayout>
       </LinearLayout>

--- a/app/src/main/res/values-night/color_palette.xml
+++ b/app/src/main/res/values-night/color_palette.xml
@@ -137,6 +137,8 @@
   <color name="color_palette_secondary_container_background_color">@color/color_def_oppia_metallic_blue</color>
   <color name="color_palette_fragment_status_bar_color">@color/color_def_dark_purple</color>
   <color name="color_palette_hint_dialog_status_bar_color">@color/color_def_catalina_blue</color>
+  <color name="color_palette_shared_radio_button_unchecked_color">@color/color_def_stroke_silver</color>
+  <color name="color_palette_shared_radio_button_checked_color">@color/color_def_radio_green</color>
   <color name="color_palette_topic_revision_background_color">@color/color_def_oppia_light_black</color>
   <color name="color_palette_completed_progress_activity_background_color">@color/color_def_oppia_light_black</color>
   <color name="color_palette_topic_fragments_background_color">@color/color_def_oppia_light_black</color>

--- a/app/src/main/res/values/color_defs.xml
+++ b/app/src/main/res/values/color_defs.xml
@@ -77,6 +77,7 @@
   <color name="color_def_dark_mode_question_player_progress_bar_gradient_end">#00C7B6</color>
   <color name="color_def_whitish_grey">#E5E5E5</color>
   <color name="color_def_checkbox_green">#008577</color>
+  <color name="color_def_radio_green">#00A89F</color>
   <color name="color_def_stroke_silver">#777777</color>
   <color name="color_def_drag_drop_single_item_gradient_center">#F7F7F7</color>
   <color name="color_def_drag_drop_single_item_gradient_end">#DCDCDC</color>

--- a/app/src/main/res/values/color_palette.xml
+++ b/app/src/main/res/values/color_palette.xml
@@ -139,6 +139,8 @@
   <color name="color_palette_secondary_container_background_color">@color/color_def_teal_blue</color>
   <color name="color_palette_fragment_status_bar_color">@color/color_def_oppia_reddish_brown</color>
   <color name="color_palette_hint_dialog_status_bar_color">@color/color_def_catalina_blue</color>
+  <color name="color_palette_shared_radio_button_unchecked_color">@color/color_def_black_54</color>
+  <color name="color_palette_shared_radio_button_checked_color">@color/color_def_radio_green</color>
   <color name="color_palette_topic_revision_background_color">@color/color_def_oppia_white</color>
   <color name="color_palette_view_all_text_color">@color/color_def_oppia_green</color>
   <color name="color_palette_completed_progress_activity_background_color">@color/color_def_white</color>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -105,6 +105,8 @@
   <color name="component_color_shared_text_input_layout_helper_text_color">@color/color_palette_helper_text_color</color>
   <color name="component_color_general_item_secondary_background_stroke_color">@color/color_palette_stroke_color</color>
   <color name="component_color_shared_hint_dialog_status_bar_color">@color/color_palette_hint_dialog_status_bar_color</color>
+  <color name="component_color_shared_radio_button_unchecked_color">@color/color_palette_shared_radio_button_unchecked_color</color>
+  <color name="component_color_shared_radio_button_checked_color">@color/color_palette_shared_radio_button_checked_color</color>
   <!-- Add Profile Activity -->
   <color name="component_color_add_profile_activity_info_icon_color">@color/color_palette_info_icon_color</color>
   <color name="component_color_add_profile_activity_switch_description_color">@color/color_palette_description_text_color</color>
@@ -148,7 +150,6 @@
   <!-- Lessons Tab Fragment -->
   <color name="component_color_lessons_tab_activity_background_color">@color/color_palette_primary_container_background_color</color>
   <color name="component_color_lessons_tab_activity_lesson_card_ripple_color">@color/color_palette_transparent_background_color</color>
-  <color name="component_color_lessons_tab_activity_lesson_card_drop_down_arrow_color">@color/color_palette_lesson_card_drop_down_arrow_color</color>
   <color name="component_color_lessons_tab_activity_lesson_card_dashed_divider_color">@color/color_palette_lesson_card_dashed_divider_color</color>
   <color name="component_color_lessons_tab_activity_lessons_in_progress_chapter_index_background_color">@color/color_palette_lesson_in_progress_chapter_index_background_color</color>
   <color name="component_color_lessons_tab_activity_lessons_in_progress_chapter_name_background_color">@color/color_palette_lesson_in_progress_chapter_name_background_color</color>
@@ -224,6 +225,5 @@
   <!-- Profile Chooser Activity -->
   <color name="component_color_profile_chooser_activity_background_color">@color/color_palette_profile_chooser_charcoal_black_background_color</color>
   <color name="component_color_profile_chooser_activity_secondary_options_color">@color/color_palette_profile_chooser_silver_text_color</color>
-  <color name="component_color_profile_chooser_activity_white_text_color">@color/color_palette_profile_chooser_white_text_color</color>
   <color name="component_color_profile_chooser_activity_avatar_border_color">@color/color_palette_profile_chooser_avatar_border_color</color>
 </resources>


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Dark mode implementation - Fixed Post PR Changes Part 2

This PR changes following Dark Mode Post PR :-

1. Check dark-mode light mode staples for all radio-buttons: ReadingTextSize,AudioLanguage,AppLanguage,etc.
2.  Merge `component_color_shared_multipane_icon_color`and `component_color_lessons_tab_activity_lesson_card_drop_down_arrow_color`
3. Try removing `component_color_profile_chooser_activity_white_text_color` 




<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only

### Radio Buttons

<img src="https://user-images.githubusercontent.com/76530270/216781619-8be9b4f2-6126-4613-9649-4dbc06a9bb76.png" height="400" style="max-width: 100%">  <img src="https://user-images.githubusercontent.com/76530270/216781614-837af21b-45b0-49fe-8f86-de63d5620b68.png" height="400" style="max-width: 100%"> 


<img src="https://user-images.githubusercontent.com/76530270/216781689-6ad86984-f2ff-42e3-866a-6d287adf8f2f.png" height="400" style="max-width: 100%">  <img src="https://user-images.githubusercontent.com/76530270/216781692-55068024-bbf2-46ed-baf5-c5abe47feb89.png" height="400" style="max-width: 100%"> 


<img src="https://user-images.githubusercontent.com/76530270/216781743-f0042e74-dfeb-4ab3-bf94-d3c90b0735c3.png" height="400" style="max-width: 100%">  <img src="https://user-images.githubusercontent.com/76530270/216781747-c20f2205-5d60-4551-8ba1-da708308c55b.png" height="400" style="max-width: 100%"> 







<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
