### PR TITLE
Fix part of #5195: RestrictedApi. Using a private API

### DIFF
--- a/app/src/main/java/org/oppia/android/app/databinding/AppCompatCheckBoxBindingAdapters.java
+++ b/app/src/main/java/org/oppia/android/app/databinding/AppCompatCheckBoxBindingAdapters.java
@@ -1,7 +1,6 @@
 package org.oppia.android.app.databinding;
 
 import android.content.res.ColorStateList;
-
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.AppCompatCheckBox;

--- a/app/src/main/java/org/oppia/android/app/databinding/AppCompatCheckBoxBindingAdapters.java
+++ b/app/src/main/java/org/oppia/android/app/databinding/AppCompatCheckBoxBindingAdapters.java
@@ -11,9 +11,7 @@ import androidx.databinding.BindingAdapter;
  * Custom data-binding adapters for {@link AppCompatCheckBox}s.
  */
 public final class AppCompatCheckBoxBindingAdapters {
-  /**
-   * Sets the button tint for the specified checkbox, via data-binding.
-   */
+  /** Sets the button tint for the specified checkbox, via data-binding. */
   @BindingAdapter("app:buttonTint")
   public static void setButtonTint(@NonNull AppCompatCheckBox checkBox, @ColorInt int colorRgb) {
     CompoundButtonCompat.setButtonTintList(checkBox, ColorStateList.valueOf(colorRgb));

--- a/app/src/main/java/org/oppia/android/app/databinding/AppCompatCheckBoxBindingAdapters.java
+++ b/app/src/main/java/org/oppia/android/app/databinding/AppCompatCheckBoxBindingAdapters.java
@@ -1,18 +1,22 @@
 package org.oppia.android.app.databinding;
 
 import android.content.res.ColorStateList;
+
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.AppCompatCheckBox;
+import androidx.core.widget.CompoundButtonCompat;
 import androidx.databinding.BindingAdapter;
 
 /**
  * Custom data-binding adapters for {@link AppCompatCheckBox}s.
  */
 public final class AppCompatCheckBoxBindingAdapters {
-  /** Sets the button tint for the specified checkbox, via data-binding. */
+  /**
+   * Sets the button tint for the specified checkbox, via data-binding.
+   */
   @BindingAdapter("app:buttonTint")
   public static void setButtonTint(@NonNull AppCompatCheckBox checkBox, @ColorInt int colorRgb) {
-    checkBox.setSupportButtonTintList(ColorStateList.valueOf(colorRgb));
+    CompoundButtonCompat.setButtonTintList(checkBox, ColorStateList.valueOf(colorRgb));
   }
 }

--- a/app/src/sharedTest/java/org/oppia/android/app/databinding/AppCompatCheckBoxBindingAdaptersTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/databinding/AppCompatCheckBoxBindingAdaptersTest.kt
@@ -127,7 +127,7 @@ class AppCompatCheckBoxBindingAdaptersTest {
     activityRule.scenario.onActivity {
       val appCompatCheckBox: AppCompatCheckBox = getAppCompatCheckBox(it)
       setButtonTint(appCompatCheckBox, colorRgb)
-      assertThat(appCompatCheckBox.supportButtonTintList?.defaultColor).isEqualTo(colorRgb)
+      assertThat(appCompatCheckBox.buttonTintList?.defaultColor).isEqualTo(colorRgb)
     }
   }
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix part of #5195: I have modified method setButtonTint to avoid an error due to using a restricted API.
This method(bindingAdapter) is not set in any of the layouts. Only test is written for it.
So it is safety to modify the test also. If not modify a test - it is failed then.

**Lint report before**
<img src="https://github.com/oppia/oppia-android/assets/71126152/fe9d691b-1bd0-45e9-9f14-7daa73839069" width="70%" height="70%" alt="callingNewApiBefore">

**Lint report after**
<img src="https://github.com/oppia/oppia-android/assets/71126152/5689d095-d4ed-4e60-b431-790037b240c3" width="50%" height="50%" alt="callingNewApiBefore">


<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
