### PR TITLE
Fix links text while dark mode audit

### DIFF
--- a/app/src/main/res/layout-land/onboarding_slide_final.xml
+++ b/app/src/main/res/layout-land/onboarding_slide_final.xml
@@ -93,7 +93,7 @@
         android:layout_marginEnd="28dp"
         android:fontFamily="sans-serif"
         android:textColor="@color/component_color_shared_primary_text_color"
-        android:textColorLink="@color/component_color_shared_primary_text_color"
+        android:textColorLink="@color/component_color_shared_link_text_color"
         android:textSize="12sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/slide_image_view"

--- a/app/src/main/res/layout-sw600dp-land/onboarding_slide_final.xml
+++ b/app/src/main/res/layout-sw600dp-land/onboarding_slide_final.xml
@@ -84,7 +84,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="24dp"
         android:textColor="@color/component_color_shared_primary_text_color"
-        android:textColorLink="@color/component_color_shared_primary_text_color"
+        android:textColorLink="@color/component_color_shared_link_text_color"
         app:layout_constraintEnd_toEndOf="@+id/slide_title_text_view"
         app:layout_constraintStart_toStartOf="@+id/slide_title_text_view"
         app:layout_constraintTop_toBottomOf="@id/get_started_button" />

--- a/app/src/main/res/layout-sw600dp-port/onboarding_slide_final.xml
+++ b/app/src/main/res/layout-sw600dp-port/onboarding_slide_final.xml
@@ -93,7 +93,7 @@
         android:layout_marginTop="24dp"
         android:layout_marginEnd="192dp"
         android:textColor="@color/component_color_shared_primary_text_color"
-        android:textColorLink="@color/component_color_shared_primary_text_color"
+        android:textColorLink="@color/component_color_shared_link_text_color"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/get_started_button" />

--- a/app/src/main/res/layout/onboarding_slide_final.xml
+++ b/app/src/main/res/layout/onboarding_slide_final.xml
@@ -94,7 +94,7 @@
         android:layout_marginEnd="48dp"
         android:fontFamily="sans-serif"
         android:textColor="@color/component_color_shared_primary_text_color"
-        android:textColorLink="@color/component_color_shared_primary_text_color"
+        android:textColorLink="@color/component_color_shared_link_text_color"
         android:textSize="12sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/solution_summary.xml
+++ b/app/src/main/res/layout/solution_summary.xml
@@ -167,6 +167,7 @@
               android:contentDescription="@{viewModel.solutionSummaryContentDescription}"
               android:fontFamily="sans-serif"
               android:textColor="@color/component_color_hints_and_solutions_fragment_description_color"
+              android:textColorLink="@color/component_color_shared_link_text_color"
               android:textSize="16sp" />
           </LinearLayout>
         </LinearLayout>


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixed some links text while dark mode audit

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only

### Hints & Solution

| Before - Light Mode | Before - Dark Mode |
| ------ | ------ |
| <img src="https://github.com/oppia/oppia-android/assets/76530270/7b83b416-9955-413a-8ba1-3d540cbf60d5" height="400" style="max-width: 100%">   |  <img src="https://github.com/oppia/oppia-android/assets/76530270/1502ca1f-3aeb-4f2a-8961-1c36e2689d8e" height="400" style="max-width: 100%">  |

| After - Light Mode | After - Dark Mode |
| ------ | ------ |
| <img src="https://github.com/oppia/oppia-android/assets/76530270/6aa5850f-e6d3-4356-80ad-ff96e61ece46" height="400" style="max-width: 100%">   |  <img src="https://github.com/oppia/oppia-android/assets/76530270/313f5171-d66e-4f17-a14b-aab38c5b381b" height="400" style="max-width: 100%">  |

### Onboarding Screen

| Before - Light Mode | Before - Dark Mode |
| ------ | ------ |
| <img src="https://github.com/oppia/oppia-android/assets/76530270/4ce8d0a9-9566-4bfb-bb8c-6fbbff1cb991" height="400" style="max-width: 100%">   |  <img src="https://github.com/oppia/oppia-android/assets/76530270/e6504784-b0f3-4d6a-8337-a30a66276da4" height="400" style="max-width: 100%">  |


| After - Light Mode | After - Dark Mode |
| ------ | ------ |
| <img src="https://github.com/oppia/oppia-android/assets/76530270/956dc64c-946a-43e0-8436-50db03885586" height="400" style="max-width: 100%">   |  <img src="https://github.com/oppia/oppia-android/assets/76530270/77676011-aa3e-430b-b4e5-09c7dffa5ecf" height="400" style="max-width: 100%">  |




<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing



