### PR TITLE
Fix part of #5070: Display empty answer message in number input interaction

### DIFF
--- a/app/src/main/java/org/oppia/android/app/parser/StringToNumberParser.kt
+++ b/app/src/main/java/org/oppia/android/app/parser/StringToNumberParser.kt
@@ -57,7 +57,8 @@ class StringToNumberParser {
     VALID(error = null),
     INVALID_FORMAT(error = R.string.number_error_invalid_format),
     STARTING_WITH_FLOATING_POINT(error = R.string.number_error_starting_with_floating_point),
-    NUMBER_TOO_LONG(error = R.string.number_error_larger_than_fifteen_characters);
+    NUMBER_TOO_LONG(error = R.string.number_error_larger_than_fifteen_characters),
+    EMPTY_INPUT(error = R.string.number_error_empty_input);
 
     /**
      * Returns the string corresponding to this error's string resources, or null if there is none.

--- a/app/src/main/java/org/oppia/android/app/parser/StringToNumberParser.kt
+++ b/app/src/main/java/org/oppia/android/app/parser/StringToNumberParser.kt
@@ -41,7 +41,7 @@ class StringToNumberParser {
    * detection should be done using [getRealTimeAnswerError], instead.
    */
   fun getSubmitTimeError(text: String): NumericInputParsingError {
-    if (text.normalizeWhitespace().isEmpty()) {
+    if (text.isBlank()) {
       return NumericInputParsingError.EMPTY_INPUT
     }
     if (text.length > 15) {

--- a/app/src/main/java/org/oppia/android/app/parser/StringToNumberParser.kt
+++ b/app/src/main/java/org/oppia/android/app/parser/StringToNumberParser.kt
@@ -41,6 +41,9 @@ class StringToNumberParser {
    * detection should be done using [getRealTimeAnswerError], instead.
    */
   fun getSubmitTimeError(text: String): NumericInputParsingError {
+    if (text.normalizeWhitespace().isEmpty()) {
+      return NumericInputParsingError.EMPTY_INPUT
+    }
     if (text.length > 15) {
       return NumericInputParsingError.NUMBER_TOO_LONG
     }

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/NumericInputViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/NumericInputViewModel.kt
@@ -36,25 +36,34 @@ class NumericInputViewModel private constructor(
         override fun onPropertyChanged(sender: Observable, propertyId: Int) {
           interactionAnswerErrorOrAvailabilityCheckReceiver.onPendingAnswerErrorOrAvailabilityCheck(
             pendingAnswerError,
-            answerText.isNotEmpty()
+            inputAnswerAvailable = true // Allow blank answer submission
           )
         }
       }
     errorMessage.addOnPropertyChangedCallback(callback)
     isAnswerAvailable.addOnPropertyChangedCallback(callback)
+
+    // Initializing with default values so that submit button is enabled by default.
+    interactionAnswerErrorOrAvailabilityCheckReceiver.onPendingAnswerErrorOrAvailabilityCheck(
+      pendingAnswerError = null,
+      inputAnswerAvailable = true
+    )
   }
 
-  /** It checks the pending error for the current numeric input, and correspondingly updates the error string based on the specified error category. */
+  /**
+   * It checks the pending error for the current numeric input, and correspondingly
+   * updates the error string based on the specified error category.
+   */
   override fun checkPendingAnswerError(category: AnswerErrorCategory): String? {
-    if (answerText.isNotEmpty()) {
-      pendingAnswerError = when (category) {
-        AnswerErrorCategory.REAL_TIME ->
+    pendingAnswerError = when (category) {
+      AnswerErrorCategory.REAL_TIME ->
+        if (answerText.isNotEmpty())
           stringToNumberParser.getRealTimeAnswerError(answerText.toString())
             .getErrorMessageFromStringRes(resourceHandler)
-        AnswerErrorCategory.SUBMIT_TIME ->
-          stringToNumberParser.getSubmitTimeError(answerText.toString())
-            .getErrorMessageFromStringRes(resourceHandler)
-      }
+        else null
+      AnswerErrorCategory.SUBMIT_TIME ->
+        stringToNumberParser.getSubmitTimeError(answerText.toString())
+          .getErrorMessageFromStringRes(resourceHandler)
     }
     errorMessage.set(pendingAnswerError)
     return pendingAnswerError

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/NumericInputViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/NumericInputViewModel.kt
@@ -36,7 +36,7 @@ class NumericInputViewModel private constructor(
         override fun onPropertyChanged(sender: Observable, propertyId: Int) {
           interactionAnswerErrorOrAvailabilityCheckReceiver.onPendingAnswerErrorOrAvailabilityCheck(
             pendingAnswerError,
-            inputAnswerAvailable = true // Allow blank answer submission
+            inputAnswerAvailable = true // Allow blank answer submission.
           )
         }
       }
@@ -51,8 +51,8 @@ class NumericInputViewModel private constructor(
   }
 
   /**
-   * It checks the pending error for the current numeric input, and correspondingly
-   * updates the error string based on the specified error category.
+   * It checks the pending error for the current numeric input, and correspondingly updates the
+   * error string based on the specified error category.
    */
   override fun checkPendingAnswerError(category: AnswerErrorCategory): String? {
     pendingAnswerError = when (category) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,6 +170,7 @@
   <string name="number_error_starting_with_floating_point">Please begin your answer with a number (e.g.,”0” in 0.5).</string>
   <string name="number_error_invalid_format">Please enter a valid number.</string>
   <string name="number_error_larger_than_fifteen_characters">The answer can contain at most 15 digits (0–9) or symbols (. or -).</string>
+  <string name="number_error_empty_input">Enter a number to continue.</string>
   <string name="ratio_error_invalid_chars" description="The error message for ratio when there is any other character used than 0123456789:. ">Please write a ratio that consists of digits separated by colons (e.g. 1:2 or 1:2:3).</string>
   <string name="ratio_error_invalid_format" description="The error message for ratio when the format is invalid. For e.g. 1:2:3: or 1:2 3:4 ">Please enter a valid ratio (e.g. 1:2 or 1:2:3).</string>
   <string name="ratio_error_invalid_colons" description="The error message for ratio when there is colons next to each other.">Your answer has two colons (:) next to each other.</string>

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/InputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/InputInteractionViewTestActivityTest.kt
@@ -253,6 +253,24 @@ class InputInteractionViewTestActivityTest {
   @Test
   @DisableAccessibilityChecks // Disabled, as InputInteractionViewTestActivity is a test file and
   // will not be used by user
+  fun testNumericInput_withBlankInput_submit_emptyInputErrorIsDisplayed() {
+    ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
+      scrollToSubmitButton()
+      onView(withId(R.id.submit_button)).check(matches(isDisplayed())).perform(click())
+      onView(withId(R.id.number_input_error))
+        .check(
+          matches(
+            withText(
+              R.string.number_error_empty_input
+            )
+          )
+        )
+    }
+  }
+
+  @Test
+  @DisableAccessibilityChecks // Disabled, as InputInteractionViewTestActivity is a test file and
+  // will not be used by user
   fun testNumericInput_withLongNumber_submit_numberTooLongErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes part of #5070

Enables the `submit_answer_button` when the pending answer is empty. Instead of disabling the button, an error message, stating "_**Enter a number to continue.**_", is now displayed when the user attempts to submit a blank answer.

https://github.com/oppia/oppia-android/assets/84731134/820021bb-94bb-432f-b545-e3bc89e49e17

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
