### PR TITLE
Fix #5404: Migrate from super.onBackPressed() to onBackPressedDispatcher.onBackPressed()

### DIFF
--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivity.kt
@@ -48,8 +48,7 @@ class ProfileEditActivity : InjectableAutoLocalizedAppCompatActivity() {
   override fun onBackPressed() {
     val isMultipane = intent.extras!!.getBoolean(IS_MULTIPANE_EXTRA_KEY, false)
     if (isMultipane) {
-      @Suppress("DEPRECATION") // TODO(#5404): Migrate to a back pressed dispatcher.
-      super.onBackPressed()
+      onBackPressedDispatcher.onBackPressed()
     } else {
       val intent = Intent(this, ProfileListActivity::class.java)
       intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivityPresenter.kt
@@ -23,11 +23,9 @@ class ProfileEditActivityPresenter @Inject constructor(
 
     val profileId = activity.intent.getIntExtra(PROFILE_EDIT_PROFILE_ID_EXTRA_KEY, 0)
     val isMultipane = activity.intent.getBooleanExtra(IS_MULTIPANE_EXTRA_KEY, false)
-
     toolbar.setNavigationOnClickListener {
       if (isMultipane) {
-        @Suppress("DEPRECATION") // TODO(#5404): Migrate to a back pressed dispatcher.
-        activity.onBackPressed()
+        activity.onBackPressedDispatcher.onBackPressed()
       } else {
         val intent = Intent(activity, ProfileListActivity::class.java)
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)

--- a/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityPresenter.kt
@@ -47,8 +47,7 @@ class QuestionPlayerActivityPresenter @Inject constructor(
     activity.setSupportActionBar(binding.questionPlayerToolbar)
 
     binding.questionPlayerToolbar.setNavigationOnClickListener {
-      @Suppress("DEPRECATION") // TODO(#5404): Migrate to a back pressed dispatcher.
-      activity.onBackPressed()
+      activity.onBackPressedDispatcher.onBackPressed()
     }
 
     if (getQuestionPlayerFragment() == null) {

--- a/app/src/main/java/org/oppia/android/app/walkthrough/end/WalkthroughFinalFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/walkthrough/end/WalkthroughFinalFragmentPresenter.kt
@@ -106,7 +106,6 @@ class WalkthroughFinalFragmentPresenter @Inject constructor(
   }
 
   override fun goBack() {
-    @Suppress("DEPRECATION") // TODO(#5404): Migrate to a back pressed dispatcher.
-    activity.onBackPressed()
+    activity.onBackPressedDispatcher.onBackPressed()
   }
 }


### PR DESCRIPTION
…ressed()

- Replaced the deprecated super.onBackPressed() method with onBackPressedDispatcher.onBackPressed()
- Ensures compatibility with newer Android SDK versions
- Updated necessary activities and fragments to use the new back pressed dispatcher
- Verified that back navigation works correctly with the toolbar back arrow, system back button, and tablet-specific behaviors

Activities and fragments corrected:
- app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivity
- app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivityPresenter
- app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityPresenter
- app/src/main/java/org/oppia/android/app/walkthrough/end/WalkthroughFinalFragmentPresenter

Fixes #5404

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #5404:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
This PR migrates from the deprecated super.onBackPressed() method to onBackPressedDispatcher.onBackPressed(), ensuring compatibility with newer Android SDK versions. The following activities and fragments have been updated to use the new back pressed dispatcher:

- ProfileEditActivity
- ProfileEditActivityPresenter
- QuestionPlayerActivityPresenter
- WalkthroughFinalFragmentPresenter

The back navigation behavior was verified to work correctly with the toolbar back arrow, system back button, and tablet-specific behaviors.

Fixes #5404



## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).


