### PR TITLE
Fix #5230: VectorDrawableCompat error lint

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ android {
         includeCompileClasspath true
       }
     }
-    vectorDrawables { useSupportLibrary true } }
+    vectorDrawables { useSupportLibrary true }
   }
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,7 @@ android {
         includeCompileClasspath true
       }
     }
+    vectorDrawables { useSupportLibrary true } }
   }
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix #5230: VectorDrawableCompat Lint error

Warning: VectorDrawableCompat
Fix: opened the app's build.gradle file.
Inside the android block, added the vectorDrawables section under defaultConfig with the code below:
android { ... defaultConfig { ... vectorDrawables { useSupportLibrary true } } }

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
