### PR TITLE
Fix #5226: EnableContinueButtonAnimation Feature Flag 

### DIFF
--- a/app/src/main/java/org/oppia/android/app/customview/ContinueButtonView.kt
+++ b/app/src/main/java/org/oppia/android/app/customview/ContinueButtonView.kt
@@ -23,10 +23,14 @@ class ContinueButtonView @JvmOverloads constructor(
   defStyleAttr: Int = R.style.StateButtonActive
 ) : androidx.appcompat.widget.AppCompatButton(context, attrs, defStyleAttr) {
 
-  @Inject lateinit var fragment: Fragment
-  @Inject lateinit var oppiaClock: OppiaClock
-  @Inject lateinit var lifecycleSafeTimerFactory: LifecycleSafeTimerFactory
-  @Inject lateinit var oppiaLogger: OppiaLogger
+  @Inject
+  lateinit var fragment: Fragment
+  @Inject
+  lateinit var oppiaClock: OppiaClock
+  @Inject
+  lateinit var lifecycleSafeTimerFactory: LifecycleSafeTimerFactory
+  @Inject
+  lateinit var oppiaLogger: OppiaLogger
 
   private var shouldAnimateContinueButtonLateinit: Boolean? = null
   private val shouldAnimateContinueButton: Boolean
@@ -115,11 +119,11 @@ class ContinueButtonView @JvmOverloads constructor(
 
   private fun startAnimating() {
     val animation = AnimationUtils.loadAnimation(context, R.anim.wobble_button_animation)
-      startAnimation(animation)
-      // Repeat the animation after a fixed interval.
-      lifecycleSafeTimerFactory.createTimer(INTERVAL_BETWEEN_CONTINUE_BUTTON_ANIM_MS)
-        .observe(fragment) {
-          startAnimating()
-        }
-    }
+    startAnimation(animation)
+    // Repeat the animation after a fixed interval.
+    lifecycleSafeTimerFactory.createTimer(INTERVAL_BETWEEN_CONTINUE_BUTTON_ANIM_MS)
+      .observe(fragment) {
+        startAnimating()
+      }
+  }
 }

--- a/app/src/main/java/org/oppia/android/app/customview/ContinueButtonView.kt
+++ b/app/src/main/java/org/oppia/android/app/customview/ContinueButtonView.kt
@@ -115,7 +115,6 @@ class ContinueButtonView @JvmOverloads constructor(
 
   private fun startAnimating() {
     val animation = AnimationUtils.loadAnimation(context, R.anim.wobble_button_animation)
-    if (enableContinueButtonAnimation.value) {
       startAnimation(animation)
       // Repeat the animation after a fixed interval.
       lifecycleSafeTimerFactory.createTimer(INTERVAL_BETWEEN_CONTINUE_BUTTON_ANIM_MS)
@@ -123,5 +122,4 @@ class ContinueButtonView @JvmOverloads constructor(
           startAnimating()
         }
     }
-  }
 }

--- a/app/src/main/java/org/oppia/android/app/customview/ContinueButtonView.kt
+++ b/app/src/main/java/org/oppia/android/app/customview/ContinueButtonView.kt
@@ -11,8 +11,6 @@ import org.oppia.android.app.utility.lifecycle.LifecycleSafeTimerFactory
 import org.oppia.android.app.view.ViewComponentFactory
 import org.oppia.android.app.view.ViewComponentImpl
 import org.oppia.android.domain.oppialogger.OppiaLogger
-import org.oppia.android.util.platformparameter.EnableContinueButtonAnimation
-import org.oppia.android.util.platformparameter.PlatformParameterValue
 import org.oppia.android.util.system.OppiaClock
 import javax.inject.Inject
 
