### PR TITLE
Fix resume lesson fragment buttons scaling issue

### DIFF
--- a/app/src/main/res/layout/resume_lesson_fragment.xml
+++ b/app/src/main/res/layout/resume_lesson_fragment.xml
@@ -41,9 +41,9 @@
         style="@style/TextViewStart"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
+        android:layout_marginStart="12dp"
         android:layout_marginTop="32dp"
-        android:layout_marginEnd="32dp"
+        android:layout_marginEnd="12dp"
         android:layout_marginBottom="16dp"
         android:fontFamily="sans-serif"
         android:text="@{viewModel.chapterTitle}"
@@ -60,24 +60,25 @@
         style="@style/Body"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
+        android:layout_marginStart="12dp"
         android:layout_marginTop="16dp"
-        android:layout_marginEnd="32dp"
+        android:layout_marginEnd="12dp"
         android:ellipsize="end"
         android:textColor="@color/component_color_shared_secondary_1_text_color"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_title_text_view" />
 
-      <androidx.constraintlayout.widget.ConstraintLayout
+      <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
+        android:layout_marginStart="12dp"
         android:layout_marginTop="32dp"
-        android:layout_marginEnd="32dp"
+        android:layout_marginEnd="12dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        android:gravity="center_horizontal"
         app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_description_text_view">
 
         <Button
@@ -85,20 +86,16 @@
           style="@style/StartOverLessonButton"
           android:layout_marginEnd="12dp"
           android:text="@string/start_over_lesson_button"
-          app:layout_constraintBottom_toBottomOf="parent"
-          app:layout_constraintEnd_toStartOf="@+id/resume_lesson_continue_button"
-          app:layout_constraintHorizontal_chainStyle="spread"
-          app:layout_constraintStart_toStartOf="parent" />
+          />
 
         <Button
           android:id="@+id/resume_lesson_continue_button"
           style="@style/ContinueLessonButton"
           android:layout_marginStart="12dp"
           android:text="@string/resume_lesson_button"
-          app:layout_constraintBottom_toBottomOf="parent"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toEndOf="@id/resume_lesson_start_over_button" />
-      </androidx.constraintlayout.widget.ConstraintLayout>
+          />
+      </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
   </ScrollView>
 </layout>
+

--- a/app/src/main/res/layout/resume_lesson_fragment.xml
+++ b/app/src/main/res/layout/resume_lesson_fragment.xml
@@ -41,9 +41,9 @@
         style="@style/TextViewStart"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
+        android:layout_marginStart="32dp"
         android:layout_marginTop="32dp"
-        android:layout_marginEnd="12dp"
+        android:layout_marginEnd="32dp"
         android:layout_marginBottom="16dp"
         android:fontFamily="sans-serif"
         android:text="@{viewModel.chapterTitle}"
@@ -60,25 +60,24 @@
         style="@style/Body"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
+        android:layout_marginStart="32dp"
         android:layout_marginTop="16dp"
-        android:layout_marginEnd="12dp"
+        android:layout_marginEnd="32dp"
         android:ellipsize="end"
         android:textColor="@color/component_color_shared_secondary_1_text_color"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_title_text_view" />
 
-      <LinearLayout
+      <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
+        android:layout_marginStart="32dp"
         android:layout_marginTop="32dp"
-        android:layout_marginEnd="12dp"
+        android:layout_marginEnd="32dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        android:gravity="center_horizontal"
         app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_description_text_view">
 
         <Button
@@ -86,16 +85,20 @@
           style="@style/StartOverLessonButton"
           android:layout_marginEnd="12dp"
           android:text="@string/start_over_lesson_button"
-          />
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toStartOf="@+id/resume_lesson_continue_button"
+          app:layout_constraintHorizontal_chainStyle="spread"
+          app:layout_constraintStart_toStartOf="parent" />
 
         <Button
           android:id="@+id/resume_lesson_continue_button"
           style="@style/ContinueLessonButton"
           android:layout_marginStart="12dp"
           android:text="@string/resume_lesson_button"
-          />
-      </LinearLayout>
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toEndOf="@id/resume_lesson_start_over_button" />
+      </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
   </ScrollView>
 </layout>
-

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -410,30 +410,29 @@
     <item name="android:textColor">@color/component_color_shared_primary_text_color</item>
   </style>
   <!-- Start Over Lesson Button -->
-  <style name="SecondaryButton" parent="TextAppearance.AppCompat.Widget.Button">
-    <item name="android:layout_width">144dp</item>
+  <style name="StartOverLessonButton" parent="TextAppearance.AppCompat.Widget.Button">
+    <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
-    <item name="android:paddingEnd">12dp</item>
-    <item name="android:paddingStart">12dp</item>
+    <item name="android:paddingEnd">4dp</item>
+    <item name="android:paddingStart">4dp</item>
     <item name="android:minWidth">144dp</item>
-    <item name="android:background">@drawable/secondary_button_background</item>
+    <item name="android:background">@drawable/start_over_button_background</item>
     <item name="android:fontFamily">sans-serif-medium</item>
