### PR TITLE
Fixed #2652

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -151,7 +151,6 @@ dependencies {
       'androidx.appcompat:appcompat:1.0.2',
       'androidx.constraintlayout:constraintlayout:1.1.3',
       'androidx.core:core-ktx:1.0.2',
-      'androidx.legacy:legacy-support-v4:1.0.0',
       'androidx.lifecycle:lifecycle-extensions:2.0.0',
       'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0-alpha03',
       'androidx.navigation:navigation-fragment:2.0.0',
@@ -180,7 +179,11 @@ dependencies {
       'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1',
       'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1',
       'org.mockito:mockito-core:2.7.22',
-      'com.github.oppia:android-spotlight:ebde38335bfb56349eae57e705b611ead9addb15'
+      'com.github.oppia:android-spotlight:ebde38335bfb56349eae57e705b611ead9addb15',
+
+      //Sambhrant Tiwari
+      'com.intuit.ssp:ssp-android:1.0.5',
+     'com.intuit.sdp:sdp-android:1.0.5'
   )
   compileOnly(
       'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2',

--- a/app/src/main/res/layout/splash_activity.xml
+++ b/app/src/main/res/layout/splash_activity.xml
@@ -35,8 +35,8 @@
 
     <ImageView
       android:id="@+id/splash_oppia_logo"
-      android:layout_width="228dp"
-      android:layout_height="88dp"
+      android:layout_width="@dimen/width_228dp"
+      android:layout_height="@dimen/height_88dp"
       android:importantForAccessibility="no"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <!-- Default screen margins, per the Android Design guidelines. -->
+  <dimen name="width_228dp">228dp</dimen>
+
+  <!-- Example dimension for height -->
+  <dimen name="height_88dp">88dp</dimen>
   <dimen name="activity_horizontal_margin">16dp</dimen>
   <dimen name="activity_vertical_margin">16dp</dimen>
   <dimen name="match_parent">-2px</dimen>


### PR DESCRIPTION

[untitled.webm](https://github.com/oppia/oppia-android/assets/105651436/60d22db7-2dbb-418e-85fa-cd6cf4164342)

[6inch.webm](https://github.com/oppia/oppia-android/assets/105651436/e4b983e0-8e9f-45d0-ab83-29f632299617)


Resolved the Streched Splash Screen issue in both mobile phones of sizes 6 inches or more and on Tablets, added the bazel dependency as well , please review it once.


earlier the splash screen use to look like this
![oppia_earlier](https://github.com/oppia/oppia-android/assets/105651436/91b35d1b-e9c1-40f3-af65-9e9ee094f98d)
