### PR TITLE
Fix #5171: Fixes all warnings in "Accessibility" category

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/state/ImageRegionSelectionInteractionView.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/ImageRegionSelectionInteractionView.kt
@@ -91,6 +91,10 @@ class ImageRegionSelectionInteractionView @JvmOverloads constructor(
     maybeInitializeClickableAreas()
   }
 
+  override fun performClick(): Boolean {
+    return super.performClick()
+  }
+
   fun setOnRegionClicked(onRegionClicked: OnClickableAreaClickedListener) {
     this.onRegionClicked = onRegionClicked
     maybeInitializeClickableAreas()

--- a/app/src/main/java/org/oppia/android/app/utility/ClickableAreasImage.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/ClickableAreasImage.kt
@@ -30,6 +30,7 @@ class ClickableAreasImage(
       if (motionEvent.action == MotionEvent.ACTION_DOWN) {
         onPhotoTap(motionEvent.x, motionEvent.y)
       }
+      view.performClick()
       return@setOnTouchListener false
     }
   }
@@ -110,10 +111,11 @@ class ClickableAreasImage(
       newView.isFocusable = true
       newView.isFocusableInTouchMode = true
       newView.tag = clickableArea.label
-      newView.setOnTouchListener { _, event ->
+      newView.setOnTouchListener { view, event ->
         if (event.action == MotionEvent.ACTION_DOWN) {
           showOrHideRegion(newView, clickableArea)
         }
+        view.performClick()
         return@setOnTouchListener true
       }
       if (isAccessibilityEnabled) {

--- a/app/src/main/res/layout-land/profile_chooser_fragment.xml
+++ b/app/src/main/res/layout-land/profile_chooser_fragment.xml
@@ -36,7 +36,8 @@
           android:visibility="gone"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintTop_toTopOf="parent"
-          app:srcCompat="@drawable/ic_language_icon_grey_24dp" />
+          app:srcCompat="@drawable/ic_language_icon_grey_24dp"
+          android:contentDescription="@string/language_icon_content_description" />
 
         <TextView
           style="@style/Subtitle1ViewCenter"
@@ -115,7 +116,8 @@
         android:paddingTop="12dp"
         android:paddingEnd="16dp"
         android:paddingBottom="12dp"
-        app:srcCompat="@drawable/ic_settings_grey_48dp" />
+        app:srcCompat="@drawable/ic_settings_grey_48dp"
+        android:contentDescription="@string/setting_icon_content_description" />
     </LinearLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout-land/topic_info_fragment.xml
+++ b/app/src/main/res/layout-land/topic_info_fragment.xml
@@ -105,7 +105,8 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/see_more_text_view"
         app:srcCompat="@{viewModel.downloadStatusIndicatorDrawableResourceId, default=@drawable/ic_available_offline_primary_24dp}"
-        app:tint="@color/component_color_topic_info_fragment_download_status_image_color" />
+        app:tint="@color/component_color_topic_info_fragment_download_status_image_color"
+        android:contentDescription="@string/download_status_content_description" />
 
       <TextView
         android:id="@+id/download_story_count_text_view"

--- a/app/src/main/res/layout-land/topic_info_fragment.xml
+++ b/app/src/main/res/layout-land/topic_info_fragment.xml
@@ -106,7 +106,7 @@
         app:layout_constraintTop_toBottomOf="@+id/see_more_text_view"
         app:srcCompat="@{viewModel.downloadStatusIndicatorDrawableResourceId, default=@drawable/ic_available_offline_primary_24dp}"
         app:tint="@color/component_color_topic_info_fragment_download_status_image_color"
-        android:contentDescription="@string/download_status_content_description" />
+        android:contentDescription="@string/download_status_image_content_description" />
 
       <TextView
         android:id="@+id/download_story_count_text_view"

--- a/app/src/main/res/layout-land/walkthrough_final_fragment.xml
+++ b/app/src/main/res/layout-land/walkthrough_final_fragment.xml
@@ -26,7 +26,8 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
-      app:srcCompat="@drawable/ic_portrait_onboarding_0" />
+      app:srcCompat="@drawable/ic_portrait_onboarding_0"
+      android:contentDescription="@string/walkthrough_final_content_description" />
 
     <LinearLayout
       android:id="@+id/walkthrough_button_container"

--- a/app/src/main/res/layout-land/walkthrough_final_fragment.xml
+++ b/app/src/main/res/layout-land/walkthrough_final_fragment.xml
@@ -27,7 +27,7 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
       app:srcCompat="@drawable/ic_portrait_onboarding_0"
-      android:contentDescription="@string/walkthrough_final_content_description" />
+      android:importantForAccessibility="no" />
 
     <LinearLayout
       android:id="@+id/walkthrough_button_container"

--- a/app/src/main/res/layout-land/walkthrough_welcome_fragment.xml
+++ b/app/src/main/res/layout-land/walkthrough_welcome_fragment.xml
@@ -61,7 +61,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_portrait_onboarding_0" />
+        app:srcCompat="@drawable/ic_portrait_onboarding_0"
+        android:contentDescription="@string/walkthrough_welcome_content_description" />
 
       <Button
         android:id="@+id/walkthrough_welcome_next_button"

--- a/app/src/main/res/layout-land/walkthrough_welcome_fragment.xml
+++ b/app/src/main/res/layout-land/walkthrough_welcome_fragment.xml
@@ -62,7 +62,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_portrait_onboarding_0"
-        android:contentDescription="@string/walkthrough_welcome_content_description" />
+        android:importantForAccessibility="no" />
 
       <Button
         android:id="@+id/walkthrough_welcome_next_button"

--- a/app/src/main/res/layout-sw600dp-land/topic_info_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-land/topic_info_fragment.xml
@@ -100,7 +100,7 @@
           app:layout_constraintTop_toBottomOf="@+id/see_more_text_view"
           app:srcCompat="@{viewModel.downloadStatusIndicatorDrawableResourceId, default=@drawable/ic_available_offline_primary_24dp}"
           app:tint="@color/component_color_topic_info_fragment_download_status_image_color"
-          android:contentDescription="@string/download_status_content_description" />
+          android:contentDescription="@string/download_status_image_content_description" />
 
         <TextView
           android:id="@+id/download_story_count_text_view"

--- a/app/src/main/res/layout-sw600dp-land/topic_info_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-land/topic_info_fragment.xml
@@ -99,7 +99,8 @@
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@+id/see_more_text_view"
           app:srcCompat="@{viewModel.downloadStatusIndicatorDrawableResourceId, default=@drawable/ic_available_offline_primary_24dp}"
-          app:tint="@color/component_color_topic_info_fragment_download_status_image_color" />
+          app:tint="@color/component_color_topic_info_fragment_download_status_image_color"
+          android:contentDescription="@string/download_status_content_description" />
 
         <TextView
           android:id="@+id/download_story_count_text_view"

--- a/app/src/main/res/layout-sw600dp-port/topic_info_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-port/topic_info_fragment.xml
@@ -119,7 +119,8 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/see_more_text_view"
         app:srcCompat="@{viewModel.downloadStatusIndicatorDrawableResourceId, default=@drawable/ic_available_offline_primary_24dp}"
-        app:tint="@color/component_color_topic_info_fragment_download_status_image_color" />
+        app:tint="@color/component_color_topic_info_fragment_download_status_image_color"
+        android:contentDescription="@string/download_status_content_description" />
 
       <TextView
         android:id="@+id/download_story_count_text_view"

--- a/app/src/main/res/layout-sw600dp-port/topic_info_fragment.xml
+++ b/app/src/main/res/layout-sw600dp-port/topic_info_fragment.xml
@@ -120,7 +120,7 @@
         app:layout_constraintTop_toBottomOf="@+id/see_more_text_view"
         app:srcCompat="@{viewModel.downloadStatusIndicatorDrawableResourceId, default=@drawable/ic_available_offline_primary_24dp}"
         app:tint="@color/component_color_topic_info_fragment_download_status_image_color"
-        android:contentDescription="@string/download_status_content_description" />
+        android:contentDescription="@string/download_status_image_content_description" />
 
       <TextView
         android:id="@+id/download_story_count_text_view"

--- a/app/src/main/res/layout-sw600dp/profile_chooser_fragment.xml
+++ b/app/src/main/res/layout-sw600dp/profile_chooser_fragment.xml
@@ -40,7 +40,8 @@
           android:visibility="gone"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintTop_toTopOf="parent"
-          app:srcCompat="@drawable/ic_language_icon_grey_24dp" />
+          app:srcCompat="@drawable/ic_language_icon_grey_24dp"
+          android:contentDescription="@string/language_icon_content_description" />
 
         <TextView
           style="@style/Subtitle1ViewCenter"
@@ -119,7 +120,8 @@
         android:layout_height="48dp"
         android:layout_marginEnd="@dimen/profile_chooser_setting_icon_margin_end"
         android:padding="8dp"
-        app:srcCompat="@drawable/ic_settings_grey_48dp" />
+        app:srcCompat="@drawable/ic_settings_grey_48dp"
+        android:contentDescription="@string/setting_icon_content_description" />
     </LinearLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout-sw600dp/story_chapter_view.xml
+++ b/app/src/main/res/layout-sw600dp/story_chapter_view.xml
@@ -115,7 +115,8 @@
             app:layout_constraintEnd_toEndOf="@id/chapter_thumbnail"
             app:layout_constraintStart_toStartOf="@id/chapter_thumbnail"
             app:layout_constraintTop_toTopOf="@id/chapter_thumbnail"
-            app:srcCompat="@drawable/ic_baseline_lock_24" />
+            app:srcCompat="@drawable/ic_baseline_lock_24"
+            android:contentDescription="@string/lock_icon_content_description" />
 
           <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_view_binding_adapters_test.xml
+++ b/app/src/main/res/layout/activity_view_binding_adapters_test.xml
@@ -17,6 +17,6 @@
       android:layout_gravity="center_vertical"
       android:padding="8dp"
       app:srcCompat="@drawable/ic_arrow_drop_down_black_24dp"
-      android:contentDescription="@string/test_drop_down_icon_content_description" />
+      android:importantForAccessibility="no" />
   </FrameLayout>
 </layout>

--- a/app/src/main/res/layout/activity_view_binding_adapters_test.xml
+++ b/app/src/main/res/layout/activity_view_binding_adapters_test.xml
@@ -16,6 +16,7 @@
       android:layout_height="48dp"
       android:layout_gravity="center_vertical"
       android:padding="8dp"
-      app:srcCompat="@drawable/ic_arrow_drop_down_black_24dp" />
+      app:srcCompat="@drawable/ic_arrow_drop_down_black_24dp"
+      android:contentDescription="@string/test_drop_down_icon_content_description" />
   </FrameLayout>
 </layout>

--- a/app/src/main/res/layout/app_version_fragment.xml
+++ b/app/src/main/res/layout/app_version_fragment.xml
@@ -41,7 +41,7 @@
       app:layout_constraintTop_toTopOf="@id/app_last_update_date_text_view"
       app:srcCompat="@drawable/ic_info_icon_gray_24dp"
       app:tint="@color/component_color_app_version_activity_info_icon_color"
-      android:contentDescription="@string/app_info_content_description" />
+      android:contentDescription="@string/app_info_icon_content_description" />
 
     <TextView
       android:id="@+id/app_last_update_date_text_view"

--- a/app/src/main/res/layout/app_version_fragment.xml
+++ b/app/src/main/res/layout/app_version_fragment.xml
@@ -40,7 +40,8 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="@id/app_last_update_date_text_view"
       app:srcCompat="@drawable/ic_info_icon_gray_24dp"
-      app:tint="@color/component_color_app_version_activity_info_icon_color" />
+      app:tint="@color/component_color_app_version_activity_info_icon_color"
+      android:contentDescription="@string/app_info_content_description" />
 
     <TextView
       android:id="@+id/app_last_update_date_text_view"

--- a/app/src/main/res/layout/bottom_left_overlay.xml
+++ b/app/src/main/res/layout/bottom_left_overlay.xml
@@ -25,7 +25,8 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
       app:srcCompat="@drawable/ic_rounded_arrow_up_right"
-      app:tint="@color/component_color_shared_spotlight_overlay_arrow_color" />
+      app:tint="@color/component_color_shared_spotlight_overlay_arrow_color"
+      android:contentDescription="@string/spotlight_overlay_arrow_content_description" />
 
     <com.google.android.material.card.MaterialCardView
       android:layout_width="0dp"
@@ -70,7 +71,8 @@
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintTop_toTopOf="parent"
           app:srcCompat="@drawable/ic_close_black_24"
-          app:tint="@color/component_color_shared_close_spotlight_button_color" />
+          app:tint="@color/component_color_shared_close_spotlight_button_color"
+          android:contentDescription="@string/close_spotlight_button_content_description" />
       </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.card.MaterialCardView>
   </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/bottom_right_overlay.xml
+++ b/app/src/main/res/layout/bottom_right_overlay.xml
@@ -26,7 +26,8 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
       app:srcCompat="@drawable/ic_rounded_arrow_up_right"
-      app:tint="@color/component_color_shared_spotlight_overlay_arrow_color" />
+      app:tint="@color/component_color_shared_spotlight_overlay_arrow_color"
+      android:contentDescription="@string/spotlight_overlay_arrow_content_description" />
 
     <com.google.android.material.card.MaterialCardView
       android:layout_width="0dp"
@@ -71,7 +72,8 @@
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintTop_toTopOf="parent"
           app:srcCompat="@drawable/ic_close_black_24"
-          app:tint="@color/component_color_shared_close_spotlight_button_color" />
+          app:tint="@color/component_color_shared_close_spotlight_button_color"
+          android:contentDescription="@string/close_spotlight_button_content_description" />
       </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.card.MaterialCardView>
   </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/continue_interaction_item.xml
+++ b/app/src/main/res/layout/continue_interaction_item.xml
@@ -46,7 +46,8 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
-      app:tint="@color/component_color_shared_back_forward_arrow_button_color" />
+      app:tint="@color/component_color_shared_back_forward_arrow_button_color"
+      android:contentDescription="@string/previous_state_navigation_button_content_description" />
 
     <org.oppia.android.app.customview.ContinueButtonView
       android:id="@+id/continue_interaction_button"

--- a/app/src/main/res/layout/continue_navigation_button_item.xml
+++ b/app/src/main/res/layout/continue_navigation_button_item.xml
@@ -45,7 +45,8 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
-      app:tint="@color/component_color_shared_back_forward_arrow_button_color" />
+      app:tint="@color/component_color_shared_back_forward_arrow_button_color"
+      android:contentDescription="@string/previous_state_navigation_button_content_description" />
 
     <org.oppia.android.app.customview.ContinueButtonView
       android:id="@+id/continue_navigation_button"

--- a/app/src/main/res/layout/drawer_fragment.xml
+++ b/app/src/main/res/layout/drawer_fragment.xml
@@ -67,7 +67,8 @@
             android:layout_height="24dp"
             android:layout_gravity="center_vertical"
             app:srcCompat="@drawable/ic_baseline_code_24"
-            android:tint="@{footerViewModel.isDeveloperOptionsSelected ? @color/component_color_drawer_fragment_developer_options_selected_image_color : @color/component_color_shared_primary_dark_text_color}" />
+            android:tint="@{footerViewModel.isDeveloperOptionsSelected ? @color/component_color_drawer_fragment_developer_options_selected_image_color : @color/component_color_shared_primary_dark_text_color}"
+            android:contentDescription="@string/developer_options_icon_content_description" />
 
           <TextView
             android:layout_width="match_parent"
@@ -98,7 +99,8 @@
             android:layout_height="24dp"
             android:layout_gravity="center_vertical"
             android:tint="@{footerViewModel.isAdministratorControlsSelected ? @color/component_color_drawer_fragment_admin_controls_selected_image_color : @color/component_color_shared_primary_dark_text_color}"
-            app:srcCompat="@drawable/ic_admin_settings_icon_brown_24dp" />
+            app:srcCompat="@drawable/ic_admin_settings_icon_brown_24dp"
+            android:contentDescription="@string/administrator_controls_icon_content_description" />
 
           <TextView
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/exploration_activity.xml
+++ b/app/src/main/res/layout/exploration_activity.xml
@@ -64,7 +64,8 @@
             android:layout_gravity="end"
             android:minWidth="48dp"
             android:minHeight="48dp"
-            android:scaleType="center" />
+            android:scaleType="center"
+            android:contentDescription="@string/options_menu_content_description" />
         </LinearLayout>
       </androidx.appcompat.widget.Toolbar>
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/math_expression_parser_fragment.xml
+++ b/app/src/main/res/layout/math_expression_parser_fragment.xml
@@ -77,6 +77,7 @@
           android:background="@drawable/state_button_primary_background"
           android:clickable="true"
           android:enabled="true"
+          android:focusable="true"
           android:onClick="@{(v) -> viewModel.onParseButtonClicked()}"
           android:text="@string/math_expression_parse_button_label"
           android:textSize="14sp"

--- a/app/src/main/res/layout/next_button_item.xml
+++ b/app/src/main/res/layout/next_button_item.xml
@@ -45,7 +45,8 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
-      app:tint="@color/component_color_shared_back_forward_arrow_button_color" />
+      app:tint="@color/component_color_shared_back_forward_arrow_button_color"
+      android:contentDescription="@string/previous_button_content_description" />
 
     <ImageButton
       android:id="@+id/next_state_navigation_button"
@@ -55,6 +56,7 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintTop_toTopOf="parent"
-      app:tint="@color/component_color_shared_back_forward_arrow_button_color" />
+      app:tint="@color/component_color_shared_back_forward_arrow_button_color"
+      android:contentDescription="@string/next_button_content_description" />
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/previous_button_item.xml
+++ b/app/src/main/res/layout/previous_button_item.xml
@@ -44,6 +44,7 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
-      app:tint="@color/component_color_shared_back_forward_arrow_button_color" />
+      app:tint="@color/component_color_shared_back_forward_arrow_button_color"
+      android:contentDescription="@string/previous_button_content_description" />
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/profile_chooser_fragment.xml
+++ b/app/src/main/res/layout/profile_chooser_fragment.xml
@@ -36,7 +36,8 @@
           android:visibility="gone"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintTop_toTopOf="parent"
-          app:srcCompat="@drawable/ic_language_icon_grey_24dp" />
+          app:srcCompat="@drawable/ic_language_icon_grey_24dp"
+          android:contentDescription="@string/language_icon_content_description" />
 
         <TextView
           style="@style/Subtitle1ViewCenter"
@@ -115,7 +116,8 @@
         android:paddingTop="12dp"
         android:paddingEnd="16dp"
         android:paddingBottom="12dp"
-        app:srcCompat="@drawable/ic_settings_grey_48dp" />
+        app:srcCompat="@drawable/ic_settings_grey_48dp"
+        android:contentDescription="@string/setting_icon_content_description" />
     </LinearLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/profile_picture_activity.xml
+++ b/app/src/main/res/layout/profile_picture_activity.xml
@@ -48,7 +48,8 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toBottomOf="@id/profile_picture_activity_app_bar_layout"
       profile:src="@{viewModel.profileAvatar}"
-      tools:src="@drawable/ic_default_avatar" />
+      tools:src="@drawable/ic_default_avatar"
+      android:contentDescription="@string/profile_picture_view_content_description" />
 
     <View
       android:id="@+id/app_version_shadow_view"

--- a/app/src/main/res/layout/profile_picture_activity.xml
+++ b/app/src/main/res/layout/profile_picture_activity.xml
@@ -49,7 +49,7 @@
       app:layout_constraintTop_toBottomOf="@id/profile_picture_activity_app_bar_layout"
       profile:src="@{viewModel.profileAvatar}"
       tools:src="@drawable/ic_default_avatar"
-      android:contentDescription="@string/profile_picture_view_content_description" />
+      android:contentDescription="@string/profile_picture_image_view_content_description" />
 
     <View
       android:id="@+id/app_version_shadow_view"

--- a/app/src/main/res/layout/return_to_topic_button_item.xml
+++ b/app/src/main/res/layout/return_to_topic_button_item.xml
@@ -27,7 +27,8 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
-      app:tint="@color/component_color_shared_back_forward_arrow_button_color" />
+      app:tint="@color/component_color_shared_back_forward_arrow_button_color"
+      android:contentDescription="@string/previous_button_content_description" />
 
     <Button
       android:id="@+id/return_to_topic_button"

--- a/app/src/main/res/layout/revision_card_activity.xml
+++ b/app/src/main/res/layout/revision_card_activity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout>
 
   <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/app/src/main/res/layout/revision_card_activity.xml
+++ b/app/src/main/res/layout/revision_card_activity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
 
   <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -37,7 +37,8 @@
           android:layout_gravity="end"
           android:minWidth="48dp"
           android:minHeight="48dp"
-          android:scaleType="center" />
+          android:scaleType="center"
+          android:contentDescription="@string/options_menu_content_description" />
 
         <TextView
           android:id="@+id/revision_card_toolbar_title"

--- a/app/src/main/res/layout/story_chapter_view.xml
+++ b/app/src/main/res/layout/story_chapter_view.xml
@@ -73,7 +73,8 @@
           app:layout_constraintEnd_toEndOf="@id/chapter_thumbnail"
           app:layout_constraintStart_toStartOf="@id/chapter_thumbnail"
           app:layout_constraintTop_toTopOf="@id/chapter_thumbnail"
-          app:srcCompat="@drawable/ic_baseline_lock_24" />
+          app:srcCompat="@drawable/ic_baseline_lock_24"
+          android:contentDescription="@string/lock_icon_content_description" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
           android:layout_width="match_parent"

--- a/app/src/main/res/layout/submit_button_item.xml
+++ b/app/src/main/res/layout/submit_button_item.xml
@@ -45,7 +45,8 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
-      app:tint="@color/component_color_shared_back_forward_arrow_button_color" />
+      app:tint="@color/component_color_shared_back_forward_arrow_button_color"
+      android:contentDescription="@string/previous_button_content_description" />
 
     <Button
       android:id="@+id/submit_answer_button"

--- a/app/src/main/res/layout/test_drawable_binding_adapter_activity.xml
+++ b/app/src/main/res/layout/test_drawable_binding_adapter_activity.xml
@@ -7,5 +7,6 @@
   <ImageView
     android:id="@+id/view_for_drawable_binding_adapters_test"
     android:layout_width="match_parent"
-    android:layout_height="320dp" />
+    android:layout_height="320dp"
+    android:contentDescription="@string/drawable_binding_content_description" />
 </LinearLayout>

--- a/app/src/main/res/layout/test_drawable_binding_adapter_activity.xml
+++ b/app/src/main/res/layout/test_drawable_binding_adapter_activity.xml
@@ -8,5 +8,5 @@
     android:id="@+id/view_for_drawable_binding_adapters_test"
     android:layout_width="match_parent"
     android:layout_height="320dp"
-    android:contentDescription="@string/drawable_binding_content_description" />
+    android:importantForAccessibility="no" />
 </LinearLayout>

--- a/app/src/main/res/layout/test_image_view_bindable_adapter_activity.xml
+++ b/app/src/main/res/layout/test_image_view_bindable_adapter_activity.xml
@@ -3,5 +3,5 @@
   android:id="@+id/image_view_for_data_binding"
   android:layout_width="32dp"
   android:layout_height="32dp"
-  android:contentDescription="@string/data_binding_content_description" />
+  android:importantForAccessibility="no" />
 

--- a/app/src/main/res/layout/test_image_view_bindable_adapter_activity.xml
+++ b/app/src/main/res/layout/test_image_view_bindable_adapter_activity.xml
@@ -2,5 +2,6 @@
 <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
   android:id="@+id/image_view_for_data_binding"
   android:layout_width="32dp"
-  android:layout_height="32dp"/>
+  android:layout_height="32dp"
+  android:contentDescription="@string/data_binding_content_description" />
 

--- a/app/src/main/res/layout/test_url_parser_activity.xml
+++ b/app/src/main/res/layout/test_url_parser_activity.xml
@@ -6,5 +6,6 @@
   <ImageView
     android:id="@+id/test_url_parser_image_view"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" />
+    android:layout_height="wrap_content"
+    android:contentDescription="@string/test_url_parser_content_description" />
 </FrameLayout>

--- a/app/src/main/res/layout/test_url_parser_activity.xml
+++ b/app/src/main/res/layout/test_url_parser_activity.xml
@@ -7,5 +7,5 @@
     android:id="@+id/test_url_parser_image_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:contentDescription="@string/test_url_parser_content_description" />
+    android:importantForAccessibility="no" />
 </FrameLayout>

--- a/app/src/main/res/layout/text_input_interaction_item.xml
+++ b/app/src/main/res/layout/text_input_interaction_item.xml
@@ -21,7 +21,6 @@
     <org.oppia.android.app.customview.interaction.TextInputInteractionView
       android:id="@+id/text_input_interaction_view"
       style="@style/InputInteractionEditText"
-      android:contentDescription="@{viewModel.hintText.length() == 0 ? @string/text_input_default_content_description : ``}"
       android:hint="@{viewModel.hintText}"
       android:inputType="text"
       android:text="@={viewModel.answerText}"

--- a/app/src/main/res/layout/text_input_interaction_item.xml
+++ b/app/src/main/res/layout/text_input_interaction_item.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:tools="http://schemas.android.com/tools"
+  xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <data>
@@ -22,12 +23,14 @@
       android:id="@+id/text_input_interaction_view"
       style="@style/InputInteractionEditText"
       android:hint="@{viewModel.hintText}"
+      android:contentDescription="@{viewModel.hintText.length() == 0 ? @string/text_input_default_content_description : ``}"
       android:inputType="text"
       android:text="@={viewModel.answerText}"
       android:textColorHint="@color/component_color_shared_edit_text_hint_color"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
-      app:textChangedListener="@{viewModel.answerTextWatcher}" />
+      app:textChangedListener="@{viewModel.answerTextWatcher}"
+      tools:ignore="ContentDescription" />
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/top_left_overlay.xml
+++ b/app/src/main/res/layout/top_left_overlay.xml
@@ -24,7 +24,8 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
       app:srcCompat="@drawable/ic_rounded_arrow_up_right"
-      app:tint="@color/component_color_shared_spotlight_overlay_arrow_color" />
+      app:tint="@color/component_color_shared_spotlight_overlay_arrow_color"
+      android:contentDescription="@string/spotlight_overlay_arrow_content_description" />
 
     <com.google.android.material.card.MaterialCardView
       android:layout_width="0dp"
@@ -67,7 +68,8 @@
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintTop_toTopOf="parent"
           app:srcCompat="@drawable/ic_close_black_24"
-          app:tint="@color/component_color_shared_close_spotlight_button_color" />
+          app:tint="@color/component_color_shared_close_spotlight_button_color"
+          android:contentDescription="@string/close_spotlight_button_content_description" />
       </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.card.MaterialCardView>
   </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/top_right_overlay.xml
+++ b/app/src/main/res/layout/top_right_overlay.xml
@@ -25,7 +25,8 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
       app:srcCompat="@drawable/ic_rounded_arrow_up_right"
-      app:tint="@color/component_color_shared_spotlight_overlay_arrow_color" />
+      app:tint="@color/component_color_shared_spotlight_overlay_arrow_color"
+      android:contentDescription="@string/spotlight_overlay_arrow_content_description" />
 
     <com.google.android.material.card.MaterialCardView
       android:layout_width="0dp"
@@ -70,7 +71,8 @@
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintTop_toTopOf="parent"
           app:srcCompat="@drawable/ic_close_black_24"
-          app:tint="@color/component_color_shared_close_spotlight_button_color" />
+          app:tint="@color/component_color_shared_close_spotlight_button_color"
+          android:contentDescription="@string/close_spotlight_button_content_description" />
       </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.card.MaterialCardView>
   </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/topic_info_fragment.xml
+++ b/app/src/main/res/layout/topic_info_fragment.xml
@@ -126,7 +126,8 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/see_more_text_view"
         app:srcCompat="@{viewModel.downloadStatusIndicatorDrawableResourceId, default=@drawable/ic_available_offline_primary_24dp}"
-        app:tint="@color/component_color_topic_info_fragment_download_status_image_color" />
+        app:tint="@color/component_color_topic_info_fragment_download_status_image_color"
+        android:contentDescription="@string/download_status_content_description" />
 
       <TextView
         android:id="@+id/download_story_count_text_view"

--- a/app/src/main/res/layout/topic_info_fragment.xml
+++ b/app/src/main/res/layout/topic_info_fragment.xml
@@ -127,7 +127,7 @@
         app:layout_constraintTop_toBottomOf="@+id/see_more_text_view"
         app:srcCompat="@{viewModel.downloadStatusIndicatorDrawableResourceId, default=@drawable/ic_available_offline_primary_24dp}"
         app:tint="@color/component_color_topic_info_fragment_download_status_image_color"
-        android:contentDescription="@string/download_status_content_description" />
+        android:contentDescription="@string/download_status_image_content_description" />
 
       <TextView
         android:id="@+id/download_story_count_text_view"

--- a/app/src/main/res/layout/walkthrough_final_fragment.xml
+++ b/app/src/main/res/layout/walkthrough_final_fragment.xml
@@ -31,7 +31,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/walkthrough_final_title_text_view"
         app:srcCompat="@drawable/ic_portrait_onboarding_0"
-        android:contentDescription="@string/walkthrough_final_content_description" />
+        android:importantForAccessibility="no" />
 
       <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/walkthrough_final_fragment.xml
+++ b/app/src/main/res/layout/walkthrough_final_fragment.xml
@@ -30,7 +30,8 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/walkthrough_final_title_text_view"
-        app:srcCompat="@drawable/ic_portrait_onboarding_0" />
+        app:srcCompat="@drawable/ic_portrait_onboarding_0"
+        android:contentDescription="@string/walkthrough_final_content_description" />
 
       <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/walkthrough_welcome_fragment.xml
+++ b/app/src/main/res/layout/walkthrough_welcome_fragment.xml
@@ -61,7 +61,8 @@
         app:srcCompat="@drawable/ic_portrait_onboarding_0"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/walkthrough_welcome_description_text_view" />
+        app:layout_constraintTop_toBottomOf="@+id/walkthrough_welcome_description_text_view"
+        android:contentDescription="@string/walkthrough_welcome_content_description" />
 
       <Button
         android:id="@+id/walkthrough_welcome_next_button"

--- a/app/src/main/res/layout/walkthrough_welcome_fragment.xml
+++ b/app/src/main/res/layout/walkthrough_welcome_fragment.xml
@@ -62,7 +62,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/walkthrough_welcome_description_text_view"
-        android:contentDescription="@string/walkthrough_welcome_content_description" />
+        android:importantForAccessibility="no" />
 
       <Button
         android:id="@+id/walkthrough_welcome_next_button"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -595,4 +595,5 @@
   <string name="setting_icon_content_description">Setting Icon</string>
   <string name="profile_picture_image_view_content_description">Profile Picture Image View</string>
   <string name="lock_icon_content_description">Lock Icon</string>
+  <string name="download_status_image_content_description">Download Status</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -581,4 +581,25 @@
   <string name="nps_score_question">On a scale from 0–10, how likely are you to recommend %s to a friend or colleague?</string>
   <string name="previous_subtopic_talkback_text">The previous subtopic is %s</string>
   <string name="next_subtopic_talkback_text">The next subtopic is %s</string>
+  <string name="test_drop_down_icon_content_description">Test Dropdown Icon</string>
+
+  <string name="app_info_content_description">App Info</string>
+  <string name="spotlight_overlay_arrow_content_description">Spotlight Overlay Arrow</string>
+  <string name="close_spotlight_button_content_description">Close Spotlight Button</string>
+  <string name="previous_state_navigation_button_content_description">Previous State Navigation Button</string>
+  <string name="developer_options_icon_content_description">Developer Options Icon</string>
+  <string name="administrator_controls_icon_content_description">Administrator Controls Icon</string>
+  <string name="options_menu_content_description">Options Menu</string>
+  <string name="previous_button_content_description">Previous Button</string>
+  <string name="next_button_content_description">Next Button</string>
+  <string name="language_icon_content_description">Language Icon</string>
+  <string name="setting_icon_content_description">Setting Icon</string>
+  <string name="profile_picture_view_content_description">Profile Picture View</string>
+  <string name="lock_icon_content_description">Lock Icon</string>
+  <string name="walkthrough_welcome_content_description">Walkthrough Welcome</string>
+  <string name="walkthrough_final_content_description">Walkthrough Final</string>
+  <string name="download_status_content_description">Download Status</string>
+  <string name="test_url_parser_content_description">Test Url Parser</string>
+  <string name="drawable_binding_content_description">Drawable Binding</string>
+  <string name="data_binding_content_description">Data Binding</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -581,9 +581,8 @@
   <string name="nps_score_question">On a scale from 0–10, how likely are you to recommend %s to a friend or colleague?</string>
   <string name="previous_subtopic_talkback_text">The previous subtopic is %s</string>
   <string name="next_subtopic_talkback_text">The next subtopic is %s</string>
-  <string name="test_drop_down_icon_content_description">Test Dropdown Icon</string>
 
-  <string name="app_info_content_description">App Info</string>
+  <string name="app_info_icon_content_description">App Info</string>
   <string name="spotlight_overlay_arrow_content_description">Spotlight Overlay Arrow</string>
   <string name="close_spotlight_button_content_description">Close Spotlight Button</string>
   <string name="previous_state_navigation_button_content_description">Previous State Navigation Button</string>
@@ -594,12 +593,6 @@
   <string name="next_button_content_description">Next Button</string>
   <string name="language_icon_content_description">Language Icon</string>
   <string name="setting_icon_content_description">Setting Icon</string>
-  <string name="profile_picture_view_content_description">Profile Picture View</string>
+  <string name="profile_picture_image_view_content_description">Profile Picture Image View</string>
   <string name="lock_icon_content_description">Lock Icon</string>
-  <string name="walkthrough_welcome_content_description">Walkthrough Welcome</string>
-  <string name="walkthrough_final_content_description">Walkthrough Final</string>
-  <string name="download_status_content_description">Download Status</string>
-  <string name="test_url_parser_content_description">Test Url Parser</string>
-  <string name="drawable_binding_content_description">Drawable Binding</string>
-  <string name="data_binding_content_description">Data Binding</string>
 </resources>


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #5171

Under this category, the warnings are mainly of 3 types:

1. Warning: Image without contentDescription.
Fix: Add a `contentDescription` to each of those `ImageView`, or mark as not important for accessibility.

2. Warning: 'onTouch' lambda should call 'View#performClick' when a click is detected
Fix: Call `customView.performClick( )`.

3. Warning: 'clickable' attribute found, please also add 'focusable'.
Fix: Set `android:focusable="true"` as its necessary if `android:clickable="true"`.

![image](https://github.com/oppia/oppia-android/assets/84731134/894a6fb3-632b-4397-bc80-16b60d06f5f2)

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
