### PR TITLE
Fix #2536: Introduce a central utility for matching item in RecyclerView

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -6,11 +6,9 @@ import android.content.Intent
 import android.view.View
 import android.view.ViewParent
 import android.widget.FrameLayout
-import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.NestedScrollView
 import androidx.drawerlayout.widget.DrawerLayout
-import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
@@ -21,9 +19,7 @@ import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.scrollTo
-import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
@@ -67,6 +63,12 @@ import org.oppia.android.app.model.ScreenName
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.profile.ProfileChooserActivity
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.scrollToPosition
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyItemDisplayedOnListItem
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyItemDisplayedOnListItemDoesNotExist
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyTextInDialog
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyTextOnListItemAtPosition
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyTextViewOnListItemAtPositionDoesNotExist
 import org.oppia.android.app.settings.profile.ProfileListActivity
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.translation.testing.ActivityRecreatorTestModule
@@ -131,7 +133,6 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
-import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyItemDisplayedOnListItem
 
 /** Tests for [AdministratorControlsActivity]. */
 @RunWith(AndroidJUnit4::class)

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -131,6 +131,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyItemDisplayedOnListItem
 
 /** Tests for [AdministratorControlsActivity]. */
 @RunWith(AndroidJUnit4::class)

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -216,14 +216,17 @@ class AdministratorControlsActivityTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      verifyItemDisplayedOnAdministratorControlListItem(
+      verifyItemDisplayedOnListItem(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 0,
         targetView = R.id.general_text_view
       )
-      verifyTextOnAdministratorListItemAtPosition(
+      verifyTextOnListItemAtPosition(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 0,
         targetViewId = R.id.edit_account_text_view,
-        stringIdToMatch = R.string.administrator_controls_edit_account
+        stringIdToMatch = R.string.administrator_controls_edit_account,
+        context = context
       )
     }
   }
@@ -238,13 +241,15 @@ class AdministratorControlsActivityTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      verifyItemDisplayedOnAdministratorControlListItemDoesNotExist(
+      verifyItemDisplayedOnListItemDoesNotExist(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 0,
         targetView = R.id.general_text_view
       )
-      verifyTextViewOnAdministratorListItemAtPositionDoesNotExist(
+      verifyTextViewOnListItemAtPositionDoesNotExist(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 0,
-        targetViewId = R.id.edit_account_text_view,
+        targetViewId = R.id.edit_account_text_view
       )
     }
   }
@@ -257,14 +262,17 @@ class AdministratorControlsActivityTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      verifyItemDisplayedOnAdministratorControlListItem(
+      verifyItemDisplayedOnListItem(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 1,
         targetView = R.id.profile_management_text_view
       )
-      verifyTextOnAdministratorListItemAtPosition(
+      verifyTextOnListItemAtPosition(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 1,
         targetViewId = R.id.edit_profiles_text_view,
-        stringIdToMatch = R.string.administrator_controls_edit_profiles
+        stringIdToMatch = R.string.administrator_controls_edit_profiles,
+        context = context
       )
     }
   }
@@ -277,9 +285,9 @@ class AdministratorControlsActivityTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 3)
+      scrollToPosition(position = 3, recyclerViewId = administratorControlsListRecyclerViewId)
       onView(withId(R.id.log_out_text_view)).perform(click())
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message, context)
       onView(withText(R.string.log_out_dialog_okay_button)).perform(click())
       intended(hasComponent(ProfileChooserActivity::class.java.name))
     }
@@ -293,7 +301,7 @@ class AdministratorControlsActivityTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 2)
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
       onView(withId(R.id.app_version_text_view)).perform(click())
       intended(hasComponent(AppVersionActivity::class.java.name))
     }
@@ -322,11 +330,11 @@ class AdministratorControlsActivityTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 3)
+      scrollToPosition(position = 3, recyclerViewId = administratorControlsListRecyclerViewId)
       onView(withId(R.id.log_out_text_view)).perform(click())
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message, context)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button, context)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button, context)
     }
   }
 
@@ -338,13 +346,13 @@ class AdministratorControlsActivityTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 3)
+      scrollToPosition(position = 3, recyclerViewId = administratorControlsListRecyclerViewId)
       onView(isRoot()).perform(orientationLandscape())
-      scrollToPosition(position = 3)
+      scrollToPosition(position = 3, recyclerViewId = administratorControlsListRecyclerViewId)
       onView(withId(R.id.log_out_text_view)).perform(click())
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message, context)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button, context)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button, context)
     }
   }
 
@@ -356,12 +364,12 @@ class AdministratorControlsActivityTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 3)
+      scrollToPosition(position = 3, recyclerViewId = administratorControlsListRecyclerViewId)
       onView(withId(R.id.log_out_text_view)).perform(click())
       onView(isRoot()).perform(orientationLandscape())
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message, context)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button, context)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button, context)
     }
   }
 
