### PR TITLE
Fix #5204 - Inconsistent Layout Lint Warning

### DIFF
--- a/app/src/main/res/layout-sw600dp/administrator_controls_activity.xml
+++ b/app/src/main/res/layout-sw600dp/administrator_controls_activity.xml
@@ -85,7 +85,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/administrator_controls_guideline"
-        app:layout_constraintTop_toBottomOf="@id/extra_controls_title" />
+        app:layout_constraintTop_toBottomOf="@id/extra_controls_title"
+        tools:ignore="InconsistentLayout" />
 
       <View
         android:id="@+id/administrator_controls_toolbar_shadow_view"

--- a/app/src/main/res/layout-sw600dp/help_activity.xml
+++ b/app/src/main/res/layout-sw600dp/help_activity.xml
@@ -47,7 +47,8 @@
         android:visibility="gone"
         app:layout_constraintStart_toEndOf="@id/multipane_guideline"
         app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_arrow_back_black_24_dp" />
+        app:srcCompat="@drawable/ic_arrow_back_black_24_dp"
+        tools:ignore="InconsistentLayout" />
 
       <TextView
         android:id="@+id/help_multipane_options_title_textview"
@@ -61,7 +62,8 @@
         android:textColor="@color/component_color_shared_primary_text_color"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/help_multipane_options_back_button"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="InconsistentLayout" />
 
       <FrameLayout
         android:id="@+id/multipane_options_container"
@@ -71,7 +73,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/multipane_guideline"
-        app:layout_constraintTop_toBottomOf="@id/help_multipane_options_title_textview" />
+        app:layout_constraintTop_toBottomOf="@id/help_multipane_options_title_textview"
+        tools:ignore="InconsistentLayout" />
 
       <androidx.constraintlayout.widget.Guideline
         android:id="@+id/multipane_guideline"

--- a/app/src/main/res/layout-sw600dp/option_activity.xml
+++ b/app/src/main/res/layout-sw600dp/option_activity.xml
@@ -45,7 +45,8 @@
         android:textSize="18sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/multipane_guideline"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="InconsistentLayout" />
 
       <FrameLayout
         android:id="@+id/multipane_options_container"
@@ -55,7 +56,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/multipane_guideline"
-        app:layout_constraintTop_toBottomOf="@id/options_activity_selected_options_title" />
+        app:layout_constraintTop_toBottomOf="@id/options_activity_selected_options_title"
+        tools:ignore="InconsistentLayout" />
 
       <androidx.constraintlayout.widget.Guideline
         android:id="@+id/multipane_guideline"

--- a/app/src/main/res/layout-sw600dp/options_without_drawer_activity.xml
+++ b/app/src/main/res/layout-sw600dp/options_without_drawer_activity.xml
@@ -1,5 +1,6 @@
 <androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/options_activity_drawer_layout"
   android:layout_width="match_parent"
   android:layout_height="match_parent">
@@ -44,7 +45,8 @@
         android:textSize="18sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/multipane_guideline"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="InconsistentLayout" />
 
       <FrameLayout
         android:id="@+id/multipane_options_container"
@@ -54,7 +56,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/multipane_guideline"
-        app:layout_constraintTop_toBottomOf="@id/options_activity_selected_options_title" />
+        app:layout_constraintTop_toBottomOf="@id/options_activity_selected_options_title"
+        tools:ignore="InconsistentLayout" />
 
       <androidx.constraintlayout.widget.Guideline
         android:id="@+id/multipane_guideline"


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix #5204 - [Part of #5169]

To address the lint warnings, two potential solutions were considered. 
1. Initially, there was an option to include the missing IDs, ensuring consistency across different layout configurations [[**Link**](https://github.com/Rd4dev/oppia-android/commit/f8977e686fcbbf362aea4a8d1a472c487bafeb0f)]. However, it was observed that implementing this solution led to functional disruptions within the current working application, as confirmed through comprehensive testing procedures (refer to the attached assets for a detailed overview).


https://github.com/oppia/oppia-android/assets/122200035/82172eaf-a555-4e76-b1ae-8f0db7ddb924



2. The second option was to suppress the lint warnings for the specific views in the layout-sw600dp configuration files [[**Link**](https://github.com/Rd4dev/oppia-android/commit/a0f5b1ed9100ecc0f578c6c4a38f4df6566724ec)] to maintain the seamless functionality of the application . This was achieved by incorporating the attribute **`tools:ignore="InconsistentLayout"`** for relevant views, without impacting the current operational stability of the application.



https://github.com/oppia/oppia-android/assets/122200035/93a65422-3526-4d76-873f-c08d24abc3ee



Taking the necessary action, I proceeded to implement the suppression of lint warnings by submitting a pull request.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
