### PR TITLE
Fix #5088 : Buttons in Resume lesson dark mode

### DIFF
--- a/app/src/main/res/drawable/secondary_button_background.xml
+++ b/app/src/main/res/drawable/secondary_button_background.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
   android:shape="rectangle">
   <corners android:radius="@dimen/state_previous_next_button_radius" />
-  <solid android:tint="@color/component_color_shared_white_background_color" />
+  <solid android:color="@color/component_color_shared_white_background_color" />
   <stroke
     android:width="2dp"
     android:color="@color/component_color_shared_secondary_button_background_trim_color" />

--- a/app/src/main/res/layout-land/resume_lesson_fragment.xml
+++ b/app/src/main/res/layout-land/resume_lesson_fragment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:tools="http://schemas.android.com/tools"
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools">
 
   <data>
 
@@ -76,36 +76,35 @@
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:background="@drawable/secondary_button_background"
-          android:gravity="center"
           android:fontFamily="sans-serif-medium"
+          android:gravity="center"
           android:minWidth="144dp"
           android:minHeight="@dimen/clickable_item_min_height"
+          android:text="@string/start_over_lesson_button"
           android:textAllCaps="true"
           android:textColor="@color/component_color_shared_secondary_button_background_trim_color"
           android:textSize="14sp"
-          android:text="@string/start_over_lesson_button"
           app:backgroundTint="@null"
           app:icon="@drawable/ic_start_over_24dp"
-          app:iconTint="@color/component_color_shared_secondary_button_background_trim_color"
-          app:iconGravity="textStart" />
-
+          app:iconGravity="textStart"
+          app:iconTint="@color/component_color_shared_secondary_button_background_trim_color" />
 
         <com.google.android.material.button.MaterialButton
           android:id="@+id/resume_lesson_continue_button"
           android:layout_width="wrap_content"
           android:layout_height="match_parent"
-          android:minWidth="144dp"
-          android:gravity="center"
           android:background="@drawable/state_button_primary_background"
-          android:drawableTint="@color/component_color_shared_white_background_color"
           android:fontFamily="sans-serif-medium"
+          android:gravity="center"
+          android:minWidth="144dp"
           android:minHeight="@dimen/clickable_item_min_height"
+          android:text="@string/resume_lesson_button"
           android:textAllCaps="true"
           android:textColor="@color/component_color_shared_secondary_4_text_color"
           android:textSize="14sp"
-          android:text="@string/resume_lesson_button"
-          app:iconGravity="textEnd"
-          app:icon="@drawable/ic_arrow_right_alt_24dp" />
+          app:backgroundTint="@null"
+          app:icon="@drawable/ic_arrow_right_alt_24dp"
+          app:iconGravity="textEnd" />
       </com.google.android.flexbox.FlexboxLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
   </ScrollView>

--- a/app/src/main/res/layout-sw600dp-land/resume_lesson_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-land/resume_lesson_fragment.xml
@@ -106,36 +106,35 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:background="@drawable/secondary_button_background"
-            android:gravity="center"
             android:fontFamily="sans-serif-medium"
+            android:gravity="center"
             android:minWidth="144dp"
             android:minHeight="@dimen/clickable_item_min_height"
+            android:text="@string/start_over_lesson_button"
             android:textAllCaps="true"
             android:textColor="@color/component_color_shared_secondary_button_background_trim_color"
             android:textSize="14sp"
-            android:text="@string/start_over_lesson_button"
             app:backgroundTint="@null"
             app:icon="@drawable/ic_start_over_24dp"
-            app:iconTint="@color/component_color_shared_secondary_button_background_trim_color"
-            app:iconGravity="textStart" />
-
+            app:iconGravity="textStart"
+            app:iconTint="@color/component_color_shared_secondary_button_background_trim_color" />
 
           <com.google.android.material.button.MaterialButton
             android:id="@+id/resume_lesson_continue_button"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:minWidth="144dp"
-            android:gravity="center"
             android:background="@drawable/state_button_primary_background"
-            android:drawableTint="@color/component_color_shared_white_background_color"
             android:fontFamily="sans-serif-medium"
+            android:gravity="center"
+            android:minWidth="144dp"
             android:minHeight="@dimen/clickable_item_min_height"
+            android:text="@string/resume_lesson_button"
             android:textAllCaps="true"
             android:textColor="@color/component_color_shared_secondary_4_text_color"
             android:textSize="14sp"
-            android:text="@string/resume_lesson_button"
-            app:iconGravity="textEnd"
-            app:icon="@drawable/ic_arrow_right_alt_24dp" />
+            app:backgroundTint="@null"
+            app:icon="@drawable/ic_arrow_right_alt_24dp"
+            app:iconGravity="textEnd" />
         </com.google.android.flexbox.FlexboxLayout>
       </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/app/src/main/res/layout/resume_lesson_fragment.xml
