### PR TITLE
Fixes part of #4938: Use TranslationController as the source of truth for the audio language setting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,7 +107,8 @@ def filesToExclude = [
     '**/*AppLanguageLocaleHandlerTest*.kt',
     '**/*AppLanguageResourceHandlerTest*.kt',
     '**/*AppLanguageWatcherMixinTest*.kt',
-    '**/*ActivityLanguageLocaleHandlerTest*.kt'
+    '**/*ActivityLanguageLocaleHandlerTest*.kt',
+    '**/*OptionsFragmentTest*.kt', // Excludes 2 tests.
 ]
 _excludeSourceFiles(filesToExclude)
 

--- a/app/src/main/java/org/oppia/android/app/player/audio/LanguageDialogFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/player/audio/LanguageDialogFragment.kt
@@ -80,8 +80,6 @@ class LanguageDialogFragment : InjectableDialogFragment() {
     for (languageCode in languageCodeArrayList) {
       val audioLanguage = when (machineLocale.run { languageCode.toMachineLowerCase() }) {
         "hi" -> AudioLanguage.HINDI_AUDIO_LANGUAGE
-        "fr" -> AudioLanguage.FRENCH_AUDIO_LANGUAGE
-        "zh" -> AudioLanguage.CHINESE_AUDIO_LANGUAGE
         "pt", "pt-br" -> AudioLanguage.BRAZILIAN_PORTUGUESE_LANGUAGE
         "ar" -> AudioLanguage.ARABIC_LANGUAGE
         "pcm" -> AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE

--- a/app/src/main/java/org/oppia/android/app/translation/AppLanguageResourceHandler.kt
+++ b/app/src/main/java/org/oppia/android/app/translation/AppLanguageResourceHandler.kt
@@ -154,8 +154,6 @@ class AppLanguageResourceHandler @Inject constructor(
   fun computeLocalizedDisplayName(audioLanguage: AudioLanguage): String {
     return when (audioLanguage) {
       AudioLanguage.HINDI_AUDIO_LANGUAGE -> getLocalizedDisplayName("hi")
-      AudioLanguage.FRENCH_AUDIO_LANGUAGE -> getLocalizedDisplayName("fr")
-      AudioLanguage.CHINESE_AUDIO_LANGUAGE -> getLocalizedDisplayName("zh")
       AudioLanguage.BRAZILIAN_PORTUGUESE_LANGUAGE -> getLocalizedDisplayName("pt", "BR")
       AudioLanguage.ARABIC_LANGUAGE -> getLocalizedDisplayName("ar", "EG")
       AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE ->

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
@@ -112,9 +112,9 @@ import javax.inject.Singleton
 class AudioLanguageFragmentTest {
   private companion object {
     private const val ENGLISH_BUTTON_INDEX = 0
-    private const val PORTUGUESE_BUTTON_INDEX = 4
-    private const val ARABIC_BUTTON_INDEX = 5
-    private const val NIGERIAN_PIDGIN_BUTTON_INDEX = 6
+    private const val PORTUGUESE_BUTTON_INDEX = 2
+    private const val ARABIC_BUTTON_INDEX = 3
+    private const val NIGERIAN_PIDGIN_BUTTON_INDEX = 4
   }
 
   @get:Rule val initializeDefaultLocaleRule = InitializeDefaultLocaleRule()

--- a/app/src/sharedTest/java/org/oppia/android/app/options/ReadingTextSizeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/ReadingTextSizeFragmentTest.kt
@@ -74,7 +74,9 @@ import org.oppia.android.domain.platformparameter.PlatformParameterModule
 import org.oppia.android.domain.platformparameter.PlatformParameterSingletonModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
+import org.oppia.android.testing.BuildEnvironment
 import org.oppia.android.testing.OppiaTestRule
+import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
@@ -180,8 +182,10 @@ class ReadingTextSizeFragmentTest {
     }
   }
 
+  // Requires language configurations.
   @Test
   @Config(qualifiers = "sw600dp")
+  @RunOn(buildEnvironments = [BuildEnvironment.BAZEL])
   fun testTextSize_changeTextSizeToMedium_mediumItemIsSelected() {
     launch<OptionsActivity>(createOptionActivityIntent(0, true)).use {
       testCoroutineDispatchers.runCurrent()

--- a/app/src/test/java/org/oppia/android/app/translation/AppLanguageResourceHandlerTest.kt
+++ b/app/src/test/java/org/oppia/android/app/translation/AppLanguageResourceHandlerTest.kt
@@ -494,8 +494,6 @@ class AppLanguageResourceHandlerTest {
   // TODO(#3793): Remove this once OppiaLanguage is used as the source of truth.
   @Test
   @Iteration("hi", "lang=HINDI_AUDIO_LANGUAGE", "expectedDisplayText=हिन्दी")
-  @Iteration("fr", "lang=FRENCH_AUDIO_LANGUAGE", "expectedDisplayText=Français")
-  @Iteration("zh", "lang=CHINESE_AUDIO_LANGUAGE", "expectedDisplayText=中文")
   @Iteration("pr-pt", "lang=BRAZILIAN_PORTUGUESE_LANGUAGE", "expectedDisplayText=Português")
   @Iteration("ar", "lang=ARABIC_LANGUAGE", "expectedDisplayText=العربية")
   @Iteration("pcm", "lang=NIGERIAN_PIDGIN_LANGUAGE", "expectedDisplayText=Naijá")

--- a/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
@@ -9,7 +9,9 @@ import android.provider.MediaStore
 import androidx.exifinterface.media.ExifInterface
 import kotlinx.coroutines.Deferred
 import org.oppia.android.app.model.AudioLanguage
+import org.oppia.android.app.model.AudioTranslationLanguageSelection
 import org.oppia.android.app.model.DeviceSettings
+import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.model.Profile
 import org.oppia.android.app.model.ProfileAvatar
 import org.oppia.android.app.model.ProfileDatabase
@@ -22,6 +24,7 @@ import org.oppia.android.domain.oppialogger.LoggingIdentifierController
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.oppialogger.analytics.LearnerAnalyticsLogger
 import org.oppia.android.domain.oppialogger.exceptions.ExceptionsController
+import org.oppia.android.domain.translation.TranslationController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders
@@ -64,8 +67,8 @@ private const val SET_CURRENT_PROFILE_ID_PROVIDER_ID = "set_current_profile_id_p
 private const val UPDATE_READING_TEXT_SIZE_PROVIDER_ID =
   "update_reading_text_size_provider_id"
 private const val UPDATE_APP_LANGUAGE_PROVIDER_ID = "update_app_language_provider_id"
-private const val UPDATE_AUDIO_LANGUAGE_PROVIDER_ID =
-  "update_audio_language_provider_id"
+private const val GET_AUDIO_LANGUAGE_PROVIDER_ID = "get_audio_language_provider_id"
+private const val UPDATE_AUDIO_LANGUAGE_PROVIDER_ID = "update_audio_language_provider_id"
 private const val UPDATE_LEARNER_ID_PROVIDER_ID = "update_learner_id_provider_id"
 private const val SET_SURVEY_LAST_SHOWN_TIMESTAMP_PROVIDER_ID =
   "record_survey_last_shown_timestamp_provider_id"
@@ -93,7 +96,8 @@ class ProfileManagementController @Inject constructor(
   private val enableLearnerStudyAnalytics: PlatformParameterValue<Boolean>,
   @EnableLoggingLearnerStudyIds
   private val enableLoggingLearnerStudyIds: PlatformParameterValue<Boolean>,
-  private val profileNameValidator: ProfileNameValidator
+  private val profileNameValidator: ProfileNameValidator,
+  private val translationController: TranslationController
 ) {
   private var currentProfileId: Int = DEFAULT_LOGGED_OUT_INTERNAL_PROFILE_ID
   private val profileDataStore =
@@ -275,7 +279,6 @@ class ProfileManagementController @Inject constructor(
         dateCreatedTimestampMs = oppiaClock.getCurrentTimeMs()
         this.isAdmin = isAdmin
         readingTextSize = ReadingTextSize.MEDIUM_TEXT_SIZE
-        audioLanguage = AudioLanguage.ENGLISH_AUDIO_LANGUAGE
         numberOfLogins = 0
 
         if (enableLoggingLearnerStudyIds.value) {
@@ -629,33 +632,51 @@ class ProfileManagementController @Inject constructor(
   }
 
   /**
+   * Returns the current audio language configured for the specified profile ID, as possibly set by
+   * [updateAudioLanguage].
+   *
+   * The return [DataProvider] will automatically update for subsequent calls to
+   * [updateAudioLanguage] for this [profileId].
+   */
+  fun getAudioLanguage(profileId: ProfileId): DataProvider<AudioLanguage> {
+    return translationController.getAudioTranslationContentLanguage(
+      profileId
+    ).transform(GET_AUDIO_LANGUAGE_PROVIDER_ID) { oppiaLanguage ->
+      when (oppiaLanguage) {
+        OppiaLanguage.UNRECOGNIZED, OppiaLanguage.LANGUAGE_UNSPECIFIED, OppiaLanguage.HINGLISH,
+        OppiaLanguage.PORTUGUESE, OppiaLanguage.SWAHILI -> AudioLanguage.AUDIO_LANGUAGE_UNSPECIFIED
+        OppiaLanguage.ARABIC -> AudioLanguage.ARABIC_LANGUAGE
+        OppiaLanguage.ENGLISH -> AudioLanguage.ENGLISH_AUDIO_LANGUAGE
+        OppiaLanguage.HINDI -> AudioLanguage.HINDI_AUDIO_LANGUAGE
+        OppiaLanguage.BRAZILIAN_PORTUGUESE -> AudioLanguage.BRAZILIAN_PORTUGUESE_LANGUAGE
+        OppiaLanguage.NIGERIAN_PIDGIN -> AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE
+      }
+    }
+  }
+
+  /**
    * Updates the audio language of the profile.
    *
-   * @param profileId the ID corresponding to the profile being updated.
-   * @param audioLanguage New audio language for the profile being updated.
-   * @return a [DataProvider] that indicates the success/failure of this update operation.
+   * @param profileId the ID corresponding to the profile being updated
+   * @param audioLanguage New audio language for the profile being updated
+   * @return a [DataProvider] that indicates the success/failure of this update operation
    */
   fun updateAudioLanguage(profileId: ProfileId, audioLanguage: AudioLanguage): DataProvider<Any?> {
-    val deferred = profileDataStore.storeDataWithCustomChannelAsync(
-      updateInMemoryCache = true
-    ) {
-      val profile =
-        it.profilesMap[profileId.internalId] ?: return@storeDataWithCustomChannelAsync Pair(
-          it,
-          ProfileActionStatus.PROFILE_NOT_FOUND
-        )
-      val updatedProfile = profile.toBuilder().setAudioLanguage(audioLanguage).build()
-      val profileDatabaseBuilder = it.toBuilder().putProfiles(
-        profileId.internalId,
-        updatedProfile
-      )
-      Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
-    }
-    return dataProviders.createInMemoryDataProviderAsync(
-      UPDATE_AUDIO_LANGUAGE_PROVIDER_ID
-    ) {
-      return@createInMemoryDataProviderAsync getDeferredResult(profileId, null, deferred)
-    }
+    val audioSelection = AudioTranslationLanguageSelection.newBuilder().apply {
+      this.selectedLanguage = when (audioLanguage) {
+        AudioLanguage.UNRECOGNIZED, AudioLanguage.AUDIO_LANGUAGE_UNSPECIFIED,
+        AudioLanguage.NO_AUDIO -> OppiaLanguage.LANGUAGE_UNSPECIFIED
+        AudioLanguage.ENGLISH_AUDIO_LANGUAGE -> OppiaLanguage.ENGLISH
+        AudioLanguage.HINDI_AUDIO_LANGUAGE -> OppiaLanguage.HINDI
+        AudioLanguage.BRAZILIAN_PORTUGUESE_LANGUAGE -> OppiaLanguage.BRAZILIAN_PORTUGUESE
+        AudioLanguage.ARABIC_LANGUAGE -> OppiaLanguage.ARABIC
+        AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE -> OppiaLanguage.NIGERIAN_PIDGIN
+      }
+    }.build()
+    // The transformation is needed to reinterpreted the result of the update to 'Any?'.
+    return translationController.updateAudioTranslationContentLanguage(
+      profileId, audioSelection
+    ).transform(UPDATE_AUDIO_LANGUAGE_PROVIDER_ID) { value -> value }
   }
 
   /**

--- a/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.junit.After
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.app.model.AudioLanguage.ARABIC_LANGUAGE
@@ -34,7 +35,10 @@ import org.oppia.android.domain.oppialogger.ApplicationIdSeed
 import org.oppia.android.domain.oppialogger.LogStorageModule
 import org.oppia.android.domain.oppialogger.LoggingIdentifierController
 import org.oppia.android.domain.oppialogger.analytics.ApplicationLifecycleModule
+import org.oppia.android.testing.BuildEnvironment
 import org.oppia.android.testing.FakeAnalyticsEventLogger
+import org.oppia.android.testing.OppiaTestRule
+import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.data.DataProviderTestMonitor
 import org.oppia.android.testing.logging.EventLogSubject.Companion.assertThat
@@ -77,6 +81,7 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = ProfileManagementControllerTest.TestApplication::class)
 class ProfileManagementControllerTest {
+  @get:Rule val oppiaTestRule = OppiaTestRule()
   @Inject lateinit var context: Context
   @Inject lateinit var profileTestHelper: ProfileTestHelper
   @Inject lateinit var profileManagementController: ProfileManagementController
@@ -716,7 +721,9 @@ class ProfileManagementControllerTest {
     assertThat(profile.readingTextSize).isEqualTo(MEDIUM_TEXT_SIZE)
   }
 
+  // Requires language configurations.
   @Test
+  @RunOn(buildEnvironments = [BuildEnvironment.BAZEL])
   fun testGetAudioLanguage_initialProfileCreation_defaultsToEnglish() {
     setUpTestApplicationComponent()
 
@@ -779,7 +786,9 @@ class ProfileManagementControllerTest {
     monitor.ensureNextResultIsSuccess()
   }
 
+  // Requires language configurations.
   @Test
+  @RunOn(buildEnvironments = [BuildEnvironment.BAZEL])
   fun testUpdateAudioLanguage_updateToHindi_updateChangesAudioLanguage() {
     setUpTestApplicationComponent()
     addTestProfiles()
@@ -793,7 +802,9 @@ class ProfileManagementControllerTest {
     assertThat(audioLanguage).isEqualTo(HINDI_AUDIO_LANGUAGE)
   }
 
+  // Requires language configurations.
   @Test
+  @RunOn(buildEnvironments = [BuildEnvironment.BAZEL])
   fun testUpdateAudioLanguage_updateToBrazilianPortuguese_updateChangesAudioLanguage() {
     setUpTestApplicationComponent()
     addTestProfiles()
@@ -807,7 +818,9 @@ class ProfileManagementControllerTest {
     assertThat(audioLanguage).isEqualTo(BRAZILIAN_PORTUGUESE_LANGUAGE)
   }
 
+  // Requires language configurations.
   @Test
+  @RunOn(buildEnvironments = [BuildEnvironment.BAZEL])
   fun testUpdateAudioLanguage_updateToArabic_updateChangesAudioLanguage() {
     setUpTestApplicationComponent()
     addTestProfiles()
@@ -821,7 +834,9 @@ class ProfileManagementControllerTest {
     assertThat(audioLanguage).isEqualTo(ARABIC_LANGUAGE)
   }
 
+  // Requires language configurations.
   @Test
+  @RunOn(buildEnvironments = [BuildEnvironment.BAZEL])
   fun testUpdateAudioLanguage_updateToNigerianPidgin_updateChangesAudioLanguage() {
     setUpTestApplicationComponent()
     addTestProfiles()
@@ -835,7 +850,9 @@ class ProfileManagementControllerTest {
     assertThat(audioLanguage).isEqualTo(NIGERIAN_PIDGIN_LANGUAGE)
   }
 
+  // Requires language configurations.
   @Test
+  @RunOn(buildEnvironments = [BuildEnvironment.BAZEL])
   fun testUpdateAudioLanguage_updateToArabicThenEnglish_updateChangesAudioLanguageToEnglish() {
     setUpTestApplicationComponent()
     addTestProfiles()
@@ -852,7 +869,9 @@ class ProfileManagementControllerTest {
     assertThat(audioLanguage).isEqualTo(ENGLISH_AUDIO_LANGUAGE)
   }
 
+  // Requires language configurations.
   @Test
+  @RunOn(buildEnvironments = [BuildEnvironment.BAZEL])
   fun testUpdateAudioLanguage_updateProfile1ToArabic_profile2IsUnchanged() {
     setUpTestApplicationComponent()
     addTestProfiles()

--- a/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
@@ -19,8 +19,11 @@ import kotlinx.coroutines.flow.StateFlow
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.oppia.android.app.model.AudioLanguage
-import org.oppia.android.app.model.AudioLanguage.FRENCH_AUDIO_LANGUAGE
+import org.oppia.android.app.model.AudioLanguage.ARABIC_LANGUAGE
+import org.oppia.android.app.model.AudioLanguage.BRAZILIAN_PORTUGUESE_LANGUAGE
+import org.oppia.android.app.model.AudioLanguage.ENGLISH_AUDIO_LANGUAGE
+import org.oppia.android.app.model.AudioLanguage.HINDI_AUDIO_LANGUAGE
+import org.oppia.android.app.model.AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE
 import org.oppia.android.app.model.Profile
 import org.oppia.android.app.model.ProfileDatabase
 import org.oppia.android.app.model.ProfileId
@@ -129,7 +132,6 @@ class ProfileManagementControllerTest {
     assertThat(profile.allowDownloadAccess).isEqualTo(true)
     assertThat(profile.id.internalId).isEqualTo(0)
     assertThat(profile.readingTextSize).isEqualTo(MEDIUM_TEXT_SIZE)
-    assertThat(profile.audioLanguage).isEqualTo(AudioLanguage.ENGLISH_AUDIO_LANGUAGE)
     assertThat(profile.numberOfLogins).isEqualTo(0)
     assertThat(profile.isContinueButtonAnimationSeen).isEqualTo(false)
     assertThat(File(getAbsoluteDirPath("0")).isDirectory).isTrue()
@@ -197,7 +199,6 @@ class ProfileManagementControllerTest {
     assertThat(profile.allowDownloadAccess).isEqualTo(false)
     assertThat(profile.id.internalId).isEqualTo(3)
     assertThat(profile.readingTextSize).isEqualTo(MEDIUM_TEXT_SIZE)
-    assertThat(profile.audioLanguage).isEqualTo(AudioLanguage.ENGLISH_AUDIO_LANGUAGE)
   }
 
   @Test
@@ -716,17 +717,153 @@ class ProfileManagementControllerTest {
   }
 
   @Test
-  fun testUpdateAudioLanguage_addProfiles_updateWithFrenchLanguage_checkUpdateIsSuccessful() {
+  fun testGetAudioLanguage_initialProfileCreation_defaultsToEnglish() {
+    setUpTestApplicationComponent()
+
+    addTestProfiles()
+
+    val audioLanguageProvider = profileManagementController.getAudioLanguage(PROFILE_ID_2)
+    val audioLanguage = monitorFactory.waitForNextSuccessfulResult(audioLanguageProvider)
+    assertThat(audioLanguage).isEqualTo(ENGLISH_AUDIO_LANGUAGE)
+  }
+
+  @Test
+  fun testUpdateAudioLanguage_updateToHindi_updateIsSuccessful() {
     setUpTestApplicationComponent()
     addTestProfiles()
 
     val updateProvider =
-      profileManagementController.updateAudioLanguage(PROFILE_ID_2, FRENCH_AUDIO_LANGUAGE)
-    val profileProvider = profileManagementController.getProfile(PROFILE_ID_2)
+      profileManagementController.updateAudioLanguage(PROFILE_ID_2, HINDI_AUDIO_LANGUAGE)
+    val monitor = monitorFactory.createMonitor(updateProvider)
+    testCoroutineDispatchers.runCurrent()
 
-    monitorFactory.waitForNextSuccessfulResult(updateProvider)
-    val profile = monitorFactory.waitForNextSuccessfulResult(profileProvider)
-    assertThat(profile.audioLanguage).isEqualTo(FRENCH_AUDIO_LANGUAGE)
+    monitor.ensureNextResultIsSuccess()
+  }
+
+  @Test
+  fun testUpdateAudioLanguage_updateToBrazilianPortuguese_updateIsSuccessful() {
+    setUpTestApplicationComponent()
+    addTestProfiles()
+
+    val updateProvider =
+      profileManagementController.updateAudioLanguage(PROFILE_ID_2, BRAZILIAN_PORTUGUESE_LANGUAGE)
+    val monitor = monitorFactory.createMonitor(updateProvider)
+    testCoroutineDispatchers.runCurrent()
+
+    monitor.ensureNextResultIsSuccess()
+  }
+
+  @Test
+  fun testUpdateAudioLanguage_updateToArabic_updateIsSuccessful() {
+    setUpTestApplicationComponent()
+    addTestProfiles()
+
+    val updateProvider =
+      profileManagementController.updateAudioLanguage(PROFILE_ID_2, ARABIC_LANGUAGE)
+    val monitor = monitorFactory.createMonitor(updateProvider)
+    testCoroutineDispatchers.runCurrent()
+
+    monitor.ensureNextResultIsSuccess()
+  }
+
+  @Test
+  fun testUpdateAudioLanguage_updateToNigerianPidgin_updateIsSuccessful() {
+    setUpTestApplicationComponent()
+    addTestProfiles()
+
+    val updateProvider =
+      profileManagementController.updateAudioLanguage(PROFILE_ID_2, NIGERIAN_PIDGIN_LANGUAGE)
+    val monitor = monitorFactory.createMonitor(updateProvider)
+    testCoroutineDispatchers.runCurrent()
+
+    monitor.ensureNextResultIsSuccess()
+  }
+
+  @Test
+  fun testUpdateAudioLanguage_updateToHindi_updateChangesAudioLanguage() {
+    setUpTestApplicationComponent()
+    addTestProfiles()
+
+    val updateProvider =
+      profileManagementController.updateAudioLanguage(PROFILE_ID_2, HINDI_AUDIO_LANGUAGE)
+    monitorFactory.ensureDataProviderExecutes(updateProvider)
+
+    val audioLanguageProvider = profileManagementController.getAudioLanguage(PROFILE_ID_2)
+    val audioLanguage = monitorFactory.waitForNextSuccessfulResult(audioLanguageProvider)
+    assertThat(audioLanguage).isEqualTo(HINDI_AUDIO_LANGUAGE)
+  }
+
+  @Test
+  fun testUpdateAudioLanguage_updateToBrazilianPortuguese_updateChangesAudioLanguage() {
+    setUpTestApplicationComponent()
+    addTestProfiles()
+
+    val updateProvider =
+      profileManagementController.updateAudioLanguage(PROFILE_ID_2, BRAZILIAN_PORTUGUESE_LANGUAGE)
+    monitorFactory.ensureDataProviderExecutes(updateProvider)
+
+    val audioLanguageProvider = profileManagementController.getAudioLanguage(PROFILE_ID_2)
+    val audioLanguage = monitorFactory.waitForNextSuccessfulResult(audioLanguageProvider)
+    assertThat(audioLanguage).isEqualTo(BRAZILIAN_PORTUGUESE_LANGUAGE)
+  }
+
+  @Test
+  fun testUpdateAudioLanguage_updateToArabic_updateChangesAudioLanguage() {
+    setUpTestApplicationComponent()
+    addTestProfiles()
+
+    val updateProvider =
+      profileManagementController.updateAudioLanguage(PROFILE_ID_2, ARABIC_LANGUAGE)
+    monitorFactory.ensureDataProviderExecutes(updateProvider)
+
+    val audioLanguageProvider = profileManagementController.getAudioLanguage(PROFILE_ID_2)
+    val audioLanguage = monitorFactory.waitForNextSuccessfulResult(audioLanguageProvider)
+    assertThat(audioLanguage).isEqualTo(ARABIC_LANGUAGE)
+  }
+
+  @Test
+  fun testUpdateAudioLanguage_updateToNigerianPidgin_updateChangesAudioLanguage() {
+    setUpTestApplicationComponent()
+    addTestProfiles()
+
+    val updateProvider =
+      profileManagementController.updateAudioLanguage(PROFILE_ID_2, NIGERIAN_PIDGIN_LANGUAGE)
+    monitorFactory.ensureDataProviderExecutes(updateProvider)
+
+    val audioLanguageProvider = profileManagementController.getAudioLanguage(PROFILE_ID_2)
+    val audioLanguage = monitorFactory.waitForNextSuccessfulResult(audioLanguageProvider)
+    assertThat(audioLanguage).isEqualTo(NIGERIAN_PIDGIN_LANGUAGE)
+  }
+
+  @Test
+  fun testUpdateAudioLanguage_updateToArabicThenEnglish_updateChangesAudioLanguageToEnglish() {
+    setUpTestApplicationComponent()
+    addTestProfiles()
+    val updateProvider1 =
+      profileManagementController.updateAudioLanguage(PROFILE_ID_2, NIGERIAN_PIDGIN_LANGUAGE)
+    monitorFactory.ensureDataProviderExecutes(updateProvider1)
+
+    val updateProvider2 =
+      profileManagementController.updateAudioLanguage(PROFILE_ID_2, ENGLISH_AUDIO_LANGUAGE)
+    monitorFactory.ensureDataProviderExecutes(updateProvider2)
+
+    val audioLanguageProvider = profileManagementController.getAudioLanguage(PROFILE_ID_2)
+    val audioLanguage = monitorFactory.waitForNextSuccessfulResult(audioLanguageProvider)
+    assertThat(audioLanguage).isEqualTo(ENGLISH_AUDIO_LANGUAGE)
+  }
+
+  @Test
+  fun testUpdateAudioLanguage_updateProfile1ToArabic_profile2IsUnchanged() {
+    setUpTestApplicationComponent()
+    addTestProfiles()
+
+    val updateProvider =
+      profileManagementController.updateAudioLanguage(PROFILE_ID_1, ARABIC_LANGUAGE)
+    monitorFactory.ensureDataProviderExecutes(updateProvider)
+
+    val audioLanguageProvider = profileManagementController.getAudioLanguage(PROFILE_ID_2)
+    val audioLanguage = monitorFactory.waitForNextSuccessfulResult(audioLanguageProvider)
+    assertThat(audioLanguage).isEqualTo(ENGLISH_AUDIO_LANGUAGE)
   }
 
   @Test

--- a/domain/src/test/java/org/oppia/android/domain/translation/TranslationControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/translation/TranslationControllerTest.kt
@@ -490,7 +490,7 @@ class TranslationControllerTest {
   }
 
   @Test
-  fun testUpdateAppLanguage_uninitializedToSystem_returnsDefaultSelection() {
+  fun testUpdateAppLanguage_uninitializedToSystem_returnsUninitialized() {
     forceDefaultLocale(Locale.ROOT)
 
     val languageSelection = AppLanguageSelection.newBuilder().apply {
@@ -503,11 +503,11 @@ class TranslationControllerTest {
 
     // The previous selection was uninitialized.
     val selection = monitorFactory.waitForNextSuccessfulResult(updateProvider)
-    assertThat(selection).isEqualTo(languageSelection)
+    assertThat(selection).isEqualToDefaultInstance()
   }
 
   @Test
-  fun testUpdateAppLanguage_uninitializedToEnglish_returnsEnglishSelection() {
+  fun testUpdateAppLanguage_uninitializedToEnglish_returnsUninitialized() {
     forceDefaultLocale(Locale.ROOT)
 
     val expectedLanguageSelection = AppLanguageSelection.newBuilder().apply {
@@ -520,7 +520,7 @@ class TranslationControllerTest {
 
     // The previous selection was uninitialized.
     val selection = monitorFactory.waitForNextSuccessfulResult(updateProvider)
-    assertThat(selection).isEqualTo(expectedLanguageSelection)
+    assertThat(selection).isEqualToDefaultInstance()
   }
 
   @Test
@@ -535,11 +535,11 @@ class TranslationControllerTest {
 
     // The previous selection was system language.
     val selection = monitorFactory.waitForNextSuccessfulResult(updateProvider)
-    assertThat(selection.selectionTypeCase).isEqualTo(SELECTED_APP_LANGUAGE)
+    assertThat(selection.selectionTypeCase).isEqualTo(USE_SYSTEM_LANGUAGE_OR_APP_DEFAULT)
   }
 
   @Test
-  fun testUpdateAppLanguage_englishToPortuguese_returnsPortugueseSelection() {
+  fun testUpdateAppLanguage_englishToPortuguese_returnsEnglishSelection() {
     forceDefaultLocale(Locale.ROOT)
     ensureAppLanguageIsUpdatedTo(PROFILE_ID_0, ENGLISH)
 
@@ -551,7 +551,7 @@ class TranslationControllerTest {
     // The previous selection was English.
     val selection = monitorFactory.waitForNextSuccessfulResult(updateProvider)
     assertThat(selection.selectionTypeCase).isEqualTo(SELECTED_APP_LANGUAGE)
-    assertThat(selection.selectedLanguage).isEqualTo(BRAZILIAN_PORTUGUESE)
+    assertThat(selection.selectedLanguage).isEqualTo(ENGLISH)
   }
 
   /* Tests for written translation content functions */

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -64,8 +64,8 @@ message Profile {
   // Represents user selected reading-text-size.
   ReadingTextSize reading_text_size = 10;
 
-  // Represents user selected audio-language.
-  AudioLanguage audio_language = 11;
+  // Represented user selected audio-language (now deprecated).
+  reserved 11;
 
   // Reserve 12 which was used before as using it might cause import issues for older profiles.
   reserved 12;
@@ -137,8 +137,10 @@ enum AudioLanguage {
   NO_AUDIO = 1;
   ENGLISH_AUDIO_LANGUAGE = 2;
   HINDI_AUDIO_LANGUAGE = 3;
-  FRENCH_AUDIO_LANGUAGE = 4;
-  CHINESE_AUDIO_LANGUAGE =  5;
+  // Previously corresponded to French.
+  reserved 4;
+  // Previously corresponded to Chinese.
+  reserved 5;
   BRAZILIAN_PORTUGUESE_LANGUAGE = 6;
   ARABIC_LANGUAGE = 7;
   NIGERIAN_PIDGIN_LANGUAGE = 8;


### PR DESCRIPTION
## Explanation
Fixes part of #4938

This primarily updates ``ProfileManagementController`` to use ``TranslationController`` as the source of truth for audio language (rather than using the audio language property stored within the ``Profile`` proto). This has some noteworthy advantages:
- It allows for proper translation setting fallback behaviors to be enabled for the audio language setting without needing to migrate UI code over to ``TranslationController``.
- It isolates changes to the domain layer (with one exception: reading the audio language setting now uses a new getter in ``ProfileManagementController`` rather than reading the profile directly).

Some peripheral changes were also needed as part of this:
- A bunch of tests needed to be disabled in Gradle now that different options UIs (including for reading text) may depend on ``TranslationController`` (which is only fully configured in Bazel builds).
- The ``Profile`` proto was updated to remove its audio language setting. This means that existing users will revert back to whichever default ``TranslationController`` decides for them (most likely English, but it depends on several factors). This is considered a reasonable regression since most users are unlikely to depend on the automatic audio language setting, and the app is currently in a beta state so regressions like this should be expected.
- French and Chinese were removed from the list of ``AudioLanguage``s since they are not currently supported by the Oppia Android app (per ``OppiaLanguage`` which, plus the configured supported language textproto files, determine for which languages the app is guaranteeing support).
- ``ProfileManagementControllerTest`` was updated to have much more thorough testing around audio language.
- ``TranslationController`` was updated to use a ``PersistentCacheStore`` backing for audio and written translation languages (in addition to app language which was already supported).
- As part of the previous change, ``TranslationController.updateAppLanguage()`` and its related tests were updated to verify the _previous_ language is returned, not the current (for consistency with voiceover and written translations).

Long-term, ``AudioLanguage`` should be removed (along with its corresponding functionality in ``ProfileManagementController``) in favor of using ``TranslationController`` and ``OppiaLocale`` as the bases for managing language functionality in the UI layer.

Note that the Gradle version of the app will have increased degraded functionality in the options menu due to no supported language configuration being included in the build for that app (see the corresponding comment thread in this PR for more context). This is considered a reasonable medium-term gap as developers ought to be using the Bazel build of the app, anyway, as the Gradle version has significant functional limitations for all aspects of language selection and management (due to the lack of language configuration).

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only

Options screen (without changes):

![image](https://github.com/user-attachments/assets/065caa9f-5815-42a5-98ec-278186fa8dcd)

Options screen (with changes):

![image](https://github.com/user-attachments/assets/f4ece283-bf0e-4490-a1bb-57e77bb7a834)

I also verified setting a profile audio setting (Portuguese) on a ``develop`` branch build and then upgrading to a build from this branch. There are no crashes or stability issues, and (per my device setup) the audio language does revert back to English as expected.

I also verified that, like before, the audio setting persists across app instances when changed and is distinct between multiple profiles.