### PR TITLE
Fix #3886 and #3887: drop remaining KitKat TODOs.

### DIFF
--- a/build_flavors.bzl
+++ b/build_flavors.bzl
@@ -92,7 +92,7 @@ _FLAVOR_METADATA = {
         "target_sdk_version": 31,
         "multidex": "manual_main_dex",
         "main_dex_list": _MAIN_DEX_LIST_TARGET_KITKAT,
-        "proguard_specs": [],  # TODO(#3886): Re-add Proguard support to alpha_kitkat.
+        "proguard_specs": [],
         "production_release": True,
         "deps": [
             "//app/src/main/java/org/oppia/android/app/application/alpha:alpha_application",

--- a/utility/src/main/java/org/oppia/android/util/parser/image/GlideImageLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/image/GlideImageLoader.kt
@@ -65,7 +65,6 @@ class GlideImageLoader @Inject constructor(
     target: ImageTarget<Drawable>,
     transformations: List<ImageTransformation>
   ) {
-    // TODO(#3887): Investigate why this has a native crash on KitKat & find a fix.
     glide
       .asDrawable()
       .load(imageDrawableResId)


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
This PR fixes #3886 and fixes #3887 by dropping TODOs for those obsolete issues so that they can be fully closed.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).