### PR TITLE
Fix #5088: Revert ""Fix #4710 the button scaling problem in largest text, and change button name""

### DIFF
--- a/app/src/main/res/drawable/secondary_button_background.xml
+++ b/app/src/main/res/drawable/secondary_button_background.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
   android:shape="rectangle">
   <corners android:radius="@dimen/state_previous_next_button_radius" />
-  <solid android:tint="@color/component_color_shared_white_background_color" />
+  <solid android:color="@color/component_color_shared_white_background_color" />
   <stroke
     android:width="2dp"
     android:color="@color/component_color_shared_secondary_button_background_trim_color" />

--- a/app/src/main/res/layout-land/resume_lesson_fragment.xml
+++ b/app/src/main/res/layout-land/resume_lesson_fragment.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:tools="http://schemas.android.com/tools"
-  xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <data>
@@ -55,58 +54,36 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_title_text_view" />
 
-      <com.google.android.flexbox.FlexboxLayout
+      <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="28dp"
+        android:layout_marginStart="32dp"
         android:layout_marginTop="32dp"
-        android:layout_marginEnd="28dp"
-        app:alignContent="flex_start"
-        app:alignItems="center"
-        app:flexDirection="row"
-        app:flexWrap="wrap"
-        app:justifyContent="space_evenly"
+        android:layout_marginEnd="32dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_description_text_view">
 
-        <com.google.android.material.button.MaterialButton
+        <Button
           android:id="@+id/resume_lesson_start_over_button"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:background="@drawable/secondary_button_background"
-          android:gravity="center"
-          android:fontFamily="sans-serif-medium"
-          android:minWidth="144dp"
-          android:minHeight="@dimen/clickable_item_min_height"
-          android:textAllCaps="true"
-          android:textColor="@color/component_color_shared_secondary_button_background_trim_color"
-          android:textSize="14sp"
+          style="@style/StartOverLessonButton"
+          android:layout_marginEnd="12dp"
           android:text="@string/start_over_lesson_button"
-          app:backgroundTint="@null"
-          app:icon="@drawable/ic_start_over_24dp"
-          app:iconTint="@color/component_color_shared_secondary_button_background_trim_color"
-          app:iconGravity="textStart" />
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toStartOf="@+id/resume_lesson_continue_button"
+          app:layout_constraintHorizontal_chainStyle="spread"
+          app:layout_constraintStart_toStartOf="parent" />
 
-
-        <com.google.android.material.button.MaterialButton
+        <Button
           android:id="@+id/resume_lesson_continue_button"
-          android:layout_width="wrap_content"
-          android:layout_height="match_parent"
-          android:minWidth="144dp"
-          android:gravity="center"
-          android:background="@drawable/state_button_primary_background"
-          android:drawableTint="@color/component_color_shared_white_background_color"
-          android:fontFamily="sans-serif-medium"
-          android:minHeight="@dimen/clickable_item_min_height"
-          android:textAllCaps="true"
-          android:textColor="@color/component_color_shared_secondary_4_text_color"
-          android:textSize="14sp"
+          style="@style/ContinueLessonButton"
+          android:layout_marginStart="12dp"
           android:text="@string/resume_lesson_button"
-          app:iconGravity="textEnd"
-          app:icon="@drawable/ic_arrow_right_alt_24dp" />
-      </com.google.android.flexbox.FlexboxLayout>
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toEndOf="@id/resume_lesson_start_over_button" />
+      </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
   </ScrollView>
 </layout>

--- a/app/src/main/res/layout-sw600dp-land/resume_lesson_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-land/resume_lesson_fragment.xml
@@ -85,58 +85,36 @@
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_title_text_view" />
 
-        <com.google.android.flexbox.FlexboxLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginStart="28dp"
+          android:layout_marginStart="32dp"
           android:layout_marginTop="32dp"
-          android:layout_marginEnd="28dp"
-          app:alignContent="flex_start"
-          app:alignItems="center"
-          app:flexDirection="row"
-          app:flexWrap="wrap"
-          app:justifyContent="space_evenly"
+          android:layout_marginEnd="32dp"
           app:layout_constraintBottom_toBottomOf="parent"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_description_text_view">
 
-          <com.google.android.material.button.MaterialButton
+          <Button
             android:id="@+id/resume_lesson_start_over_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@drawable/secondary_button_background"
