### PR TITLE
Fix #5592 : Enable submit button after linking items in Drag & Drop Sort Interaction

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/DragAndDropSortInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/DragAndDropSortInteractionViewModel.kt
@@ -219,8 +219,12 @@ class DragAndDropSortInteractionViewModel private constructor(
       dragDropInteractionContentViewModel.itemIndex = index
       dragDropInteractionContentViewModel.listSize = _choiceItems.size
     }
-    // to update the content of grouped item
+
+    // To update the list
     (adapter as BindableAdapter<*>).setDataUnchecked(_choiceItems)
+
+    // *Trigger pending answer check* to re-enable submit button
+    checkPendingAnswerError(AnswerErrorCategory.REAL_TIME)
   }
 
   fun unlinkElement(itemIndex: Int, adapter: RecyclerView.Adapter<RecyclerView.ViewHolder>) {
@@ -246,15 +250,24 @@ class DragAndDropSortInteractionViewModel private constructor(
       dragDropInteractionContentViewModel.itemIndex = index
       dragDropInteractionContentViewModel.listSize = _choiceItems.size
     }
-    // to update the list
+
+    // *Update the list*
     (adapter as BindableAdapter<*>).setDataUnchecked(_choiceItems)
+
+    // *Trigger pending answer check* to re-enable submit button
+    checkPendingAnswerError(AnswerErrorCategory.REAL_TIME)
   }
 
   private fun getSubmitTimeError(): DragAndDropSortInteractionError {
-    return if (_originalChoiceItems == _choiceItems) {
+    val hasItemsChanged = _originalChoiceItems.size != _choiceItems.size ||
+      _originalChoiceItems.zip(_choiceItems).any { (originalItem, currentItem) ->
+        originalItem.htmlContent != currentItem.htmlContent
+      }
+    return if (!hasItemsChanged) {
       DragAndDropSortInteractionError.EMPTY_INPUT
-    } else
+    } else {
       DragAndDropSortInteractionError.VALID
+    }
   }
 
   /** Implementation of [StateItemViewModel.InteractionItemFactory] for this view model. */

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/DragAndDropSortInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/DragAndDropSortInteractionViewModel.kt
@@ -223,7 +223,7 @@ class DragAndDropSortInteractionViewModel private constructor(
     // To update the list
     (adapter as BindableAdapter<*>).setDataUnchecked(_choiceItems)
 
-    // *Trigger pending answer check* to re-enable submit button
+    // Trigger pending answer check to re-enable submit button
     checkPendingAnswerError(AnswerErrorCategory.REAL_TIME)
   }
 
@@ -251,19 +251,19 @@ class DragAndDropSortInteractionViewModel private constructor(
       dragDropInteractionContentViewModel.listSize = _choiceItems.size
     }
 
-    // *Update the list*
+    // Update the list
     (adapter as BindableAdapter<*>).setDataUnchecked(_choiceItems)
 
-    // *Trigger pending answer check* to re-enable submit button
+    // Trigger pending answer check* to re-enable submit button
     checkPendingAnswerError(AnswerErrorCategory.REAL_TIME)
   }
 
   private fun getSubmitTimeError(): DragAndDropSortInteractionError {
-    val hasItemsChanged = _originalChoiceItems.size != _choiceItems.size ||
+    val haveItemsChanged = _originalChoiceItems.size != _choiceItems.size ||
       _originalChoiceItems.zip(_choiceItems).any { (originalItem, currentItem) ->
         originalItem.htmlContent != currentItem.htmlContent
       }
-    return if (!hasItemsChanged) {
+    return if (!haveItemsChanged) {
       DragAndDropSortInteractionError.EMPTY_INPUT
     } else {
       DragAndDropSortInteractionError.VALID

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -1118,6 +1118,18 @@ class StateFragmentTest {
   }
 
   @Test
+  fun testStateFragment_loadDragDropExp_groupingItemsEnablesSubmitButton() {
+    setUpTestWithLanguageSwitchingFeatureOff()
+    launchForExploration(TEST_EXPLORATION_ID_4, shouldSavePartialProgress = false).use {
+      startPlayingExploration()
+      clickSubmitAnswerButton()
+      verifySubmitAnswerButtonIsDisabled()
+      mergeDragAndDropItems(position = 0)
+      verifySubmitAnswerButtonIsEnabled()
+    }
+  }
+
+  @Test
   @RunOn(TestPlatform.ESPRESSO) // TODO(#1612): Enable for Robolectric.
   fun testStateFragment_loadDragDropExp_retainStateOnConfigurationChange() {
     setUpTestWithLanguageSwitchingFeatureOff()


### PR DESCRIPTION
## Explanation
Fixes #5592 , where the submit button did not become enabled after linking items in the Drag & Drop Sort Interaction. Previously, even when the items were correctly linked, the submit button remained disabled, preventing users from proceeding.

### **Changes Made**
- Updated logic to track linking and unlinking of items as a meaningful "state change."
- Ensured that the submit button becomes enabled as soon as items are linked or unlinked.
- Refactored the relevant functions to make sure the submit button reflects changes in real-time.

This change improves the overall UX, making it more intuitive for users to submit their answers after linking items. 
---

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix #5592 ".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

---
After Changes Video : 

https://github.com/user-attachments/assets/b6e3830c-e01c-4e70-933d-8d24cfee2a41

Screenshot of Passing Tests :
![Screenshot 2024-12-13 232845](https://github.com/user-attachments/assets/1ebdcf82-03ce-4984-a799-d99c2f17f5af)

