### PR TITLE
Fix #5120 Missing Text Margins In Topic Revision Cards in Large Screens

### DIFF
--- a/app/src/main/res/layout-sw600dp/revision_card_fragment.xml
+++ b/app/src/main/res/layout-sw600dp/revision_card_fragment.xml
@@ -33,7 +33,9 @@
         <TextView
           android:id="@+id/revision_card_explanation_text"
           style="@style/Body"
+          android:layout_marginStart="@dimen/revision_card_fragment_layout_margin_start"
           android:layout_marginTop="@dimen/revision_card_fragment_layout_text_margin_top"
+          android:layout_marginEnd="@dimen/revision_card_fragment_layout_margin_end"
           android:textColorLink="@color/component_color_shared_link_text_color" />
 
         <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
  - Fixes #5120
For small screen **revision_card_fragment** has three side margins as **top, start & end** but for large screen there was only one side margin which is at the **top**. So, I added the remaining two side margins as in the small screen.



## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes

### Before:
![Screenshot_20230809_143310](https://github.com/oppia/oppia-android/assets/99060332/de50b98f-5945-4a89-9e02-f53160b3f8f9)

### After:
![after](https://github.com/oppia/oppia-android/assets/99060332/b7134347-c2a9-4232-aa50-453bd8d4b428)