-            android:gravity="center"
-            android:fontFamily="sans-serif-medium"
-            android:minWidth="144dp"
-            android:minHeight="@dimen/clickable_item_min_height"
-            android:textAllCaps="true"
-            android:textColor="@color/component_color_shared_secondary_button_background_trim_color"
-            android:textSize="14sp"
+            style="@style/StartOverLessonButton"
+            android:layout_marginEnd="12dp"
             android:text="@string/start_over_lesson_button"
-            app:backgroundTint="@null"
-            app:icon="@drawable/ic_start_over_24dp"
-            app:iconTint="@color/component_color_shared_secondary_button_background_trim_color"
-            app:iconGravity="textStart" />
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/resume_lesson_continue_button"
+            app:layout_constraintHorizontal_chainStyle="spread"
+            app:layout_constraintStart_toStartOf="parent" />
 
-
-          <com.google.android.material.button.MaterialButton
+          <Button
             android:id="@+id/resume_lesson_continue_button"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:minWidth="144dp"
-            android:gravity="center"
-            android:background="@drawable/state_button_primary_background"
-            android:drawableTint="@color/component_color_shared_white_background_color"
-            android:fontFamily="sans-serif-medium"
-            android:minHeight="@dimen/clickable_item_min_height"
-            android:textAllCaps="true"
-            android:textColor="@color/component_color_shared_secondary_4_text_color"
-            android:textSize="14sp"
+            style="@style/ContinueLessonButton"
+            android:layout_marginStart="12dp"
             android:text="@string/resume_lesson_button"
-            app:iconGravity="textEnd"
-            app:icon="@drawable/ic_arrow_right_alt_24dp" />
-        </com.google.android.flexbox.FlexboxLayout>
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/resume_lesson_start_over_button" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
       </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
   </LinearLayout>

--- a/app/src/main/res/layout/resume_lesson_fragment.xml
+++ b/app/src/main/res/layout/resume_lesson_fragment.xml
@@ -69,59 +69,36 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_title_text_view" />
 
-      <com.google.android.flexbox.FlexboxLayout
+      <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="28dp"
+        android:layout_marginStart="32dp"
         android:layout_marginTop="32dp"
-        android:layout_marginEnd="28dp"
-        app:alignContent="flex_start"
-        app:alignItems="center"
-        app:flexDirection="row"
-        app:flexWrap="wrap"
-        app:justifyContent="space_evenly"
+        android:layout_marginEnd="32dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/resume_lesson_chapter_description_text_view">
 
-        <com.google.android.material.button.MaterialButton
-          android:layout_margin="8dp"
+        <Button
           android:id="@+id/resume_lesson_start_over_button"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:background="@drawable/secondary_button_background"
-          android:gravity="center"
-          android:fontFamily="sans-serif-medium"
-          android:minWidth="144dp"
-          android:minHeight="@dimen/clickable_item_min_height"
-          android:textAllCaps="true"
-          android:textColor="@color/component_color_shared_secondary_button_background_trim_color"
-          android:textSize="14sp"
+          style="@style/StartOverLessonButton"
+          android:layout_marginEnd="12dp"
           android:text="@string/start_over_lesson_button"
-          app:backgroundTint="@null"
-          app:icon="@drawable/ic_start_over_24dp"
-          app:iconTint="@color/component_color_shared_secondary_button_background_trim_color"
-          app:iconGravity="textStart" />
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toStartOf="@+id/resume_lesson_continue_button"
+          app:layout_constraintHorizontal_chainStyle="spread"
+          app:layout_constraintStart_toStartOf="parent" />
 
-
-        <com.google.android.material.button.MaterialButton
+        <Button
           android:id="@+id/resume_lesson_continue_button"
-          android:layout_width="wrap_content"
-          android:layout_height="match_parent"
-          android:minWidth="144dp"
-          android:gravity="center"
-          android:background="@drawable/state_button_primary_background"
-          android:drawableTint="@color/component_color_shared_white_background_color"
-          android:fontFamily="sans-serif-medium"
-          android:minHeight="@dimen/clickable_item_min_height"
-          android:textAllCaps="true"
-          android:textColor="@color/component_color_shared_secondary_4_text_color"
-          android:textSize="14sp"
+          style="@style/ContinueLessonButton"
+          android:layout_marginStart="12dp"
           android:text="@string/resume_lesson_button"