@@ -373,9 +381,9 @@ class AdministratorControlsActivityTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 3)
+      scrollToPosition(position = 3, recyclerViewId = administratorControlsListRecyclerViewId)
       onView(withId(R.id.log_out_text_view)).perform(click())
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message, context)
       onView(withText(R.string.log_out_dialog_cancel_button)).perform(click())
       onView(withId(R.id.log_out_text_view)).check(matches(isDisplayed()))
     }
@@ -409,7 +417,7 @@ class AdministratorControlsActivityTest {
       )
 
       // Open the app version fragment
-      scrollToPosition(position = 3)
+      scrollToPosition(position = 3, recyclerViewId = administratorControlsListRecyclerViewId)
       onView(withId(R.id.app_version_text_view)).perform(click())
 
       // Check that the multipane container has only one child and it is the app version fragment
@@ -880,70 +888,6 @@ class AdministratorControlsActivityTest {
 
   private fun findParent(view: ViewParent): ViewParent {
     return view.getParent()
-  }
-
-  private fun verifyItemDisplayedOnAdministratorControlListItem(
-    itemPosition: Int,
-    targetView: Int
-  ) {
-    onView(
-      atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
-        position = itemPosition,
-        targetViewId = targetView
-      )
-    ).check(matches(isDisplayed()))
-  }
-
-  private fun verifyItemDisplayedOnAdministratorControlListItemDoesNotExist(
-    itemPosition: Int,
-    targetView: Int
-  ) {
-    onView(
-      atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
-        position = itemPosition,
-        targetViewId = targetView
-      )
-    ).check(doesNotExist())
-  }
-
-  private fun verifyTextOnAdministratorListItemAtPosition(
-    itemPosition: Int,
-    targetViewId: Int,
-    @StringRes stringIdToMatch: Int
-  ) {
-    onView(
-      atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
-        position = itemPosition,
-        targetViewId = targetViewId
-      )
-    ).check(matches(withText(context.getString(stringIdToMatch))))
-  }
-
-  private fun verifyTextViewOnAdministratorListItemAtPositionDoesNotExist(
-    itemPosition: Int,
-    targetViewId: Int,
-  ) {
-    onView(
-      atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
-        position = itemPosition,
-        targetViewId = targetViewId
-      )
-    ).check(doesNotExist())
-  }
-
-  private fun scrollToPosition(position: Int) {
-    onView(withId(R.id.administrator_controls_list))
-      .perform(scrollToPosition<RecyclerView.ViewHolder>(position))
-  }
-
-  private fun verifyTextInDialog(@StringRes textInDialogId: Int) {
-    onView(withText(context.getString(textInDialogId)))
-      .inRoot(isDialog())
-      .check(matches(isDisplayed()))
   }
 
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.view.View
 import android.view.ViewParent
 import android.widget.FrameLayout
-import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.NestedScrollView
 import androidx.drawerlayout.widget.DrawerLayout
@@ -67,6 +66,7 @@ import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPositi
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.scrollToPosition
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyItemDisplayedOnListItem
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyItemDisplayedOnListItemDoesNotExist
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyTextInDialog
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyTextOnListItemAtPosition
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyTextViewOnListItemAtPositionDoesNotExist
 import org.oppia.android.app.settings.profile.ProfileListActivity
@@ -385,7 +385,7 @@ class AdministratorControlsActivityTest {
       testCoroutineDispatchers.runCurrent()
       scrollToPosition(position = 3, recyclerViewId = administratorControlsListRecyclerViewId)
       onView(withId(R.id.log_out_text_view)).perform(click())
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message, context)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
       onView(withText(R.string.log_out_dialog_cancel_button)).perform(click())
       onView(withId(R.id.log_out_text_view)).check(matches(isDisplayed()))
     }
@@ -890,12 +890,6 @@ class AdministratorControlsActivityTest {
 
   private fun findParent(view: ViewParent): ViewParent {
     return view.getParent()
-  }
-
-  private fun verifyTextInDialog(@StringRes textInDialogId: Int) {
-    onView(withText(context.getString(textInDialogId)))
-      .inRoot(isDialog())
-      .check(matches(isDisplayed()))
   }
 
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -227,8 +227,7 @@ class AdministratorControlsActivityTest {
         recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 0,
         targetViewId = R.id.edit_account_text_view,
-        stringIdToMatch = R.string.administrator_controls_edit_account,
-        context = context
+        stringIdToMatch = R.string.administrator_controls_edit_account
       )
     }
   }
@@ -273,8 +272,7 @@ class AdministratorControlsActivityTest {
         recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 1,
         targetViewId = R.id.edit_profiles_text_view,
-        stringIdToMatch = R.string.administrator_controls_edit_profiles,
-        context = context
+        stringIdToMatch = R.string.administrator_controls_edit_profiles
       )
     }
   }

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.view.View
 import android.view.ViewParent
 import android.widget.FrameLayout
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.NestedScrollView
 import androidx.drawerlayout.widget.DrawerLayout
@@ -66,7 +67,6 @@ import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPositi
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.scrollToPosition
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyItemDisplayedOnListItem
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyItemDisplayedOnListItemDoesNotExist
-import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyTextInDialog
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyTextOnListItemAtPosition
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyTextViewOnListItemAtPositionDoesNotExist
 import org.oppia.android.app.settings.profile.ProfileListActivity
