### PR TITLE
Fix #4735 Text unit is set in dp instead of sp

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -137,6 +137,7 @@
       android:windowSoftInputMode="adjustResize" />
     <activity
       android:name=".app.profile.AdminPinActivity"
+      android:label="@string/admin_pin_activity_title"
     android:theme="@style/OppiaThemeWithoutActionBar"
       android:windowSoftInputMode="adjustResize" />
     <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -138,7 +138,7 @@
     <activity
       android:name=".app.profile.AdminPinActivity"
       android:label="@string/admin_pin_activity_title"
-    android:theme="@style/OppiaThemeWithoutActionBar"
+      android:theme="@style/OppiaThemeWithoutActionBar"
       android:windowSoftInputMode="adjustResize" />
     <activity
       android:name=".app.profile.PinPasswordActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -137,7 +137,7 @@
       android:windowSoftInputMode="adjustResize" />
     <activity
       android:name=".app.profile.AdminPinActivity"
-      android:label="@string/admin_pin_activity_title"
+    android:theme="@style/OppiaThemeWithoutActionBar"
       android:windowSoftInputMode="adjustResize" />
     <activity
       android:name=".app.profile.PinPasswordActivity"

--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.widget.Toolbar
+import org.oppia.android.R
 import org.oppia.android.app.activity.ActivityComponentImpl
 import org.oppia.android.app.activity.InjectableAutoLocalizedAppCompatActivity
 import org.oppia.android.app.model.ScreenName.ADMIN_PIN_ACTIVITY
 import org.oppia.android.util.logging.CurrentAppScreenNameIntentDecorator.decorateWithScreenName
 import javax.inject.Inject
-import org.oppia.android.R
 
 const val ADMIN_PIN_PROFILE_ID_EXTRA_KEY = "AdminPinActivity.admin_pin_profile_id"
 const val ADMIN_PIN_COLOR_RGB_EXTRA_KEY = "AdminPinActivity.admin_pin_color_rgb"

--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivity.kt
@@ -3,11 +3,13 @@ package org.oppia.android.app.profile
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.appcompat.widget.Toolbar
 import org.oppia.android.app.activity.ActivityComponentImpl
 import org.oppia.android.app.activity.InjectableAutoLocalizedAppCompatActivity
 import org.oppia.android.app.model.ScreenName.ADMIN_PIN_ACTIVITY
 import org.oppia.android.util.logging.CurrentAppScreenNameIntentDecorator.decorateWithScreenName
 import javax.inject.Inject
+import org.oppia.android.R
 
 const val ADMIN_PIN_PROFILE_ID_EXTRA_KEY = "AdminPinActivity.admin_pin_profile_id"
 const val ADMIN_PIN_COLOR_RGB_EXTRA_KEY = "AdminPinActivity.admin_pin_color_rgb"
