### PR TITLE
Fix #5407: Fix Bazel CI runs on develop

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -76,8 +76,8 @@ jobs:
         id: compute-test-matrix
         env:
           compute_all_targets: ${{ contains(github.event.pull_request.title, '[RunAllTests]') }}
-          # See: https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request.
-          base_commit_hash: ${{ github.event.pull_request.base.sha }}
+          # See: https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request. Defer to origin/develop outside a PR (such as develop's main CI runs).
+          base_commit_hash: ${{ github.event.pull_request.base.sha || "origin/develop" }}
         # https://unix.stackexchange.com/a/338124 for reference on creating a JSON-friendly
         # comma-separated list of test targets for the matrix.
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -77,7 +77,7 @@ jobs:
         env:
           compute_all_targets: ${{ contains(github.event.pull_request.title, '[RunAllTests]') }}
           # See: https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request. Defer to origin/develop outside a PR (such as develop's main CI runs).
-          base_commit_hash: ${{ github.event.pull_request.base.sha || "origin/develop" }}
+          base_commit_hash: ${{ github.event.pull_request.base.sha || 'origin/develop' }}
         # https://unix.stackexchange.com/a/338124 for reference on creating a JSON-friendly
         # comma-separated list of test targets for the matrix.
         run: |


### PR DESCRIPTION
## Explanation
Fixes #5407

This introduces a proper fallback for the base branch used for computing affected tests when off-develop: ``origin/develop`` (which was the same base used prior to #4929 being merged).

This can't easily be verified without being merged, but I have high confidence it'll work since we've used the JavaScript ``||`` fallback syntax in GitHub workflow ``if`` conditionals in the past (and the environment should be the same for ``env`` variables).

Note that this is being fixed forward rather than reverted because the only verification is merging the PR, so it's actually faster and simpler to fix forward than to revert the original PR and re-submit a fix (which has the same likelihood of fixing CI as this fix forward).

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- This only affects CI infrastructure.