### PR TITLE
Fix part of #3926: Add support for CI checks in merge queues [Blocked: #4929]

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -5,6 +5,8 @@ name: Build Tests
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       # Push events on develop branch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ name: Unit Tests (Robolectric -- Gradle)
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       # Push events on develop branch

--- a/.github/workflows/oppiabot.yml
+++ b/.github/workflows/oppiabot.yml
@@ -3,6 +3,8 @@
 name: Oppiabot
 
 on:
+  merge_group:
+    types: [checks_requested]
   pull_request_target:
     branches:
       - develop

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -5,6 +5,8 @@ name: Static Checks
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - develop

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,6 +7,8 @@ name: Unit Tests (Robolectric - Bazel)
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       # Push events on develop branch


### PR DESCRIPTION
## Explanation
Fixes part of #3926 by introducing the necessary workflow adjustments to ensure all required CI workflows will be run when a PR is added to a merge queue (per https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group).

Note that this PR needs to be merged before merge queues can actually be enabled.

#3926 has some context, but the main benefit that we'll see from merge queues is the ability to avoid needing to keep branches up-to-date with the latest develop without risking non-conflicting changes causing breakages/incompatibilities (since merge queues always verify against the latest changes relative to that PR, even if others go in before it). They technically also offer better merge throughput, but this won't really affect us since we generally only have a few PRs merged each week (versus every hour, for example).

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- This is a GitHub infrastructure-only change and won't affect build outputs (including the app).