@@ -289,7 +289,7 @@ class AdministratorControlsActivityTest {
       testCoroutineDispatchers.runCurrent()
       scrollToPosition(position = 3, recyclerViewId = administratorControlsListRecyclerViewId)
       onView(withId(R.id.log_out_text_view)).perform(click())
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message, context)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
       onView(withText(R.string.log_out_dialog_okay_button)).perform(click())
       intended(hasComponent(ProfileChooserActivity::class.java.name))
     }
@@ -334,9 +334,9 @@ class AdministratorControlsActivityTest {
       testCoroutineDispatchers.runCurrent()
       scrollToPosition(position = 3, recyclerViewId = administratorControlsListRecyclerViewId)
       onView(withId(R.id.log_out_text_view)).perform(click())
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message, context)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button, context)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button, context)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button)
     }
   }
 
@@ -352,9 +352,9 @@ class AdministratorControlsActivityTest {
       onView(isRoot()).perform(orientationLandscape())
       scrollToPosition(position = 3, recyclerViewId = administratorControlsListRecyclerViewId)
       onView(withId(R.id.log_out_text_view)).perform(click())
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message, context)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button, context)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button, context)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button)
     }
   }
 
@@ -369,9 +369,9 @@ class AdministratorControlsActivityTest {
       scrollToPosition(position = 3, recyclerViewId = administratorControlsListRecyclerViewId)
       onView(withId(R.id.log_out_text_view)).perform(click())
       onView(isRoot()).perform(orientationLandscape())
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message, context)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button, context)
-      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button, context)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_message)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_okay_button)
+      verifyTextInDialog(textInDialogId = R.string.log_out_dialog_cancel_button)
     }
   }
 
