### PR TITLE
Fix #5094 : [Wiki update] Bazel build failed in mac m1

### DIFF
--- a/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
+++ b/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
@@ -125,7 +125,7 @@ const val FAST_LANGUAGE_SWITCHING_IN_LESSON = "fast_language_switching_in_lesson
 /**
  * The default enabled state for the feature corresponding to [EnableFastLanguageSwitchingInLesson].
  */
-const val FAST_LANGUAGE_SWITCHING_IN_LESSON_DEFAULT_VALUE = true
+const val FAST_LANGUAGE_SWITCHING_IN_LESSON_DEFAULT_VALUE = false
 
 /**
  * Qualifier for a feature flag that controls whether learner study IDs should be generated and

--- a/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
+++ b/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
@@ -125,7 +125,7 @@ const val FAST_LANGUAGE_SWITCHING_IN_LESSON = "fast_language_switching_in_lesson
 /**
  * The default enabled state for the feature corresponding to [EnableFastLanguageSwitchingInLesson].
  */
-const val FAST_LANGUAGE_SWITCHING_IN_LESSON_DEFAULT_VALUE = false
+const val FAST_LANGUAGE_SWITCHING_IN_LESSON_DEFAULT_VALUE = true
 
 /**
  * Qualifier for a feature flag that controls whether learner study IDs should be generated and

--- a/wiki/Troubleshooting-Installation.md
+++ b/wiki/Troubleshooting-Installation.md
@@ -10,9 +10,12 @@ Here are some general troubleshooting tips for oppia-android. The specific platf
 
 1. If you find any error related to `cURL`, please set up cURL on your machine. For Linux, you can use `sudo apt install curl`. No need to set up `cURL` for Windows as you are using git bash command line.<br>
 
+
 2. If you find any error which says `java: command not found`, please check you have Java installed correctly in your machine and the [environment path variable](https://www.java.com/en/download/help/path.html) is also set up correctly.
 
+
 3. If you find any error related to Kotlin or Java/Checkstyle while pushing the code, please check [this link](https://github.com/oppia/oppia-android/wiki/Android-Studio-UI-based-Github-workflow#how-to-fix-push-failures).
+
 
 4. If you see the error
 
@@ -21,6 +24,7 @@ Here are some general troubleshooting tips for oppia-android. The specific platf
    ```
 
    then please follow the 2nd step mentioned in [this wiki](https://github.com/oppia/oppia-android/wiki/Installing-Oppia-Android#install-oppia-android) for Mac with Apple silicon(M1/M2) chips.
+
 
 5. If you see the error
 
@@ -70,6 +74,7 @@ Here are some general troubleshooting tips for oppia-android. The specific platf
     ```
     [Steps](https://docs.bazel.build/versions/main/tutorial/android-app.html#integrate-with-the-android-sdk) to add ANDROID_HOME environment variable.
 
+
 2. If you encounter the following:
 
    ```
@@ -79,10 +84,32 @@ Here are some general troubleshooting tips for oppia-android. The specific platf
    
    Try to delete the `.bazelrc` file to solve the above error. 
 
+
 3. **java.lang.ClassNotFoundException: com.android.tools.r8.compatdx.CompatDx**
 
    If, when building the app binary, you encounter a failure that indicates that the CompatDx file cannot be found, this is likely due to you using a newer version of the Android build tools. You can manually downgrade to an older version of build-tools (particularly 29.0.2). Unfortunately, this can't be done through Android Studio but it can be done over a terminal. Follow the instructions listed [here](https://github.com/oppia/oppia-android/issues/3024#issuecomment-884513455) to downgrade your build tools & then try to build the app again.
 
+
+4. If you encounter this error while building bazel in Mac M1:
+      ```
+      ERROR: /Users/OpenSource/oppia-android/model/src/main/proto/BUILD.bazel:167:20: Generating JavaLite proto_library //model/src/main/proto:profile_proto failed: (Segmentation fault): protoc failed: error executing command bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/protoc '--proto_path=bazel-out/android-armeabi-v7a-fastbuild/bin/model/src/main/proto/_virtual_imports/languages_proto' ... (remaining 8 argument(s) skipped)
+
+      Use --sandbox_debug to see verbose messages from the sandbox protoc failed: error executing command bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/protoc '--proto_path=bazel-out/android-armeabi-v7a-fastbuild/bin/model/src/main/proto/_virtual_imports/languages_proto' ... (remaining 8 argument(s) skipped)
+      ```
+
+   **Follow these steps to solve this error:**
+      ```
+      xcode-select --install
+      sudo xcodebuild -licence
+      sudo xcode-select -r 
+      sudo xcode-select -s /Library/Developer/CommandLineTools
+      xcode-select -p 
+      ```
+   After you successfully run above commands, build app using Bazel by following command:
+      ```
+      bazel clean --expunge
+      bazel build //:oppia --noexperimental_check_desugar_deps
+      ```
 
 ### Can’t find a particular issue?
 

--- a/wiki/Troubleshooting-Installation.md
+++ b/wiki/Troubleshooting-Installation.md
@@ -96,20 +96,29 @@ Here are some general troubleshooting tips for oppia-android. The specific platf
 
       Use --sandbox_debug to see verbose messages from the sandbox protoc failed: error executing command bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/protoc '--proto_path=bazel-out/android-armeabi-v7a-fastbuild/bin/model/src/main/proto/_virtual_imports/languages_proto' ... (remaining 8 argument(s) skipped)
       ```
+Bazel requires Xcode commandline tools to build on M1, and the Xcode license also needs to be accepted.
 
    **Follow these steps to solve this error:**
-      ```
-      xcode-select --install
-      sudo xcodebuild -licence
-      sudo xcode-select -r 
-      sudo xcode-select -s /Library/Developer/CommandLineTools
-      xcode-select -p 
-      ```
-   After you successfully run above commands, build app using Bazel by following command:
+
+- Install the commandline tools: `xcode-select --install`
+
+- Accept the Xcode licence: `sudo xcodebuild -licence`
+
+- Reset the xcode select path: `sudo xcode-select -r `
+
+ - Set the xcode select path to use CommandLineTools: `sudo xcode-select -s /Library/Developer/CommandLineTools`
+
+- Confirm that the path was correctly set. The expected output is: `/Library/Developer/CommandLineTools`
+
+      xcode-select -p
+
+After you successfully run above commands, build app using Bazel by following command:
+
       ```
       bazel clean --expunge
       bazel build //:oppia --noexperimental_check_desugar_deps
       ```
+The `--noexperimental_check_desugar_deps` flag is explained in the [bazel blog](https://blog.bazel.build/2018/12/19/bazel-0.21.html#android).
 
 ### Can’t find a particular issue?
 

--- a/wiki/Troubleshooting-Installation.md
+++ b/wiki/Troubleshooting-Installation.md
@@ -112,7 +112,7 @@ Bazel requires Xcode commandline tools to build on M1, and the Xcode license als
 
       xcode-select -p
 
-After you successfully run above commands, build app using Bazel by following command:
+After successfully running the above commands, build the app using Bazel by running the following command:
 
       ```
       bazel clean --expunge


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fix #5094 : [Wiki update] Bazel build failed in mac m1

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
