### PR TITLE
Fix part of #5284: Revert "Fix #5266: Call setUpDrawer( ) directly if binding already initialized"

### DIFF
--- a/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
@@ -374,21 +374,6 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
     this.drawerLayout = drawerLayout
     this.toolbar = toolbar
     this.menuItemId = menuItemId
-
-    /**
-     * [setUpDrawer] is called directly if binding is already initialized.
-     * Otherwise, [setUpDrawer] is called from [handleCreateView].
-     *
-     * Note: [binding] is already initialized when [initializeDrawer] is called via [onRestart]
-     * and [handleCreateView] will not be called in that case.
-     */
-    if (this::binding.isInitialized) {
-      setUpDrawer(
-        this.drawerLayout,
-        this.toolbar,
-        this.menuItemId
-      )
-    }
   }
 
   /**


### PR DESCRIPTION
Fixes part of #5284

Reverts #5276 as part of preparing to revert #5191.

Note that this reintroduces #5266 but that should stay fixed once #5191 is reverted.

This should be a clean revert.