### PR TITLE
Fix #5395: Fixed concept card not closing when opened from hint

### DIFF
--- a/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragment.kt
@@ -26,6 +26,7 @@ class ConceptCardFragment : InjectableDialogFragment() {
   companion object {
 
     const val CONCEPT_CARD_FRAGMENT_ARGUMENTS_KEY = "ConceptCardFragment.arguments"
+    private var conceptCardFragment: ConceptCardFragment? = null
 
     /** The fragment tag corresponding to the concept card dialog fragment. */
     private const val CONCEPT_CARD_DIALOG_FRAGMENT_TAG = "CONCEPT_CARD_FRAGMENT"
@@ -82,11 +83,15 @@ class ConceptCardFragment : InjectableDialogFragment() {
     fun dismissAll(fragmentManager: FragmentManager) {
       val toDismiss = fragmentManager.fragments.filterIsInstance<ConceptCardFragment>()
       if (toDismiss.isNotEmpty()) {
-        val transaction = fragmentManager.beginTransaction()
-        for (fragment in toDismiss) {
-          transaction.remove(fragment)
+        fragmentManager.beginTransaction().apply {
+          for (fragment in toDismiss) {
+            remove(fragment)
+          }
+          commitNow()
         }
-        transaction.commitNow()
+      } else {
+        conceptCardFragment?.dismiss()
+        conceptCardFragment = null
       }
     }
 
@@ -97,6 +102,7 @@ class ConceptCardFragment : InjectableDialogFragment() {
     ): ConceptCardFragment {
       val conceptCardFragment = newInstance(skillId, profileId)
       conceptCardFragment.showNow(fragmentManager, CONCEPT_CARD_DIALOG_FRAGMENT_TAG)
+      this.conceptCardFragment = conceptCardFragment
       return conceptCardFragment
     }
   }


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix #5395: fixed concept card not closing.

Check:

https://github.com/oppia/oppia-android/assets/54560535/490606f0-b022-4f04-95c7-48362f57c31f

In the ConceptCardFragment.kt file
1. Declared a member variable for the fragment
<img width="672" alt="Screenshot 2024-06-25 at 03 00 22" src="https://github.com/oppia/oppia-android/assets/54560535/56acd4d2-784a-4d92-bd93-a1b4e4afab94">

2. I modified the showNewInstance function to store the fragment instance in the member variable:
<img width="688" alt="Screenshot 2024-06-25 at 03 09 18" src="https://github.com/oppia/oppia-android/assets/54560535/00c147bd-0047-4550-ac99-17f44fec3ac6">

3. Dismissed the fragment in the else condition of dismisAll() function for case where the filterInstance list is empty

<img width="743" alt="Screenshot 2024-06-25 at 03 08 56" src="https://github.com/oppia/oppia-android/assets/54560535/b58eb704-f1af-4d15-b1de-521ba9f006d8">

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing