### PR TITLE
Fix #3345 Images are not fully displayed 

### DIFF
--- a/utility/src/main/java/org/oppia/android/util/parser/image/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/image/UrlImageParser.kt
@@ -312,7 +312,9 @@ class UrlImageParser private constructor(
           }
         }
 
-        drawableWidth-=maxContentItemPadding
+        if (drawableWidth >= (maxAvailableWidth - maxContentItemPadding)) {
+          drawableWidth -= maxContentItemPadding
+        }
 
         val drawableLeft = if (imageCenterAlign && !isRTLMode()) {
           calculateInitialMargin(maxAvailableWidth, drawableWidth)

--- a/utility/src/main/java/org/oppia/android/util/parser/image/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/image/UrlImageParser.kt
@@ -268,6 +268,8 @@ class UrlImageParser private constructor(
 
         var drawableWidth = drawable.intrinsicWidth.toFloat()
         var drawableHeight = drawable.intrinsicHeight.toFloat()
+        val maxContentItemPadding =
+          context.resources.getDimensionPixelSize(R.dimen.maximum_content_item_padding)
         if (autoResizeImage) {
           // Treat the drawable's dimensions as dp so that the image scales for higher density
           // displays.
@@ -291,8 +293,7 @@ class UrlImageParser private constructor(
             drawableHeight *= multipleFactor
             drawableWidth *= multipleFactor
           }
-          val maxContentItemPadding =
-            context.resources.getDimensionPixelSize(R.dimen.maximum_content_item_padding)
+
           val maximumImageSize = maxAvailableWidth - maxContentItemPadding
           if (drawableWidth >= maximumImageSize) {
             // The multipleFactor value is used to make sure that the aspect ratio of the image
@@ -310,6 +311,8 @@ class UrlImageParser private constructor(
             drawableWidth *= multipleFactor
           }
         }
+
+        drawableWidth-=maxContentItemPadding
 
         val drawableLeft = if (imageCenterAlign && !isRTLMode()) {
           calculateInitialMargin(maxAvailableWidth, drawableWidth)


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixes #3345, substracting drawableWidth from maxContentItemPadding only if drawableWidth >= (maxcontentWidth - 
 maxContentItemPadding) would solve the issue.
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
### Before

https://user-images.githubusercontent.com/82181327/122643554-54f1ac00-d108-11eb-906f-6748d2facf2f.jpg

https://user-images.githubusercontent.com/101634267/245153650-cd8335df-01ec-47e6-97b2-7f7244d95efb.jpg

https://user-images.githubusercontent.com/101634267/245153665-cb9506d2-6d0d-4231-8a42-5f8ab15cf4d4.jpg

### After

![after_image_cut](https://github.com/oppia/oppia-android/assets/76042077/babacf98-1ef6-4f29-98a4-cc46c5f53303)

![after_imagecut](https://github.com/oppia/oppia-android/assets/76042077/e08cf8d0-5f25-46bb-afbe-124952d19bfc)



![after_image_cut2](https://github.com/oppia/oppia-android/assets/76042077/85e950df-1ae9-48f2-b46c-c610b838593a)

### After RTL

![After_RTL](https://github.com/oppia/oppia-android/assets/76042077/586ade28-a45e-4f0a-9ac8-51457ccf8b5a)

![after_no_effect_RTL](https://github.com/oppia/oppia-android/assets/76042077/75820a6d-cc76-4ec0-b90e-ede7e5a72643)

<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included 
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
