### PR TITLE
Fix part of #5343: Implement script to run code coverage for a specific file

### DIFF
--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -246,6 +246,15 @@ kt_jvm_binary(
     ],
 )
 
+kt_jvm_binary(
+    name = "run_coverage",
+    testonly = True,
+    main_class = "org.oppia.android.scripts.coverage.RunCoverageKt",
+    runtime_deps = [
+        "//scripts/src/java/org/oppia/android/scripts/coverage:run_coverage_lib",
+    ],
+)
+
 # Note that this is intentionally not test-only since it's used by the app build pipeline. Also,
 # this apparently needs to be a java_binary to set up runfiles correctly when executed within a
 # Starlark rule as a tool.

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -249,6 +249,7 @@ kt_jvm_binary(
 kt_jvm_binary(
     name = "run_coverage",
     testonly = True,
+    data = TEST_FILE_EXEMPTION_ASSETS,
     main_class = "org.oppia.android.scripts.coverage.RunCoverageKt",
     runtime_deps = [
         "//scripts/src/java/org/oppia/android/scripts/coverage:run_coverage_lib",

--- a/scripts/src/java/org/oppia/android/scripts/coverage/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/BUILD.bazel
@@ -5,6 +5,20 @@ Libraries corresponding to developer scripts that obtain coverage data for test 
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 
 kt_jvm_library(
+    name = "run_coverage_lib",
+    testonly = True,
+    srcs = [
+        "RunCoverage.kt",
+    ],
+    visibility = ["//scripts:oppia_script_binary_visibility"],
+    deps = [
+        "//scripts/src/java/org/oppia/android/scripts/common:bazel_client",
+        "//scripts/src/java/org/oppia/android/scripts/common:git_client",
+        "//scripts/src/java/org/oppia/android/scripts/coverage:run_coverage_for_test_target_lib",
+    ],
+)
+
+kt_jvm_library(
     name = "run_coverage_for_test_target_lib",
     testonly = True,
     srcs = [

--- a/scripts/src/java/org/oppia/android/scripts/coverage/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/BUILD.bazel
@@ -13,8 +13,6 @@ kt_jvm_library(
     visibility = ["//scripts:oppia_script_binary_visibility"],
     deps = [
         "//scripts/src/java/org/oppia/android/scripts/common:bazel_client",
-        "//scripts/src/java/org/oppia/android/scripts/common:git_client",
-        "//scripts/src/java/org/oppia/android/scripts/common:repository_file",
         "//scripts/src/java/org/oppia/android/scripts/proto:script_exemptions_java_proto",
         "//scripts/src/java/org/oppia/android/scripts/coverage:run_coverage_for_test_target_lib",
     ],
@@ -29,7 +27,6 @@ kt_jvm_library(
     visibility = ["//scripts:oppia_script_binary_visibility"],
     deps = [
         "//scripts/src/java/org/oppia/android/scripts/common:bazel_client",
-        "//scripts/src/java/org/oppia/android/scripts/common:git_client",
         "//scripts/src/java/org/oppia/android/scripts/coverage:coverage_runner",
     ],
 )

--- a/scripts/src/java/org/oppia/android/scripts/coverage/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/BUILD.bazel
@@ -14,6 +14,8 @@ kt_jvm_library(
     deps = [
         "//scripts/src/java/org/oppia/android/scripts/common:bazel_client",
         "//scripts/src/java/org/oppia/android/scripts/common:git_client",
+        "//scripts/src/java/org/oppia/android/scripts/common:repository_file",
+        "//scripts/src/java/org/oppia/android/scripts/proto:script_exemptions_java_proto",
         "//scripts/src/java/org/oppia/android/scripts/coverage:run_coverage_for_test_target_lib",
     ],
 )

--- a/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
@@ -93,14 +93,14 @@ class RunCoverage(
     }
   }
 
-  private fun findTestFile(repoRoot: String, filePath: String): List<String> {
+  fun findTestFile(repoRoot: String, filePath: String): List<String> {
     val file = File(filePath)
     val parts = file.parent.split(File.separator)
     val testFiles = mutableListOf<String>()
 
     if (parts.isNotEmpty() && parts[0] == "scripts") {
       val testFilePath = filePath.replace("/java/", "/javatests/").replace(".kt", "Test.kt")
-      if (File(testFilePath).exists()) {
+      if (File(repoRoot, testFilePath).exists()) {
         testFiles.add(testFilePath)
       }
     } else if (parts.isNotEmpty() && parts[0] == "app") {

--- a/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
@@ -31,20 +31,6 @@ fun main(vararg args: String) {
   val repoRoot = args[0]
   val filePath = args[1]
 
-  val rootDirectory = File(repoRoot).absoluteFile
-
-  val testFileExemptiontextProto = "scripts/assets/test_file_exemptions"
-
-  // A list of all the files to be exempted for this check.
-  val testFileExemptionList = loadTestFileExemptionsProto(testFileExemptiontextProto)
-    .getExemptedFilePathList()
-
-  val isExempted = testFileExemptionList.contains(filePath)
-  if (isExempted) {
-    println("This file is exempted from having a test file. Hence No coverage!")
-    return
-  }
-
   ScriptBackgroundCoroutineDispatcher().use { scriptBgDispatcher ->
     val processTimeout: Long = args.find { it.startsWith("processTimeout=") }
       ?.substringAfter("=")
@@ -54,10 +40,48 @@ fun main(vararg args: String) {
       scriptBgDispatcher, processTimeout = processTimeout, processTimeoutUnit = TimeUnit.MINUTES
     )
 
-    val bazelClient = BazelClient(rootDirectory, commandExecutor)
+    RunCoverage(repoRoot, filePath, commandExecutor,  scriptBgDispatcher).execute()
+  }
+}
 
-    val testFilePath = findTestFile(repoRoot, filePath)
-    val testTargets = bazelClient.retrieveBazelTargets(testFilePath)
+/**
+ * Class responsible for executing coverage on a given file.
+ *
+ * @param repoRoot the root directory of the repository
+ * @param filePath the relative path to the file to analyse coverage
+ * @param commandExecutor Executes the specified command in the specified working directory
+ * @param scriptBgDispatcher the [ScriptBackgroundCoroutineDispatcher] to be used for running the coverage command
+ */
+class RunCoverage(
+  private val repoRoot: String,
+  private val filePath: String,
+  private val commandExecutor: CommandExecutor,
+  private val scriptBgDispatcher: ScriptBackgroundCoroutineDispatcher
+) {
+  private val rootDirectory = File(repoRoot).absoluteFile
+  private val testFileExemptionTextProto = "scripts/assets/test_file_exemptions"
+
+  /**
+   * Executes coverage analysis for the specified file.
+   *
+   * Loads test file exemptions and checks if the specified file is exempted. If exempted,
+   * prints a message indicating no coverage analysis is performed. Otherwise, initializes
+   * a Bazel client, finds potential test file paths, retrieves Bazel targets, and initiates
+   * coverage analysis for each test target found.
+   */
+  fun execute() {
+    val testFileExemptionList = loadTestFileExemptionsProto(testFileExemptionTextProto)
+      .getExemptedFilePathList()
+
+    val isExempted = testFileExemptionList.contains(filePath)
+    if (isExempted) {
+      println("This file is exempted from having a test file. Hence No coverage!")
+      return
+    }
+
+    val bazelClient = BazelClient(rootDirectory, commandExecutor)
+    val testFilePaths = findTestFile(repoRoot, filePath)
+    val testTargets = bazelClient.retrieveBazelTargets(testFilePaths)
 
     for (testTarget in testTargets) {
       RunCoverageForTestTarget(
@@ -68,51 +92,51 @@ fun main(vararg args: String) {
       ).runCoverage()
     }
   }
-}
 
-private fun findTestFile(repoRoot: String, filePath: String): List<String> {
-  val file = File(filePath)
-  val parts = file.parent.split(File.separator)
-  val testFiles = mutableListOf<String>()
+  private fun findTestFile(repoRoot: String, filePath: String): List<String> {
+    val file = File(filePath)
+    val parts = file.parent.split(File.separator)
+    val testFiles = mutableListOf<String>()
 
-  if (parts.isNotEmpty() && parts[0] == "scripts") {
-    val testFilePath = filePath.replace("/java/", "/javatests/").replace(".kt", "Test.kt")
-    if (File(testFilePath).exists()) {
-      testFiles.add(testFilePath)
-    }
-  } else if (parts.isNotEmpty() && parts[0] == "app") {
-    val sharedTestFilePath = filePath.replace("/main/", "/sharedTest/").replace(".kt", "Test.kt")
-    val testFilePath = filePath.replace("/main/", "/test/").replace(".kt", "Test.kt")
-    val localTestFilePath = filePath.replace("/main/", "/test/").replace(".kt", "LocalTest.kt")
+    if (parts.isNotEmpty() && parts[0] == "scripts") {
+      val testFilePath = filePath.replace("/java/", "/javatests/").replace(".kt", "Test.kt")
+      if (File(testFilePath).exists()) {
+        testFiles.add(testFilePath)
+      }
+    } else if (parts.isNotEmpty() && parts[0] == "app") {
+      val sharedTestFilePath = filePath.replace("/main/", "/sharedTest/").replace(".kt", "Test.kt")
+      val testFilePath = filePath.replace("/main/", "/test/").replace(".kt", "Test.kt")
+      val localTestFilePath = filePath.replace("/main/", "/test/").replace(".kt", "LocalTest.kt")
 
-    if (File(repoRoot, sharedTestFilePath).exists()) {
-      testFiles.add(sharedTestFilePath)
+      if (File(repoRoot, sharedTestFilePath).exists()) {
+        testFiles.add(sharedTestFilePath)
+      }
+      if (File(repoRoot, testFilePath).exists()) {
+        testFiles.add(testFilePath)
+      }
+      if (File(repoRoot, localTestFilePath).exists()) {
+        testFiles.add(localTestFilePath)
+      }
+    } else {
+      val defaultTestFilePath = filePath.replace("/main/", "/test/").replace(".kt", "Test.kt")
+      if (File(repoRoot, defaultTestFilePath).exists()) {
+        testFiles.add(defaultTestFilePath)
+      }
     }
-    if (File(repoRoot, testFilePath).exists()) {
-      testFiles.add(testFilePath)
-    }
-    if (File(repoRoot, localTestFilePath).exists()) {
-      testFiles.add(localTestFilePath)
-    }
-  } else {
-    val defaultTestFilePath = filePath.replace("/main/", "/test/").replace(".kt", "Test.kt")
-    if (File(repoRoot, defaultTestFilePath).exists()) {
-      testFiles.add(defaultTestFilePath)
-    }
+    return testFiles
   }
-  return testFiles
-}
 
-private fun loadTestFileExemptionsProto(testFileExemptiontextProto: String): TestFileExemptions {
-  val protoBinaryFile = File("$testFileExemptiontextProto.pb")
-  val builder = TestFileExemptions.getDefaultInstance().newBuilderForType()
+  private fun loadTestFileExemptionsProto(testFileExemptiontextProto: String): TestFileExemptions {
+    val protoBinaryFile = File("$testFileExemptiontextProto.pb")
+    val builder = TestFileExemptions.getDefaultInstance().newBuilderForType()
 
-  // This cast is type-safe since proto guarantees type consistency from mergeFrom(),
-  // and this method is bounded by the generic type T.
-  @Suppress("UNCHECKED_CAST")
-  val protoObj: TestFileExemptions =
-    FileInputStream(protoBinaryFile).use {
-      builder.mergeFrom(it)
-    }.build() as TestFileExemptions
-  return protoObj
+    // This cast is type-safe since proto guarantees type consistency from mergeFrom(),
+    // and this method is bounded by the generic type T.
+    @Suppress("UNCHECKED_CAST")
+    val protoObj: TestFileExemptions =
+      FileInputStream(protoBinaryFile).use {
+        builder.mergeFrom(it)
+      }.build() as TestFileExemptions
+    return protoObj
+  }
 }

--- a/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
@@ -80,15 +80,11 @@ class RunCoverage(
     val isExempted = testFileExemptionList.contains(filePath)
     if (isExempted) {
       println("This file is exempted from having a test file. Hence No coverage!")
-//      return null
       return emptyList()
     }
 
-//    val bazelClient = BazelClient(rootDirectory, commandExecutor)
     val testFilePaths = findTestFile(repoRoot, filePath)
-//    return findTestFile(repoRoot, filePath)
     val testTargets = bazelClient.retrieveBazelTargets(testFilePaths)
-//    val testTargets = bazelClient.retrieveBazelTargets(testFilePaths)
 
     for (testTarget in testTargets) {
       val coverageData = RunCoverageForTestTarget(
@@ -100,17 +96,6 @@ class RunCoverage(
       coverageDataList.add(coverageData)
     }
     return coverageDataList
-
-    //this works
-    /*val covdat = RunCoverageForTestTarget(
-      rootDirectory,
-      "//coverage/test/java/com/example:test",
-      commandExecutor,
-      scriptBgDispatcher
-    ).runCoverage()
-    coverageDataList.add(covdat!!)
-    return coverageDataList*/
-//    return covdat
   }
 
   fun findTestFile(repoRoot: String, filePath: String): List<String> {

--- a/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
@@ -9,72 +9,65 @@ import java.util.concurrent.TimeUnit
 import java.io.File
 import java.io.FileInputStream
 
+/**
+ * Entry point function for running coverage analysis for a source file.
+ *
+ * Usage:
+ *   bazel run //scripts:run_coverage_for_test_target -- <path_to_root> <relative_path_to_file>
+ *
+ * Arguments:
+ * - path_to_root: directory path to the root of the Oppia Android repository.
+ * - relative_path_to_file: the relative path to the file to analyse coverage
+ *
+ * Example:
+ *     bazel run //scripts:run_coverage -- $(pwd)
+ *     utility/src/main/java/org/oppia/android/util/parser/math/MathModel.kt
+ * Example with custom process timeout:
+ *     bazel run //scripts:run_coverage -- $(pwd)
+ *     utility/src/main/java/org/oppia/android/util/parser/math/MathModel.kt processTimeout=10
+ *
+ */
 fun main(vararg args: String) {
   val repoRoot = args[0]
+  val filePath = args[1]
+
   val rootDirectory = File(repoRoot).absoluteFile
-  val targetPath = args[1]
-  val filePath = args[2]
+
+  val testFileExemptiontextProto = "scripts/assets/test_file_exemptions"
+
+  // A list of all the files to be exempted for this check.
+  val testFileExemptionList = loadTestFileExemptionsProto(testFileExemptiontextProto)
+    .getExemptedFilePathList()
+
+  val isExempted = testFileExemptionList.contains(filePath)
+  if (isExempted) {
+    println("This file is exempted from having a test file. Hence No coverage!")
+    return
+  }
 
   ScriptBackgroundCoroutineDispatcher().use { scriptBgDispatcher ->
+    val processTimeout: Long = args.find { it.startsWith("processTimeout=") }
+      ?.substringAfter("=")
+      ?.toLongOrNull() ?: 5
+
     val commandExecutor: CommandExecutor = CommandExecutorImpl(
-      scriptBgDispatcher, processTimeout = 5, processTimeoutUnit = TimeUnit.MINUTES
+      scriptBgDispatcher, processTimeout = processTimeout, processTimeoutUnit = TimeUnit.MINUTES
     )
 
     val bazelClient = BazelClient(rootDirectory, commandExecutor)
 
-    println("Repo root: $repoRoot")
-    println("Targetpath: $targetPath")
-    println("Filepath: $filePath")
-
-    val testFileExemptiontextProto = "scripts/assets/test_file_exemptions"
-
-    // A list of all the files to be exempted for this check.
-    // TODO(#3436): Develop a mechanism for permanently exempting files which do not ever need tests.
-    val testFileExemptionList = loadTestFileExemptionsProto(testFileExemptiontextProto)
-      .getExemptedFilePathList()
-
-//  println("test file exemption list: $testFileExemptionList")
-
-    val isExempted = testFileExemptionList.contains(filePath)
-    if (isExempted) {
-      println("This file is exempted from having a test file. Hence No coverage!")
-      return
-    }
-
     val testFilePath = findTestFile(repoRoot, filePath)
-    println("Test File paths list: $testFilePath")
+    val testTargets = bazelClient.retrieveBazelTargets(testFilePath)
 
-    val result = bazelClient.retrieveBazelTargets(testFilePath)
-    println("Result from Retrieve Bazel Target; $result")
-
-    val testResults = listOf(
-      "//utility/src/test/java/org/oppia/android/util/parser/math:MathModelTest",
-      "//utility/src/test/java/org/oppia/android/util/math:FloatExtensionsTest")
-
-    //.substringBeforeLast(".kt")
-
-    for (r in testResults) {
+    for (testTarget in testTargets) {
       RunCoverageForTestTarget(
         rootDirectory,
-        r,
+        testTarget.substringBeforeLast(".kt"),
         commandExecutor,
         scriptBgDispatcher
       ).runCoverage()
     }
   }
-
-
-//  ScriptBackgroundCoroutineDispatcher().use { scriptBgDispatcher ->
-//    val commandExecutor: CommandExecutor = CommandExecutorImpl(
-//      scriptBgDispatcher, processTimeout = 5, processTimeoutUnit = TimeUnit.MINUTES
-//    )
-    /*RunCoverageForTestTarget(
-      repoRoot,
-      targetPath,
-      commandExecutor,
-      scriptBgDispatcher
-    ).runCoverage()*/
-//  }
 }
 
 private fun findTestFile(repoRoot: String, filePath: String): List<String> {
@@ -91,10 +84,6 @@ private fun findTestFile(repoRoot: String, filePath: String): List<String> {
     val sharedTestFilePath = filePath.replace("/main/", "/sharedTest/").replace(".kt", "Test.kt")
     val testFilePath = filePath.replace("/main/", "/test/").replace(".kt", "Test.kt")
     val localTestFilePath = filePath.replace("/main/", "/test/").replace(".kt", "LocalTest.kt")
-
-    println("Shared: $sharedTestFilePath")
-    println("Test: $testFilePath")
-    println("LocalTest: $localTestFilePath")
 
     if (File(repoRoot, sharedTestFilePath).exists()) {
       testFiles.add(sharedTestFilePath)

--- a/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
@@ -1,0 +1,24 @@
+package org.oppia.android.scripts.coverage
+
+import org.oppia.android.scripts.common.CommandExecutor
+import org.oppia.android.scripts.common.CommandExecutorImpl
+import org.oppia.android.scripts.common.ScriptBackgroundCoroutineDispatcher
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+fun main(vararg args: String) {
+  val repoRoot = File(args[0]).absoluteFile.normalize()
+  val targetPath = args[1]
+
+  ScriptBackgroundCoroutineDispatcher().use { scriptBgDispatcher ->
+    val commandExecutor: CommandExecutor = CommandExecutorImpl(
+      scriptBgDispatcher, processTimeout = 5, processTimeoutUnit = TimeUnit.MINUTES
+    )
+    RunCoverageForTestTarget(
+      repoRoot,
+      targetPath,
+      commandExecutor,
+      scriptBgDispatcher
+    ).runCoverage()
+  }
+}

--- a/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
@@ -3,22 +3,94 @@ package org.oppia.android.scripts.coverage
 import org.oppia.android.scripts.common.CommandExecutor
 import org.oppia.android.scripts.common.CommandExecutorImpl
 import org.oppia.android.scripts.common.ScriptBackgroundCoroutineDispatcher
-import java.io.File
+import org.oppia.android.scripts.proto.TestFileExemptions
 import java.util.concurrent.TimeUnit
+import java.io.File
+import java.io.FileInputStream
 
 fun main(vararg args: String) {
-  val repoRoot = File(args[0]).absoluteFile.normalize()
+  val repoRoot = args[0]
   val targetPath = args[1]
+  val filePath = args[2]
 
-  ScriptBackgroundCoroutineDispatcher().use { scriptBgDispatcher ->
-    val commandExecutor: CommandExecutor = CommandExecutorImpl(
-      scriptBgDispatcher, processTimeout = 5, processTimeoutUnit = TimeUnit.MINUTES
-    )
-    RunCoverageForTestTarget(
+  println("Repo root: $repoRoot")
+  println("Targetpath: $targetPath")
+  println("Filepath: $filePath")
+
+  val testFileExemptiontextProto = "scripts/assets/test_file_exemptions"
+
+  // A list of all the files to be exempted for this check.
+  // TODO(#3436): Develop a mechanism for permanently exempting files which do not ever need tests.
+  val testFileExemptionList = loadTestFileExemptionsProto(testFileExemptiontextProto)
+    .getExemptedFilePathList()
+
+//  println("test file exemption list: $testFileExemptionList")
+
+  val isExempted = testFileExemptionList.contains(filePath)
+  if(isExempted) {
+    println("This file is exempted from having a test file. Hence No coverage!")
+    return
+  }
+
+  val testFilePath = findTestFile(repoRoot, filePath)
+  println("Test File path: $testFilePath")
+
+//  ScriptBackgroundCoroutineDispatcher().use { scriptBgDispatcher ->
+//    val commandExecutor: CommandExecutor = CommandExecutorImpl(
+//      scriptBgDispatcher, processTimeout = 5, processTimeoutUnit = TimeUnit.MINUTES
+//    )
+    /*RunCoverageForTestTarget(
       repoRoot,
       targetPath,
       commandExecutor,
       scriptBgDispatcher
-    ).runCoverage()
+    ).runCoverage()*/
+//  }
+}
+
+private fun findTestFile(repoRoot: String, filePath: String): List<String> {
+  val file = File(filePath)
+  val parts = file.parent.split(File.separator)
+  val testFiles = mutableListOf<String>()
+
+  if (parts.isNotEmpty() && parts[0] == "scripts") {
+    val testFilePath = filePath.replace("/java/", "/javatests/").replace(".kt", "Test.kt")
+    if (File(testFilePath).exists()) {
+      testFiles.add(testFilePath)
+    }
+  } else if (parts.isNotEmpty() && parts[0] == "app") {
+    val sharedTestFilePath = filePath.replace("/main/", "/sharedTest/").replace(".kt", "Test.kt")
+    val testFilePath = filePath.replace("/main/", "/test/").replace(".kt", "Test.kt")
+    val localTestFilePath = filePath.replace("/main/", "/test/").replace(".kt", "LocalTest.kt")
+
+    if (File(repoRoot, sharedTestFilePath).exists()) {
+      testFiles.add(sharedTestFilePath)
+    }
+    if (File(repoRoot, testFilePath).exists()) {
+      testFiles.add(testFilePath)
+    }
+    if (File(repoRoot, localTestFilePath).exists()) {
+      testFiles.add(localTestFilePath)
+    }
+  } else {
+    val defaultTestFilePath = filePath.replace("/main/", "/test/").replace(".kt", "Test.kt")
+    if (File(defaultTestFilePath).exists()) {
+      testFiles.add(defaultTestFilePath)
+    }
   }
+  return testFiles
+}
+
+private fun loadTestFileExemptionsProto(testFileExemptiontextProto: String): TestFileExemptions {
+  val protoBinaryFile = File("$testFileExemptiontextProto.pb")
+  val builder = TestFileExemptions.getDefaultInstance().newBuilderForType()
+
+  // This cast is type-safe since proto guarantees type consistency from mergeFrom(),
+  // and this method is bounded by the generic type T.
+  @Suppress("UNCHECKED_CAST")
+  val protoObj: TestFileExemptions =
+    FileInputStream(protoBinaryFile).use {
+      builder.mergeFrom(it)
+    }.build() as TestFileExemptions
+  return protoObj
 }

--- a/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
@@ -1,5 +1,6 @@
 package org.oppia.android.scripts.coverage
 
+import org.oppia.android.scripts.common.BazelClient
 import org.oppia.android.scripts.common.CommandExecutor
 import org.oppia.android.scripts.common.CommandExecutorImpl
 import org.oppia.android.scripts.common.ScriptBackgroundCoroutineDispatcher
@@ -10,30 +11,58 @@ import java.io.FileInputStream
 
 fun main(vararg args: String) {
   val repoRoot = args[0]
+  val rootDirectory = File(repoRoot).absoluteFile
   val targetPath = args[1]
   val filePath = args[2]
 
-  println("Repo root: $repoRoot")
-  println("Targetpath: $targetPath")
-  println("Filepath: $filePath")
+  ScriptBackgroundCoroutineDispatcher().use { scriptBgDispatcher ->
+    val commandExecutor: CommandExecutor = CommandExecutorImpl(
+      scriptBgDispatcher, processTimeout = 5, processTimeoutUnit = TimeUnit.MINUTES
+    )
 
-  val testFileExemptiontextProto = "scripts/assets/test_file_exemptions"
+    val bazelClient = BazelClient(rootDirectory, commandExecutor)
 
-  // A list of all the files to be exempted for this check.
-  // TODO(#3436): Develop a mechanism for permanently exempting files which do not ever need tests.
-  val testFileExemptionList = loadTestFileExemptionsProto(testFileExemptiontextProto)
-    .getExemptedFilePathList()
+    println("Repo root: $repoRoot")
+    println("Targetpath: $targetPath")
+    println("Filepath: $filePath")
+
+    val testFileExemptiontextProto = "scripts/assets/test_file_exemptions"
+
+    // A list of all the files to be exempted for this check.
+    // TODO(#3436): Develop a mechanism for permanently exempting files which do not ever need tests.
+    val testFileExemptionList = loadTestFileExemptionsProto(testFileExemptiontextProto)
+      .getExemptedFilePathList()
 
 //  println("test file exemption list: $testFileExemptionList")
 
-  val isExempted = testFileExemptionList.contains(filePath)
-  if(isExempted) {
-    println("This file is exempted from having a test file. Hence No coverage!")
-    return
+    val isExempted = testFileExemptionList.contains(filePath)
+    if (isExempted) {
+      println("This file is exempted from having a test file. Hence No coverage!")
+      return
+    }
+
+    val testFilePath = findTestFile(repoRoot, filePath)
+    println("Test File paths list: $testFilePath")
+
+    val result = bazelClient.retrieveBazelTargets(testFilePath)
+    println("Result from Retrieve Bazel Target; $result")
+
+    val testResults = listOf(
+      "//utility/src/test/java/org/oppia/android/util/parser/math:MathModelTest",
+      "//utility/src/test/java/org/oppia/android/util/math:FloatExtensionsTest")
+
+    //.substringBeforeLast(".kt")
+
+    for (r in testResults) {
+      RunCoverageForTestTarget(
+        rootDirectory,
+        r,
+        commandExecutor,
+        scriptBgDispatcher
+      ).runCoverage()
+    }
   }
 
-  val testFilePath = findTestFile(repoRoot, filePath)
-  println("Test File path: $testFilePath")
 
 //  ScriptBackgroundCoroutineDispatcher().use { scriptBgDispatcher ->
 //    val commandExecutor: CommandExecutor = CommandExecutorImpl(
@@ -63,6 +92,10 @@ private fun findTestFile(repoRoot: String, filePath: String): List<String> {
     val testFilePath = filePath.replace("/main/", "/test/").replace(".kt", "Test.kt")
     val localTestFilePath = filePath.replace("/main/", "/test/").replace(".kt", "LocalTest.kt")
 
+    println("Shared: $sharedTestFilePath")
+    println("Test: $testFilePath")
+    println("LocalTest: $localTestFilePath")
+
     if (File(repoRoot, sharedTestFilePath).exists()) {
       testFiles.add(sharedTestFilePath)
     }
@@ -74,7 +107,7 @@ private fun findTestFile(repoRoot: String, filePath: String): List<String> {
     }
   } else {
     val defaultTestFilePath = filePath.replace("/main/", "/test/").replace(".kt", "Test.kt")
-    if (File(defaultTestFilePath).exists()) {
+    if (File(repoRoot, defaultTestFilePath).exists()) {
       testFiles.add(defaultTestFilePath)
     }
   }

--- a/scripts/src/java/org/oppia/android/scripts/testing/TestBazelWorkspace.kt
+++ b/scripts/src/java/org/oppia/android/scripts/testing/TestBazelWorkspace.kt
@@ -172,7 +172,7 @@ class TestBazelWorkspace(private val temporaryRootFolder: TemporaryFolder) {
     testBuildFile.appendText(
       """
       kt_jvm_test(
-          name = "test",
+          name = "$testName",
           srcs = ["$testName.kt"],
           deps = [
               "//$sourceSubpackage:${filename.lowercase()}",

--- a/scripts/src/javatests/org/oppia/android/scripts/common/BazelClientTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/common/BazelClientTest.kt
@@ -512,7 +512,7 @@ class BazelClientTest {
       subpackage = "coverage"
     )
 
-    val result = bazelClient.runCoverageForTestTarget("//coverage/test/java/com/example:test")
+    val result = bazelClient.runCoverageForTestTarget("//coverage/test/java/com/example:TwoSumTest")
 
     // Check if ByteArray is returned from executing coverage command
     assertThat(result).isInstanceOf(ByteArray::class.java)

--- a/scripts/src/javatests/org/oppia/android/scripts/coverage/BUILD.bazel
+++ b/scripts/src/javatests/org/oppia/android/scripts/coverage/BUILD.bazel
@@ -27,3 +27,16 @@ kt_jvm_test(
         "//third_party:org_jetbrains_kotlin_kotlin-test-junit",
     ],
 )
+
+kt_jvm_test(
+    name = "RunCoverageTest",
+    srcs = ["RunCoverageTest.kt"],
+    deps = [
+        "//scripts:test_file_check_assets",
+        "//scripts/src/java/org/oppia/android/scripts/coverage:run_coverage_lib",
+        "//scripts/src/java/org/oppia/android/scripts/testing:test_bazel_workspace",
+        "//testing:assertion_helpers",
+        "//third_party:com_google_truth_truth",
+        "//third_party:org_jetbrains_kotlin_kotlin-test-junit",
+    ],
+)

--- a/scripts/src/javatests/org/oppia/android/scripts/coverage/CoverageRunnerTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/coverage/CoverageRunnerTest.kt
@@ -36,7 +36,7 @@ class CoverageRunnerTest {
   }
 
   @Test
-  fun testRunCoverage_emptyDirectory_throwsException() {
+  fun testCoverageRunner_emptyDirectory_throwsException() {
     val exception = assertThrows<IllegalStateException>() {
       coverageRunner.getCoverage(bazelTestTarget)
     }
@@ -45,7 +45,7 @@ class CoverageRunnerTest {
   }
 
   @Test
-  fun testRunCoverage_invalidTestTarget_throwsException() {
+  fun testCoverageRunner_invalidTestTarget_throwsException() {
     testBazelWorkspace.initEmptyWorkspace()
 
     val exception = assertThrows<IllegalStateException>() {
@@ -57,7 +57,7 @@ class CoverageRunnerTest {
   }
 
   @Test
-  fun testRunCoverage_validSampleTestTarget_returnsCoverageData() {
+  fun testCoverageRunner_validSampleTestTarget_returnsCoverageData() {
     testBazelWorkspace.initEmptyWorkspace()
 
     val sourceContent =
@@ -103,7 +103,7 @@ class CoverageRunnerTest {
       subpackage = "coverage"
     )
 
-    val result = coverageRunner.getCoverage("//coverage/test/java/com/example:test")
+    val result = coverageRunner.getCoverage("//coverage/test/java/com/example:TwoSumTest")
     val expectedResult =
       "SF:coverage/main/java/com/example/TwoSum.kt\n" +
         "FN:7,com/example/TwoSum${'$'}Companion::sumNumbers (II)Ljava/lang/Object;\n" +

--- a/scripts/src/javatests/org/oppia/android/scripts/coverage/RunCoverageForTestTargetTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/coverage/RunCoverageForTestTargetTest.kt
@@ -114,7 +114,7 @@ class RunCoverageForTestTargetTest {
 
     val result = RunCoverageForTestTarget(
       tempFolder.root,
-      "//coverage/test/java/com/example:test",
+      "//coverage/test/java/com/example:TwoSumTest",
       longCommandExecutor,
       scriptBgDispatcher
     ).runCoverage()

--- a/scripts/src/javatests/org/oppia/android/scripts/coverage/RunCoverageTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/coverage/RunCoverageTest.kt
@@ -169,6 +169,107 @@ class RunCoverageTest {
     assertEquals(expectedLocalTestFilePaths, result)
   }
 
+  @Test
+  fun testRunCoverage_validSampleTestFile_returnsCoverageData() {
+    testBazelWorkspace.initEmptyWorkspace()
+
+    val sourceContent =
+      """
+      package com.example
+      
+      class TwoSum {
+      
+          companion object {
+              fun sumNumbers(a: Int, b: Int): Any {
+                  return if (a ==0 && b == 0) {
+                      "Both numbers are zero"
+                  } else {
+                      a + b
+                  }
+              }
+          }
+      }
+      """.trimIndent()
+
+    val testContent =
+      """
+      package com.example
+      
+      import org.junit.Assert.assertEquals
+      import org.junit.Test
+      
+      class TwoSumTest {
+      
+          @Test
+          fun testSumNumbers() {
+              assertEquals(TwoSum.sumNumbers(0, 1), 1)
+              assertEquals(TwoSum.sumNumbers(3, 4), 7)         
+              assertEquals(TwoSum.sumNumbers(0, 0), "Both numbers are zero")
+          }
+      }
+      """.trimIndent()
+
+    testBazelWorkspace.addSourceAndTestFileWithContent(
+      filename = "TwoSum",
+      sourceContent = sourceContent,
+      testContent = testContent,
+      subpackage = "coverage"
+    )
+
+    val result = RunCoverage(
+      "${tempFolder.root}",
+      "coverage/main/java/com/example/TwoSum.kt",
+      longCommandExecutor,
+      scriptBgDispatcher).execute()
+
+    /*val expectedResult =
+      "["+"SF:coverage/main/java/com/example/TwoSum.kt\n" +
+        "FN:7,com/example/TwoSum${'$'}Companion::sumNumbers (II)Ljava/lang/Object;\n" +
+        "FN:3,com/example/TwoSum::<init> ()V\n" +
+        "FNDA:1,com/example/TwoSum${'$'}Companion::sumNumbers (II)Ljava/lang/Object;\n" +
+        "FNDA:0,com/example/TwoSum::<init> ()V\n" +
+        "FNF:2\n" +
+        "FNH:1\n" +
+        "BRDA:7,0,0,1\n" +
+        "BRDA:7,0,1,1\n" +
+        "BRDA:7,0,2,1\n" +
+        "BRDA:7,0,3,1\n" +
+        "BRF:4\n" +
+        "BRH:4\n" +
+        "DA:3,0\n" +
+        "DA:7,1\n" +
+        "DA:8,1\n" +
+        "DA:10,1\n" +
+        "LH:3\n" +
+        "LF:4\n" +
+        "end_of_record\n"+"]"*/
+
+      val expectedResultList = listOf(
+        "SF:coverage/main/java/com/example/TwoSum.kt\n"+
+        "FN:7,com/example/TwoSum${'$'}Companion::sumNumbers (II)Ljava/lang/Object;\n"+
+        "FN:3,com/example/TwoSum::<init> ()V\n"+
+        "FNDA:1,com/example/TwoSum${'$'}Companion::sumNumbers (II)Ljava/lang/Object;\n"+
+        "FNDA:0,com/example/TwoSum::<init> ()V\n"+
+        "FNF:2\n"+
+        "FNH:1\n"+
+        "BRDA:7,0,0,1\n"+
+        "BRDA:7,0,1,1\n"+
+        "BRDA:7,0,2,1\n"+
+        "BRDA:7,0,3,1\n"+
+        "BRF:4\n"+
+        "BRH:4\n"+
+        "DA:3,0\n"+
+        "DA:7,1\n"+
+        "DA:8,1\n"+
+        "DA:10,1\n"+
+        "LH:3\n"+
+        "LF:4\n"+
+        "end_of_record\n"
+      )
+
+    assertThat(result).isEqualTo(expectedResultList)
+  }
+
   private fun initializeCommandExecutorWithLongProcessWaitTime(): CommandExecutorImpl {
     return CommandExecutorImpl(
       scriptBgDispatcher, processTimeout = 5, processTimeoutUnit = TimeUnit.MINUTES

--- a/scripts/src/javatests/org/oppia/android/scripts/coverage/RunCoverageTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/coverage/RunCoverageTest.kt
@@ -222,28 +222,6 @@ class RunCoverageTest {
       longCommandExecutor,
       scriptBgDispatcher).execute()
 
-    /*val expectedResult =
-      "["+"SF:coverage/main/java/com/example/TwoSum.kt\n" +
-        "FN:7,com/example/TwoSum${'$'}Companion::sumNumbers (II)Ljava/lang/Object;\n" +
-        "FN:3,com/example/TwoSum::<init> ()V\n" +
-        "FNDA:1,com/example/TwoSum${'$'}Companion::sumNumbers (II)Ljava/lang/Object;\n" +
-        "FNDA:0,com/example/TwoSum::<init> ()V\n" +
-        "FNF:2\n" +
-        "FNH:1\n" +
-        "BRDA:7,0,0,1\n" +
-        "BRDA:7,0,1,1\n" +
-        "BRDA:7,0,2,1\n" +
-        "BRDA:7,0,3,1\n" +
-        "BRF:4\n" +
-        "BRH:4\n" +
-        "DA:3,0\n" +
-        "DA:7,1\n" +
-        "DA:8,1\n" +
-        "DA:10,1\n" +
-        "LH:3\n" +
-        "LF:4\n" +
-        "end_of_record\n"+"]"*/
-
       val expectedResultList = listOf(
         "SF:coverage/main/java/com/example/TwoSum.kt\n"+
         "FN:7,com/example/TwoSum${'$'}Companion::sumNumbers (II)Ljava/lang/Object;\n"+
@@ -274,14 +252,5 @@ class RunCoverageTest {
     return CommandExecutorImpl(
       scriptBgDispatcher, processTimeout = 5, processTimeoutUnit = TimeUnit.MINUTES
     )
-  }
-
-  /** Runs the run_coverage. */
-  private fun runScript(filePath: String) {
-    RunCoverage(
-      "${tempFolder.root}",
-      filePath,
-      commandExecutor,
-      scriptBgDispatcher).execute()
   }
 }

--- a/scripts/src/javatests/org/oppia/android/scripts/coverage/RunCoverageTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/coverage/RunCoverageTest.kt
@@ -2,6 +2,7 @@ package org.oppia.android.scripts.coverage
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -12,6 +13,7 @@ import org.oppia.android.scripts.testing.TestBazelWorkspace
 import org.oppia.android.testing.assertThrows
 import java.util.concurrent.TimeUnit
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.PrintStream
 
 /** Tests for [RunCoverage]. */
@@ -26,11 +28,11 @@ class RunCoverageTest {
   private val longCommandExecutor by lazy { initializeCommandExecutorWithLongProcessWaitTime() }
 
   private lateinit var testBazelWorkspace: TestBazelWorkspace
-  private lateinit var bazelTestTarget: String
+  private lateinit var sampleFilePath: String
 
   @Before
   fun setUp() {
-    bazelTestTarget = "//:testTarget"
+    sampleFilePath = "/path/to/Sample.kt"
     testBazelWorkspace = TestBazelWorkspace(tempFolder)
     System.setOut(PrintStream(outContent))
   }
@@ -45,9 +47,126 @@ class RunCoverageTest {
   fun testRunCoverage_testFileExempted_noCoverage() {
     val exemptedFilePath = "app/src/main/java/org/oppia/android/app/activity/ActivityComponent.kt"
 
-    runScript(exemptedFilePath)
+    RunCoverage(
+      "${tempFolder.root}",
+      exemptedFilePath,
+      commandExecutor,
+      scriptBgDispatcher).execute()
 
     assertThat(outContent.toString()).isEqualTo("This file is exempted from having a test file. Hence No coverage!\n")
+  }
+
+  @Test
+  fun testRunCoverage_ScriptsPath_returnTestFilePath() {
+    val rootFolderPath = tempFolder.root.absolutePath
+    val expectedTestFilePath = "scripts/javatests/sample/ExampleTest.kt"
+    val file = File(rootFolderPath, expectedTestFilePath)
+
+    file.parentFile?.mkdirs()
+    file.createNewFile()
+
+    val expectedTestFilePaths = listOf(expectedTestFilePath)
+
+    val result = RunCoverage(
+      rootFolderPath,
+      sampleFilePath,
+      commandExecutor,
+      scriptBgDispatcher
+    ).findTestFile(rootFolderPath, "scripts/java/sample/Example.kt")
+
+    assertEquals(expectedTestFilePaths, result)
+  }
+
+  @Test
+  fun testRunCoverage_AppPath_returnSharedTestFilePath() {
+    val rootFolderPath = tempFolder.root.absolutePath
+    val expectedSharedTestFilePath = "app/sharedTest/sample/ExampleTest.kt"
+    val file = File(rootFolderPath, expectedSharedTestFilePath)
+
+    file.parentFile?.mkdirs()
+    file.createNewFile()
+
+    val expectedSharedTestFilePaths = listOf(expectedSharedTestFilePath)
+
+    val result = RunCoverage(
+      rootFolderPath,
+      sampleFilePath,
+      commandExecutor,
+      scriptBgDispatcher
+    ).findTestFile(rootFolderPath, "app/main/sample/Example.kt")
+
+    assertEquals(expectedSharedTestFilePaths, result)
+  }
+
+  @Test
+  fun testRunCoverage_AppPath_returnLocalTestFilePath() {
+    val rootFolderPath = tempFolder.root.absolutePath
+    val expectedLocalTestFilePath = "app/test/sample/ExampleTest.kt"
+    val file = File(rootFolderPath, expectedLocalTestFilePath)
+
+    file.parentFile?.mkdirs()
+    file.createNewFile()
+
+    val expectedLocalTestFilePaths = listOf(expectedLocalTestFilePath)
+
+    val result = RunCoverage(
+      rootFolderPath,
+      sampleFilePath,
+      commandExecutor,
+      scriptBgDispatcher
+    ).findTestFile(rootFolderPath, "app/main/sample/Example.kt")
+
+    assertEquals(expectedLocalTestFilePaths, result)
+  }
+
+  @Test
+  fun testRunCoverage_AppPath_returnSharedAndLocalTestFilePath() {
+    val rootFolderPath = tempFolder.root.absolutePath
+    val expectedLocalTestFilePath = "app/test/sample/ExampleTest.kt"
+    val expectedSharedTestFilePath = "app/sharedTest/sample/ExampleTest.kt"
+
+    val sharedFile = File(rootFolderPath, expectedSharedTestFilePath)
+    sharedFile.parentFile?.mkdirs()
+    sharedFile.createNewFile()
+
+    val localFile = File(rootFolderPath, expectedLocalTestFilePath)
+    localFile.parentFile?.mkdirs()
+    localFile.createNewFile()
+
+    val expectedLocalAndSharedTestFilePaths = listOf(
+      expectedSharedTestFilePath,
+      expectedLocalTestFilePath
+    )
+
+    val result = RunCoverage(
+      rootFolderPath,
+      sampleFilePath,
+      commandExecutor,
+      scriptBgDispatcher
+    ).findTestFile(rootFolderPath, "app/main/sample/Example.kt")
+
+    assertEquals(expectedLocalAndSharedTestFilePaths, result)
+  }
+
+  @Test
+  fun testRunCoverage_AppPath_returnDefaultTestFilePath() {
+    val rootFolderPath = tempFolder.root.absolutePath
+    val expectedLocalTestFilePath = "util/test/sample/ExampleTest.kt"
+    val file = File(rootFolderPath, expectedLocalTestFilePath)
+
+    file.parentFile?.mkdirs()
+    file.createNewFile()
+
+    val expectedLocalTestFilePaths = listOf(expectedLocalTestFilePath)
+
+    val result = RunCoverage(
+      rootFolderPath,
+      sampleFilePath,
+      commandExecutor,
+      scriptBgDispatcher
+    ).findTestFile(rootFolderPath, "util/main/sample/Example.kt")
+
+    assertEquals(expectedLocalTestFilePaths, result)
   }
 
   private fun initializeCommandExecutorWithLongProcessWaitTime(): CommandExecutorImpl {

--- a/scripts/src/javatests/org/oppia/android/scripts/coverage/RunCoverageTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/coverage/RunCoverageTest.kt
@@ -1,0 +1,67 @@
+package org.oppia.android.scripts.coverage
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.oppia.android.scripts.common.CommandExecutorImpl
+import org.oppia.android.scripts.common.ScriptBackgroundCoroutineDispatcher
+import org.oppia.android.scripts.testing.TestBazelWorkspace
+import org.oppia.android.testing.assertThrows
+import java.util.concurrent.TimeUnit
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+/** Tests for [RunCoverage]. */
+class RunCoverageTest {
+  @field:[Rule JvmField] val tempFolder = TemporaryFolder()
+
+  private val outContent: ByteArrayOutputStream = ByteArrayOutputStream()
+  private val originalOut: PrintStream = System.out
+
+  private val scriptBgDispatcher by lazy { ScriptBackgroundCoroutineDispatcher() }
+  private val commandExecutor by lazy { CommandExecutorImpl(scriptBgDispatcher) }
+  private val longCommandExecutor by lazy { initializeCommandExecutorWithLongProcessWaitTime() }
+
+  private lateinit var testBazelWorkspace: TestBazelWorkspace
+  private lateinit var bazelTestTarget: String
+
+  @Before
+  fun setUp() {
+    bazelTestTarget = "//:testTarget"
+    testBazelWorkspace = TestBazelWorkspace(tempFolder)
+    System.setOut(PrintStream(outContent))
+  }
+
+  @After
+  fun tearDown() {
+    System.setOut(originalOut)
+    scriptBgDispatcher.close()
+  }
+
+  @Test
+  fun testRunCoverage_testFileExempted_noCoverage() {
+    val exemptedFilePath = "app/src/main/java/org/oppia/android/app/activity/ActivityComponent.kt"
+
+    runScript(exemptedFilePath)
+
+    assertThat(outContent.toString()).isEqualTo("This file is exempted from having a test file. Hence No coverage!\n")
+  }
+
+  private fun initializeCommandExecutorWithLongProcessWaitTime(): CommandExecutorImpl {
+    return CommandExecutorImpl(
+      scriptBgDispatcher, processTimeout = 5, processTimeoutUnit = TimeUnit.MINUTES
+    )
+  }
+
+  /** Runs the run_coverage. */
+  private fun runScript(filePath: String) {
+    RunCoverage(
+      "${tempFolder.root}",
+      filePath,
+      commandExecutor,
+      scriptBgDispatcher).execute()
+  }
+}


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes part of #5343 

### Project
[PR 1.3 of Project 4.1]

### Changes Made

- Added a new script utility `RunCoverage.kt` that takes a filename as an argument.
- Implements handling for exempted files and test target mapping.

---

### Implementation Details

- **Exemption Check**: The script first checks if the provided file is exempted from having test file [the implemetation will be changed once PR 1.2 is merged]. If exempted, it exits early with the message "The file is exempted hence no coverage!".
  
- **Test Target Mapping**:
  - **Script, App, and Default Subpackages**: Constructs mappings for files within these subpackages to their corresponding test targets.
  - **App Subpackage**: Handles mapping for both `test` and `Localtests`.
  
- **Code Coverage Execution**:
  - Utilizes the `RunCoverageForTestTarget` script to execute code coverage analysis.
  - Returns a list of coverage data strings for each run, which will be subsequently saved as protos in PR 1.4.

### Example Usage

```bash
bazel run //scripts:run_coverage -- $(pwd) utility/src/main/java/org/oppia/android/util/parser/math/MathModel.kt
```

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