-    <item name="android:drawablePadding">4dp</item>
-    <item name="drawableTint">@color/component_color_shared_secondary_button_background_trim_color</item>
-    <item name="android:textAllCaps">true</item>
-    <item name="android:textColor">@color/component_color_shared_secondary_button_background_trim_color</item>
-    <item name="android:textSize">14sp</item>
-  </style>
-  <style name="StartOverLessonButton" parent="SecondaryButton">
     <item name="drawableStartCompat">@drawable/ic_start_over_24dp</item>
+    <item name="android:drawablePadding">4dp</item>
+    <item name="drawableTint">@color/component_color_shared_resume_lesson_start_over_button_color</item>
+    <item name="android:textAllCaps">true</item>
+    <item name="android:textColor">@color/component_color_shared_resume_lesson_start_over_button_color</item>
+    <item name="android:textSize">14sp</item>
+    <item name="android:lines">1</item>
   </style>
   <!-- Continue Lesson Button -->
   <style name="ContinueLessonButton" parent="TextAppearance.AppCompat.Widget.Button">
-    <item name="android:layout_width">144dp</item>
+    <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:drawablePadding">4dp</item>
-    <item name="android:paddingEnd">12dp</item>
-    <item name="android:paddingStart">12dp</item>
+    <item name="android:paddingEnd">4dp</item>
+    <item name="android:paddingStart">4dp</item>
     <item name="android:minWidth">144dp</item>
     <item name="android:background">@drawable/state_button_primary_background</item>
     <item name="drawableEndCompat">@drawable/ic_arrow_right_alt_24dp</item>
@@ -443,6 +442,7 @@
     <item name="android:textAllCaps">true</item>
     <item name="android:textColor">@color/component_color_shared_secondary_4_text_color</item>
     <item name="android:textSize">14sp</item>
+    <item name="android:lines">1</item>
   </style>
 
   <style name="BorderlessMaterialButton" parent="Widget.AppCompat.Button.Borderless" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -411,10 +411,10 @@
   </style>
   <!-- Start Over Lesson Button -->
   <style name="StartOverLessonButton" parent="TextAppearance.AppCompat.Widget.Button">
-    <item name="android:layout_width">wrap_content</item>
+    <item name="android:layout_width">0dp</item>
     <item name="android:layout_height">wrap_content</item>
-    <item name="android:paddingEnd">4dp</item>
-    <item name="android:paddingStart">4dp</item>
+    <item name="android:paddingEnd">12dp</item>
+    <item name="android:paddingStart">12dp</item>
     <item name="android:minWidth">144dp</item>
     <item name="android:background">@drawable/start_over_button_background</item>
     <item name="android:fontFamily">sans-serif-medium</item>
@@ -424,15 +424,14 @@
     <item name="android:textAllCaps">true</item>
     <item name="android:textColor">@color/component_color_shared_resume_lesson_start_over_button_color</item>
     <item name="android:textSize">14sp</item>
-    <item name="android:lines">1</item>
   </style>
   <!-- Continue Lesson Button -->
   <style name="ContinueLessonButton" parent="TextAppearance.AppCompat.Widget.Button">
-    <item name="android:layout_width">wrap_content</item>
+    <item name="android:layout_width">0dp</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:drawablePadding">4dp</item>
-    <item name="android:paddingEnd">4dp</item>
-    <item name="android:paddingStart">4dp</item>
+    <item name="android:paddingEnd">12dp</item>
+    <item name="android:paddingStart">12dp</item>
     <item name="android:minWidth">144dp</item>
     <item name="android:background">@drawable/state_button_primary_background</item>
     <item name="drawableEndCompat">@drawable/ic_arrow_right_alt_24dp</item>
@@ -442,7 +441,6 @@
     <item name="android:textAllCaps">true</item>
     <item name="android:textColor">@color/component_color_shared_secondary_4_text_color</item>
     <item name="android:textSize">14sp</item>
-    <item name="android:lines">1</item>
   </style>
 
   <style name="BorderlessMaterialButton" parent="Widget.AppCompat.Button.Borderless" />


### PR DESCRIPTION
Fixes #4710, #4362 and also #3833. The second 2 consecutive issues were closed as they might be possibly duplicates of #4710
- Updating width on both the buttons width 0dp actually gives them equal width enabling the button text and child drawables to scale as expected on max display and font config. Main issue is that the currently used width "144dp" doesn't work when the device's display and font config is set to max.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing

| Before Fix            |  After Fix |
:-------------------------:|:-------------------------:
Nexus 5X Api 29
<img src="https://user-images.githubusercontent.com/20886444/223451827-3c3e630d-36c0-42d2-a47c-f1ff42f693d4.png" width="300"/> | <img src="https://user-images.githubusercontent.com/20886444/224729990-d8694c3f-175e-49a7-96ec-f39f1602f157.png" width="300"/> 

Google Pixel 3XL
<img src="https://user-images.githubusercontent.com/20886444/223452280-31f47401-3215-4017-9643-0ea7b97586ff.png" width="300"/> | <img src="https://user-images.githubusercontent.com/20886444/224729403-96a214a9-4afe-406b-a677-37c130fd9aeb.png" width="300"/>