### PR TITLE
Fix #3841: Combine time and quantity plurals

### DIFF
--- a/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapters.java
+++ b/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapters.java
@@ -83,13 +83,13 @@ public final class TextViewBindingAdapters {
     } else if (timeDifferenceMillis < TimeUnit.MINUTES.toMillis(50)) {
       return getPluralString(
               resourceHandler,
-          R.plurals.minutes,
+          R.plurals.minutes_ago,
           (int) TimeUnit.MILLISECONDS.toMinutes(timeDifferenceMillis)
       );
     } else if (timeDifferenceMillis < TimeUnit.DAYS.toMillis(1)) {
       return getPluralString(
               resourceHandler,
-          R.plurals.hours,
+          R.plurals.hours_ago,
           (int) TimeUnit.MILLISECONDS.toHours(timeDifferenceMillis)
       );
     } else if (timeDifferenceMillis < TimeUnit.DAYS.toMillis(2)) {
@@ -97,7 +97,7 @@ public final class TextViewBindingAdapters {
     }
     return getPluralString(
             resourceHandler,
-        R.plurals.days,
+        R.plurals.days_ago,
         (int) TimeUnit.MILLISECONDS.toDays(timeDifferenceMillis)
     );
   }

--- a/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapters.java
+++ b/app/src/main/java/org/oppia/android/app/databinding/TextViewBindingAdapters.java
@@ -107,13 +107,9 @@ public final class TextViewBindingAdapters {
       @PluralsRes int pluralsResId,
       int count
   ) {
-    // TODO(#3841): Combine these strings together.
-    return resourceHandler.getStringInLocaleWithWrapping(
-        R.string.time_ago,
-        resourceHandler.getQuantityStringInLocaleWithWrapping(
+    return resourceHandler.getQuantityStringInLocaleWithWrapping(
             pluralsResId, count, String.valueOf(count)
-        )
-    );
+        );
   }
 
   private static long ensureTimestampIsInMilliseconds(long lastVisitedTimestamp) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -468,7 +468,7 @@
   <!-- TextViewBindingAdapters -->
   <string name="just_now">just now</string>
   <string name="last_logged_in_recently">recently</string>
-  <string name="time_ago">%s ago</string>
+  <string name="time_ago">%s</string>
   <string name="yesterday">yesterday</string>
   <string name="return_to_topic">Return to topic</string>
   <string name="return_to_lesson">Return to lesson</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -481,17 +481,18 @@
   <string name="up_button_disabled">Up</string>
   <string name="down_button_disabled">Down</string>
   <string name="profile_last_visited">%s %s</string>
-  <plurals name="minutes">
-    <item quantity="one">a minute</item>
-    <item quantity="other">%s minutes</item>
+  <plurals name="minutes_ago">
+    <item quantity="zero">zero minutes ago</item>
+    <item quantity="one">a minute ago</item>
+    <item quantity="other">%s minutes ago</item>
   </plurals>
-  <plurals name="hours">
-    <item quantity="one">an hour</item>
-    <item quantity="other">%s hours</item>
+  <plurals name="hours_ago">
+    <item quantity="one">an hour ago</item>
+    <item quantity="other">%s hours ago</item>
   </plurals>
-  <plurals name="days">
-    <item quantity="one">a day</item>
-    <item quantity="other">%s days</item>
+  <plurals name="days_ago">
+    <item quantity="one">a day ago</item>
+    <item quantity="other">%s days ago</item>
   </plurals>
   <!-- ViewTags -->
   <string name="topic_revision_recyclerview_tag">topic_revision_recyclerview_tag</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -468,7 +468,6 @@
   <!-- TextViewBindingAdapters -->
   <string name="just_now">just now</string>
   <string name="last_logged_in_recently">recently</string>
-  <string name="time_ago">%s</string>
   <string name="yesterday">yesterday</string>
   <string name="return_to_topic">Return to topic</string>
   <string name="return_to_lesson">Return to lesson</string>
@@ -482,7 +481,7 @@
   <string name="down_button_disabled">Down</string>
   <string name="profile_last_visited">%s %s</string>
   <plurals name="minutes_ago">
-    <item quantity="zero">0 minute ago</item>
+    <item quantity="zero">0 minutes ago</item>
     <item quantity="one">a minute ago</item>
     <item quantity="other">%s minutes ago</item>
   </plurals>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -482,7 +482,7 @@
   <string name="down_button_disabled">Down</string>
   <string name="profile_last_visited">%s %s</string>
   <plurals name="minutes_ago">
-    <item quantity="zero">zero minutes ago</item>
+    <item quantity="zero">0 minute ago</item>
     <item quantity="one">a minute ago</item>
     <item quantity="other">%s minutes ago</item>
   </plurals>


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->Fixes #3841 

This PR involves Combining plurals and quantity strings from:
` <string name="time_ago">%s ago</string>`

and

```
<plurals name="minutes">
  <item quantity="one">a minute</item>
  <item quantity="other">%s minutes</item>
</plurals>
```

to

```
 <plurals name="minutes_ago">
    <item quantity="one">a minute ago</item>
    <item quantity="other">%s minutes ago</item>
  </plurals>
```

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing

| BEFORE  | AFTER |
| ------------- | ------------- |
| ![Before](https://github.com/oppia/oppia-android/assets/92685651/f3daf711-b96d-4ca7-8e49-d13c14769fb4)| ![after](https://github.com/oppia/oppia-android/assets/92685651/e303564a-9961-49fb-8258-75743bc5fb51)  |
| ![arabicbefore](https://github.com/oppia/oppia-android/assets/92685651/9c9d5c34-9ebb-42c3-9176-f69775f28e58) |![afterarabic](https://github.com/oppia/oppia-android/assets/92685651/471799da-10e9-4691-beb5-3b87edea1e8f) |
