### PR TITLE
Fix #5049, Fix #5050: Empty hints being shown and Failures in Fraction Answer Submission

### DIFF
--- a/domain/BUILD.bazel
+++ b/domain/BUILD.bazel
@@ -53,6 +53,7 @@ DOMAIN_ASSETS = generate_assets_list_from_text_protos(
         "test_single_interactive_state_exp_with_one_hint_and_no_solution",
         "test_single_interactive_state_exp_with_only_solution",
         "test_single_interactive_state_exp_with_solution_missing_answer",
+        "test_single_interactive_state_exp_with_solution_missing_explanation",
         "test_checkpointing_base_exploration",
         "test_checkpointing_exploration_missing_first_state",
         "test_checkpointing_exploration_multiple_compatible_updates",

--- a/domain/src/main/assets/test_single_interactive_state_exp_with_solution_missing_explanation.json
+++ b/domain/src/main/assets/test_single_interactive_state_exp_with_solution_missing_explanation.json
@@ -1,0 +1,115 @@
+{
+  "exploration_id": "test_single_interactive_state_exp_with_solution_missing_explanation",
+  "version": 1,
+  "exploration": {
+    "init_state_name": "Text",
+    "states": {
+      "Text": {
+        "content": {
+          "content_id": "content",
+          "html": "<p>In which language does Oppia mean 'to learn'?</p>"
+        },
+        "interaction": {
+          "id": "TextInput",
+          "customization_args": {
+            "rows": {
+              "value": 1.0
+            },
+            "placeholder": {
+              "value": {
+                "content_id": "ca_placeholder_0",
+                "unicode_str": "Enter a language"
+              }
+            }
+          },
+          "answer_groups": [{
+            "rule_specs": [{
+              "rule_type": "Equals",
+              "inputs": {
+                "x": {
+                  "contentId": "<unknown>",
+                  "normalizedStrSet": ["finnish"]
+                }
+              }
+            }],
+            "outcome": {
+              "dest": "End",
+              "feedback": {
+                "content_id": "feedback_1",
+                "html": "<p>Correct!</p>"
+              },
+              "labelled_as_correct": false
+            }
+          }],
+          "default_outcome": {
+            "dest": "Text",
+            "feedback": {
+              "content_id": "default_outcome",
+              "html": "<p>Not quite. Try again (or maybe use a search engine).</p>"
+            },
+            "labelled_as_correct": false
+          },
+          "hints": [],
+          "solution": {
+            "answer_is_exclusive": false,
+            "correct_answer": {
+              "normalized_string": "Finnish"
+            },
+            "explanation": {
+              "content_id": "solution",
+              "html": ""
+            }
+          }
+        },
+        "recorded_voiceovers": {
+          "voiceovers_mapping": {
+            "feedback_1": {},
+            "content": {},
+            "default_outcome": {},
+            "solution": {}
+          }
+        },
+        "written_translations": {
+          "translations_mapping": {
+            "feedback_1": {},
+            "content": {},
+            "default_outcome": {},
+            "solution": {}
+          }
+        }
+      },
+      "End": {
+        "content": {
+          "content_id": "content",
+          "html": "Congratulations, you have finished!"
+        },
+        "param_changes": [],
+        "interaction": {
+          "id": "EndExploration",
+          "customization_args": {
+            "recommendedExplorationIds": {
+              "value": []
+            }
+          },
+          "answer_groups": [],
+          "default_outcome": null,
+          "hints": [],
+          "solution": null
+        },
+        "recorded_voiceovers": {
+          "voiceovers_mapping": {
+            "content": {}
+          }
+        },
+        "written_translations": {
+          "translations_mapping": {
+            "content": {}
+          }
+        }
+      }
+    },
+    "objective": "Test exploration.",
+    "language_code": "en",
+    "title": "Prototype exploration with only one solution and no hints"
+  }
+}

--- a/domain/src/main/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProvider.kt
+++ b/domain/src/main/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProvider.kt
@@ -22,7 +22,7 @@ class FractionInputHasNumeratorEqualToRuleClassifierProvider @Inject constructor
   override fun createRuleClassifier(): RuleClassifier {
     return classifierFactory.createMultiTypeSingleInputClassifier(
       InteractionObject.ObjectTypeCase.FRACTION,
-      InteractionObject.ObjectTypeCase.SIGNED_INT,
+      InteractionObject.ObjectTypeCase.NON_NEGATIVE_INT,
       "x",
       this
     )

--- a/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintHandlerProdImpl.kt
+++ b/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintHandlerProdImpl.kt
@@ -1,5 +1,6 @@
 package org.oppia.android.domain.hintsandsolution
 
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -12,9 +13,9 @@ import org.oppia.android.app.model.HelpIndex.IndexTypeCase.INDEXTYPE_NOT_SET
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.LATEST_REVEALED_HINT_INDEX
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.NEXT_AVAILABLE_HINT_INDEX
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.SHOW_SOLUTION
+import org.oppia.android.app.model.Solution
 import org.oppia.android.app.model.State
 import org.oppia.android.util.threading.BackgroundDispatcher
-import javax.inject.Inject
 
 /**
  * Production implementation of [HintHandler] that implements hints & solutions in parity with the
@@ -355,7 +356,11 @@ class HintHandlerProdImpl private constructor(
 }
 
 /** Returns whether this state has a solution to show. */
-private fun State.hasSolution(): Boolean = interaction.hasSolution()
+private fun State.hasSolution(): Boolean =
+  interaction.hasSolution() && !interaction.solution.isEmpty()
+
+/** Returns whether this solution has an explanation. */
+private fun Solution.isEmpty(): Boolean = explanation.html.isNullOrBlank()
 
 /** Returns whether this state has help that the user can see. */
 internal fun State.offersHelp(): Boolean = interaction.hintList.isNotEmpty() || hasSolution()

--- a/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintHandlerProdImpl.kt
+++ b/domain/src/main/java/org/oppia/android/domain/hintsandsolution/HintHandlerProdImpl.kt
@@ -1,6 +1,5 @@
 package org.oppia.android.domain.hintsandsolution
 
-import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -16,6 +15,7 @@ import org.oppia.android.app.model.HelpIndex.IndexTypeCase.SHOW_SOLUTION
 import org.oppia.android.app.model.Solution
 import org.oppia.android.app.model.State
 import org.oppia.android.util.threading.BackgroundDispatcher
+import javax.inject.Inject
 
 /**
  * Production implementation of [HintHandler] that implements hints & solutions in parity with the

--- a/domain/src/main/java/org/oppia/android/domain/util/StateRetriever.kt
+++ b/domain/src/main/java/org/oppia/android/domain/util/StateRetriever.kt
@@ -312,7 +312,7 @@ class StateRetriever @Inject constructor() {
     return when (ruleType) {
       "HasNumeratorEqualTo" ->
         InteractionObject.newBuilder()
-          .setSignedInt(inputJson.getInt(keyName))
+          .setNonNegativeInt(inputJson.getInt(keyName))
           .build()
       "HasDenominatorEqualTo" ->
         InteractionObject.newBuilder()

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/fractioninput/FractionInputHasNumeratorEqualToRuleClassifierProviderTest.kt
@@ -24,9 +24,13 @@ import javax.inject.Singleton
 @Config(manifest = Config.NONE)
 class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
 
-  private val NON_NEGATIVE_VALUE_TEST_0 =
+  private val NON_NEGATIVE_VALUE_TEST_1 =
     InteractionObjectTestBuilder.createNonNegativeInt(
-      value = 0
+      value = 1
+    )
+  private val NON_NEGATIVE_VALUE_TEST_2 =
+    InteractionObjectTestBuilder.createNonNegativeInt(
+      value = 2
     )
   private val WHOLE_NUMBER_VALUE_TEST_123 =
     InteractionObjectTestBuilder.createWholeNumber(
@@ -49,10 +53,6 @@ class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
     InteractionObjectTestBuilder.createSignedInt(
       value = 1
     )
-  private val SIGNED_INT_VALUE_TEST_2 =
-    InteractionObjectTestBuilder.createSignedInt(
-      value = 2
-    )
   private val SIGNED_INT_NEGATIVE_VALUE_TEST_2 =
     InteractionObjectTestBuilder.createSignedInt(
       value = -2
@@ -72,78 +72,46 @@ class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
   }
 
   @Test
-  fun testNumeratorEquals_negativeNumerators_bothValuesMatch() {
+  fun testNumeratorEquals_negativeNumerators_throwsException() {
     val inputs = mapOf("x" to SIGNED_INT_NEGATIVE_VALUE_TEST_2)
 
-    val matches =
+    val exception = assertThrows(IllegalStateException::class) {
       numeratorIsEqualClassifierProvider.matches(
         answer = FRACTION_VALUE_TEST_NEGATIVE_2_OVER_4,
         inputs = inputs,
         classificationContext = ClassificationContext()
       )
+    }
 
-    assertThat(matches).isTrue()
+    assertThat(exception)
+      .hasMessageThat()
+      .contains(
+        "Expected input value to be of type NON_NEGATIVE_INT not SIGNED_INT"
+      )
   }
 
   @Test
-  fun testNumeratorEquals_wholeNumber123Answer_withSignedInt1Input_bothValuesDoNotMatch() {
+  fun testNumeratorEquals_wholeNumber123Answer_withSignedInt1Input_throwsException() {
     val inputs = mapOf("x" to SIGNED_INT_VALUE_TEST_1)
 
-    val matches =
+    val exception = assertThrows(IllegalStateException::class) {
       numeratorIsEqualClassifierProvider.matches(
         answer = WHOLE_NUMBER_VALUE_TEST_123,
         inputs = inputs,
         classificationContext = ClassificationContext()
       )
+    }
 
-    assertThat(matches).isFalse()
+    assertThat(exception)
+      .hasMessageThat()
+      .contains(
+        "Expected input value to be of type NON_NEGATIVE_INT not SIGNED_INT"
+      )
   }
 
   @Test
-  fun testNumeratorEquals_fraction2Over4Answer_withSignedInt1Input_bothValuesDoNotMatch() {
+  fun testNumeratorEquals_fraction2Over4Answer_withSignedInt1Input_throwsException() {
     val inputs = mapOf("x" to SIGNED_INT_VALUE_TEST_1)
-
-    val matches =
-      numeratorIsEqualClassifierProvider.matches(
-        answer = FRACTION_VALUE_TEST_2_OVER_4,
-        inputs = inputs,
-        classificationContext = ClassificationContext()
-      )
-
-    assertThat(matches).isFalse()
-  }
-
-  @Test
-  fun testNumeratorEquals_fraction2Over4Answer_withSignedIntNegative2Input_bothValuesDoNotMatch() {
-    val inputs = mapOf("x" to SIGNED_INT_NEGATIVE_VALUE_TEST_2)
-
-    val matches =
-      numeratorIsEqualClassifierProvider.matches(
-        answer = FRACTION_VALUE_TEST_2_OVER_4,
-        inputs = inputs,
-        classificationContext = ClassificationContext()
-      )
-
-    assertThat(matches).isFalse()
-  }
-
-  @Test
-  fun testNumeratorEquals_fraction2Over4Answer_withSignedInt2Input_bothValuesMatch() {
-    val inputs = mapOf("x" to SIGNED_INT_VALUE_TEST_2)
-
-    val matches =
-      numeratorIsEqualClassifierProvider.matches(
-        answer = FRACTION_VALUE_TEST_2_OVER_4,
-        inputs = inputs,
-        classificationContext = ClassificationContext()
-      )
-
-    assertThat(matches).isTrue()
-  }
-
-  @Test
-  fun testNumeratorEquals_nonNegativeInput_inputWithIncorrectType_throwsException() {
-    val inputs = mapOf("x" to NON_NEGATIVE_VALUE_TEST_0)
 
     val exception = assertThrows(IllegalStateException::class) {
       numeratorIsEqualClassifierProvider.matches(
@@ -156,7 +124,59 @@ class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
     assertThat(exception)
       .hasMessageThat()
       .contains(
-        "Expected input value to be of type SIGNED_INT not NON_NEGATIVE_INT"
+        "Expected input value to be of type NON_NEGATIVE_INT not SIGNED_INT"
+      )
+  }
+
+  @Test
+  fun testNumeratorEquals_fraction2Over4Answer_withSignedIntNegative2Input_throwsException() {
+    val inputs = mapOf("x" to SIGNED_INT_NEGATIVE_VALUE_TEST_2)
+
+    val exception = assertThrows(IllegalStateException::class) {
+      numeratorIsEqualClassifierProvider.matches(
+        answer = FRACTION_VALUE_TEST_2_OVER_4,
+        inputs = inputs,
+        classificationContext = ClassificationContext()
+      )
+    }
+
+    assertThat(exception)
+      .hasMessageThat()
+      .contains(
+        "Expected input value to be of type NON_NEGATIVE_INT not SIGNED_INT"
+      )
+  }
+
+  @Test
+  fun testNumeratorEquals_fraction2Over4Answer_withNonNegative2Input_bothValuesMatch() {
+    val inputs = mapOf("x" to NON_NEGATIVE_VALUE_TEST_2)
+
+    val matches =
+      numeratorIsEqualClassifierProvider.matches(
+        answer = FRACTION_VALUE_TEST_2_OVER_4,
+        inputs = inputs,
+        classificationContext = ClassificationContext()
+      )
+
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testNumeratorEquals_SignedIntInput_inputWithIncorrectType_throwsException() {
+    val inputs = mapOf("x" to SIGNED_INT_NEGATIVE_VALUE_TEST_2)
+
+    val exception = assertThrows(IllegalStateException::class) {
+      numeratorIsEqualClassifierProvider.matches(
+        answer = FRACTION_VALUE_TEST_2_OVER_4,
+        inputs = inputs,
+        classificationContext = ClassificationContext()
+      )
+    }
+
+    assertThat(exception)
+      .hasMessageThat()
+      .contains(
+        "Expected input value to be of type NON_NEGATIVE_INT not SIGNED_INT"
       )
   }
 
@@ -175,6 +195,19 @@ class FractionInputHasNumeratorEqualToRuleClassifierProviderTest {
     assertThat(exception)
       .hasMessageThat()
       .contains("Expected classifier inputs to contain parameter with name 'x' but had: [y]")
+  }
+
+  @Test
+  fun testNumeratorEquals_wholeNumber123Answer_withNoneNegative1Input_bothValuesDoNotMatch() {
+    val inputs = mapOf("x" to NON_NEGATIVE_VALUE_TEST_1)
+
+    val matches = numeratorIsEqualClassifierProvider.matches(
+      answer = WHOLE_NUMBER_VALUE_TEST_123,
+      inputs = inputs,
+      classificationContext = ClassificationContext()
+    )
+
+    assertThat(matches).isFalse()
   }
 
   private fun setUpTestApplicationComponent() {

--- a/domain/src/test/java/org/oppia/android/domain/hintsandsolution/HintHandlerProdImplTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/hintsandsolution/HintHandlerProdImplTest.kt
@@ -110,6 +110,13 @@ class HintHandlerProdImplTest {
       )
     }
   }
+  private val expWithSolutionMissingExplanation by lazy {
+    runBlocking {
+      explorationRetriever.loadExploration(
+        "test_single_interactive_state_exp_with_solution_missing_explanation"
+      )
+    }
+  }
 
   @Before
   fun setUp() {
@@ -2006,6 +2013,28 @@ class HintHandlerProdImplTest {
         everythingRevealed = true
       }.build()
     )
+  }
+
+  @Test
+  fun testGetCurrentHelpIndex_onlySolution_missingExplanation_isEmpty() {
+    val state = expWithSolutionMissingExplanation.getInitialState()
+    hintHandler.startWatchingForHintsInNewStateSync(state)
+
+    val helpIndex = hintHandler.getCurrentHelpIndex().value
+
+    assertThat(helpIndex).isEqualToDefaultInstance()
+  }
+
+  @Test
+  fun testGetCurrentHelpIndex_onlySolution_missingExplanation_twoWrongAnswers_isEmpty() {
+    val state = expWithSolutionMissingExplanation.getInitialState()
+    hintHandler.startWatchingForHintsInNewStateSync(state)
+    hintHandler.handleWrongAnswerSubmissionSync(wrongAnswerCount = 1)
+    hintHandler.handleWrongAnswerSubmissionSync(wrongAnswerCount = 2)
+
+    val helpIndex = hintHandler.getCurrentHelpIndex().value
+
+    assertThat(helpIndex).isEqualToDefaultInstance()
   }
 
   private fun HintHandler.startWatchingForHintsInNewStateSync(

--- a/utility/src/main/java/org/oppia/android/util/parser/image/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/image/UrlImageParser.kt
@@ -288,7 +288,7 @@ class UrlImageParser private constructor(
           val maxContentItemPadding =
             context.resources.getDimensionPixelSize(R.dimen.maximum_content_item_padding)
           val maximumImageSize = maxAvailableWidth - maxContentItemPadding
-          if (drawableWidth >= maximumImageSize) {
+          if (drawableWidth >= maximumImageSize || drawableHeight >= maximumImageSize) {
             // The multipleFactor value is used to make sure that the aspect ratio of the image
             // remains the same. Example: Height is 420, width is 440 and maximumImageSize is 200.
             // Then multipleFactor will be (200/440). The new height will be 191 and new width will


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixes #5049 
Fixes #5050 

### Fraction Answer Submission
The answer classification for numerators was previously failing on wrong answer entered because the classifier on android was expecting a SignedInt input, but what was received was a non_negative_int, per https://github.com/oppia/oppia/blob/develop/extensions/interactions/interaction_specs.json#L997.

My hypothesis is that this change was a result of the recent change to the asset download pipeline, which could have changed how the interactions were generated. 

### Incorrect Hint Trigger
This is more of an edge case where we were previously not checking for the solution body missing an explanation. A solution with no explanation equals an empty solution.

### Test File Changes
I added a new test interaction json to be able to test for hints having a solution with no explanation.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