@@ -25,8 +23,6 @@ class ContinueButtonView @JvmOverloads constructor(
   defStyleAttr: Int = R.style.StateButtonActive
 ) : androidx.appcompat.widget.AppCompatButton(context, attrs, defStyleAttr) {
 
-  @field:[Inject EnableContinueButtonAnimation]
-  lateinit var enableContinueButtonAnimation: PlatformParameterValue<Boolean>
   @Inject lateinit var fragment: Fragment
   @Inject lateinit var oppiaClock: OppiaClock
   @Inject lateinit var lifecycleSafeTimerFactory: LifecycleSafeTimerFactory

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -226,7 +226,6 @@ class ExplorationActivityTest {
   @Before
   fun setUp() {
     Intents.init()
-    TestPlatformParameterModule.forceEnableContinueButtonAnimation(false)
     setUpTestApplicationComponent()
     testCoroutineDispatchers.registerIdlingResource()
     profileTestHelper.initializeProfiles()

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -4749,7 +4749,6 @@ class StateFragmentTest {
   }
 
   private fun setUpTest() {
-    TestPlatformParameterModule.forceEnableContinueButtonAnimation(false)
     Intents.init()
     setUpTestApplicationComponent()
     testCoroutineDispatchers.registerIdlingResource()

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -269,7 +269,6 @@ class StateFragmentLocalTest {
 
   @Test
   fun testContinueInteractionAnim_openPrototypeExp_checkContinueButtonAnimatesAfter45Seconds() {
-    TestPlatformParameterModule.forceEnableContinueButtonAnimation(true)
     launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       testCoroutineDispatchers.runCurrent()
@@ -339,7 +338,6 @@ class StateFragmentLocalTest {
 
   @Test
   fun testConIntAnim_openProtExp_orientLandscapeAfter30Sec_checkAnimHasNotStarted() {
-    TestPlatformParameterModule.forceEnableContinueButtonAnimation(true)
     launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
 
@@ -353,7 +351,6 @@ class StateFragmentLocalTest {
 
   @Test
   fun testConIntAnim_openProtExp_orientLandAfter30Sec_checkAnimStartsIn15SecAfterOrientChange() {
-    TestPlatformParameterModule.forceEnableContinueButtonAnimation(true)
     launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
 
@@ -368,7 +365,6 @@ class StateFragmentLocalTest {
 
   @Test
   fun testContNavBtnAnim_openMathExp_checkContNavBtnAnimatesAfter45Seconds() {
-    TestPlatformParameterModule.forceEnableContinueButtonAnimation(true)
     launchForExploration(TEST_EXPLORATION_ID_5).use {
       startPlayingExploration()
       onView(withId(R.id.state_recycler_view)).perform(
@@ -391,7 +387,6 @@ class StateFragmentLocalTest {
   @Ignore("Continue navigation animation behavior fails during testing")
   @Test
   fun testContNavBtnAnim_openMathExp_playThroughSecondState_checkContBtnDoesNotAnimateAfter45Sec() {
-    TestPlatformParameterModule.forceEnableContinueButtonAnimation(true)
     launchForExploration(TEST_EXPLORATION_ID_5).use {
       startPlayingExploration()
       onView(withId(R.id.state_recycler_view)).perform(
@@ -424,7 +419,6 @@ class StateFragmentLocalTest {
   @Ignore("Continue navigation animation behavior fails during testing")
   @Test
   fun testConIntAnim_openFractions_expId1_checkButtonDoesNotAnimate() {
-    TestPlatformParameterModule.forceEnableContinueButtonAnimation(true)
     launchForExploration(TEST_EXPLORATION_ID_2).use {
       startPlayingExploration()
       playThroughTestState1()

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterAlphaKenyaModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterAlphaKenyaModule.kt
@@ -8,7 +8,6 @@ import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING
 import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.CacheLatexRendering
 import org.oppia.android.util.platformparameter.ENABLE_APP_AND_OS_DEPRECATION_DEFAULT_VALUE
-import org.oppia.android.util.platformparameter.ENABLE_CONTINUE_BUTTON_ANIMATION_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_DOWNLOADS_SUPPORT_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EDIT_ACCOUNTS_OPTIONS_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EXTRA_TOPIC_TABS_UI_DEFAULT_VALUE
@@ -18,7 +17,6 @@ import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLE
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_SPOTLIGHT_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.EnableAppAndOsDeprecation
-import org.oppia.android.util.platformparameter.EnableContinueButtonAnimation
 import org.oppia.android.util.platformparameter.EnableDownloadsSupport
 import org.oppia.android.util.platformparameter.EnableEditAccountsOptionsUi
 import org.oppia.android.util.platformparameter.EnableExtraTopicTabsUi
@@ -212,14 +210,6 @@ class PlatformParameterAlphaKenyaModule {
   fun provideEnableInteractionConfigChangeStateRetention(): PlatformParameterValue<Boolean> {
     return PlatformParameterValue.createDefaultParameter(
       ENABLE_INTERACTION_CONFIG_CHANGE_STATE_RETENTION_DEFAULT_VALUE
-    )
-  }
-
-  @Provides
-  @EnableContinueButtonAnimation
-  fun provideEnableContinueButtonAnimation(): PlatformParameterValue<Boolean> {
-    return PlatformParameterValue.createDefaultParameter(
-      ENABLE_CONTINUE_BUTTON_ANIMATION_DEFAULT_VALUE
     )
   }
 

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterAlphaModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterAlphaModule.kt
@@ -8,7 +8,6 @@ import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING
 import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.CacheLatexRendering
 import org.oppia.android.util.platformparameter.ENABLE_APP_AND_OS_DEPRECATION_DEFAULT_VALUE
-import org.oppia.android.util.platformparameter.ENABLE_CONTINUE_BUTTON_ANIMATION_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_DOWNLOADS_SUPPORT_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EDIT_ACCOUNTS_OPTIONS_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EXTRA_TOPIC_TABS_UI_DEFAULT_VALUE
@@ -17,7 +16,6 @@ import org.oppia.android.util.platformparameter.ENABLE_LANGUAGE_SELECTION_UI_DEF
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.EnableAppAndOsDeprecation
-import org.oppia.android.util.platformparameter.EnableContinueButtonAnimation
 import org.oppia.android.util.platformparameter.EnableDownloadsSupport
 import org.oppia.android.util.platformparameter.EnableEditAccountsOptionsUi
 import org.oppia.android.util.platformparameter.EnableExtraTopicTabsUi
@@ -213,14 +211,6 @@ class PlatformParameterAlphaModule {
   fun provideEnableInteractionConfigChangeStateRetention(): PlatformParameterValue<Boolean> {
     return PlatformParameterValue.createDefaultParameter(
       ENABLE_INTERACTION_CONFIG_CHANGE_STATE_RETENTION_DEFAULT_VALUE
-    )
-  }
-
-  @Provides
-  @EnableContinueButtonAnimation
-  fun provideEnableContinueButtonAnimation(): PlatformParameterValue<Boolean> {
-    return PlatformParameterValue.createDefaultParameter(
-      ENABLE_CONTINUE_BUTTON_ANIMATION_DEFAULT_VALUE
     )
   }
 

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterModule.kt
@@ -8,7 +8,6 @@ import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING
 import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.CacheLatexRendering
 import org.oppia.android.util.platformparameter.ENABLE_APP_AND_OS_DEPRECATION_DEFAULT_VALUE
-import org.oppia.android.util.platformparameter.ENABLE_CONTINUE_BUTTON_ANIMATION_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_DOWNLOADS_SUPPORT_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EDIT_ACCOUNTS_OPTIONS_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EXTRA_TOPIC_TABS_UI_DEFAULT_VALUE
@@ -18,7 +17,6 @@ import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLE
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_SPOTLIGHT_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.EnableAppAndOsDeprecation
-import org.oppia.android.util.platformparameter.EnableContinueButtonAnimation
 import org.oppia.android.util.platformparameter.EnableDownloadsSupport
 import org.oppia.android.util.platformparameter.EnableEditAccountsOptionsUi
 import org.oppia.android.util.platformparameter.EnableExtraTopicTabsUi
@@ -218,14 +216,6 @@ class PlatformParameterModule {
   fun provideEnableInteractionConfigChangeStateRetention(): PlatformParameterValue<Boolean> {
     return PlatformParameterValue.createDefaultParameter(
       ENABLE_INTERACTION_CONFIG_CHANGE_STATE_RETENTION_DEFAULT_VALUE
-    )
-  }
-
-  @Provides
-  @EnableContinueButtonAnimation
-  fun provideEnableContinueButtonAnimation(): PlatformParameterValue<Boolean> {
-    return PlatformParameterValue.createDefaultParameter(
-      ENABLE_CONTINUE_BUTTON_ANIMATION_DEFAULT_VALUE
     )
   }
 

--- a/testing/src/main/java/org/oppia/android/testing/platformparameter/TestPlatformParameterModule.kt
+++ b/testing/src/main/java/org/oppia/android/testing/platformparameter/TestPlatformParameterModule.kt
@@ -9,7 +9,6 @@ import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING
 import org.oppia.android.util.platformparameter.CACHE_LATEX_RENDERING_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.CacheLatexRendering
 import org.oppia.android.util.platformparameter.ENABLE_APP_AND_OS_DEPRECATION_DEFAULT_VALUE
-import org.oppia.android.util.platformparameter.ENABLE_CONTINUE_BUTTON_ANIMATION_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_DOWNLOADS_SUPPORT_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EDIT_ACCOUNTS_OPTIONS_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_EXTRA_TOPIC_TABS_UI_DEFAULT_VALUE
@@ -17,7 +16,6 @@ import org.oppia.android.util.platformparameter.ENABLE_INTERACTION_CONFIG_CHANGE
 import org.oppia.android.util.platformparameter.ENABLE_LANGUAGE_SELECTION_UI_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.ENABLE_PERFORMANCE_METRICS_COLLECTION_DEFAULT_VALUE
 import org.oppia.android.util.platformparameter.EnableAppAndOsDeprecation
-import org.oppia.android.util.platformparameter.EnableContinueButtonAnimation
 import org.oppia.android.util.platformparameter.EnableDownloadsSupport
 import org.oppia.android.util.platformparameter.EnableEditAccountsOptionsUi
 import org.oppia.android.util.platformparameter.EnableExtraTopicTabsUi
@@ -207,14 +205,6 @@ class TestPlatformParameterModule {
     PlatformParameterValue.createDefaultParameter(enableInteractionConfigChangeStateRetention)
 
   @Provides
-  @EnableContinueButtonAnimation
-  fun provideEnableContinueButtonAnimation(): PlatformParameterValue<Boolean> {
-    return PlatformParameterValue.createDefaultParameter(
-      enableContinueButtonAnimation
-    )
-  }
-
-  @Provides
   @EnableSpotlightUi
   fun provideEnableSpotlightUi(): PlatformParameterValue<Boolean> {
     return PlatformParameterValue.createDefaultParameter(
@@ -304,7 +294,6 @@ class TestPlatformParameterModule {
     fun forceEnableDownloadsSupport(value: Boolean) {
       enableDownloadsSupport = value
     }
-    private var enableContinueButtonAnimation = ENABLE_CONTINUE_BUTTON_ANIMATION_DEFAULT_VALUE
 
     /** Enables forcing [EnableLanguageSelectionUi] platform parameter flag from tests. */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
@@ -352,12 +341,6 @@ class TestPlatformParameterModule {
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun forceEnablePerformanceMetricsCollection(value: Boolean) {
       enablePerformanceMetricsCollection = value
-    }
-
-    /** Enables forcing [EnableContinueButtonAnimation] platform parameter flag from tests. */
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun forceEnableContinueButtonAnimation(value: Boolean) {
-      enableContinueButtonAnimation = value
     }
 
     /** Enables forcing [EnableSpotlightUi] platform parameter flag from tests. */

--- a/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
+++ b/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
@@ -171,17 +171,6 @@ const val ENABLE_PERFORMANCE_METRICS_COLLECTION = "enable_performance_metrics_co
 const val ENABLE_PERFORMANCE_METRICS_COLLECTION_DEFAULT_VALUE = false
 
 /**
- * Qualifier for the platform parameter that controls whether to animate the continue button
- * interaction and navigation items. This is used to disable the animation during testing because
- * Espresso has known problems while testing views that contain animations.
- */
-@Qualifier
-annotation class EnableContinueButtonAnimation
-
-/** Default value for whether to enable continue button animation. */
-const val ENABLE_CONTINUE_BUTTON_ANIMATION_DEFAULT_VALUE = true
-
-/**
  * Qualifier for the platform parameter that controls the time interval in minutes of uploading
  * previously recorded performance metrics to the remote service.
  */


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix #5226 

Remove declarations and usages of the enableContinueButtonAnimation PlatformParameter.

### Description of changes introduced to pass the failing tests.

(A) Removed declaration of TestPlatformParameterModule.forceEnableContinueButtonAnimation() from all test functions namely:
testContinueInteractionAnim_openPrototypeExp_checkContinueButtonAnimatesAfter45Seconds(), testConIntAnim_openProtExp_orientLandscapeAfter30Sec_checkAnimHasNotStarted(), testConIntAnim_openProtExp_orientLandAfter30Sec_checkAnimStartsIn15SecAfterOrientChange(), testContNavBtnAnim_openMathExp_checkContNavBtnAnimatesAfter45Seconds(), testContNavBtnAnim_openMathExp_playThroughSecondState_checkContBtnDoesNotAnimateAfter45Sec(), testConIntAnim_openFractions_expId1_checkButtonDoesNotAnimate()
in StateFragmentLocalTest.kt file

(B) Removed function declaration TestPlatformParameterModule.forceEnableContinueButtonAnimation(false) from setup() function
in StateFragmentTest.kt
 
(C) Removed function declaration TestPlatformParameterModule.forceEnableContinueButtonAnimation(false) from setup() function
in ExploreActivityTest.kt

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

