### PR TITLE
Fix #5072 : Remove condition of hex color for drawables from regex

### DIFF
--- a/scripts/assets/file_content_validation_checks.textproto
+++ b/scripts/assets/file_content_validation_checks.textproto
@@ -354,7 +354,7 @@ file_content_checks {
 }
 file_content_checks {
   file_path_regex: "app/src/main/res/drawable.*?/.+?\\.xml"
-  prohibited_content_regex: "@color/(?!component_color_).+|\"#\\p{XDigit}+\""
+  prohibited_content_regex: "@color/(?!component_color_).+"
   failure_message: "Only colors from component_colors.xml may be used in drawables except vector assets."
   exempted_file_patterns: "app/src/main/res/drawable.*?/(ic_|lesson_thumbnail_graphic_).+?\\.xml"
   exempted_file_patterns: "app/src/main/res/drawable/full_oppia_logo.xml"

--- a/scripts/assets/file_content_validation_checks.textproto
+++ b/scripts/assets/file_content_validation_checks.textproto
@@ -353,17 +353,6 @@ file_content_checks {
   failure_message: "Only colors from component_colors.xml may be used in layouts."
 }
 file_content_checks {
-  file_path_regex: "app/src/main/res/drawable.*?/.+?\\.xml"
-  prohibited_content_regex: "@color/(?!component_color_).+"
-  failure_message: "Only colors from component_colors.xml may be used in drawables except vector assets."
-  exempted_file_patterns: "app/src/main/res/drawable.*?/(ic_|lesson_thumbnail_graphic_).+?\\.xml"
-  exempted_file_patterns: "app/src/main/res/drawable/full_oppia_logo.xml"
-  exempted_file_patterns: "app/src/main/res/drawable/rounded_white_background_with_shadow.xml"
-  exempted_file_patterns: "app/src/main/res/drawable/profile_image_shadow.xml"
-  exempted_file_patterns: "app/src/main/res/drawable/selected_region_background.xml"
-  exempted_file_patterns: "app/src/main/res/drawable/splash_page.xml"
-}
-file_content_checks {
   file_path_regex: "app/src/main/java/org/oppia/android/app.?/.+(ActivityPresenter|FragmentPresenter|ViewPresenter|Activity|Fragment|View)\\.kt"
   prohibited_content_regex: "R.color.(?!component_color_).+"
   failure_message: "Only colors from component_colors.xml may be used in Kotlin Files (Activities, Fragments, Views and Presenters)."

--- a/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
@@ -2345,6 +2345,7 @@ class RegexPatternValidationCheckTest {
       )
   }
 
+  // TODO(#5075): Add hex color into prohibitedContent for drawables
   @Test
   fun testFileContent_xmlDrawables_includesNonColorComponentReferences_fileContentIsNotCorrect() {
     val prohibitedContent =
@@ -2352,7 +2353,6 @@ class RegexPatternValidationCheckTest {
         android:color="@color/component_color_shared_primary_text_color"
         android:color="@color/color_defs_shared_primary_text_color"
         android:color="@color/color_palette_primary_text_color"
-        android:color="#003933"
       """.trimIndent()
     tempFolder.newFolder("testfiles", "app", "src", "main", "res", "drawable")
     val stringFilePath = "app/src/main/res/drawable/test_layout.xml"
@@ -2369,7 +2369,6 @@ class RegexPatternValidationCheckTest {
         """
         $stringFilePath:2: $doesNotReferenceColorFromComponentColorInDrawables
         $stringFilePath:3: $doesNotReferenceColorFromComponentColorInDrawables
-        $stringFilePath:4: $doesNotReferenceColorFromComponentColorInDrawables
         $wikiReferenceNote
         """.trimIndent()
       )

--- a/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/regex/RegexPatternValidationCheckTest.kt
@@ -173,8 +173,6 @@ class RegexPatternValidationCheckTest {
     "Only colors from color_defs.xml may be used in color_palette.xml."
   private val doesNotReferenceColorFromComponentColorInLayouts =
     "Only colors from component_colors.xml may be used in layouts."
-  private val doesNotReferenceColorFromComponentColorInDrawables =
-    "Only colors from component_colors.xml may be used in drawables except vector assets."
   private val doesNotReferenceColorFromComponentColorInKotlinFiles =
     "Only colors from component_colors.xml may be used in Kotlin Files (Activities, Fragments, " +
       "Views and Presenters)."
@@ -2345,34 +2343,7 @@ class RegexPatternValidationCheckTest {
       )
   }
 
-  // TODO(#5075): Add hex color into prohibitedContent for drawables
-  @Test
-  fun testFileContent_xmlDrawables_includesNonColorComponentReferences_fileContentIsNotCorrect() {
-    val prohibitedContent =
-      """
-        android:color="@color/component_color_shared_primary_text_color"
-        android:color="@color/color_defs_shared_primary_text_color"
-        android:color="@color/color_palette_primary_text_color"
-      """.trimIndent()
-    tempFolder.newFolder("testfiles", "app", "src", "main", "res", "drawable")
-    val stringFilePath = "app/src/main/res/drawable/test_layout.xml"
-    tempFolder.newFile("testfiles/$stringFilePath").writeText(prohibitedContent)
-
-    val exception = assertThrows(Exception::class) {
-      runScript()
-    }
-
-    // Verify that all patterns are properly detected & prohibited.
-    assertThat(exception).hasMessageThat().contains(REGEX_CHECK_FAILED_OUTPUT_INDICATOR)
-    assertThat(outContent.toString().trim())
-      .isEqualTo(
-        """
-        $stringFilePath:2: $doesNotReferenceColorFromComponentColorInDrawables
-        $stringFilePath:3: $doesNotReferenceColorFromComponentColorInDrawables
-        $wikiReferenceNote
-        """.trimIndent()
-      )
-  }
+  // TODO(#5075): Add test for drawables file that checks color uses only component colors
 
   @Test
   fun testFileContent_kotlinFiles_includesNonColorComponentReferences_fileContentIsNotCorrect() {


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix https://github.com/oppia/oppia-android/issues/5072 : Remove condition of hex color for drawables from regex

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
