### PR TITLE
Fix Part of #5086: Add Layout Land for Survey UI

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -311,7 +311,7 @@
       android:name=".app.survey.SurveyActivity"
       android:label="@string/survey_activity_title"
       android:theme="@style/OppiaThemeWithoutActionBar"
-      android:windowSoftInputMode="adjustResize" />
+      android:windowSoftInputMode="adjustNothing" />
 
     <provider
       android:name="androidx.work.impl.WorkManagerInitializer"

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
@@ -286,6 +286,8 @@ class ExplorationActivityPresenter @Inject constructor(
               oppiaLogger.d("ExplorationActivity", "Successfully stopped exploration")
               if (isCompletion) {
                 maybeShowSurveyDialog(profileId, topicId)
+              } else {
+                backPressActivitySelector()
               }
             }
           }
@@ -310,8 +312,6 @@ class ExplorationActivityPresenter @Inject constructor(
    * current exploration.
    */
   fun backButtonPressed() {
-    // check if survey should be shown
-    maybeShowSurveyDialog(profileId, topicId)
     // If checkpointing is not enabled, show StopExplorationDialogFragment to exit the exploration,
     // this is expected to happen if the exploration is marked as completed.
     if (!isCheckpointingEnabled) {

--- a/app/src/main/java/org/oppia/android/app/survey/ExitSurveyConfirmationDialogFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/survey/ExitSurveyConfirmationDialogFragment.kt
@@ -5,13 +5,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import javax.inject.Inject
 import org.oppia.android.R
 import org.oppia.android.app.fragment.FragmentComponentImpl
 import org.oppia.android.app.fragment.InjectableDialogFragment
 import org.oppia.android.app.model.ProfileId
 import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.extensions.putProto
-import javax.inject.Inject
 
 /** Fragment that displays a dialog for survey exit confirmation. */
 class ExitSurveyConfirmationDialogFragment : InjectableDialogFragment() {
@@ -60,6 +60,9 @@ class ExitSurveyConfirmationDialogFragment : InjectableDialogFragment() {
       ) { "Expected arguments to be passed to ExitSurveyConfirmationDialogFragment" }
 
     val profileId = args.getProto(PROFILE_ID_KEY, ProfileId.getDefaultInstance())
+
+    dialog?.setCanceledOnTouchOutside(false)
+    dialog?.setCancelable(false)
 
     return exitSurveyConfirmationDialogFragmentPresenter.handleCreateView(
       inflater,

--- a/app/src/main/java/org/oppia/android/app/survey/ExitSurveyConfirmationDialogFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/survey/ExitSurveyConfirmationDialogFragment.kt
@@ -5,13 +5,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import javax.inject.Inject
 import org.oppia.android.R
 import org.oppia.android.app.fragment.FragmentComponentImpl
 import org.oppia.android.app.fragment.InjectableDialogFragment
 import org.oppia.android.app.model.ProfileId
 import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.extensions.putProto
+import javax.inject.Inject
 
 /** Fragment that displays a dialog for survey exit confirmation. */
 class ExitSurveyConfirmationDialogFragment : InjectableDialogFragment() {

--- a/app/src/main/java/org/oppia/android/app/survey/SurveyActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/survey/SurveyActivity.kt
@@ -18,16 +18,25 @@ class SurveyActivity : InjectableAutoLocalizedAppCompatActivity() {
   @Inject
   lateinit var surveyActivityPresenter: SurveyActivityPresenter
 
+  private lateinit var profileId: ProfileId
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     (activityComponent as ActivityComponentImpl).inject(this)
 
     val params = intent.extractParams()
+    this.profileId = params.profileId ?: ProfileId.newBuilder().setInternalId(-1).build()
+
     surveyActivityPresenter.handleOnCreate(
-      params.profileId,
+      profileId,
       params.topicId,
       params.explorationId
     )
+  }
+
+  override fun onBackPressed() {
+    val dialogFragment = ExitSurveyConfirmationDialogFragment.newInstance(profileId)
+    dialogFragment.showNow(supportFragmentManager, TAG_EXIT_SURVEY_CONFIRMATION_DIALOG)
   }
 
   companion object {

--- a/app/src/main/java/org/oppia/android/app/survey/SurveyWelcomeDialogFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/survey/SurveyWelcomeDialogFragmentPresenter.kt
@@ -11,6 +11,7 @@ import org.oppia.android.app.model.SurveyQuestionName
 import org.oppia.android.databinding.SurveyWelcomeDialogFragmentBinding
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.oppialogger.analytics.AnalyticsController
+import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.domain.survey.SurveyController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
@@ -25,7 +26,8 @@ class SurveyWelcomeDialogFragmentPresenter @Inject constructor(
   private val fragment: Fragment,
   private val surveyController: SurveyController,
   private val oppiaLogger: OppiaLogger,
-  private val analyticsController: AnalyticsController
+  private val analyticsController: AnalyticsController,
+  private val profileManagementController: ProfileManagementController
 ) {
   private lateinit var explorationId: String
 
@@ -54,6 +56,7 @@ class SurveyWelcomeDialogFragmentPresenter @Inject constructor(
         .commitNow()
     }
 
+    profileManagementController.updateSurveyLastShownTimestamp(profileId)
     logSurveyPopUpShownEvent(explorationId, topicId, profileId)
 
     return binding.root

--- a/app/src/main/res/layout-land/survey_fragment.xml
+++ b/app/src/main/res/layout-land/survey_fragment.xml
@@ -78,7 +78,9 @@
         style="@style/TextViewStart"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/survey_question_text_margin"
+        android:layout_marginStart="@dimen/survey_question_text_margin"
+        android:layout_marginTop="@dimen/survey_question_text_margin"
+        android:layout_marginEnd="@dimen/survey_question_text_margin"
         android:fontFamily="sans-serif-medium"
         android:text="@{viewModel.questionText}"
         android:textColor="@color/component_color_shared_primary_text_color"
@@ -91,13 +93,14 @@
         android:id="@+id/survey_answers_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/survey_question_recycler_view_margin"
+        android:layout_marginStart="@dimen/survey_question_recycler_view_margin"
+        android:layout_marginTop="@dimen/survey_question_recycler_view_margin"
+        android:layout_marginEnd="@dimen/survey_question_recycler_view_margin"
         android:clipToPadding="false"
         android:overScrollMode="never"
         android:scrollbars="none"
         app:data="@{viewModel.itemList}"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/survey_question_text"
         tools:itemCount="1" />
     </androidx.constraintlayout.widget.ConstraintLayout>
@@ -106,6 +109,8 @@
       android:id="@+id/survey_buttons_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:layout_marginTop="@dimen/survey_navigation_buttons_container_margin"
+      android:layout_marginBottom="@dimen/survey_navigation_buttons_container_margin"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent">
@@ -121,8 +126,8 @@
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:text="@string/survey_previous_button"
-          app:layout_constraintBottom_toBottomOf="parent"
-          app:layout_constraintStart_toStartOf="parent" />
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="parent" />
 
         <Button
           android:id="@+id/survey_next_button"
@@ -133,8 +138,8 @@
           android:enabled="@{viewModel.canMoveToNextQuestion}"
           android:text="@string/next"
           android:textColor="@{viewModel.canMoveToNextQuestion ? @color/component_color_shared_secondary_4_text_color : @color/component_color_survey_disabled_button_text_color}"
-          app:layout_constraintBottom_toBottomOf="parent"
-          app:layout_constraintEnd_toEndOf="parent" />
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toTopOf="parent" />
       </androidx.constraintlayout.widget.ConstraintLayout>
     </FrameLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-land/survey_welcome_dialog_fragment.xml
+++ b/app/src/main/res/layout-land/survey_welcome_dialog_fragment.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+      android:id="@+id/survey_onboarding_title_text"
+      style="@style/SurveyPopupHeaderStyle"
+      android:text="@string/survey_onboarding_title_text"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintBottom_toTopOf="@id/survey_onboarding_title_guide"
+      app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.widget.Guideline
+      android:id="@+id/survey_onboarding_title_guide"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal"
+      app:layout_constraintGuide_percent="0.10" />
+
+    <org.oppia.android.app.customview.SurveyOnboardingBackgroundView
+      android:id="@+id/survey_onboarding_background"
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      app:layout_constraintTop_toBottomOf="@id/survey_onboarding_title_guide" />
+
+    <androidx.constraintlayout.widget.Guideline
+      android:id="@+id/survey_onboarding_center_guide"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal"
+      app:layout_constraintGuide_percent="0.20" />
+
+    <TextView
+      android:id="@+id/survey_onboarding_text"
+      style="@style/SurveyPopupMessageStyle"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      android:text="@string/survey_onboarding_message_text"
+      app:layout_constraintTop_toTopOf="@id/survey_onboarding_center_guide" />
+
+    <Button
+      android:id="@+id/begin_survey_button"
+      style="@style/SurveyPrimaryButton"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:text="@string/survey_begin_survey_button"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/survey_onboarding_text"
+      app:layout_constraintVertical_chainStyle="packed" />
+
+    <Button
+      android:id="@+id/maybe_later_button"
+      style="@style/SurveySecondaryButton"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="@dimen/survey_navigation_buttons_margin"
+      android:text="@string/survey_maybe_later_button"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/begin_survey_button" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout-w600dp/survey_welcome_dialog_fragment.xml
+++ b/app/src/main/res/layout-w600dp/survey_welcome_dialog_fragment.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+      android:id="@+id/survey_onboarding_title_text"
+      style="@style/SurveyPopupHeaderStyle"
+      android:text="@string/survey_onboarding_title_text"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintBottom_toTopOf="@id/survey_onboarding_title_guide"
+      app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.widget.Guideline
+      android:id="@+id/survey_onboarding_title_guide"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal"
+      app:layout_constraintGuide_percent="0.10" />
+
+    <org.oppia.android.app.customview.SurveyOnboardingBackgroundView
+      android:id="@+id/survey_onboarding_background"
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      app:layout_constraintTop_toBottomOf="@id/survey_onboarding_title_guide" />
+
+    <androidx.constraintlayout.widget.Guideline
+      android:id="@+id/survey_onboarding_center_guide"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal"
+      app:layout_constraintGuide_percent="0.25" />
+
+    <TextView
+      android:id="@+id/survey_onboarding_text"
+      style="@style/SurveyPopupMessageStyle"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      android:text="@string/survey_onboarding_message_text"
+      app:layout_constraintTop_toTopOf="@id/survey_onboarding_center_guide" />
+
+    <Button
+      android:id="@+id/begin_survey_button"
+      style="@style/SurveyPrimaryButton"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:text="@string/survey_begin_survey_button"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/survey_onboarding_text"
+      app:layout_constraintVertical_chainStyle="packed" />
+
+    <Button
+      android:id="@+id/maybe_later_button"
+      style="@style/SurveySecondaryButton"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="@dimen/survey_navigation_buttons_margin"
+      android:text="@string/survey_maybe_later_button"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/begin_survey_button" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -777,6 +777,7 @@
   <dimen name="survey_question_text_margin">28dp</dimen>
   <dimen name="survey_question_recycler_view_margin">28dp</dimen>
   <dimen name="survey_navigation_buttons_margin">28dp</dimen>
+  <dimen name="survey_navigation_buttons_container_margin">14dp</dimen>
   <dimen name="survey_shared_corner_radius">4dp</dimen>
   <dimen name="survey_popup_header_text_size">28sp</dimen>
   <dimen name="survey_popup_message_text_size">14sp</dimen>


### PR DESCRIPTION
## Explanation
Fix Part of #5086: We found that the navigation buttons in some questions were not displaying correctly in landscape mode on phones. This issue affects the survey popup as well. See https://github.com/oppia/oppia-android/pull/5104#issuecomment-1649935209.

This PR introduces dedicated landscape layouts for the affected screens.

There are some minor bug fixes/ ux improvements also added that are related to the survey behaviour:
1. Make the exit confirmation dialog non-cancelable so that the user makes use of the dialog buttons.
2. Prevent accidentally exiting the survey by showing the exit confirmation dialog on backpress.
3. Resume normal flow on exiting an exploration, when the survey is not to be shown.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only

### Before 
![image](https://github.com/oppia/oppia-android/assets/59600948/46b76a8e-82f3-4dd3-9f95-d83268ccf9a5)

### After
![Screenshot 2023-07-28 at 00 25 19](https://github.com/oppia/oppia-android/assets/59600948/c9518e0b-d610-4532-91ce-d23b80e4dd1a)

### Before+Light Mode, After+Dark Mode
![Screenshot 2023-07-28 at 01 32 02](https://github.com/oppia/oppia-android/assets/59600948/89fbbdb5-7905-4afb-abb4-6bfd041466ae)

### Before+Light Mode, After+Dark Mode
![Screenshot 2023-07-28 at 01 40 50](https://github.com/oppia/oppia-android/assets/59600948/88ba0852-a95d-4b86-bc2f-2682da5908b0)

