### PR TITLE
Fix part of #4865: Use profileId in classroom activity and presenter

### DIFF
--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListActivity.kt
@@ -47,7 +47,7 @@ class ClassroomListActivity :
   @Inject
   lateinit var activityRouter: ActivityRouter
 
-  private var internalProfileId: Int = -1
+  private lateinit var profileId: ProfileId
 
   @Inject
   @field:EnableOnboardingFlowV2
@@ -67,7 +67,7 @@ class ClassroomListActivity :
     super.onCreate(savedInstanceState)
     (activityComponent as ActivityComponentImpl).inject(this)
 
-    internalProfileId = intent.extractCurrentUserProfileId().internalId
+    profileId = intent.extractCurrentUserProfileId()
     classroomListActivityPresenter.handleOnCreate()
     title = resourceHandler.getStringInLocale(R.string.classroom_list_activity_title)
   }
@@ -92,7 +92,7 @@ class ClassroomListActivity :
     val recentlyPlayedActivityParams =
       RecentlyPlayedActivityParams
         .newBuilder()
-        .setProfileId(ProfileId.newBuilder().setInternalId(internalProfileId).build())
+        .setProfileId(profileId)
         .setActivityTitle(recentlyPlayedActivityTitle).build()
 
     activityRouter.routeToScreen(

--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
@@ -99,7 +99,6 @@ class ClassroomListFragmentPresenter @Inject constructor(
   private val exitProfileListener = activity as ExitProfileListener
   private lateinit var binding: ClassroomListFragmentBinding
   private lateinit var classroomListViewModel: ClassroomListViewModel
-  private var internalProfileId: Int = -1
   private val profileId = activity.intent.extractCurrentUserProfileId()
   private var onBackPressedCallback: OnBackPressedCallback? = null
 
@@ -111,15 +110,13 @@ class ClassroomListFragmentPresenter @Inject constructor(
       /* attachToRoot= */ false
     )
 
-    internalProfileId = profileId.internalId
-
     logHomeActivityEvent()
 
     classroomListViewModel = ClassroomListViewModel(
       activity,
       fragment,
       oppiaLogger,
-      internalProfileId,
+      profileId,
       profileManagementController,
       topicListController,
       classroomController,
@@ -177,7 +174,7 @@ class ClassroomListFragmentPresenter @Inject constructor(
   /** Routes to the play story view for the first story in the given topic summary. */
   fun onTopicSummaryClicked(topicSummary: TopicSummary) {
     routeToTopicPlayStoryListener.routeToTopicPlayStory(
-      internalProfileId,
+      profileId.internalId,
       topicSummary.classroomId,
       topicSummary.topicId,
       topicSummary.firstStoryId

--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListViewModel.kt
@@ -53,7 +53,7 @@ class ClassroomListViewModel(
   private val activity: AppCompatActivity,
   private val fragment: Fragment,
   private val oppiaLogger: OppiaLogger,
-  private val internalProfileId: Int,
+  private val profileId: ProfileId,
   private val profileManagementController: ProfileManagementController,
   private val topicListController: TopicListController,
   private val classroomController: ClassroomController,
@@ -63,7 +63,7 @@ class ClassroomListViewModel(
   private val dateTimeUtil: DateTimeUtil,
   private val translationController: TranslationController
 ) : ObservableViewModel() {
-  private val profileId: ProfileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
+
   private val promotedStoryListLimit = activity.resources.getInteger(
     R.integer.promoted_story_list_limit
   )
@@ -226,7 +226,7 @@ class ClassroomListViewModel(
         .mapIndexed { index, promotedStory ->
           PromotedStoryViewModel(
             activity,
-            internalProfileId,
+            profileId.internalId,
             sortedStoryList.size,
             storyEntityType,
             promotedStory,


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
### Fixes part of #4865
This is a step towards the whole migration, as proposed we should address this by each feature to make PRs smaller and easy to review. 
- The changes here are only scoped to classroom.
- routes to other features maintain `internalProfileId` until the destination parameter is migrated to `profileId`

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Screen record


https://github.com/user-attachments/assets/c474a78f-0331-4b0e-918b-abc07df380c4
