### PR TITLE
Fix #5231: "Implied quantity lint warning in pt-rBR strings"

### DIFF
--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -185,11 +185,11 @@
   <string name="correct">Correto!</string>
   <string name="topic_prefix">Tópico: %s</string>
   <plurals name="chapter_count" fuzzy="true">
-    <item quantity="one">%d Capítulo</item>
+    <item quantity="one">%s Capítulo</item>
     <item quantity="other">%s Capítulos</item>
   </plurals>
   <plurals name="story_count" fuzzy="true">
-    <item quantity="one">%d História</item>
+    <item quantity="one">%s História</item>
     <item quantity="other">%s Histórias</item>
   </plurals>
   <plurals name="story_total_chapters">
@@ -197,16 +197,16 @@
     <item quantity="other">%s de %s Capítulos Concluídos</item>
   </plurals>
   <plurals name="lesson_count" fuzzy="true">
-    <item quantity="one">%d Lição</item>
+    <item quantity="one">%s Lição</item>
     <item quantity="other">%s Lições</item>
   </plurals>
   <plurals name="completed_story_count" fuzzy="true">
-    <item quantity="one">%d história concluída</item>
+    <item quantity="one">%s história concluída</item>
     <item quantity="zero">%s Histórias concluídas</item>
     <item quantity="other">%s Histórias concluídas</item>
   </plurals>
   <plurals name="ongoing_topic_count" fuzzy="true">
-    <item quantity="one">%d Tópico em andamento</item>
+    <item quantity="one">%s Tópico em andamento</item>
     <item quantity="zero">%s Tópicos em andamento</item>
     <item quantity="other">%s Tópicos em andamento</item>
   </plurals>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -185,20 +185,20 @@
   <string name="correct">Correto!</string>
   <string name="topic_prefix">Tópico: %s</string>
   <plurals name="chapter_count" fuzzy="true">
-    <item quantity="one">%d Capítulo\n    </item>
-    <item quantity="other">\n      %s Capítulos\n    </item>
+    <item quantity="one">%d Capítulo</item>
+    <item quantity="other">%s Capítulos</item>
   </plurals>
   <plurals name="story_count" fuzzy="true">
-    <item quantity="one">%d História\n    </item>
-    <item quantity="other">\n      %s Histórias\n    </item>
+    <item quantity="one">%d História</item>
+    <item quantity="other">%s Histórias</item>
   </plurals>
   <plurals name="story_total_chapters">
     <item quantity="one">%s de %s Capítulo Concluído</item>
     <item quantity="other">%s de %s Capítulos Concluídos</item>
   </plurals>
   <plurals name="lesson_count" fuzzy="true">
-    <item quantity="one">%d Lição\n    </item>
-    <item quantity="other">\n      %s Lições\n    </item>
+    <item quantity="one">%d Lição</item>
+    <item quantity="other">%s Lições</item>
   </plurals>
   <plurals name="completed_story_count" fuzzy="true">
     <item quantity="one">%d história concluída</item>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -185,11 +185,11 @@
   <string name="correct">Correto!</string>
   <string name="topic_prefix">Tópico: %s</string>
   <plurals name="chapter_count" fuzzy="true">
-    <item quantity="one">1 Capítulo\n    </item>
+    <item quantity="one">%d Capítulo\n    </item>
     <item quantity="other">\n      %s Capítulos\n    </item>
   </plurals>
   <plurals name="story_count" fuzzy="true">
-    <item quantity="one">1 História\n    </item>
+    <item quantity="one">%d História\n    </item>
     <item quantity="other">\n      %s Histórias\n    </item>
   </plurals>
   <plurals name="story_total_chapters">
@@ -197,16 +197,16 @@
     <item quantity="other">%s de %s Capítulos Concluídos</item>
   </plurals>
   <plurals name="lesson_count" fuzzy="true">
-    <item quantity="one">1 Lição\n    </item>
+    <item quantity="one">%d Lição\n    </item>
     <item quantity="other">\n      %s Lições\n    </item>
   </plurals>
   <plurals name="completed_story_count" fuzzy="true">
-    <item quantity="one">1 história concluída</item>
+    <item quantity="one">%d história concluída</item>
     <item quantity="zero">%s Histórias concluídas</item>
     <item quantity="other">%s Histórias concluídas</item>
   </plurals>
   <plurals name="ongoing_topic_count" fuzzy="true">
-    <item quantity="one">1 Tópico em andamento</item>
+    <item quantity="one">%d Tópico em andamento</item>
     <item quantity="zero">%s Tópicos em andamento</item>
     <item quantity="other">%s Tópicos em andamento</item>
   </plurals>


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix #5231 

1. Replaced quantity "one" with %s at warnings of implied quantity in pt-rBR strings.
2. Removed new line formats.

<img width="1085" alt="Screenshot 2023-12-04 at 21 22 46" src="https://github.com/oppia/oppia-android/assets/54560535/852c14eb-c523-4515-b152-32ea6adc9615">

Before 
![Screenshot 2023-12-04 at 20 50 19](https://github.com/oppia/oppia-android/assets/54560535/a6118bc9-6592-49b8-a17a-e9d0995edda2)

After
![Screenshot 2023-12-04 at 20 50 29](https://github.com/oppia/oppia-android/assets/54560535/aefeba2d-9b13-4db2-9a2a-8dd665f8e476)


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