@@ -890,6 +890,12 @@ class AdministratorControlsActivityTest {
 
   private fun findParent(view: ViewParent): ViewParent {
     return view.getParent()
+  }
+
+  private fun verifyTextInDialog(@StringRes textInDialogId: Int) {
+    onView(withText(context.getString(textInDialogId)))
+      .inRoot(isDialog())
+      .check(matches(isDisplayed()))
   }
 
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -157,6 +157,8 @@ class AdministratorControlsActivityTest {
   @Inject
   lateinit var context: Context
 
+  private val administratorControlsListRecyclerViewId: Int = R.id.administrator_controls_list
+
   @get:Rule
   val activityTestRule = ActivityTestRule(
     AdministratorControlsActivity::class.java,

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -6,10 +6,8 @@ import android.content.Intent
 import android.view.View
 import android.view.ViewParent
 import android.widget.FrameLayout
-import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.NestedScrollView
-import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
@@ -17,18 +15,12 @@ import androidx.test.espresso.PerformException
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isClickable
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.espresso.util.HumanReadables
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Component
@@ -54,6 +46,10 @@ import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.scrollToPosition
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyItemDisplayedOnListItem
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyItemDisplayedOnListItemDoesNotExist
+import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.verifyTextOnListItemAtPosition
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.testing.AdministratorControlsFragmentTestActivity
 import org.oppia.android.app.translation.testing.ActivityRecreatorTestModule
@@ -144,6 +140,8 @@ class AdministratorControlsFragmentTest {
   @Inject
   lateinit var context: Context
 
+  private val administratorControlsListRecyclerViewId: Int = R.id.administrator_controls_list
+
   @Before
   fun setUp() {
     TestPlatformParameterModule.forceEnableEditAccountsOptionsUi(true)
@@ -172,23 +170,30 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      verifyItemDisplayedOnAdministratorControlListItem(
+
+      verifyItemDisplayedOnListItem(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 0,
         targetView = R.id.general_text_view
       )
-      verifyTextOnAdministratorListItemAtPosition(
+      verifyTextOnListItemAtPosition(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 0,
         targetViewId = R.id.edit_account_text_view,
-        stringIdToMatch = R.string.administrator_controls_edit_account
+        stringIdToMatch = R.string.administrator_controls_edit_account,
+        context = context
       )
-      verifyItemDisplayedOnAdministratorControlListItem(
+      verifyItemDisplayedOnListItem(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 1,
         targetView = R.id.profile_management_text_view
       )
-      verifyTextOnAdministratorListItemAtPosition(
+      verifyTextOnListItemAtPosition(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 1,
         targetViewId = R.id.edit_profiles_text_view,
-        stringIdToMatch = R.string.administrator_controls_edit_profiles
+        stringIdToMatch = R.string.administrator_controls_edit_profiles,
+        context = context
       )
     }
   }
@@ -201,17 +206,21 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      verifyTextOnAdministratorListItemAtPosition(
+      verifyTextOnListItemAtPosition(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 2,
         targetViewId = R.id.download_permissions_text_view,
-        stringIdToMatch = R.string.administrator_controls_download_permissions_label
+        stringIdToMatch = R.string.administrator_controls_download_permissions_label,
+        context = context
       )
-      verifyItemDisplayedOnAdministratorControlListItem(
+      verifyItemDisplayedOnListItem(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 2,
         targetView = R.id.topic_update_on_wifi_constraint_layout
       )
-      scrollToPosition(position = 2)
-      verifyItemDisplayedOnAdministratorControlListItem(
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
+      verifyItemDisplayedOnListItem(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 2,
         targetView = R.id.auto_update_topic_constraint_layout
       )
@@ -227,12 +236,14 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 2)
-      verifyItemDoesNotExistInAdministratorControlListItem(
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
+      verifyItemDisplayedOnListItemDoesNotExist(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 2,
         targetView = R.id.download_permissions_text_view
       )
-      verifyItemDoesNotExistInAdministratorControlListItem(
+      verifyItemDisplayedOnListItemDoesNotExist(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 2,
         targetView = R.id.auto_update_topic_constraint_layout
       )
@@ -247,24 +258,30 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 3)
-      verifyItemDisplayedOnAdministratorControlListItem(
+      scrollToPosition(position = 3, recyclerViewId = administratorControlsListRecyclerViewId)
+      verifyItemDisplayedOnListItem(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 3,
         targetView = R.id.app_information_text_view
       )
-      verifyTextOnAdministratorListItemAtPosition(
+      verifyTextOnListItemAtPosition(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 3,
         targetViewId = R.id.app_version_text_view,
-        stringIdToMatch = R.string.administrator_controls_app_version
+        stringIdToMatch = R.string.administrator_controls_app_version,
+        context = context
       )
-      verifyItemDisplayedOnAdministratorControlListItem(
+      verifyItemDisplayedOnListItem(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 4,
         targetView = R.id.account_actions_text_view
       )
-      verifyTextOnAdministratorListItemAtPosition(
+      verifyTextOnListItemAtPosition(
+        recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 4,
         targetViewId = R.id.log_out_text_view,
-        stringIdToMatch = R.string.administrator_controls_log_out
+        stringIdToMatch = R.string.administrator_controls_log_out,
+        context = context
       )
     }
   }
@@ -289,7 +306,7 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 2)
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
       checkAutoUpdateSwitchIsUnchecked()
     }
   }
@@ -302,7 +319,7 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 2)
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
       clickUpdateOnWifiSwitch()
       atAdminControlsItem(position = 2, viewId = R.id.topic_update_on_wifi_constraint_layout)
       testCoroutineDispatchers.runCurrent()
@@ -318,12 +335,12 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 2)
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
       clickUpdateOnWifiSwitch()
       atAdminControlsItem(position = 2, viewId = R.id.topic_update_on_wifi_constraint_layout)
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
-      scrollToPosition(position = 2)
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
       checkUpdateOnWifiSwitchIsChecked()
     }
   }
@@ -336,13 +353,13 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 2)
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
       clickUpdateOnWifiSwitch()
       atAdminControlsItem(position = 2, viewId = R.id.topic_update_on_wifi_constraint_layout)
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
       onView(isRoot()).perform(orientationPortrait())
-      scrollToPosition(position = 2)
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
       checkUpdateOnWifiSwitchIsChecked()
     }
   }
@@ -355,11 +372,11 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 2)
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
       clickAutoUpdateTopicSwitch()
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
-      scrollToPosition(position = 2)
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
       checkAutoUpdateTopicSwitchIsChecked()
     }
   }
@@ -372,12 +389,12 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 2)
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
       clickAutoUpdateTopicSwitch()
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
       onView(isRoot()).perform(orientationPortrait())
-      scrollToPosition(position = 2)
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
       checkAutoUpdateTopicSwitchIsChecked()
     }
   }
@@ -390,7 +407,7 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 2)
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
       clickAutoUpdateTopicContainer()
       testCoroutineDispatchers.runCurrent()
       checkAutoUpdateTopicSwitchIsChecked()
@@ -405,7 +422,7 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 2)
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
       checkUpdateOnWifiSwitchNotClickable()
     }
   }
@@ -418,7 +435,7 @@ class AdministratorControlsFragmentTest {
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
-      scrollToPosition(position = 2)
+      scrollToPosition(position = 2, recyclerViewId = administratorControlsListRecyclerViewId)
       checkAutoUpdateTopicSwitchNotClickable()
     }
   }