+++ b/app/src/main/res/layout/resume_lesson_fragment.xml
@@ -109,7 +109,6 @@
           android:layout_width="wrap_content"
           android:layout_height="match_parent"
           android:background="@drawable/state_button_primary_background"
-          app:backgroundTint="@null"
           android:fontFamily="sans-serif-medium"
           android:gravity="center"
           android:minWidth="144dp"
@@ -118,6 +117,7 @@
           android:textAllCaps="true"
           android:textColor="@color/component_color_shared_secondary_4_text_color"
           android:textSize="14sp"
+          app:backgroundTint="@null"
           app:icon="@drawable/ic_arrow_right_alt_24dp"
           app:iconGravity="textEnd" />
       </com.google.android.flexbox.FlexboxLayout>

--- a/app/src/main/res/layout/resume_lesson_fragment.xml
+++ b/app/src/main/res/layout/resume_lesson_fragment.xml
@@ -86,41 +86,40 @@
         app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_description_text_view">
 
         <com.google.android.material.button.MaterialButton
-          android:layout_margin="8dp"
           android:id="@+id/resume_lesson_start_over_button"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          android:layout_margin="8dp"
           android:background="@drawable/secondary_button_background"
-          android:gravity="center"
           android:fontFamily="sans-serif-medium"
+          android:gravity="center"
           android:minWidth="144dp"
           android:minHeight="@dimen/clickable_item_min_height"
+          android:text="@string/start_over_lesson_button"
           android:textAllCaps="true"
           android:textColor="@color/component_color_shared_secondary_button_background_trim_color"
           android:textSize="14sp"
-          android:text="@string/start_over_lesson_button"
           app:backgroundTint="@null"
           app:icon="@drawable/ic_start_over_24dp"
-          app:iconTint="@color/component_color_shared_secondary_button_background_trim_color"
-          app:iconGravity="textStart" />
-
+          app:iconGravity="textStart"
+          app:iconTint="@color/component_color_shared_secondary_button_background_trim_color" />
 
         <com.google.android.material.button.MaterialButton
           android:id="@+id/resume_lesson_continue_button"
           android:layout_width="wrap_content"
           android:layout_height="match_parent"
-          android:minWidth="144dp"
-          android:gravity="center"
           android:background="@drawable/state_button_primary_background"
-          android:drawableTint="@color/component_color_shared_white_background_color"
+          app:backgroundTint="@null"
           android:fontFamily="sans-serif-medium"
+          android:gravity="center"
+          android:minWidth="144dp"
           android:minHeight="@dimen/clickable_item_min_height"
+          android:text="@string/resume_lesson_button"
           android:textAllCaps="true"
           android:textColor="@color/component_color_shared_secondary_4_text_color"
           android:textSize="14sp"
-          android:text="@string/resume_lesson_button"
-          app:iconGravity="textEnd"
-          app:icon="@drawable/ic_arrow_right_alt_24dp" />
+          app:icon="@drawable/ic_arrow_right_alt_24dp"
+          app:iconGravity="textEnd" />
       </com.google.android.flexbox.FlexboxLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
   </ScrollView>


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fix #5088 : Buttons in Resume lesson dark mode

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->

### Resume Lesson

| Before - Light Mode | Before - Dark Mode |
| ------ | ------ |
| <img src="https://github.com/oppia/oppia-android/assets/76530270/8494dcd1-c8cf-441a-9cea-305cc1afdb1e" height="400" style="max-width: 100%">  | <img src="https://github.com/oppia/oppia-android/assets/76530270/e823a67e-3eb2-4f4d-86c1-7bbcb4bd4380" height="400" style="max-width: 100%"> |

| After - Light Mode | After - Dark Mode |
| ------ | ------ |
| <img src="https://github.com/oppia/oppia-android/assets/76530270/9651500d-3434-4d44-b2b4-9ea3b28c072b" height="400" style="max-width: 100%">  | <img src="https://github.com/oppia/oppia-android/assets/76530270/bba4d86f-2ea8-4401-9e81-6d8d3318ac5f" height="400" style="max-width: 100%"> |

| Before - Dark Mode Landscape | After - Dark Mode Landscape |
| ------ | ------ |
| <img src="https://github.com/oppia/oppia-android/assets/76530270/36d3fb9d-3388-4c78-ba57-c932f360a7b0" >  | <img src="https://github.com/oppia/oppia-android/assets/76530270/143434c9-6288-4d44-8390-c4d55f28fc40"> |

| Before - Dark Mode Tab | After - Dark Mode Tab |
| ------ | ------ |
| <img src="https://github.com/oppia/oppia-android/assets/76530270/a4155c3f-ec4e-4b82-b113-eb7739af70e5" >  | <img src="https://github.com/oppia/oppia-android/assets/76530270/ff604777-1581-41b7-b738-337814c9ac73" > |

If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
