### PR TITLE
Fix part of #5070: In FractionInteraction UI, leave submit button enabled when answer is empty

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/FractionInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/FractionInteractionViewModel.kt
@@ -81,13 +81,10 @@ class FractionInteractionViewModel private constructor(
         }
       }
       AnswerErrorCategory.SUBMIT_TIME -> {
-        pendingAnswerError = if (answerText.isNotEmpty()) {
+        pendingAnswerError =
           FractionParsingUiError.createFromParsingError(
             fractionParser.getSubmitTimeError(answerText.toString())
           ).getErrorMessageFromStringRes(resourceHandler)
-        } else {
-          resourceHandler.getStringInLocale(R.string.interaction_answer_empty_on_submit)
-        }
       }
     }
     errorMessage.set(pendingAnswerError)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -606,4 +606,5 @@
   <string name="lock_icon_content_description">Lock Icon</string>
   <string name="download_status_image_content_description">Download Status</string>
   <string name="font_scale_html_content_text">html Content</string>
+  <string name="interaction_answer_empty_on_submit">"Enter an answer to continue"</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -606,5 +606,4 @@
   <string name="lock_icon_content_description">Lock Icon</string>
   <string name="download_status_image_content_description">Download Status</string>
   <string name="font_scale_html_content_text">html Content</string>
-  <string name="interaction_answer_empty_on_submit">"Enter an answer to continue"</string>
 </resources>


### PR DESCRIPTION
Fix part of #5070: In FractionInteraction UI, leave submit button enabled when answer is empty. Show an error on submitting an empty answer. The error message already exists and is the same as in [web](https://github.com/oppia/oppia/pull/18379).

Demo video: [leave_submit_button_enabled_on_empty_answer_v2.webm](https://github.com/oppia/oppia-android/assets/103062089/355b664f-1954-4012-bae8-3badb1aebfb3)


<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
