### PR TITLE
Add seanlip as codeowner for Android wiki pages.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,7 +49,7 @@ gradlew.bat @BenHenning
 /.github/stale.yml @BenHenning
 
 # Wiki
-/wiki/ @BenHenning
+/wiki/ @BenHenning @seanlip
 
 # Devbots configurations.
 /.devbots/ @BenHenning


### PR DESCRIPTION
## Explanation
This PR adds me (@seanlip) as a codeowner for the Android wiki pages (per discussion with @BenHenning).


## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