@@ -38,6 +40,9 @@ class AdminPinActivity : InjectableAutoLocalizedAppCompatActivity() {
     super.onCreate(savedInstanceState)
     (activityComponent as ActivityComponentImpl).inject(this)
     adminPinActivityPresenter.handleOnCreate()
+
+    val toolbar: Toolbar = findViewById(R.id.admin_pin_toolbar)
+    setSupportActionBar(toolbar)
   }
 
   override fun onSupportNavigateUp(): Boolean {

--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
@@ -45,8 +45,6 @@ class AdminPinActivityPresenter @Inject constructor(
     val binding =
       DataBindingUtil.setContentView<AdminPinActivityBinding>(activity, R.layout.admin_pin_activity)
 
-
-
     binding.apply {
       lifecycleOwner = activity
       viewModel = adminViewModel

--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
@@ -2,8 +2,10 @@ package org.oppia.android.app.profile
 
 import android.content.Context
 import android.view.KeyEvent
+import android.view.View
 import android.view.inputmethod.EditorInfo
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
 import org.oppia.android.R
@@ -38,12 +40,14 @@ class AdminPinActivityPresenter @Inject constructor(
 
   /** Binds ViewModel and sets up text and button listeners. */
   fun handleOnCreate() {
-    activity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
-    activity.supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_close_white_24dp)
-    activity.supportActionBar?.setHomeActionContentDescription(R.string.admin_auth_close)
 
     val binding =
       DataBindingUtil.setContentView<AdminPinActivityBinding>(activity, R.layout.admin_pin_activity)
+
+    activity.setSupportActionBar(binding.adminPinToolbar)
+    activity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
+    activity.supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_close_white_24dp)
+    activity.supportActionBar?.setHomeActionContentDescription(R.string.admin_auth_close)
 
     binding.apply {
       lifecycleOwner = activity

--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
@@ -2,10 +2,8 @@ package org.oppia.android.app.profile
 
 import android.content.Context
 import android.view.KeyEvent
-import android.view.View
 import android.view.inputmethod.EditorInfo
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.Toolbar
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
 import org.oppia.android.R

--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
@@ -45,11 +45,15 @@ class AdminPinActivityPresenter @Inject constructor(
     val binding =
       DataBindingUtil.setContentView<AdminPinActivityBinding>(activity, R.layout.admin_pin_activity)
 
+
+
     binding.apply {
       lifecycleOwner = activity
       viewModel = adminViewModel
     }
 
+    binding.adminPinToolbar.title = resourceHandler
+      .getStringInLocale(R.string.admin_auth_activity_add_profiles_title)
     // [onTextChanged] is a extension function defined at [TextInputEditTextHelper]
     binding.adminPinInputPinEditText.onTextChanged { pin ->
       pin?.let {

--- a/app/src/main/res/layout/admin_pin_activity.xml
+++ b/app/src/main/res/layout/admin_pin_activity.xml
@@ -17,10 +17,10 @@
     <androidx.appcompat.widget.Toolbar
       android:id="@+id/admin_pin_toolbar"
       android:layout_width="match_parent"
-      android:layout_height="?attr/actionBarSize"
-
+      android:layout_height="wrap_content"
+      android:minHeight="?attr/actionBarSize"
       android:elevation="4dp"
-android:theme="@style/OppiaActionBarTheme"
+      android:theme="@style/OppiaActionBarTheme"
       style="@style/AdminPinToolbarTextAppearance"
       app:titleTextAppearance="@style/AdminPinToolbarTextAppearance"
       app:titleTextColor="@color/component_color_shared_activity_toolbar_text_color"

--- a/app/src/main/res/layout/admin_pin_activity.xml
+++ b/app/src/main/res/layout/admin_pin_activity.xml
@@ -29,16 +29,15 @@
 
     <androidx.core.widget.NestedScrollView
       android:id="@+id/scrollViewAdminPin"
-      android:layout_width="match_parent"
+      android:layout_width="@dimen/admin_auth_activity_layout_width"
       android:layout_height="0dp"
-      android:background="@color/component_color_shared_screen_secondary_background_color"
       android:fillViewport="true"
       android:overScrollMode="never"
       android:scrollbars="none"
-
-      android:layout_marginTop="0dp"
-      app:layout_constraintTop_toBottomOf="@id/admin_pin_toolbar"
       app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/admin_pin_toolbar"
       >
 
       <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/admin_pin_activity.xml
+++ b/app/src/main/res/layout/admin_pin_activity.xml
@@ -24,7 +24,6 @@
       style="@style/AdminPinToolbarTextAppearance"
       app:titleTextAppearance="@style/AdminPinToolbarTextAppearance"
       app:titleTextColor="@color/component_color_shared_activity_toolbar_text_color"
-      app:navigationIcon="@drawable/ic_close_white_24dp"
       app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.core.widget.NestedScrollView

--- a/app/src/main/res/layout/admin_pin_activity.xml
+++ b/app/src/main/res/layout/admin_pin_activity.xml
@@ -13,14 +13,33 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+
+    <androidx.appcompat.widget.Toolbar
+      android:id="@+id/admin_pin_toolbar"
+      android:layout_width="match_parent"
+      android:layout_height="?attr/actionBarSize"
+
+      android:elevation="4dp"
+android:theme="@style/OppiaActionBarTheme"
+      style="@style/AdminPinToolbarTextAppearance"
+      app:titleTextAppearance="@style/AdminPinToolbarTextAppearance"
+      app:titleTextColor="@color/component_color_shared_activity_toolbar_text_color"
+      app:navigationIcon="@drawable/ic_close_white_24dp"
+      app:layout_constraintTop_toTopOf="parent" />
+
     <androidx.core.widget.NestedScrollView
       android:id="@+id/scrollViewAdminPin"
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
+      android:layout_height="0dp"
       android:background="@color/component_color_shared_screen_secondary_background_color"
       android:fillViewport="true"
       android:overScrollMode="never"
-      android:scrollbars="none">
+      android:scrollbars="none"
+
+      android:layout_marginTop="0dp"
+      app:layout_constraintTop_toBottomOf="@id/admin_pin_toolbar"
+      app:layout_constraintBottom_toBottomOf="parent"
+      >
 
       <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/admin_auth_container"

--- a/app/src/main/res/layout/admin_pin_activity.xml
+++ b/app/src/main/res/layout/admin_pin_activity.xml
@@ -34,6 +34,7 @@
       android:fillViewport="true"
       android:overScrollMode="never"
       android:scrollbars="none"
+      android:background="@color/component_color_shared_screen_secondary_background_color"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -632,4 +632,8 @@
     <item name="android:windowEnterAnimation">@anim/slide_up</item>
     <item name="android:windowExitAnimation">@anim/slide_down</item>
   </style>
+
+  <style name="AdminPinToolbarTextAppearance" parent="TextAppearance.Widget.AppCompat.Toolbar.Title">
+    <item name="android:textSize">20sp</item>
+  </style>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.2.2'
+    classpath 'com.android.tools.build:gradle:3.6.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.17'
     classpath 'com.google.gms:google-services:4.3.3'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.6.1'
+    classpath 'com.android.tools.build:gradle:4.2.2'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.17'
     classpath 'com.google.gms:google-services:4.3.3'


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix  #4735 , Added toolbar in admin_pin_activity xml file inorder to control the title size using sp.

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only

Before fix
Admin pin activity
| Light mode| 
|--------|
|![before light](https://github.com/oppia/oppia-android/assets/76042077/e80cd747-b04c-43c5-96b9-848dc5db3400) | 

After fix
|Light mode| Dark mode|
|-----------|--------------|
| ![afterlightmode](https://github.com/oppia/oppia-android/assets/76042077/4445ebd1-3fde-40f4-a4cb-cb3716aad43e) | ![afterdarkmode](https://github.com/oppia/oppia-android/assets/76042077/98bd0994-5f4d-464f-b170-d21e167a9eaa) |




<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
