### PR TITLE
Fix #5170 [Feature Request]: Display some kind of loading animation/graphic when topics are loading in Home Page

### DIFF
--- a/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
@@ -101,7 +101,6 @@ class HomeFragmentPresenter @Inject constructor(
 
   private fun createRecyclerViewAdapter(): BindableAdapter<HomeItemViewModel> {
     return multiTypeBuilderFactory.create<HomeItemViewModel, ViewType> { viewModel ->
-      binding.homeFragmentProgressBar.visibility = View.GONE
       when (viewModel) {
         is WelcomeViewModel -> ViewType.WELCOME_MESSAGE
         is PromotedStoryListViewModel -> ViewType.PROMOTED_STORY_LIST

--- a/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
@@ -101,7 +101,7 @@ class HomeFragmentPresenter @Inject constructor(
 
   private fun createRecyclerViewAdapter(): BindableAdapter<HomeItemViewModel> {
     return multiTypeBuilderFactory.create<HomeItemViewModel, ViewType> { viewModel ->
-      binding.homeFragmentProgressBar.visibility=View.GONE
+      binding.homeFragmentProgressBar.visibility = View.GONE
       when (viewModel) {
         is WelcomeViewModel -> ViewType.WELCOME_MESSAGE
         is PromotedStoryListViewModel -> ViewType.PROMOTED_STORY_LIST

--- a/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
@@ -101,6 +101,7 @@ class HomeFragmentPresenter @Inject constructor(
 
   private fun createRecyclerViewAdapter(): BindableAdapter<HomeItemViewModel> {
     return multiTypeBuilderFactory.create<HomeItemViewModel, ViewType> { viewModel ->
+      binding.homeFragmentProgressBar.visibility=View.GONE
       when (viewModel) {
         is WelcomeViewModel -> ViewType.WELCOME_MESSAGE
         is PromotedStoryListViewModel -> ViewType.PROMOTED_STORY_LIST

--- a/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
@@ -1,8 +1,7 @@
 package org.oppia.android.app.home
 
-import android.view.View
-import android.widget.ProgressBar
 import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.ObservableField
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Transformations
@@ -60,6 +59,8 @@ class HomeViewModel(
     R.integer.promoted_story_list_limit
   )
 
+  val isProgressBarVisible=ObservableField(true)
+
   private val profileDataProvider: DataProvider<Profile> by lazy {
     profileManagementController.getProfile(profileId)
   }
@@ -96,13 +97,6 @@ class HomeViewModel(
     }
   }
 
-  fun hideProgressBar() {
-    val homefragment_progressbar = activity.findViewById<ProgressBar>(
-      R.id.home_fragment_progress_bar
-    )
-    homefragment_progressbar.visibility = View.GONE
-  }
-
   /**
    * [LiveData] of the list of items displayed in the HomeFragment RecyclerView. The list backing this live data will
    * automatically update if constituent parts of the UI change (e.g. if the promoted story list changes). If an error
@@ -121,7 +115,7 @@ class HomeViewModel(
         }
         is AsyncResult.Pending -> listOf()
         is AsyncResult.Success -> {
-          hideProgressBar()
+          isProgressBarVisible.set(false)
           itemListResult.value
         }
       }

--- a/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
@@ -59,6 +59,13 @@ class HomeViewModel(
     R.integer.promoted_story_list_limit
   )
 
+/**
+ * A Boolean property indicating the visibility state of a progress bar.
+ * This property is used to control the visibility of a progress bar in a user interface.
+ * When set to true, the progress bar is made visible, indicating that an ongoing task
+ * or operation is in progress. When set to false, the progress bar is hidden, indicating
+ * that the operation has completed.
+ */
   val isProgressBarVisible = ObservableField(true)
 
   private val profileDataProvider: DataProvider<Profile> by lazy {

--- a/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
@@ -97,7 +97,9 @@ class HomeViewModel(
   }
 
   fun hideProgressBar() {
-    val homefragment_progressbar = activity.findViewById<ProgressBar>(R.id.home_fragment_progress_bar)
+    val homefragment_progressbar = activity.findViewById<ProgressBar>(
+      R.id.home_fragment_progress_bar
+    )
     homefragment_progressbar.visibility = View.GONE
   }
 

--- a/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
@@ -1,6 +1,5 @@
 package org.oppia.android.app.home
 
-import android.opengl.Visibility
 import android.view.View
 import android.widget.ProgressBar
 import androidx.appcompat.app.AppCompatActivity
@@ -97,9 +96,9 @@ class HomeViewModel(
     }
   }
 
-  fun hideProgressBar(){
-    val homefragment_progressbar=activity.findViewById<ProgressBar>(R.id.home_fragment_progress_bar)
-    homefragment_progressbar.visibility=View.GONE
+  fun hideProgressBar() {
+    val homefragment_progressbar = activity.findViewById<ProgressBar>(R.id.home_fragment_progress_bar)
+    homefragment_progressbar.visibility = View.GONE
   }
 
   /**

--- a/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
@@ -60,12 +60,12 @@ class HomeViewModel(
   )
 
 /**
- * A Boolean property indicating the visibility state of a progress bar.
- * This property is used to control the visibility of a progress bar in a user interface.
- * When set to true, the progress bar is made visible, indicating that an ongoing task
- * or operation is in progress. When set to false, the progress bar is hidden, indicating
- * that the operation has completed.
- */
+   * A Boolean property indicating the visibility state of a progress bar.
+   * This property is used to control the visibility of a progress bar in a user interface.
+   * When set to true, the progress bar is made visible, indicating that an ongoing task
+   * or operation is in progress. When set to false, the progress bar is hidden, indicating
+   * that the operation has completed.
+   */
   val isProgressBarVisible = ObservableField(true)
 
   private val profileDataProvider: DataProvider<Profile> by lazy {

--- a/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
@@ -63,7 +63,7 @@ class HomeViewModel(
    * A Boolean property indicating the visibility state of a progress bar.
    * This property is used to control the visibility of a progress bar in a user interface.
    * When set to true, the progress bar is made visible, indicating that an ongoing task
-   * or operation is in progress. When set to false, the progress bar is hidden, indicating
+   * or operation is in progress or pending or failed. When set to false, the progress bar is hidden, indicating
    * that the operation has completed.
    */
   val isProgressBarVisible = ObservableField(true)

--- a/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
@@ -59,7 +59,7 @@ class HomeViewModel(
     R.integer.promoted_story_list_limit
   )
 
-  val isProgressBarVisible=ObservableField(true)
+  val isProgressBarVisible = ObservableField(true)
 
   private val profileDataProvider: DataProvider<Profile> by lazy {
     profileManagementController.getProfile(profileId)

--- a/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
@@ -1,5 +1,8 @@
 package org.oppia.android.app.home
 
+import android.opengl.Visibility
+import android.view.View
+import android.widget.ProgressBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LiveData
@@ -94,6 +97,11 @@ class HomeViewModel(
     }
   }
 
+  fun hideProgressBar(){
+    val homefragment_progressbar=activity.findViewById<ProgressBar>(R.id.home_fragment_progress_bar)
+    homefragment_progressbar.visibility=View.GONE
+  }
+
   /**
    * [LiveData] of the list of items displayed in the HomeFragment RecyclerView. The list backing this live data will
    * automatically update if constituent parts of the UI change (e.g. if the promoted story list changes). If an error
@@ -111,7 +119,10 @@ class HomeViewModel(
           listOf()
         }
         is AsyncResult.Pending -> listOf()
-        is AsyncResult.Success -> itemListResult.value
+        is AsyncResult.Success -> {
+          hideProgressBar()
+          itemListResult.value
+        }
       }
     }
   }

--- a/app/src/main/res/layout/home_fragment.xml
+++ b/app/src/main/res/layout/home_fragment.xml
@@ -17,6 +17,13 @@
     android:background="@color/component_color_shared_screen_primary_background_color"
     android:gravity="center">
 
+    <ProgressBar
+      android:id="@+id/home_fragment_progress_bar"
+      android:layout_width="60dp"
+      android:layout_height="60dp"
+      android:layout_gravity="center"
+      />
+
     <androidx.recyclerview.widget.RecyclerView
       android:id="@+id/home_recycler_view"
       android:layout_width="match_parent"

--- a/app/src/main/res/layout/home_fragment.xml
+++ b/app/src/main/res/layout/home_fragment.xml
@@ -21,6 +21,7 @@
       android:layout_width="60dp"
       android:layout_height="60dp"
       android:layout_gravity="center"
+      android:indeterminateTint="@color/component_color_home_activity_progressbar_color"
       android:visibility="@{viewModel.isProgressBarVisible?View.VISIBLE:View.GONE}"
       />
 

--- a/app/src/main/res/layout/home_fragment.xml
+++ b/app/src/main/res/layout/home_fragment.xml
@@ -3,9 +3,8 @@
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <data>
-
     <import type="org.oppia.android.R" />
-
+    <import type="android.view.View" />
     <variable
       name="viewModel"
       type="org.oppia.android.app.home.HomeViewModel" />
@@ -22,6 +21,7 @@
       android:layout_width="60dp"
       android:layout_height="60dp"
       android:layout_gravity="center"
+      android:visibility="@{viewModel.isProgressBarVisible?View.VISIBLE:View.GONE}"
       />
 
     <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -223,6 +223,7 @@
   <!-- Home Activity -->
   <color name="component_color_home_activity_view_all_text_color">@color/color_palette_view_all_text_color</color>
   <color name="component_color_home_activity_layout_greeting_text_line_color">@color/color_palette_layout_below_greeting_text_color</color>
+  <color name="component_color_home_activity_progressbar_color">@color/color_palette_progress_bar_solid_color</color>
   <!-- CONFETTI COLORS -->
   <color name="component_color_confetti_red_color">@color/color_palette_confetti_red_color</color>
   <color name="component_color_confetti_yellow_color">@color/color_palette_confetti_yellow_color</color>

--- a/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
@@ -266,7 +266,7 @@ class HomeActivityTest {
       onView(withId(R.id.home_fragment_progress_bar)).check(
         matches(
           not(
-            isDisplayed()
+           isDisplayed()
           )
         )
       )

--- a/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
@@ -266,7 +266,7 @@ class HomeActivityTest {
       onView(withId(R.id.home_fragment_progress_bar)).check(
         matches(
           not(
-           isDisplayed()
+            isDisplayed()
           )
         )
       )

--- a/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
@@ -247,6 +247,19 @@ class HomeActivityTest {
   }
 
   @Test
+  fun testHomeActivity_loadingItemsPending_progressbarIsDisplayed() {
+    fakeOppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
+
+    launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      onView(withId(R.id.home_fragment_progress_bar)).check(
+        matches(
+          isDisplayed()
+        )
+      )
+    }
+  }
+
+  @Test
   fun testHomeActivity_withAdminProfile_profileNameIsDisplayed() {
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
       testCoroutineDispatchers.runCurrent()

--- a/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
@@ -259,6 +259,21 @@ class HomeActivityTest {
   }
 
   @Test
+  fun testHomeActivity_loadingItemsSuccess_checkProgressbarIsNotDisplayed() {
+    fakeOppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
+    launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(withId(R.id.home_fragment_progress_bar)).check(
+        matches(
+          not(
+            isDisplayed()
+          )
+        )
+      )
+    }
+  }
+
+  @Test
   fun testHomeActivity_hasCorrectActivityLabel() {
     launch(HomeActivity::class.java).use { scenario ->
       scenario.onActivity { activity ->

--- a/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
@@ -247,7 +247,6 @@ class HomeActivityTest {
   }
 
   @Test
-<<<<<<< HEAD
   fun testHomeActivity_loadingItemsPending_progressbarIsDisplayed() {
     fakeOppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
 

--- a/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
@@ -273,8 +273,6 @@ class HomeActivityTest {
   }
 
   @Test
-=======
->>>>>>> 136bb440ba294dac28c22dc5a8da5af46c943aed
   fun testHomeActivity_hasCorrectActivityLabel() {
     launch(HomeActivity::class.java).use { scenario ->
       scenario.onActivity { activity ->

--- a/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/HomeActivityTest.kt
@@ -249,25 +249,11 @@ class HomeActivityTest {
   @Test
   fun testHomeActivity_loadingItemsPending_progressbarIsDisplayed() {
     fakeOppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
-
     launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
       onView(withId(R.id.home_fragment_progress_bar)).check(
         matches(
           isDisplayed()
         )
-      )
-    }
-  }
-
-  @Test
-  fun testHomeActivity_withAdminProfile_profileNameIsDisplayed() {
-    launch<HomeActivity>(createHomeActivityIntent(internalProfileId)).use {
-      testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 0)
-      verifyExactTextOnHomeListItemAtPosition(
-        itemPosition = 0,
-        targetViewId = R.id.profile_name_text_view,
-        stringToMatch = "Admin!"
       )
     }
   }


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fix oppia/oppia-android#5170. Added progressbar to the home fragment to show loading. 
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only

Light mode

https://github.com/oppia/oppia-android/assets/76042077/d7ac57cb-47e0-43a1-b80c-7c64eaa67ddd

Darkmode

https://github.com/oppia/oppia-android/assets/76042077/1a13dd22-df4d-4dbd-bd06-19882a123d98




<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
