### PR TITLE
Fixes #4708: Don't submit answer if it's invalid according to the input

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
@@ -202,7 +202,10 @@ class StateFragmentPresenter @Inject constructor(
 
   fun onSubmitButtonClicked() {
     hideKeyboard()
-    handleSubmitAnswer(viewModel.getPendingAnswer(recyclerViewAssembler::getPendingAnswerHandler))
+    val answer = viewModel.getPendingAnswer(recyclerViewAssembler::getPendingAnswerHandler)
+    if (answer != null) {
+      handleSubmitAnswer(answer)
+    }
   }
 
   fun onResponsesHeaderClicked() {
@@ -215,7 +218,10 @@ class StateFragmentPresenter @Inject constructor(
   fun handleKeyboardAction() {
     hideKeyboard()
     if (viewModel.getCanSubmitAnswer().get() == true) {
-      handleSubmitAnswer(viewModel.getPendingAnswer(recyclerViewAssembler::getPendingAnswerHandler))
+      val answer = viewModel.getPendingAnswer(recyclerViewAssembler::getPendingAnswerHandler)
+      if (answer != null) {
+        handleSubmitAnswer(answer)
+      }
     }
   }
 

--- a/app/src/main/java/org/oppia/android/app/player/state/StateViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateViewModel.kt
@@ -101,12 +101,12 @@ class StateViewModel @Inject constructor(
 
   fun getPendingAnswer(
     retrieveAnswerHandler: (List<StateItemViewModel>) -> InteractionAnswerHandler?
-  ): UserAnswer {
+  ): UserAnswer? {
     return getPendingAnswerWithoutError(
       retrieveAnswerHandler(
         getAnswerItemList()
       )
-    ) ?: UserAnswer.getDefaultInstance()
+    )
   }
 
   fun canQuicklyToggleBetweenSwahiliAndEnglish(

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -443,6 +443,24 @@ class StateFragmentTest {
   }
 
   @Test
+  @RunOn(TestPlatform.ESPRESSO) // Robolectric tests don't rotate like this to recreate activity
+  fun testStateFragment_loadExp_secondState_invalidAnswer_changeConfiguration_submitButtonIsEnabled() { // ktlint-disable max-line-length
+    setUpTestWithLanguageSwitchingFeatureOff()
+    launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
+      startPlayingExploration()
+      clickContinueInteractionButton()
+
+      typeFractionText("1/")
+
+      clickSubmitAnswerButton()
+
+      rotateToLandscape()
+
+      onView(withId(R.id.submit_answer_button)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
   fun testStateFragment_loadExp_secondState_invalidAnswer_updated_submitAnswerIsEnabled() {
     setUpTestWithLanguageSwitchingFeatureOff()
     launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -444,7 +444,7 @@ class StateFragmentTest {
 
   @Test
   @RunOn(TestPlatform.ESPRESSO) // Robolectric tests don't rotate like this to recreate activity
-  fun testStateFragment_loadExp_secondState_invalidAnswer_changeConfiguration_submitButtonIsEnabled() { // ktlint-disable max-line-length
+  fun testStateFragment_loadExp_invalidAnswer_changeConfiguration_submitButtonIsDisplayed() {
     setUpTestWithLanguageSwitchingFeatureOff()
     launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
       startPlayingExploration()


### PR DESCRIPTION
## Explanation
Fixes #4708: Don't submit answer if it's invalid according to the input
or else after submitting the recycler view will not restore items on configuration change. See #4708 for more details

Video demo:
[before](https://drive.google.com/file/d/1bLgo-AYro0UbffR6X8nWo8Xv7oUuNJFa/view?usp=sharing)
[after](https://drive.google.com/file/d/1Oek7j6dgjJmgasyyd9FHtQo4E7zTvEBd/view?usp=sharing)

Continuation of PR #5202 since that one's no longer viable due to being force pushed in a repo sync through GitHub UI.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing

Change unrelated to concerns like dark mode, RTL, accessibility. PR #5202 had passing test checks for these changes, so that'll be my demonstration of tests passing.