### PR TITLE
Fix issue with resume buttons not scaling as expected

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -411,7 +411,7 @@
   </style>
   <!-- Start Over Lesson Button -->
   <style name="SecondaryButton" parent="TextAppearance.AppCompat.Widget.Button">
-    <item name="android:layout_width">144dp</item>
+    <item name="android:layout_width">0dp</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:paddingEnd">12dp</item>
     <item name="android:paddingStart">12dp</item>
@@ -429,7 +429,7 @@
   </style>
   <!-- Continue Lesson Button -->
   <style name="ContinueLessonButton" parent="TextAppearance.AppCompat.Widget.Button">
-    <item name="android:layout_width">144dp</item>
+    <item name="android:layout_width">0dp</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:drawablePadding">4dp</item>
     <item name="android:paddingEnd">12dp</item>


### PR DESCRIPTION
## Explanation
Fixes #4710 and #3833. The second issue was closed as it is possibly a duplicate of #4710

Updating width on both the buttons width 0dp actually gives them equal width enabling the button text and child drawables to scale as expected on max display and font config. Main issue is that the currently used width "144dp" doesn't work when the device's display and font config is set to max. This update works better and is per @adhiamboperes comments on previous PR submitted, The previous fix involved using a LinearLayout which had other caveats.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-(A11y)-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing

## Before and after screenshots demo
Nexus 5x API 29
| Before Portrait            |  After Portrait |
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/20886444/224750256-dd9446d3-0eb4-4f25-bafc-4bdcf411818c.png" width="300"/> | <img src="https://user-images.githubusercontent.com/20886444/224750387-c8ffa8e9-e76a-4be0-9820-a3121d12b9b5.png" width="300"/>

Google Pixel 3xl
| Before Portrait            |  After Portrait |
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/20886444/224750707-c8bb1ad8-69f0-4937-a830-d9f36db7a4a1.png" width="300"/> | <img src="https://user-images.githubusercontent.com/20886444/224750792-791880e2-9509-4d15-ad21-b887fd675dc5.png" width="300"/>