### PR TITLE
Fix #5214 good first issues link fixed under wiki/Installing-Oppia-Android.md

### DIFF
--- a/wiki/Installing-Oppia-Android.md
+++ b/wiki/Installing-Oppia-Android.md
@@ -112,7 +112,7 @@ These are tests that are in non-app modules, such as **domain** or **utility**.
    - ![](https://user-images.githubusercontent.com/59600948/272657015-158117e5-47d2-40fc-a38b-5dee6c347556.png)
 
 ### Next Steps
-- Congratulations, you are ready to work on your first issue! Take a look at our [good first issues](https://github.com/oppia/oppia-android/wiki/Oppia-Android-Testing) and leave a comment with your suggested fix. A maintainer will assign you the issue and provide any necessary guidance.
+- Congratulations, you are ready to work on your first issue! Take a look at our [good first issues](https://github.com/oppia/oppia-android/labels/good%20first%20issue) and leave a comment with your suggested fix. A maintainer will assign you the issue and provide any necessary guidance.
 
 - When you are ready to submit a PR, please follow [these instructions](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR) on submitting a PR.
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix #5214  under this PR, the link has been correctly updated to https://github.com/oppia/oppia-android/labels/good%20first%20issue from the wrong one, that is https://github.com/oppia/oppia-android/wiki/Oppia-Android-Testing in wiki/Installing-Oppia-Android.md under Next Steps Section.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
