### PR TITLE
Fix #4652 : Implemented Learner Progress for Exploration State

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/state/StateViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateViewModel.kt
@@ -45,6 +45,8 @@ class StateViewModel @Inject constructor(
   val itemList: ObservableList<StateItemViewModel> = ObservableArrayList()
   val rightItemList: ObservableList<StateItemViewModel> = ObservableArrayList()
 
+  var stateProgress = ObservableField(0)
+
   val isSplitView = ObservableField(false)
   val centerGuidelinePercentage = ObservableField(0.5f)
 
@@ -81,6 +83,10 @@ class StateViewModel @Inject constructor(
 
   fun initializeProfile(profileId: ProfileId) {
     this.profileId = profileId
+  }
+
+  fun setStateProgress(progress: Int) {
+    stateProgress.set(progress)
   }
 
   fun setAudioBarVisibility(audioBarVisible: Boolean) {

--- a/app/src/main/res/layout/state_fragment.xml
+++ b/app/src/main/res/layout/state_fragment.xml
@@ -24,6 +24,22 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent">
 
+      <ProgressBar
+        android:id="@+id/state_progress_bar"
+        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+        android:layout_width="0dp"
+        android:layout_height="12dp"
+        android:max="100"
+        android:progress="@{viewModel.stateProgress}"
+        android:progressDrawable="@drawable/progress_bar"
+        android:layout_marginStart="32dp"
+        android:layout_marginEnd="32dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
       <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/state_recycler_view"
         android:layout_width="0dp"
@@ -39,7 +55,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/center_guideline"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/state_progress_bar" />
 
       <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/extra_interaction_recycler_view"
@@ -56,7 +72,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/center_guideline"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/state_progress_bar" />
 
       <androidx.constraintlayout.widget.Guideline
         android:id="@+id/center_guideline"

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationRetriever.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationRetriever.kt
@@ -6,4 +6,8 @@ import org.oppia.android.app.model.Exploration
 interface ExplorationRetriever {
   /** Loads and returns an exploration for the specified exploration ID, or fails. */
   suspend fun loadExploration(explorationId: String): Exploration
+  /** Loads and returns Pair of Total number of states for the specified exploration ID
+   * and a Mutable Map of State Names and their position in the exploration list
+   */
+  suspend fun loadExplorationPosition(explorationId: String): Pair<Int, MutableMap<String, Int>>
 }

--- a/domain/src/main/java/org/oppia/android/domain/exploration/testing/FakeExplorationRetriever.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/testing/FakeExplorationRetriever.kt
@@ -22,6 +22,11 @@ class FakeExplorationRetriever @Inject constructor(
     return productionImpl.loadExploration(expIdToLoad)
   }
 
+  override suspend fun loadExplorationPosition(explorationId: String): Pair<Int, MutableMap<String, Int>> {
+    val expIdToLoad = explorationProxies[explorationId] ?: explorationId
+    return productionImpl.loadExplorationPosition(expIdToLoad)
+  }
+
   /**
    * Sets the exploration ID that should be loaded in place of [expIdToLoad] on all future calls to
    * [loadExploration].


### PR DESCRIPTION
Fixes #4652

<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
- This PR provides an implementation for displaying learning progress in the exploration lessons.
- As mentioned [in the issue](https://github.com/oppia/oppia-android/issues/4652#issuecomment-1314591992), Oppia lessons are dynamic in nature, and to define the progress, the flow of lessons is mandatory. 
  - One way we could fix this is by providing order numbers to the JSON files themselves, but that would make it difficult to scale and add other states in the future. 
  - So, I implemented a small parser that identifies the order of the lessons by going through the JSON.

![Screenshot (450)](https://github.com/oppia/oppia-android/assets/122200035/5e989a2c-57e9-4285-b439-e39435921fd7)

- The way the parser works is as follows: 
  - It starts off with **init_state_name**. 
  - With each state, it first identifies its **default_outcome** and assigns a position to them. 
  - Then, it checks the **answers_group** from bottom to top and assigns those states their positions one by one (note that only the first entries are noted). 
  - Thereby, the order of the exploration lessons is obtained. I have attached the pseudocode for reference and the obtained list of **statename** : **positions** below.

![exploration_pseudo_code](https://github.com/oppia/oppia-android/assets/122200035/38f23ed3-b8ef-416b-9ff8-1a3e9e44ef0a)

- The way it handles the dynamic changes of questions is that the total number of questions remains the same as the total number of states. The current state is checked on every new exploration. Let's say we have 3 states; 
  - answering state 1 correctly will skip you to state 3, making the progress jump from 10% to 30%. 
  - If state 1 is answered incorrectly, the result_answers are checked, and state 2 is triggered, making the progress go from 10% to 20%. 
  - The same applies to the decrement of progress when recapping back to previous states.
- The progress bar uses the same design as the question player progress bar.

## TODO: 
- runBlocking should be properly checked and handled if needed, replaced with proper coroutine. 
- Tests will be updated soon. -[Hindered Implementation due to Bug #5379 
- Check landscape implementation
- To check visibility and proper positioning with audio block
## Note: 
- This is a proposed solution. I would love to hear feedback on whether this would be viable or not.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Demonstration
https://github.com/oppia/oppia-android/assets/122200035/1ac1b67a-6ab0-4b81-9511-23759a86b244

