### PR TITLE
Fix #248, #501, #179, #762, #207: Remove obsolete TODOs.

### DIFF
--- a/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerFragmentPresenter.kt
@@ -330,8 +330,6 @@ class QuestionPlayerFragmentPresenter @Inject constructor(
     congratulationsTextView: TextView,
     congratulationsTextConfettiView: KonfettiView
   ): StatePlayerRecyclerViewAssembler {
-    // TODO(#501): Add support early exit detection & message, which requires changes in the training progress
-    //  controller & possibly the ephemeral question data model.
     // TODO(#502): Add support for surfacing skills that need to be reviewed by the learner.
     return builder
       .hasConversationView(hasConversationView)

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -262,7 +262,6 @@ class AdministratorControlsActivityTest {
     }
   }
 
-  // TODO(#762): Replace [ProfileChooserActivity] to [LoginActivity] once it is added.
   @Test
   fun testAdministratorControlsFragment_clickOkButtonInLogoutDialog_opensProfileChooserActivity() {
     launch<AdministratorControlsActivity>(

--- a/domain/src/main/java/org/oppia/android/domain/classify/AnswerClassificationController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/classify/AnswerClassificationController.kt
@@ -35,7 +35,6 @@ class AnswerClassificationController @Inject constructor(
       "Encountered unknown interaction type: ${interaction.id}, " +
         "expected one of: ${interactionClassifiers.keys}"
     }
-    // TODO(#207): Add support for additional classification types.
     return classifyAnswer(
       answer,
       interaction.answerGroupsList,

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
@@ -113,7 +113,6 @@ class ExplorationProgressController @Inject constructor(
   private val learnerAnalyticsLogger: LearnerAnalyticsLogger,
   @BackgroundDispatcher private val backgroundCoroutineDispatcher: CoroutineDispatcher
 ) {
-  // TODO(#179): Add support for parameters.
   // TODO(#3467): Update the mechanism to save checkpoints to eliminate the race condition that may
   //  arise if the function finishExplorationAsync acquires lock before the invokeOnCompletion
   //  callback on the deferred returned on saving checkpoints. In this case ExplorationActivity will

--- a/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgressController.kt
@@ -102,8 +102,6 @@ class QuestionAssessmentProgressController @Inject constructor(
 ) {
   // TODO(#247): Add support for populating the list of skill IDs to review at the end of the
   //  training session.
-  // TODO(#248): Add support for the assessment ending prematurely due to learner demonstrating
-  //  sufficient proficiency.
 
   // TODO(#606): Replace this with a profile scope to avoid this hacky workaround (which is needed
   //  for getCurrentQuestion).


### PR DESCRIPTION
## Explanation

Fixes #248
Fixes #501
Fixes #179
Fixes #762
Fixes #207

This PR removes some obsolete TODOs so that the corresponding issues on GitHub can be properly closed.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