-          app:iconGravity="textEnd"
-          app:icon="@drawable/ic_arrow_right_alt_24dp" />
-      </com.google.android.flexbox.FlexboxLayout>
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toEndOf="@id/resume_lesson_start_over_button" />
+      </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
   </ScrollView>
 </layout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -411,15 +411,37 @@
   </style>
   <!-- Start Over Lesson Button -->
   <style name="SecondaryButton" parent="TextAppearance.AppCompat.Widget.Button">
-    <item name="android:layout_width">0dp</item>
+    <item name="android:layout_width">144dp</item>
     <item name="android:layout_height">wrap_content</item>
+    <item name="android:paddingEnd">12dp</item>
+    <item name="android:paddingStart">12dp</item>
+    <item name="android:minWidth">144dp</item>
     <item name="android:background">@drawable/secondary_button_background</item>
     <item name="android:fontFamily">sans-serif-medium</item>
-    <item name="android:minWidth">144dp</item>
     <item name="android:drawablePadding">4dp</item>
     <item name="drawableTint">@color/component_color_shared_secondary_button_background_trim_color</item>
     <item name="android:textAllCaps">true</item>
     <item name="android:textColor">@color/component_color_shared_secondary_button_background_trim_color</item>
+    <item name="android:textSize">14sp</item>
+  </style>
+  <style name="StartOverLessonButton" parent="SecondaryButton">
+    <item name="drawableStartCompat">@drawable/ic_start_over_24dp</item>
+  </style>
+  <!-- Continue Lesson Button -->
+  <style name="ContinueLessonButton" parent="TextAppearance.AppCompat.Widget.Button">
+    <item name="android:layout_width">144dp</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:drawablePadding">4dp</item>
+    <item name="android:paddingEnd">12dp</item>
+    <item name="android:paddingStart">12dp</item>
+    <item name="android:minWidth">144dp</item>
+    <item name="android:background">@drawable/state_button_primary_background</item>
+    <item name="drawableEndCompat">@drawable/ic_arrow_right_alt_24dp</item>
+    <item name="drawableTint">@color/component_color_shared_white_background_color</item>
+    <item name="android:fontFamily">sans-serif-medium</item>
+    <item name="android:minHeight">@dimen/clickable_item_min_height</item>
+    <item name="android:textAllCaps">true</item>
+    <item name="android:textColor">@color/component_color_shared_secondary_4_text_color</item>
     <item name="android:textSize">14sp</item>
   </style>
 


### PR DESCRIPTION
Fixes #5088.
Reverts oppia/oppia-android#4987 which removed styles and added changes that broke the dark mode support previously correctly implmented in #4796.

This is a clean revert so it can be merged directly.

| Before - Light Mode | Before - Dark Mode |
| ------ | ------ |
| <img src="https://github.com/oppia/oppia-android/assets/76530270/8494dcd1-c8cf-441a-9cea-305cc1afdb1e" height="400" style="max-width: 100%">  | <img src="https://github.com/oppia/oppia-android/assets/76530270/e823a67e-3eb2-4f4d-86c1-7bbcb4bd4380" height="400" style="max-width: 100%"> |

| After - Light Mode | After - Dark Mode |
| ------ | ------ |
| <img src="https://github.com/oppia/oppia-android/assets/76530270/9651500d-3434-4d44-b2b4-9ea3b28c072b" height="400" style="max-width: 100%">  | <img src="https://github.com/oppia/oppia-android/assets/76530270/bba4d86f-2ea8-4401-9e81-6d8d3318ac5f" height="400" style="max-width: 100%"> |

| Before - Dark Mode Landscape | After - Dark Mode Landscape |
| ------ | ------ |
| <img src="https://github.com/oppia/oppia-android/assets/76530270/36d3fb9d-3388-4c78-ba57-c932f360a7b0" >  | <img src="https://github.com/oppia/oppia-android/assets/76530270/143434c9-6288-4d44-8390-c4d55f28fc40"> |

| Before - Dark Mode Tab | After - Dark Mode Tab |
| ------ | ------ |
| <img src="https://github.com/oppia/oppia-android/assets/76530270/a4155c3f-ec4e-4b82-b113-eb7739af70e5" >  | <img src="https://github.com/oppia/oppia-android/assets/76530270/ff604777-1581-41b7-b738-337814c9ac73" > |