@@ -426,7 +443,7 @@ class AdministratorControlsFragmentTest {
   private fun clickAutoUpdateTopicContainer() {
     onView(
       atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
+        recyclerViewId = administratorControlsListRecyclerViewId,
         position = 2,
         targetViewId = R.id.auto_update_topic_constraint_layout
       )
@@ -436,7 +453,7 @@ class AdministratorControlsFragmentTest {
   private fun checkUpdateOnWifiSwitchNotClickable() {
     onView(
       atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
+        recyclerViewId = administratorControlsListRecyclerViewId,
         position = 2,
         targetViewId = R.id.topic_update_on_wifi_switch
       )
@@ -446,7 +463,7 @@ class AdministratorControlsFragmentTest {
   private fun checkAutoUpdateTopicSwitchNotClickable() {
     onView(
       atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
+        recyclerViewId = administratorControlsListRecyclerViewId,
         position = 2,
         targetViewId = R.id.auto_update_topic_switch
       )
@@ -456,7 +473,7 @@ class AdministratorControlsFragmentTest {
   private fun checkUpdateOnWifiSwitchNotChecked() {
     onView(
       atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
+        recyclerViewId = administratorControlsListRecyclerViewId,
         position = 2,
         targetViewId = R.id.topic_update_on_wifi_switch
       )
@@ -466,7 +483,7 @@ class AdministratorControlsFragmentTest {
   private fun clickAutoUpdateTopicSwitch() {
     onView(
       atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
+        recyclerViewId = administratorControlsListRecyclerViewId,
         position = 2,
         targetViewId = R.id.auto_update_topic_switch
       )
@@ -476,7 +493,7 @@ class AdministratorControlsFragmentTest {
   private fun checkAutoUpdateTopicSwitchIsChecked() {
     onView(
       atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
+        recyclerViewId = administratorControlsListRecyclerViewId,
         position = 2,
         targetViewId = R.id.auto_update_topic_switch
       )
@@ -486,7 +503,7 @@ class AdministratorControlsFragmentTest {
   private fun checkAutoUpdateSwitchIsUnchecked() {
     onView(
       atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
+        recyclerViewId = administratorControlsListRecyclerViewId,
         position = 2,
         targetViewId = R.id.auto_update_topic_switch
       )
@@ -496,7 +513,7 @@ class AdministratorControlsFragmentTest {
   private fun checkUpdateOnWifiSwitchIsChecked() {
     onView(
       atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
+        recyclerViewId = administratorControlsListRecyclerViewId,
         position = 2,
         targetViewId = R.id.topic_update_on_wifi_switch
       )
@@ -510,7 +527,11 @@ class AdministratorControlsFragmentTest {
   }
 
   private fun atAdminControlsItem(position: Int, viewId: Int): Matcher<View> {
-    return atPositionOnView(recyclerViewId = R.id.administrator_controls_list, position, viewId)
+    return atPositionOnView(
+      recyclerViewId = administratorControlsListRecyclerViewId,
+      position,
+      viewId
+    )
   }
 
   private fun createAdministratorControlsFragmentTestActivityIntent(profileId: Int): Intent {
@@ -573,60 +594,6 @@ class AdministratorControlsFragmentTest {
 
   private fun findParent(view: ViewParent): ViewParent {
     return view.getParent()
-  }
-
-  private fun verifyItemDisplayedOnAdministratorControlListItem(
-    itemPosition: Int,
-    targetView: Int
-  ) {
-    onView(
-      atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
-        position = itemPosition,
-        targetViewId = targetView
-      )
-    ).check(matches(isDisplayed()))
-  }
-
-  private fun verifyItemDoesNotExistInAdministratorControlListItem(
-    itemPosition: Int,
-    targetView: Int
-  ) {
-    onView(
-      atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
-        position = itemPosition,
-        targetViewId = targetView
-      )
-    ).check(doesNotExist())
-  }
-
-  private fun verifyTextOnAdministratorListItemAtPosition(
-    itemPosition: Int,
-    targetViewId: Int,
-    @StringRes stringIdToMatch: Int
-  ) {
-    onView(
-      atPositionOnView(
-        recyclerViewId = R.id.administrator_controls_list,
-        position = itemPosition,
-        targetViewId = targetViewId
-      )
-    ).check(matches(withText(context.getString(stringIdToMatch))))
-  }
-
-  private fun scrollToPosition(position: Int) {
-    onView(withId(R.id.administrator_controls_list)).perform(
-      scrollToPosition<RecyclerView.ViewHolder>(
-        position
-      )
-    )
-  }
-
-  private fun verifyTextInDialog(@StringRes textInDialogId: Int) {
-    onView(withText(context.getString(textInDialogId)))
-      .inRoot(RootMatchers.isDialog())
-      .check(matches(isDisplayed()))
   }
 
   @Singleton

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -180,8 +180,7 @@ class AdministratorControlsFragmentTest {
         recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 0,
         targetViewId = R.id.edit_account_text_view,
-        stringIdToMatch = R.string.administrator_controls_edit_account,
-        context = context
+        stringIdToMatch = R.string.administrator_controls_edit_account
       )
       verifyItemDisplayedOnListItem(
         recyclerViewId = administratorControlsListRecyclerViewId,
@@ -192,8 +191,7 @@ class AdministratorControlsFragmentTest {
         recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 1,
         targetViewId = R.id.edit_profiles_text_view,
-        stringIdToMatch = R.string.administrator_controls_edit_profiles,
-        context = context
+        stringIdToMatch = R.string.administrator_controls_edit_profiles
       )
     }
   }
@@ -210,8 +208,7 @@ class AdministratorControlsFragmentTest {
         recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 2,
         targetViewId = R.id.download_permissions_text_view,
-        stringIdToMatch = R.string.administrator_controls_download_permissions_label,
-        context = context
+        stringIdToMatch = R.string.administrator_controls_download_permissions_label
       )
       verifyItemDisplayedOnListItem(
         recyclerViewId = administratorControlsListRecyclerViewId,
@@ -268,8 +265,7 @@ class AdministratorControlsFragmentTest {
         recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 3,
         targetViewId = R.id.app_version_text_view,
-        stringIdToMatch = R.string.administrator_controls_app_version,
-        context = context
+        stringIdToMatch = R.string.administrator_controls_app_version
       )
       verifyItemDisplayedOnListItem(
         recyclerViewId = administratorControlsListRecyclerViewId,
@@ -280,8 +276,7 @@ class AdministratorControlsFragmentTest {
         recyclerViewId = administratorControlsListRecyclerViewId,
         itemPosition = 4,
         targetViewId = R.id.log_out_text_view,
-        stringIdToMatch = R.string.administrator_controls_log_out,
-        context = context
+        stringIdToMatch = R.string.administrator_controls_log_out
       )
     }
   }

--- a/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
@@ -1,11 +1,18 @@
 package org.oppia.android.app.recyclerview
 
+import android.content.Context
 import android.content.res.Resources
 import android.view.View
+import androidx.annotation.StringRes
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.ViewAssertion
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.RootMatchers
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.Description
@@ -73,6 +80,117 @@ class RecyclerViewMatcher {
 
     fun hasGridColumnCount(expectedColumnCount: Int): ViewAssertion {
       return GridLayoutManagerColumnCountAssertion(expectedColumnCount)
+    }
+
+    /**
+     * Verifies if an item at a specified position in a RecyclerView with the given ID contains a target view that is displayed.
+     *
+     * @param recyclerViewId The resource ID of the RecyclerView.
+     * @param itemPosition The position of the item in the RecyclerView.
+     * @param targetView The resource ID of the target view within the item.
+     */
+    fun verifyItemDisplayedOnListItem(
+      recyclerViewId: Int,
+      itemPosition: Int,
+      targetView: Int
+    ) {
+      Espresso.onView(
+        atPositionOnView(
+          recyclerViewId = recyclerViewId,
+          position = itemPosition,
+          targetViewId = targetView
+        )
+      ).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+    }
+
+    /**
+     * Verifies if an item at a specified position in a RecyclerView with the given ID does not contain a target view.
+     *
+     * @param recyclerViewId The resource ID of the RecyclerView.
+     * @param itemPosition The position of the item in the RecyclerView.
+     * @param targetView The resource ID of the target view within the item.
+     */
+    fun verifyItemDisplayedOnListItemDoesNotExist(
+      recyclerViewId: Int,
+      itemPosition: Int,
+      targetView: Int
+    ) {
+      Espresso.onView(
+        atPositionOnView(
+          recyclerViewId = recyclerViewId,
+          position = itemPosition,
+          targetViewId = targetView
+        )
+      ).check(ViewAssertions.doesNotExist())
+    }
+
+    /**
+     * Verifies if the text of a target view within an item at a specified position in a RecyclerView with the given ID matches the provided string resource.
+     *
+     * @param recyclerViewId The resource ID of the RecyclerView.
+     * @param itemPosition The position of the item in the RecyclerView.
+     * @param targetViewId The resource ID of the target view within the item.
+     * @param stringIdToMatch The resource ID of the string to match against the target view's text.
+     * @param context The context used to access resources.
+     */
+    fun verifyTextOnListItemAtPosition(
+      recyclerViewId: Int,
+      itemPosition: Int,
+      targetViewId: Int,
+      @StringRes stringIdToMatch: Int,
+      context: Context
+    ) {
+      Espresso.onView(
+        atPositionOnView(
+          recyclerViewId = recyclerViewId,
+          position = itemPosition,
+          targetViewId = targetViewId
+        )
+      ).check(ViewAssertions.matches(ViewMatchers.withText(context.getString(stringIdToMatch))))
+    }
+
+    /**
+     * Verifies if a target view within an item at a specified position in a RecyclerView with the given ID does not exist.
+     *
+     * @param recyclerViewId The resource ID of the RecyclerView.
+     * @param itemPosition The position of the item in the RecyclerView.
+     * @param targetViewId The resource ID of the target view within the item.
+     */
+    fun verifyTextViewOnListItemAtPositionDoesNotExist(
+      recyclerViewId: Int,
+      itemPosition: Int,
+      targetViewId: Int
+    ) {
+      Espresso.onView(
+        atPositionOnView(
+          recyclerViewId = recyclerViewId,
+          position = itemPosition,
+          targetViewId = targetViewId
+        )
+      ).check(ViewAssertions.doesNotExist())
+    }
+
+    /**
+     * Verifies if the provided text, referenced by its String resource ID, is displayed in a dialog.
+     *
+     * @param textInDialogId The resource ID of the text to verify in the dialog.
+     * @param context The context used to retrieve the actual text from the provided resource ID.
+     */
+    fun verifyTextInDialog(@StringRes textInDialogId: Int, context: Context) {
+      Espresso.onView(ViewMatchers.withText(context.getString(textInDialogId)))
+        .inRoot(RootMatchers.isDialog())
+        .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+    }
+
+    /**
+     * Scrolls to the specified position within a RecyclerView.
+     *
+     * @param position The position to scroll to within the RecyclerView.
+     * @param recyclerViewId The resource ID of the RecyclerView to perform scrolling on.
+     */
+    fun scrollToPosition(position: Int, recyclerViewId: Int) {
+      Espresso.onView(ViewMatchers.withId(recyclerViewId))
+        .perform(RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(position))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
@@ -21,15 +21,11 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
-import org.oppia.android.app.translation.AppLanguageResourceHandler
-import javax.inject.Inject
 
 // Reference Link: https://github.com/dannyroa/espresso-samples/blob/master/RecyclerView/app/src/androidTest/java/com/dannyroa/espresso_samples/recyclerview/RecyclerViewMatcher.java
 class RecyclerViewMatcher {
 
   companion object {
-    @Inject
-    lateinit var resourceHandler: AppLanguageResourceHandler
 
     /**
      * This function returns a Matcher for an item inside RecyclerView from a specified position.
@@ -186,7 +182,7 @@ class RecyclerViewMatcher {
      * @param context The context used to retrieve the actual text from the provided resource ID.
      */
     fun verifyTextInDialog(@StringRes textInDialogId: Int) {
-      onView(withText(resourceHandler.getStringInLocale(textInDialogId)))
+      onView(withText(textInDialogId))
         .inRoot(isDialog())
         .check(matches(isDisplayed()))
     }

--- a/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
@@ -17,12 +17,12 @@ import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import javax.inject.Inject
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
 import org.oppia.android.app.translation.AppLanguageResourceHandler
+import javax.inject.Inject
 
 // Reference Link: https://github.com/dannyroa/espresso-samples/blob/master/RecyclerView/app/src/androidTest/java/com/dannyroa/espresso_samples/recyclerview/RecyclerViewMatcher.java
 class RecyclerViewMatcher {

--- a/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.ViewAssertion
-import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 import androidx.test.espresso.matcher.RootMatchers.isDialog
@@ -125,7 +125,7 @@ class RecyclerViewMatcher {
           position = itemPosition,
           targetViewId = targetView
         )
-      ).check(ViewAssertions.doesNotExist())
+      ).check(doesNotExist())
     }
 
     /**
@@ -169,7 +169,7 @@ class RecyclerViewMatcher {
           position = itemPosition,
           targetViewId = targetViewId
         )
-      ).check(ViewAssertions.doesNotExist())
+      ).check(doesNotExist())
     }
 
     /**

--- a/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
@@ -143,7 +143,6 @@ class RecyclerViewMatcher {
       itemPosition: Int,
       targetViewId: Int,
       @StringRes stringIdToMatch: Int,
-      context: Context
     ) {
       onView(
         atPositionOnView(
@@ -151,7 +150,7 @@ class RecyclerViewMatcher {
           position = itemPosition,
           targetViewId = targetViewId
         )
-      ).check(matches(withText(context.getString(stringIdToMatch))))
+      ).check(matches(withText(stringIdToMatch)))
     }
 
     /**

--- a/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
@@ -174,18 +174,6 @@ class RecyclerViewMatcher {
     }
 
     /**
-     * Verifies if the provided text, referenced by its String resource ID, is displayed in a dialog.
-     *
-     * @param textInDialogId The resource ID of the text to verify in the dialog.
-     * @param context The context used to retrieve the actual text from the provided resource ID.
-     */
-    fun verifyTextInDialog(@StringRes textInDialogId: Int, context: Context) {
-      onView(withText(context.getString(textInDialogId)))
-        .inRoot(isDialog())
-        .check(matches(isDisplayed()))
-    }
-
-    /**
      * Scrolls to the specified position within a RecyclerView.
      *
      * @param position The position to scroll to within the RecyclerView.

--- a/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
@@ -6,14 +6,17 @@ import android.view.View
 import androidx.annotation.StringRes
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.ViewAssertion
 import androidx.test.espresso.assertion.ViewAssertions
-import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.matcher.RootMatchers
-import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
+import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -94,13 +97,13 @@ class RecyclerViewMatcher {
       itemPosition: Int,
       targetView: Int
     ) {
-      Espresso.onView(
+      onView(
         atPositionOnView(
           recyclerViewId = recyclerViewId,
           position = itemPosition,
           targetViewId = targetView
         )
-      ).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+      ).check(matches(isDisplayed()))
     }
 
     /**
@@ -115,7 +118,7 @@ class RecyclerViewMatcher {
       itemPosition: Int,
       targetView: Int
     ) {
-      Espresso.onView(
+      onView(
         atPositionOnView(
           recyclerViewId = recyclerViewId,
           position = itemPosition,
@@ -140,13 +143,13 @@ class RecyclerViewMatcher {
       @StringRes stringIdToMatch: Int,
       context: Context
     ) {
-      Espresso.onView(
+      onView(
         atPositionOnView(
           recyclerViewId = recyclerViewId,
           position = itemPosition,
           targetViewId = targetViewId
         )
-      ).check(ViewAssertions.matches(ViewMatchers.withText(context.getString(stringIdToMatch))))
+      ).check(matches(withText(context.getString(stringIdToMatch))))
     }
 
     /**
@@ -161,7 +164,7 @@ class RecyclerViewMatcher {
       itemPosition: Int,
       targetViewId: Int
     ) {
-      Espresso.onView(
+      onView(
         atPositionOnView(
           recyclerViewId = recyclerViewId,
           position = itemPosition,
@@ -177,9 +180,9 @@ class RecyclerViewMatcher {
      * @param context The context used to retrieve the actual text from the provided resource ID.
      */
     fun verifyTextInDialog(@StringRes textInDialogId: Int, context: Context) {
-      Espresso.onView(ViewMatchers.withText(context.getString(textInDialogId)))
-        .inRoot(RootMatchers.isDialog())
-        .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+      onView(withText(context.getString(textInDialogId)))
+        .inRoot(isDialog())
+        .check(matches(isDisplayed()))
     }
 
     /**
@@ -189,8 +192,8 @@ class RecyclerViewMatcher {
      * @param recyclerViewId The resource ID of the RecyclerView to perform scrolling on.
      */
     fun scrollToPosition(position: Int, recyclerViewId: Int) {
-      Espresso.onView(ViewMatchers.withId(recyclerViewId))
-        .perform(RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(position))
+      onView(withId(recyclerViewId))
+        .perform(scrollToPosition<RecyclerView.ViewHolder>(position))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
@@ -1,6 +1,5 @@
 package org.oppia.android.app.recyclerview
 
-import android.content.Context
 import android.content.res.Resources
 import android.view.View
 import androidx.annotation.StringRes
@@ -136,7 +135,6 @@ class RecyclerViewMatcher {
      * @param itemPosition The position of the item in the RecyclerView.
      * @param targetViewId The resource ID of the target view within the item.
      * @param stringIdToMatch The resource ID of the string to match against the target view's text.
-     * @param context The context used to access resources.
      */
     fun verifyTextOnListItemAtPosition(
       recyclerViewId: Int,
@@ -178,7 +176,6 @@ class RecyclerViewMatcher {
      * Verifies if the provided text, referenced by its String resource ID, is displayed in a dialog.
      *
      * @param textInDialogId The resource ID of the text to verify in the dialog.
-     * @param context The context used to retrieve the actual text from the provided resource ID.
      */
     fun verifyTextInDialog(@StringRes textInDialogId: Int) {
       onView(withText(textInDialogId))

--- a/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
@@ -12,7 +12,6 @@ import androidx.test.espresso.ViewAssertion
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
-import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId

--- a/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt
@@ -12,18 +12,25 @@ import androidx.test.espresso.ViewAssertion
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
+import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import javax.inject.Inject
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
+import org.oppia.android.app.translation.AppLanguageResourceHandler
 
 // Reference Link: https://github.com/dannyroa/espresso-samples/blob/master/RecyclerView/app/src/androidTest/java/com/dannyroa/espresso_samples/recyclerview/RecyclerViewMatcher.java
 class RecyclerViewMatcher {
+
   companion object {
+    @Inject
+    lateinit var resourceHandler: AppLanguageResourceHandler
+
     /**
      * This function returns a Matcher for an item inside RecyclerView from a specified position.
      */
@@ -170,6 +177,18 @@ class RecyclerViewMatcher {
           targetViewId = targetViewId
         )
       ).check(ViewAssertions.doesNotExist())
+    }
+
+    /**
+     * Verifies if the provided text, referenced by its String resource ID, is displayed in a dialog.
+     *
+     * @param textInDialogId The resource ID of the text to verify in the dialog.
+     * @param context The context used to retrieve the actual text from the provided resource ID.
+     */
+    fun verifyTextInDialog(@StringRes textInDialogId: Int) {
+      onView(withText(resourceHandler.getStringInLocale(textInDialogId)))
+        .inRoot(isDialog())
+        .check(matches(isDisplayed()))
     }
 
     /**


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix #2536

I worked on the below functions renaming the title and adding an argument for the recyclerviewId to each function to make it reusable, I also added kdocs to help understand the functions.
P.S:- I created the functions in the RecyclerviewMatcher class.
 
![Screenshot 2024-04-30 at 01 24 45](https://github.com/oppia/oppia-android/assets/54560535/6a0464e0-e72f-4516-83e1-3a53d2025a6b)

![Screenshot 2024-04-30 at 01 24 26](https://github.com/oppia/oppia-android/assets/54560535/34332586-e082-4991-9b6b-b8f8c647e7d0)

![Screenshot 2024-04-30 at 01 24 57](https://github.com/oppia/oppia-android/assets/54560535/7090b959-fb45-4787-9957-7e182d47a042)


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
