### PR TITLE
fix #5150: set layout params correctly

### DIFF
--- a/app/src/main/java/org/oppia/android/app/databinding/MarginBindingAdapters.java
+++ b/app/src/main/java/org/oppia/android/app/databinding/MarginBindingAdapters.java
@@ -15,7 +15,7 @@ public final class MarginBindingAdapters {
     if (view.getLayoutParams() instanceof MarginLayoutParams) {
       MarginLayoutParams params = (MarginLayoutParams) view.getLayoutParams();
       MarginLayoutParamsCompat.setMarginStart(params, (int) marginStart);
-      view.requestLayout();
+      view.setLayoutParams(params);
     }
   }
 
@@ -25,7 +25,7 @@ public final class MarginBindingAdapters {
     if (view.getLayoutParams() instanceof MarginLayoutParams) {
       MarginLayoutParams params = (MarginLayoutParams) view.getLayoutParams();
       MarginLayoutParamsCompat.setMarginEnd(params, (int) marginEnd);
-      view.requestLayout();
+      view.setLayoutParams(params);
     }
   }
 
@@ -36,7 +36,6 @@ public final class MarginBindingAdapters {
       MarginLayoutParams params = (MarginLayoutParams) view.getLayoutParams();
       params.topMargin = (int) marginTop;
       view.setLayoutParams(params);
-      view.requestLayout();
     }
   }
 
@@ -47,22 +46,6 @@ public final class MarginBindingAdapters {
       MarginLayoutParams params = (MarginLayoutParams) view.getLayoutParams();
       params.bottomMargin = (int) marginBottom;
       view.setLayoutParams(params);
-      view.requestLayout();
-    }
-  }
-
-  /** Used to set a margin for views. */
-  @BindingAdapter("app:layoutMargin")
-  public static void setLayoutMargin(@NonNull View view, float margin) {
-    if (view.getLayoutParams() instanceof MarginLayoutParams) {
-      MarginLayoutParams params = (MarginLayoutParams) view.getLayoutParams();
-      params.setMargins(
-          (int) margin,
-          (int) margin,
-          (int) margin,
-          (int) margin
-      );
-      view.requestLayout();
     }
   }
 }


### PR DESCRIPTION
fix #5150. Previously layout params were not set after being updated. Also, the `requestLayout` call on the view is not needed, because the view layout is not changing. [Video](https://drive.google.com/file/d/13sw2PiZ_5lu2mnW0y4PjSS502hOZ_Vni/view?usp=sharing) which shows that it works.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
