### PR TITLE
Fix #5164 Format strings.xml(values-en) so that string tags are on one line

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,21 +164,11 @@
   <string name="number_error_starting_with_floating_point">Please begin your answer with a number (e.g.,”0” in 0.5).</string>
   <string name="number_error_invalid_format">Please enter a valid number.</string>
   <string name="number_error_larger_than_fifteen_characters">The answer can contain at most 15 digits (0–9) or symbols (. or -).</string>
-  <string name="ratio_error_invalid_chars" description="The error message for ratio when there is any other character used than 0123456789:. ">
-    Please write a ratio that consists of digits separated by colons (e.g. 1:2 or 1:2:3).
-  </string>
-  <string name="ratio_error_invalid_format" description="The error message for ratio when the format is invalid. For e.g. 1:2:3: or 1:2 3:4 ">
-    Please enter a valid ratio (e.g. 1:2 or 1:2:3).
-  </string>
-  <string name="ratio_error_invalid_colons" description="The error message for ratio when there is colons next to each other.">
-    Your answer has two colons (:) next to each other.
-  </string>
-  <string name="ratio_error_invalid_size" description="The error message for ratio when there is less number of terms than the creator has specified in customization arg.">
-    Number of terms is not equal to the required terms.
-  </string>
-  <string name="ratio_error_includes_zero" description="The error message for ratio when there is 0 term in the ratio.">
-    Ratios cannot have 0 as an element.
-  </string>
+  <string name="ratio_error_invalid_chars" description="The error message for ratio when there is any other character used than 0123456789:. ">Please write a ratio that consists of digits separated by colons (e.g. 1:2 or 1:2:3).</string>
+  <string name="ratio_error_invalid_format" description="The error message for ratio when the format is invalid. For e.g. 1:2:3: or 1:2 3:4 ">Please enter a valid ratio (e.g. 1:2 or 1:2:3).</string>
+  <string name="ratio_error_invalid_colons" description="The error message for ratio when there is colons next to each other.">Your answer has two colons (:) next to each other.</string>
+  <string name="ratio_error_invalid_size" description="The error message for ratio when there is less number of terms than the creator has specified in customization arg.">Number of terms is not equal to the required terms.</string>
+  <string name="ratio_error_includes_zero" description="The error message for ratio when there is 0 term in the ratio.">Ratios cannot have 0 as an element.</string>
   <string name="unknown_size">Unknown size</string>
   <string name="size_bytes">%s Bytes</string>
   <string name="size_kb">%s KB</string>
@@ -188,54 +178,30 @@
   <string name="topic_prefix">Topic: %s</string>
   <string name="welcome_profile_name">%s!</string>
   <plurals name="chapter_count">
-    <item quantity="one">
-      1 Chapter
-    </item>
-    <item quantity="other">
-      %s Chapters
-    </item>
+    <item quantity="one">1 Chapter</item>
+    <item quantity="other">%s Chapters</item>
   </plurals>
   <plurals name="story_count">
-    <item quantity="one">
-      1 Story
-    </item>
-    <item quantity="other">
-      %s Stories
-    </item>
+    <item quantity="one">1 Story</item>
+    <item quantity="other">%s Stories</item>
   </plurals>
   <plurals name="story_total_chapters">
     <item quantity="one">%s of %s Chapter Completed</item>
     <item quantity="other">%s of %s Chapters Completed</item>
   </plurals>
   <plurals name="lesson_count">
-    <item quantity="one">
-      1 Lesson
-    </item>
-    <item quantity="other">
-      %s Lessons
-    </item>
+    <item quantity="one">1 Lesson</item>
+    <item quantity="other">%s Lessons</item>
   </plurals>
   <plurals name="completed_story_count">
-    <item quantity="one">
-      1 Story Completed
-    </item>
-    <item quantity="other">
-      %s Stories Completed
-    </item>
-    <item quantity="zero">
-      %s Stories Completed
-    </item>
+    <item quantity="one">1 Story Completed</item>
+    <item quantity="other">%s Stories Completed</item>
+    <item quantity="zero">%s Stories Completed</item>
   </plurals>
   <plurals name="ongoing_topic_count">
-    <item quantity="one">
-      1 Topic in Progress
-    </item>
-    <item quantity="other">
-      %s Topics in Progress
-    </item>
-    <item quantity="zero">
-      %s Topics in Progress
-    </item>
+    <item quantity="one">1 Topic in Progress</item>
+    <item quantity="other">%s Topics in Progress</item>
+    <item quantity="zero">%s Topics in Progress</item>
   </plurals>
   <string name="bar_separator">\u0020|\u0020</string>
   <!-- ProfileChooserFragment -->
@@ -499,15 +465,9 @@
   <string name="completed_story_list_recyclerview_tag">completed_story_list_recyclerview_tag</string>
   <string name="item_selection_text">Please select all correct choices.</string>
   <!-- SplashActivity -->
-  <string name="unsupported_app_version_dialog_title" description="The title of the dialog shown when a user's pre-release app has expired.">
-    Unsupported app version
-  </string>
-  <string name="unsupported_app_version_dialog_message" description="The main message of the dialog shown when a user's pre-release app has expired.">
-    This version of the app is no longer supported. Please update it through the Play Store.
-  </string>
-  <string name="unsupported_app_version_dialog_close_button_text" description="The close button text of the dialog shown when a user's pre-release app has expired.">
-    Close app
-  </string>
+  <string name="unsupported_app_version_dialog_title" description="The title of the dialog shown when a user's pre-release app has expired.">Unsupported app version</string>
+  <string name="unsupported_app_version_dialog_message" description="The main message of the dialog shown when a user's pre-release app has expired.">This version of the app is no longer supported. Please update it through the Play Store.</string>
+  <string name="unsupported_app_version_dialog_close_button_text" description="The close button text of the dialog shown when a user's pre-release app has expired.">Close app</string>
   <string name="splash_screen_developer_label">Developer Build</string>
   <string name="splash_screen_alpha_label">Alpha</string>
   <string name="splash_screen_beta_label">Beta</string>
@@ -519,12 +479,8 @@
   <string name="general_availability_notice_dialog_message">Hello! Your app is now being updated to the General Availability version. If you experience problems while using the app, or have questions, please contact us at android-feedback@oppia.org.</string>
   <string name="general_availability_notice_dialog_do_not_show_again_text">Don\'t show this message again</string>
   <string name="general_availability_notice_dialog_close_button_text">OK</string>
-  <string name="ratio_content_description_separator" description="The separator that would be used to build the text that would be read out for ratio interaction.For e.g if the input is 1:2:3 the read out text would be 1 to 2 to 3">
-    \u0020to\u0020
-  </string>
-  <string name="ratio_default_hint_text" description="The default hint text for the ratio interaction if the placeholder text is not available.">
-    Enter a ratio in the form x:y.
-  </string>
+  <string name="ratio_content_description_separator" description="The separator that would be used to build the text that would be read out for ratio interaction.For e.g if the input is 1:2:3 the read out text would be 1 to 2 to 3">\u0020to\u0020</string>
+  <string name="ratio_default_hint_text" description="The default hint text for the ratio interaction if the placeholder text is not available.">Enter a ratio in the form x:y.</string>
   <string name="text_input_default_hint_text">Tap here to enter text.</string>
   <string name="smallest_text_size_content_description">Smallest text size</string>
   <string name="largest_text_size_content_description">Largest text size</string>


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix #5164 , format the strings.xml(values-en).
Because some strings are multiline, they are parsed with newlines on translatewiki which cascades down to the translated strings. This causes a problem with display. So formatted them to single line
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
