### PR TITLE
Fix #5266: Call setUpDrawer( ) directly if binding already initialized

### DIFF
--- a/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
@@ -374,6 +374,21 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
     this.drawerLayout = drawerLayout
     this.toolbar = toolbar
     this.menuItemId = menuItemId
+
+    /**
+     * [setUpDrawer] is called directly if binding is already initialized.
+     * Otherwise, [setUpDrawer] is called from [handleCreateView].
+     *
+     * Note: [binding] is already initialized when [initializeDrawer] is called via [onRestart]
+     * and [handleCreateView] will not be called in that case.
+     */
+    if (this::binding.isInitialized) {
+      setUpDrawer(
+        this.drawerLayout,
+        this.toolbar,
+        this.menuItemId
+      )
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #5266

This is happening because `setUpDrawer()` is not called when we go back to a particular fragment/activity. `setUpDrawer()` is now called from `handleCreateView()` which is called only when the fragment/activity is created. This is fixed by calling `setUpDrawer()` directly when calling via `onRestart()`.

|Before|After|
|--|--|
|<video src="https://github.com/oppia/oppia-android/assets/84731134/6cf0743d-e615-4950-a3fa-4a31c147099a" />|<video src="https://github.com/oppia/oppia-android/assets/84731134/42c4a7c8-47dd-44b2-817d-2f2ee4069589" />|



## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
