### PR TITLE
Fix part of #5079 : Updated wiki for Gradle Build Failed - Task :utility:kaptGenerateStubsDebugKotlin FAILED 

### DIFF
--- a/wiki/Troubleshooting-Installation.md
+++ b/wiki/Troubleshooting-Installation.md
@@ -39,6 +39,23 @@ Here are some general troubleshooting tips for oppia-android. The specific platf
    or `Module not specified` while running Unit Tests, try to downgrade Android Studio to [Bumblebee (Patch 3)](https://developer.android.com/studio/archive). That should resolve this issue.
 
 
+7. If you getting this error while gradle build
+
+   ```
+   > Task :utility:kaptGenerateStubsDebugKotlin FAILED
+   Execution failed for task ':utility:kaptGenerateStubsDebugKotlin'.
+   > Could not resolve all files for configuration ':utility:debugCompileClasspath'.
+      > Failed to transform model.jar (project :model) to match attributes {artifactType=android-classes, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.jvm.version=15, org.gradle.libraryelements=jar, org.gradle.usage=java-api}.
+         > Execution failed for JetifyTransform: E:\Android\open-source\oppia-android\model\build\libs\model.jar.
+            > Failed to transform 'E:\Android\open-source\oppia-android\model\build\libs\model.jar' using Jetifier. Reason: Unsupported class file major version 59. (Run with --stacktrace for more details.)
+   ```
+   This error occur because of our use of jetifier. In gradle.properties, `android.enableJetifier=true` automatically converts third-party libraries to use AndroidX.
+   The maximum supported major version for jetifier class file format in Android is 58, which corresponds to Java 14.
+   The `model.jar` was compiled with Java 15/major version 59, hence the incompatibility.
+   
+
+   To fix this error you need to lower version of Java to compile JAR file. Check [here](https://developer.android.com/studio/intro/studio-config#jdk) more about Java version.
+
 ### Bazel issues
 
 1. No matching toolchains (sdk_toolchain_type)

--- a/wiki/Troubleshooting-Installation.md
+++ b/wiki/Troubleshooting-Installation.md
@@ -39,7 +39,7 @@ Here are some general troubleshooting tips for oppia-android. The specific platf
    or `Module not specified` while running Unit Tests, try to downgrade Android Studio to [Bumblebee (Patch 3)](https://developer.android.com/studio/archive). That should resolve this issue.
 
 
-7. If you getting this error while gradle build
+7. If you encounter this error while building gradle:
 
    ```
    > Task :utility:kaptGenerateStubsDebugKotlin FAILED
@@ -49,12 +49,12 @@ Here are some general troubleshooting tips for oppia-android. The specific platf
          > Execution failed for JetifyTransform: E:\Android\open-source\oppia-android\model\build\libs\model.jar.
             > Failed to transform 'E:\Android\open-source\oppia-android\model\build\libs\model.jar' using Jetifier. Reason: Unsupported class file major version 59. (Run with --stacktrace for more details.)
    ```
-   This error occur because of our use of jetifier. In gradle.properties, `android.enableJetifier=true` automatically converts third-party libraries to use AndroidX.
-   The maximum supported major version for jetifier class file format in Android is 58, which corresponds to Java 14.
-   The `model.jar` was compiled with Java 15/major version 59, hence the incompatibility.
-   
+   You are seeing this because Oppia android currently compiles with Java 8, or 9. Higher versions of Java are not supported by our version of Gradle.
 
-   To fix this error you need to lower version of Java to compile JAR file. Check [here](https://developer.android.com/studio/intro/studio-config#jdk) more about Java version.
+   The `model.jar` was compiled with Java 15/major version 59, hence the incompatibility.
+
+
+   To fix this error, you need to lower the version of Java to compile the JAR file. Please see [here](https://developer.android.com/studio/intro/studio-config#jdk) for more information about Java versions.
 
 ### Bazel issues
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fix part of #5079 : Updated wiki to add information about resolving common setup error: Gradle Build Failed - Task :utility:kaptGenerateStubsDebugKotlin FAILED 

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
