### PR TITLE
Fix part of #5261: Unused Quantity

### DIFF
--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -202,12 +202,10 @@
   </plurals>
   <plurals name="completed_story_count" fuzzy="true">
     <item quantity="one">%s história concluída</item>
-    <item quantity="zero">%s Histórias concluídas</item>
     <item quantity="other">%s Histórias concluídas</item>
   </plurals>
   <plurals name="ongoing_topic_count" fuzzy="true">
     <item quantity="one">%s Tópico em andamento</item>
-    <item quantity="zero">%s Tópicos em andamento</item>
     <item quantity="other">%s Tópicos em andamento</item>
   </plurals>
   <string name="profile_chooser_activity_label">Página de seleção de perfil</string>


### PR DESCRIPTION
Fix part of #5261

Remove quantity zero from pt-rBR/strings.xml: line 208  [<plurals name="ongoing_topic_count" fuzzy="true">]                                                 
Do the same for <plurals name="completed_story_count" fuzzy="true"> line  203              


<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Before:
        
<img width="1266" alt="Screenshot 2024-01-20 at 21 07 05" src="https://github.com/oppia/oppia-android/assets/54560535/dee10ff1-b395-47b2-958d-a47bc0c1461c">

After:

<img width="1373" alt="Screenshot 2024-01-20 at 22 09 41" src="https://github.com/oppia/oppia-android/assets/54560535/aea2de1d-a7fc-409b-b6eb-6483ad271402">


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [X] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [X] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [X] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [X] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [X] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
