### PR TITLE
Fix part of #4865: Refactor topic to use profileId

### DIFF
--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListActivity.kt
@@ -103,14 +103,14 @@ class ClassroomListActivity :
     )
   }
 
-  override fun routeToTopic(internalProfileId: Int, classroomId: String, topicId: String) {
+  override fun routeToTopic(profileId: ProfileId, classroomId: String, topicId: String) {
     startActivity(
-      createTopicActivityIntent(this, internalProfileId, classroomId, topicId)
+      createTopicActivityIntent(this, profileId, classroomId, topicId)
     )
   }
 
   override fun routeToTopicPlayStory(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String
@@ -118,7 +118,7 @@ class ClassroomListActivity :
     startActivity(
       createTopicPlayStoryActivityIntent(
         this,
-        internalProfileId,
+        profileId,
         classroomId,
         topicId,
         storyId

--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
@@ -51,6 +51,7 @@ import org.oppia.android.app.model.ClassroomSummary
 import org.oppia.android.app.model.LessonThumbnail
 import org.oppia.android.app.model.LessonThumbnailGraphic
 import org.oppia.android.app.model.Profile
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.ProfileType
 import org.oppia.android.app.model.TopicSummary
 import org.oppia.android.app.translation.AppLanguageResourceHandler
@@ -72,7 +73,6 @@ import org.oppia.android.util.platformparameter.EnableOnboardingFlowV2
 import org.oppia.android.util.platformparameter.PlatformParameterValue
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
 import javax.inject.Inject
-import org.oppia.android.app.model.ProfileId
 
 /** Test tag for the classroom list screen. */
 const val CLASSROOM_LIST_SCREEN_TEST_TAG = "TEST_TAG.classroom_list_screen"

--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
@@ -51,7 +51,6 @@ import org.oppia.android.app.model.ClassroomSummary
 import org.oppia.android.app.model.LessonThumbnail
 import org.oppia.android.app.model.LessonThumbnailGraphic
 import org.oppia.android.app.model.Profile
-import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.ProfileType
 import org.oppia.android.app.model.TopicSummary
 import org.oppia.android.app.translation.AppLanguageResourceHandler

--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
@@ -72,6 +72,7 @@ import org.oppia.android.util.platformparameter.EnableOnboardingFlowV2
 import org.oppia.android.util.platformparameter.PlatformParameterValue
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
 import javax.inject.Inject
+import org.oppia.android.app.model.ProfileId
 
 /** Test tag for the classroom list screen. */
 const val CLASSROOM_LIST_SCREEN_TEST_TAG = "TEST_TAG.classroom_list_screen"
@@ -177,7 +178,7 @@ class ClassroomListFragmentPresenter @Inject constructor(
   /** Routes to the play story view for the first story in the given topic summary. */
   fun onTopicSummaryClicked(topicSummary: TopicSummary) {
     routeToTopicPlayStoryListener.routeToTopicPlayStory(
-      internalProfileId,
+      ProfileId.newBuilder().setInternalId(internalProfileId).build(),
       topicSummary.classroomId,
       topicSummary.topicId,
       topicSummary.firstStoryId

--- a/app/src/main/java/org/oppia/android/app/completedstorylist/CompletedStoryItemViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/completedstorylist/CompletedStoryItemViewModel.kt
@@ -3,6 +3,7 @@ package org.oppia.android.app.completedstorylist
 import androidx.appcompat.app.AppCompatActivity
 import org.oppia.android.app.home.RouteToTopicPlayStoryListener
 import org.oppia.android.app.model.CompletedStory
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.shim.IntentFactoryShim
 import org.oppia.android.app.viewmodel.ObservableViewModel
 import org.oppia.android.domain.translation.TranslationController
@@ -32,7 +33,7 @@ class CompletedStoryItemViewModel(
   /** Called when user clicks on CompletedStoryItem. */
   fun onCompletedStoryItemClicked() {
     routeToTopicPlayStory(
-      internalProfileId,
+      ProfileId.newBuilder().setInternalId(internalProfileId).build(),
       completedStory.classroomId,
       completedStory.topicId,
       completedStory.storyId
@@ -40,14 +41,14 @@ class CompletedStoryItemViewModel(
   }
 
   override fun routeToTopicPlayStory(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String
   ) {
     val intent = intentFactoryShim.createTopicPlayStoryActivityIntent(
       activity.applicationContext,
-      internalProfileId,
+      profileId.internalId,
       classroomId,
       topicId,
       storyId

--- a/app/src/main/java/org/oppia/android/app/home/HomeActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeActivity.kt
@@ -69,14 +69,14 @@ class HomeActivity :
     title = resourceHandler.getStringInLocale(R.string.home_activity_title)
   }
 
-  override fun routeToTopic(internalProfileId: Int, classroomId: String, topicId: String) {
+  override fun routeToTopic(profileId: ProfileId, classroomId: String, topicId: String) {
     startActivity(
-      TopicActivity.createTopicActivityIntent(this, internalProfileId, classroomId, topicId)
+      TopicActivity.createTopicActivityIntent(this, profileId, classroomId, topicId)
     )
   }
 
   override fun routeToTopicPlayStory(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String
@@ -84,7 +84,7 @@ class HomeActivity :
     startActivity(
       TopicActivity.createTopicPlayStoryActivityIntent(
         this,
-        internalProfileId,
+        profileId,
         classroomId,
         topicId,
         storyId

--- a/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
@@ -202,7 +202,7 @@ class HomeFragmentPresenter @Inject constructor(
 
   fun onTopicSummaryClicked(topicSummary: TopicSummary) {
     routeToTopicPlayStoryListener.routeToTopicPlayStory(
-      internalProfileId,
+      ProfileId.newBuilder().setInternalId(internalProfileId).build(),
       topicSummary.classroomId,
       topicSummary.topicId,
       topicSummary.firstStoryId

--- a/app/src/main/java/org/oppia/android/app/home/RouteToTopicListener.kt
+++ b/app/src/main/java/org/oppia/android/app/home/RouteToTopicListener.kt
@@ -1,6 +1,8 @@
 package org.oppia.android.app.home
 
+import org.oppia.android.app.model.ProfileId
+
 /** Listener for when an activity should route to a topic. */
 interface RouteToTopicListener {
-  fun routeToTopic(internalProfileId: Int, classroomId: String, topicId: String)
+  fun routeToTopic(profileId: ProfileId, classroomId: String, topicId: String)
 }

--- a/app/src/main/java/org/oppia/android/app/home/RouteToTopicPlayStoryListener.kt
+++ b/app/src/main/java/org/oppia/android/app/home/RouteToTopicPlayStoryListener.kt
@@ -1,9 +1,11 @@
 package org.oppia.android.app.home
 
+import org.oppia.android.app.model.ProfileId
+
 /** Listener for when an activity should route to a story-item in TopicPlay tab. */
 interface RouteToTopicPlayStoryListener {
   fun routeToTopicPlayStory(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String

--- a/app/src/main/java/org/oppia/android/app/home/promotedlist/PromotedStoryViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/home/promotedlist/PromotedStoryViewModel.kt
@@ -7,11 +7,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModel
 import org.oppia.android.R
 import org.oppia.android.app.home.RouteToTopicPlayStoryListener
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.PromotedStory
 import org.oppia.android.app.viewmodel.ObservableViewModel
 import org.oppia.android.domain.translation.TranslationController
 import java.util.Objects
-import org.oppia.android.app.model.ProfileId
 
 // TODO(#283): Add download status information to promoted-story-card.
 

--- a/app/src/main/java/org/oppia/android/app/home/promotedlist/PromotedStoryViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/home/promotedlist/PromotedStoryViewModel.kt
@@ -11,6 +11,7 @@ import org.oppia.android.app.model.PromotedStory
 import org.oppia.android.app.viewmodel.ObservableViewModel
 import org.oppia.android.domain.translation.TranslationController
 import java.util.Objects
+import org.oppia.android.app.model.ProfileId
 
 // TODO(#283): Add download status information to promoted-story-card.
 
@@ -62,7 +63,7 @@ class PromotedStoryViewModel(
 
   fun clickOnStoryTile() {
     routeToTopicPlayStoryListener.routeToTopicPlayStory(
-      internalProfileId,
+      ProfileId.newBuilder().setInternalId(internalProfileId).build(),
       promotedStory.classroomId,
       promotedStory.topicId,
       promotedStory.storyId

--- a/app/src/main/java/org/oppia/android/app/ongoingtopiclist/OngoingTopicItemViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/ongoingtopiclist/OngoingTopicItemViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import org.oppia.android.R
 import org.oppia.android.app.home.RouteToTopicListener
 import org.oppia.android.app.model.EphemeralTopic
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.shim.IntentFactoryShim
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.viewmodel.ObservableViewModel
@@ -27,7 +28,7 @@ class OngoingTopicItemViewModel(
   }
 
   fun onTopicItemClicked() {
-    routeToTopic(internalProfileId, topic.classroomId, topic.topicId)
+    routeToTopic(ProfileId.newBuilder().setInternalId(internalProfileId).build(), topic.classroomId, topic.topicId)
   }
 
   fun computeStoryCountText(): String {
@@ -36,7 +37,7 @@ class OngoingTopicItemViewModel(
     )
   }
 
-  override fun routeToTopic(internalProfileId: Int, classroomId: String, topicId: String) {
+  override fun routeToTopic(profileId: ProfileId, classroomId: String, topicId: String) {
     val intent = intentFactoryShim.createTopicActivityIntent(
       activity.applicationContext,
       internalProfileId,

--- a/app/src/main/java/org/oppia/android/app/ongoingtopiclist/OngoingTopicItemViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/ongoingtopiclist/OngoingTopicItemViewModel.kt
@@ -28,7 +28,11 @@ class OngoingTopicItemViewModel(
   }
 
   fun onTopicItemClicked() {
-    routeToTopic(ProfileId.newBuilder().setInternalId(internalProfileId).build(), topic.classroomId, topic.topicId)
+    routeToTopic(
+      profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build(),
+      classroomId = topic.classroomId,
+      topicId = topic.topicId
+    )
   }
 
   fun computeStoryCountText(): String {

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
@@ -387,7 +387,7 @@ class ExplorationActivityPresenter @Inject constructor(
         activity.startActivity(
           TopicActivity.createTopicActivityIntent(
             context,
-            profileId.internalId,
+            profileId,
             classroomId,
             topicId
           )

--- a/app/src/main/java/org/oppia/android/app/profileprogress/RecentlyPlayedStorySummaryViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/profileprogress/RecentlyPlayedStorySummaryViewModel.kt
@@ -3,6 +3,7 @@ package org.oppia.android.app.profileprogress
 import androidx.appcompat.app.AppCompatActivity
 import org.oppia.android.R
 import org.oppia.android.app.home.RouteToTopicPlayStoryListener
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.PromotedStory
 import org.oppia.android.app.shim.IntentFactoryShim
 import org.oppia.android.app.translation.AppLanguageResourceHandler
@@ -36,7 +37,7 @@ class RecentlyPlayedStorySummaryViewModel(
 
   fun onStoryItemClicked() {
     routeToTopicPlayStory(
-      internalProfileId, promotedStory.classroomId, promotedStory.topicId, promotedStory.storyId
+      ProfileId.newBuilder().setInternalId(internalProfileId).build(), promotedStory.classroomId, promotedStory.topicId, promotedStory.storyId
     )
   }
 
@@ -47,14 +48,14 @@ class RecentlyPlayedStorySummaryViewModel(
   }
 
   override fun routeToTopicPlayStory(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String
   ) {
     val intent = intentFactoryShim.createTopicPlayStoryActivityIntent(
       activity.applicationContext,
-      internalProfileId,
+      profileId.internalId,
       classroomId,
       topicId,
       storyId

--- a/app/src/main/java/org/oppia/android/app/profileprogress/RecentlyPlayedStorySummaryViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/profileprogress/RecentlyPlayedStorySummaryViewModel.kt
@@ -37,7 +37,10 @@ class RecentlyPlayedStorySummaryViewModel(
 
   fun onStoryItemClicked() {
     routeToTopicPlayStory(
-      ProfileId.newBuilder().setInternalId(internalProfileId).build(), promotedStory.classroomId, promotedStory.topicId, promotedStory.storyId
+      profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build(),
+      classroomId = promotedStory.classroomId,
+      topicId = promotedStory.topicId,
+      storyId = promotedStory.storyId
     )
   }
 

--- a/app/src/main/java/org/oppia/android/app/testing/HomeFragmentTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/HomeFragmentTestActivity.kt
@@ -9,6 +9,7 @@ import org.oppia.android.app.home.HomeFragment
 import org.oppia.android.app.home.RouteToRecentlyPlayedListener
 import org.oppia.android.app.home.RouteToTopicListener
 import org.oppia.android.app.home.RouteToTopicPlayStoryListener
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.ProfileType
 import org.oppia.android.app.model.RecentlyPlayedActivityTitle
 import org.oppia.android.app.testing.activity.TestActivity
@@ -36,9 +37,9 @@ class HomeFragmentTestActivity :
   }
 
   // Override functions are needed to fulfill listener definitions.
-  override fun routeToTopic(internalProfileId: Int, classroomId: String, topicId: String) {}
+  override fun routeToTopic(profileId: ProfileId, classroomId: String, topicId: String) {}
   override fun routeToTopicPlayStory(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String

--- a/app/src/main/java/org/oppia/android/app/testing/NavigationDrawerTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/NavigationDrawerTestActivity.kt
@@ -59,14 +59,14 @@ class NavigationDrawerTestActivity :
     title = resourceHandler.getStringInLocale(R.string.home_activity_title)
   }
 
-  override fun routeToTopic(internalProfileId: Int, classroomId: String, topicId: String) {
+  override fun routeToTopic(profileId: ProfileId, classroomId: String, topicId: String) {
     startActivity(
-      TopicActivity.createTopicActivityIntent(this, internalProfileId, classroomId, topicId)
+      TopicActivity.createTopicActivityIntent(this, profileId, classroomId, topicId)
     )
   }
 
   override fun routeToTopicPlayStory(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String
@@ -74,7 +74,7 @@ class NavigationDrawerTestActivity :
     startActivity(
       TopicActivity.createTopicPlayStoryActivityIntent(
         this,
-        internalProfileId,
+        profileId,
         classroomId,
         topicId,
         storyId

--- a/app/src/main/java/org/oppia/android/app/testing/TopicRevisionTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/TopicRevisionTestActivity.kt
@@ -3,11 +3,11 @@ package org.oppia.android.app.testing
 import android.os.Bundle
 import org.oppia.android.app.activity.ActivityComponentImpl
 import org.oppia.android.app.activity.InjectableAutoLocalizedAppCompatActivity
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.topic.RouteToRevisionCardListener
 import org.oppia.android.app.topic.revision.TopicRevisionFragment
 import org.oppia.android.app.topic.revisioncard.RevisionCardActivity
 import javax.inject.Inject
-import org.oppia.android.app.model.ProfileId
 
 /** Test Activity used for testing [TopicRevisionFragment]. */
 class TopicRevisionTestActivity :

--- a/app/src/main/java/org/oppia/android/app/testing/TopicRevisionTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/TopicRevisionTestActivity.kt
@@ -7,6 +7,7 @@ import org.oppia.android.app.topic.RouteToRevisionCardListener
 import org.oppia.android.app.topic.revision.TopicRevisionFragment
 import org.oppia.android.app.topic.revisioncard.RevisionCardActivity
 import javax.inject.Inject
+import org.oppia.android.app.model.ProfileId
 
 /** Test Activity used for testing [TopicRevisionFragment]. */
 class TopicRevisionTestActivity :
@@ -23,7 +24,7 @@ class TopicRevisionTestActivity :
   }
 
   override fun routeToRevisionCard(
-    internalProfileId: Int,
+    profileId: ProfileId,
     topicId: String,
     subtopicId: Int,
     subtopicListSize: Int
@@ -31,7 +32,7 @@ class TopicRevisionTestActivity :
     startActivity(
       RevisionCardActivity.createRevisionCardActivityIntent(
         this,
-        internalProfileId,
+        profileId,
         topicId,
         subtopicId,
         subtopicListSize

--- a/app/src/main/java/org/oppia/android/app/testing/TopicRevisionTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/TopicRevisionTestActivityPresenter.kt
@@ -5,6 +5,7 @@ import org.oppia.android.R
 import org.oppia.android.app.activity.ActivityScope
 import org.oppia.android.app.topic.revision.TopicRevisionFragment
 import javax.inject.Inject
+import org.oppia.android.app.model.ProfileId
 
 /** The presenter for [TopicRevisionTestActivity]. */
 @ActivityScope
@@ -14,8 +15,9 @@ class TopicRevisionTestActivityPresenter @Inject constructor(
 
   fun handleOnCreate() {
     activity.setContentView(R.layout.topic_revision_test_activity)
+    val profileId = ProfileId.newBuilder().setInternalId(0).build()
     val topicRevisionFragment =
-      TopicRevisionFragment.newInstance(internalProfileId = 0, topicId = "")
+      TopicRevisionFragment.newInstance(profileId = profileId , topicId = "")
     activity.supportFragmentManager.beginTransaction()
       .add(
         R.id.topic_revision_container,

--- a/app/src/main/java/org/oppia/android/app/testing/TopicRevisionTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/TopicRevisionTestActivityPresenter.kt
@@ -3,9 +3,9 @@ package org.oppia.android.app.testing
 import androidx.appcompat.app.AppCompatActivity
 import org.oppia.android.R
 import org.oppia.android.app.activity.ActivityScope
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.topic.revision.TopicRevisionFragment
 import javax.inject.Inject
-import org.oppia.android.app.model.ProfileId
 
 /** The presenter for [TopicRevisionTestActivity]. */
 @ActivityScope
@@ -17,7 +17,7 @@ class TopicRevisionTestActivityPresenter @Inject constructor(
     activity.setContentView(R.layout.topic_revision_test_activity)
     val profileId = ProfileId.newBuilder().setInternalId(0).build()
     val topicRevisionFragment =
-      TopicRevisionFragment.newInstance(profileId = profileId , topicId = "")
+      TopicRevisionFragment.newInstance(profileId = profileId, topicId = "")
     activity.supportFragmentManager.beginTransaction()
       .add(
         R.id.topic_revision_container,

--- a/app/src/main/java/org/oppia/android/app/testing/TopicTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/TopicTestActivity.kt
@@ -32,9 +32,10 @@ class TopicTestActivity :
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    val profileId = ProfileId.newBuilder().setInternalId(0).build()
     (activityComponent as ActivityComponentImpl).inject(this)
     topicActivityPresenter.handleOnCreate(
-      internalProfileId = 0,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID_0,
       topicId = TEST_TOPIC_ID_0,
       storyId = ""
@@ -90,14 +91,14 @@ class TopicTestActivity :
   }
 
   override fun routeToRevisionCard(
-    internalProfileId: Int,
+    profileId: ProfileId,
     topicId: String,
     subtopicId: Int,
     subtopicListSize: Int
   ) {
     startActivity(
       RevisionCardActivity.createRevisionCardActivityIntent(
-        this, internalProfileId, topicId, subtopicId, subtopicListSize
+        this, profileId, topicId, subtopicId, subtopicListSize
       )
     )
   }

--- a/app/src/main/java/org/oppia/android/app/testing/TopicTestActivityForStory.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/TopicTestActivityForStory.kt
@@ -37,9 +37,10 @@ class TopicTestActivityForStory :
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    val profileId = ProfileId.newBuilder().setInternalId(0).build()
     (activityComponent as ActivityComponentImpl).inject(this)
     topicActivityPresenter.handleOnCreate(
-      internalProfileId = 0,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID_0,
       topicId = TEST_TOPIC_ID_0,
       storyId = TEST_STORY_ID_0
@@ -118,14 +119,14 @@ class TopicTestActivityForStory :
   }
 
   override fun routeToRevisionCard(
-    internalProfileId: Int,
+    profileId: ProfileId,
     topicId: String,
     subtopicId: Int,
     subtopicListSize: Int
   ) {
     startActivity(
       RevisionCardActivity.createRevisionCardActivityIntent(
-        this, internalProfileId, topicId, subtopicId, subtopicListSize
+        this, profileId, topicId, subtopicId, subtopicListSize
       )
     )
   }

--- a/app/src/main/java/org/oppia/android/app/topic/RouteToRevisionCardListener.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/RouteToRevisionCardListener.kt
@@ -1,9 +1,11 @@
 package org.oppia.android.app.topic
 
+import org.oppia.android.app.model.ProfileId
+
 /** Listener for when an [TopicActivity] should route to a [RevisionCardFragment]. */
 interface RouteToRevisionCardListener {
   fun routeToRevisionCard(
-    internalProfileId: Int,
+    profileId: ProfileId,
     topicId: String,
     subtopicId: Int,
     subtopicListSize: Int

--- a/app/src/main/java/org/oppia/android/app/topic/TopicActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicActivity.kt
@@ -45,8 +45,7 @@ class TopicActivity :
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     (activityComponent as ActivityComponentImpl).inject(this)
-    profileId =
-      intent?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
+    profileId = intent?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
 
     val args = intent?.getProtoExtra(
       TOPIC_ACTIVITY_PARAMS_KEY,

--- a/app/src/main/java/org/oppia/android/app/topic/TopicActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicActivity.kt
@@ -45,7 +45,8 @@ class TopicActivity :
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     (activityComponent as ActivityComponentImpl).inject(this)
-    profileId = intent?.extractCurrentUserProfileId()?: ProfileId.newBuilder().setInternalId(-1).build()
+    profileId =
+      intent?.extractCurrentUserProfileId() ?: ProfileId.newBuilder().setInternalId(-1).build()
 
     val args = intent?.getProtoExtra(
       TOPIC_ACTIVITY_PARAMS_KEY,

--- a/app/src/main/java/org/oppia/android/app/topic/TopicActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicActivity.kt
@@ -46,7 +46,7 @@ class TopicActivity :
     super.onCreate(savedInstanceState)
     (activityComponent as ActivityComponentImpl).inject(this)
     profileId =
-      intent?.extractCurrentUserProfileId() ?: ProfileId.newBuilder().setInternalId(-1).build()
+      intent?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
 
     val args = intent?.getProtoExtra(
       TOPIC_ACTIVITY_PARAMS_KEY,

--- a/app/src/main/java/org/oppia/android/app/topic/TopicActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicActivity.kt
@@ -34,7 +34,7 @@ class TopicActivity :
   RouteToResumeLessonListener,
   RouteToRevisionCardListener {
 
-  private var internalProfileId: Int = -1
+  private lateinit var profileId: ProfileId
   private lateinit var topicId: String
   private lateinit var classroomId: String
   private var storyId: String? = null
@@ -45,7 +45,8 @@ class TopicActivity :
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     (activityComponent as ActivityComponentImpl).inject(this)
-    internalProfileId = intent?.extractCurrentUserProfileId()?.internalId ?: -1
+    profileId = intent?.extractCurrentUserProfileId()?: ProfileId.newBuilder().setInternalId(-1).build()
+
     val args = intent?.getProtoExtra(
       TOPIC_ACTIVITY_PARAMS_KEY,
       TopicActivityParams.getDefaultInstance()
@@ -57,7 +58,7 @@ class TopicActivity :
       "Expected topic ID to be included in intent for TopicActivity."
     }
     storyId = args?.storyId
-    topicActivityPresenter.handleOnCreate(internalProfileId, classroomId, topicId, storyId)
+    topicActivityPresenter.handleOnCreate(profileId, classroomId, topicId, storyId)
   }
 
   override fun routeToQuestionPlayer(skillIdList: ArrayList<String>) {
@@ -65,7 +66,7 @@ class TopicActivity :
       QuestionPlayerActivity.createQuestionPlayerActivityIntent(
         this,
         skillIdList,
-        ProfileId.newBuilder().setInternalId(internalProfileId).build()
+        profileId
       )
     )
   }
@@ -88,7 +89,7 @@ class TopicActivity :
   }
 
   override fun routeToRevisionCard(
-    internalProfileId: Int,
+    profileId: ProfileId,
     topicId: String,
     subtopicId: Int,
     subtopicListSize: Int
@@ -96,7 +97,7 @@ class TopicActivity :
     startActivity(
       RevisionCardActivity.createRevisionCardActivityIntent(
         this,
-        internalProfileId,
+        profileId,
         topicId,
         subtopicId,
         subtopicListSize
@@ -158,7 +159,7 @@ class TopicActivity :
     private val activity: AppCompatActivity
   ) : ActivityIntentFactories.TopicActivityIntentFactory {
     override fun createIntent(profileId: ProfileId, classroomId: String, topicId: String): Intent =
-      createTopicActivityIntent(activity, profileId.internalId, classroomId, topicId)
+      createTopicActivityIntent(activity, profileId, classroomId, topicId)
 
     override fun createIntent(
       profileId: ProfileId,
@@ -168,7 +169,7 @@ class TopicActivity :
     ): Intent =
       createTopicPlayStoryActivityIntent(
         activity,
-        profileId.internalId,
+        profileId,
         classroomId,
         topicId,
         storyId
@@ -182,7 +183,7 @@ class TopicActivity :
     /** Returns a new [Intent] to route to [TopicActivity] for a specified topic ID. */
     fun createTopicActivityIntent(
       context: Context,
-      internalProfileId: Int,
+      profileId: ProfileId,
       classroomId: String,
       topicId: String
     ): Intent {
@@ -190,7 +191,6 @@ class TopicActivity :
         this.topicId = topicId
         this.classroomId = classroomId
       }.build()
-      val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
       return Intent(context, TopicActivity::class.java).apply {
         putProtoExtra(TOPIC_ACTIVITY_PARAMS_KEY, args)
         decorateWithUserProfileId(profileId)
@@ -201,12 +201,12 @@ class TopicActivity :
     /** Returns a new [Intent] to route to [TopicLessonsFragment] for a specified story ID. */
     fun createTopicPlayStoryActivityIntent(
       context: Context,
-      internalProfileId: Int,
+      profileId: ProfileId,
       classroomId: String,
       topicId: String,
       storyId: String
     ): Intent {
-      return createTopicActivityIntent(context, internalProfileId, classroomId, topicId).apply {
+      return createTopicActivityIntent(context, profileId, classroomId, topicId).apply {
         val args =
           getProtoExtra(TOPIC_ACTIVITY_PARAMS_KEY, TopicActivityParams.getDefaultInstance())
         val updateArg = args.toBuilder().setStoryId(storyId).build()

--- a/app/src/main/java/org/oppia/android/app/topic/TopicActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicActivityPresenter.kt
@@ -13,7 +13,6 @@ import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.decora
 import javax.inject.Inject
 
 const val TOPIC_FRAGMENT_TAG = "TopicFragment"
-const val PROFILE_ID_ARGUMENT_KEY = "profile_id"
 const val TOPIC_FRAGMENT_ARGUMENTS_KEY = "TopicFragment.arguments"
 
 /** The presenter for [TopicActivity]. */
@@ -22,10 +21,8 @@ class TopicActivityPresenter @Inject constructor(private val activity: AppCompat
   private lateinit var classroomId: String
   private lateinit var topicId: String
 
-  private lateinit var profileId: ProfileId
-
   fun handleOnCreate(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String?
@@ -33,7 +30,7 @@ class TopicActivityPresenter @Inject constructor(private val activity: AppCompat
     this.topicId = topicId
     this.classroomId = classroomId
     activity.setContentView(R.layout.topic_activity)
-    profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
+
     if (getTopicFragment() == null) {
       val topicFragment = TopicFragment()
       val arguments = Bundle().apply {
@@ -58,7 +55,7 @@ class TopicActivityPresenter @Inject constructor(private val activity: AppCompat
     if (getSpotlightFragment() == null) {
       activity.supportFragmentManager.beginTransaction().add(
         R.id.topic_spotlight_fragment_placeholder,
-        SpotlightFragment.newInstance(internalProfileId),
+        SpotlightFragment.newInstance(profileId.internalId),
         SpotlightManager.SPOTLIGHT_FRAGMENT_TAG
       ).commitNow()
     }

--- a/app/src/main/java/org/oppia/android/app/topic/TopicFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicFragment.kt
@@ -36,7 +36,7 @@ class TopicFragment : InjectableFragment() {
       TopicFragmentArguments.getDefaultInstance()
     )
     val profileId =
-      arguments?.extractCurrentUserProfileId() ?: ProfileId.newBuilder().setInternalId(-1).build()
+      arguments?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
 
     val classroomId = args?.classroomId ?: TEST_CLASSROOM_ID_0
     val topicId = args?.topicId ?: TEST_TOPIC_ID_0

--- a/app/src/main/java/org/oppia/android/app/topic/TopicFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicFragment.kt
@@ -13,6 +13,7 @@ import org.oppia.android.domain.topic.TEST_TOPIC_ID_0
 import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
 import javax.inject.Inject
+import org.oppia.android.app.model.ProfileId
 
 /** Fragment that contains tabs for Topic. */
 class TopicFragment : InjectableFragment() {
@@ -34,7 +35,9 @@ class TopicFragment : InjectableFragment() {
       TOPIC_FRAGMENT_ARGUMENTS_KEY,
       TopicFragmentArguments.getDefaultInstance()
     )
-    val internalProfileId = arguments?.extractCurrentUserProfileId()?.internalId ?: -1
+    val profileId =
+      arguments?.extractCurrentUserProfileId() ?: ProfileId.newBuilder().setInternalId(-1).build()
+
     val classroomId = args?.classroomId ?: TEST_CLASSROOM_ID_0
     val topicId = args?.topicId ?: TEST_TOPIC_ID_0
     val storyId = args?.storyId ?: ""
@@ -42,7 +45,7 @@ class TopicFragment : InjectableFragment() {
     return topicFragmentPresenter.handleCreateView(
       inflater,
       container,
-      internalProfileId,
+      profileId,
       classroomId,
       topicId,
       storyId,

--- a/app/src/main/java/org/oppia/android/app/topic/TopicFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicFragment.kt
@@ -35,8 +35,7 @@ class TopicFragment : InjectableFragment() {
       TOPIC_FRAGMENT_ARGUMENTS_KEY,
       TopicFragmentArguments.getDefaultInstance()
     )
-    val profileId =
-      arguments?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
+    val profileId = arguments?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
 
     val classroomId = args?.classroomId ?: TEST_CLASSROOM_ID_0
     val topicId = args?.topicId ?: TEST_TOPIC_ID_0

--- a/app/src/main/java/org/oppia/android/app/topic/TopicFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicFragment.kt
@@ -7,13 +7,13 @@ import android.view.View
 import android.view.ViewGroup
 import org.oppia.android.app.fragment.FragmentComponentImpl
 import org.oppia.android.app.fragment.InjectableFragment
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.TopicFragmentArguments
 import org.oppia.android.domain.classroom.TEST_CLASSROOM_ID_0
 import org.oppia.android.domain.topic.TEST_TOPIC_ID_0
 import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
 import javax.inject.Inject
-import org.oppia.android.app.model.ProfileId
 
 /** Fragment that contains tabs for Topic. */
 class TopicFragment : InjectableFragment() {

--- a/app/src/main/java/org/oppia/android/app/topic/TopicFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicFragmentPresenter.kt
@@ -74,7 +74,7 @@ class TopicFragmentPresenter @Inject constructor(
         binding.topicToolbarTitle.isSelected = true
       }
     }
-    viewModel.setInternalProfileId(profileId)
+    viewModel.setProfileId(profileId)
     viewModel.setTopicId(topicId)
     binding.viewModel = viewModel
 

--- a/app/src/main/java/org/oppia/android/app/topic/TopicFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicFragmentPresenter.kt
@@ -40,7 +40,7 @@ class TopicFragmentPresenter @Inject constructor(
   lateinit var accessibilityService: AccessibilityService
 
   private lateinit var tabLayout: TabLayout
-  private var internalProfileId: Int = -1
+  private lateinit var profileId: ProfileId
   private lateinit var topicId: String
   private lateinit var storyId: String
   private lateinit var viewPager: ViewPager2
@@ -48,7 +48,7 @@ class TopicFragmentPresenter @Inject constructor(
   fun handleCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
@@ -63,7 +63,7 @@ class TopicFragmentPresenter @Inject constructor(
     this.storyId = storyId
     viewPager = binding.root.findViewById(R.id.topic_tabs_viewpager) as ViewPager2
     tabLayout = binding.root.findViewById(R.id.topic_tabs_container) as TabLayout
-    this.internalProfileId = internalProfileId
+    this.profileId = profileId
     this.topicId = topicId
 
     binding.topicToolbar.setNavigationOnClickListener {
@@ -74,7 +74,7 @@ class TopicFragmentPresenter @Inject constructor(
         binding.topicToolbarTitle.isSelected = true
       }
     }
-    viewModel.setInternalProfileId(internalProfileId)
+    viewModel.setInternalProfileId(profileId)
     viewModel.setTopicId(topicId)
     binding.viewModel = viewModel
 
@@ -134,7 +134,7 @@ class TopicFragmentPresenter @Inject constructor(
     val adapter =
       ViewPagerAdapter(
         fragment,
-        internalProfileId,
+        profileId,
         classroomId,
         topicId,
         storyId,
@@ -168,9 +168,6 @@ class TopicFragmentPresenter @Inject constructor(
       TopicTab.PRACTICE -> oppiaLogger.createOpenPracticeTabContext(topicId)
       TopicTab.REVISION -> oppiaLogger.createOpenRevisionTabContext(topicId)
     }
-    analyticsController.logImportantEvent(
-      eventContext,
-      ProfileId.newBuilder().apply { internalId = internalProfileId }.build()
-    )
+    analyticsController.logImportantEvent(eventContext, profileId)
   }
 }

--- a/app/src/main/java/org/oppia/android/app/topic/TopicViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicViewModel.kt
@@ -78,7 +78,7 @@ class TopicViewModel @Inject constructor(
     }
   }
 
-  fun setInternalProfileId(profileId: ProfileId) {
+  fun setProfileId(profileId: ProfileId) {
     this.profileId = profileId
   }
 

--- a/app/src/main/java/org/oppia/android/app/topic/TopicViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicViewModel.kt
@@ -26,21 +26,16 @@ class TopicViewModel @Inject constructor(
   private val resourceHandler: AppLanguageResourceHandler,
   private val translationController: TranslationController
 ) : ObservableViewModel() {
-  private var internalProfileId: Int = -1
+  private lateinit var profileId: ProfileId
   private lateinit var topicId: String
 
   private val topicResultLiveData: LiveData<AsyncResult<EphemeralTopic>> by lazy {
-    topicController.getTopic(
-      ProfileId.newBuilder().setInternalId(internalProfileId).build(),
-      topicId
-    ).toLiveData()
+    topicController.getTopic(profileId, topicId).toLiveData()
   }
 
   private val topicListResultLiveData: LiveData<AsyncResult<PromotedActivityList>> by lazy {
     // TODO(#4754): Replace with a mechanism that properly accounts for fully completed stories.
-    topicListController.getPromotedActivityList(
-      ProfileId.newBuilder().setInternalId(internalProfileId).build()
-    ).toLiveData()
+    topicListController.getPromotedActivityList(profileId).toLiveData()
   }
 
   val numberOfChaptersCompletedLiveData: LiveData<Int> by lazy {
@@ -83,8 +78,8 @@ class TopicViewModel @Inject constructor(
     }
   }
 
-  fun setInternalProfileId(internalProfileId: Int) {
-    this.internalProfileId = internalProfileId
+  fun setInternalProfileId(profileId: ProfileId) {
+    this.profileId = profileId
   }
 
   fun setTopicId(topicId: String) {

--- a/app/src/main/java/org/oppia/android/app/topic/ViewPagerAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/ViewPagerAdapter.kt
@@ -2,6 +2,7 @@ package org.oppia.android.app.topic
 
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.topic.info.TopicInfoFragment
 import org.oppia.android.app.topic.lessons.TopicLessonsFragment
 import org.oppia.android.app.topic.practice.TopicPracticeFragment
@@ -10,7 +11,7 @@ import org.oppia.android.app.topic.revision.TopicRevisionFragment
 /** Adapter to bind fragments to [FragmentStateAdapter] inside [TopicFragment]. */
 class ViewPagerAdapter(
   fragment: Fragment,
-  private val internalProfileId: Int,
+  private val profileId: ProfileId,
   private val classroomId: String,
   private val topicId: String,
   private val storyId: String,
@@ -22,16 +23,16 @@ class ViewPagerAdapter(
   override fun createFragment(position: Int): Fragment {
     return when (TopicTab.getTabForPosition(position, enableExtraTopicTabsUi)) {
       TopicTab.INFO -> {
-        TopicInfoFragment.newInstance(internalProfileId, topicId)
+        TopicInfoFragment.newInstance(profileId, topicId)
       }
       TopicTab.LESSONS -> {
-        TopicLessonsFragment.newInstance(internalProfileId, classroomId, topicId, storyId)
+        TopicLessonsFragment.newInstance(profileId, classroomId, topicId, storyId)
       }
       TopicTab.PRACTICE -> {
-        TopicPracticeFragment.newInstance(internalProfileId, topicId)
+        TopicPracticeFragment.newInstance(profileId, topicId)
       }
       TopicTab.REVISION -> {
-        TopicRevisionFragment.newInstance(internalProfileId, topicId)
+        TopicRevisionFragment.newInstance(profileId, topicId)
       }
     }
   }

--- a/app/src/main/java/org/oppia/android/app/topic/info/TopicInfoFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/info/TopicInfoFragment.kt
@@ -53,8 +53,7 @@ class TopicInfoFragment : InjectableFragment() {
       TopicInfoFragmentArguments.getDefaultInstance()
     )
 
-    val profileId =
-      arguments?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
+    val profileId = arguments?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
 
     val topicId = checkNotNull(args?.topicId) {
       "Expected topic ID to be included in arguments for TopicInfoFragment."

--- a/app/src/main/java/org/oppia/android/app/topic/info/TopicInfoFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/info/TopicInfoFragment.kt
@@ -23,8 +23,7 @@ class TopicInfoFragment : InjectableFragment() {
     const val TOPIC_INFO_FRAGMENT_ARGUMENTS_KEY = "TopicInfoFragment.arguments"
 
     /** Returns a new [TopicInfoFragment]. */
-    fun newInstance(internalProfileId: Int, topicId: String): TopicInfoFragment {
-      val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
+    fun newInstance(profileId: ProfileId, topicId: String): TopicInfoFragment {
       val args = TopicInfoFragmentArguments.newBuilder().setTopicId(topicId).build()
 
       return TopicInfoFragment().apply {
@@ -54,14 +53,16 @@ class TopicInfoFragment : InjectableFragment() {
       TopicInfoFragmentArguments.getDefaultInstance()
     )
 
-    val internalProfileId = arguments?.extractCurrentUserProfileId()?.internalId ?: -1
+    val profileId =
+      arguments?.extractCurrentUserProfileId() ?: ProfileId.newBuilder().setInternalId(-1).build()
+
     val topicId = checkNotNull(args?.topicId) {
       "Expected topic ID to be included in arguments for TopicInfoFragment."
     }
     return topicInfoFragmentPresenter.handleCreateView(
       inflater,
       container,
-      internalProfileId,
+      profileId,
       topicId
     )
   }

--- a/app/src/main/java/org/oppia/android/app/topic/info/TopicInfoFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/info/TopicInfoFragment.kt
@@ -54,7 +54,7 @@ class TopicInfoFragment : InjectableFragment() {
     )
 
     val profileId =
-      arguments?.extractCurrentUserProfileId() ?: ProfileId.newBuilder().setInternalId(-1).build()
+      arguments?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
 
     val topicId = checkNotNull(args?.topicId) {
       "Expected topic ID to be included in arguments for TopicInfoFragment."

--- a/app/src/main/java/org/oppia/android/app/topic/info/TopicInfoFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/info/TopicInfoFragmentPresenter.kt
@@ -30,16 +30,16 @@ class TopicInfoFragmentPresenter @Inject constructor(
   @DefaultResourceBucketName private val resourceBucketName: String
 ) {
   private lateinit var binding: TopicInfoFragmentBinding
-  private var internalProfileId: Int = -1
+  private lateinit var profileId: ProfileId
   private lateinit var topicId: String
 
   fun handleCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
-    internalProfileId: Int,
+    profileId: ProfileId,
     topicId: String
   ): View? {
-    this.internalProfileId = internalProfileId
+    this.profileId = profileId
     this.topicId = topicId
     binding = TopicInfoFragmentBinding.inflate(
       inflater,
@@ -68,10 +68,7 @@ class TopicInfoFragmentPresenter @Inject constructor(
   }
 
   private val topicResultLiveData: LiveData<AsyncResult<EphemeralTopic>> by lazy {
-    topicController.getTopic(
-      ProfileId.newBuilder().setInternalId(internalProfileId).build(),
-      topicId
-    ).toLiveData()
+    topicController.getTopic(profileId, topicId).toLiveData()
   }
 
   private fun getTopicList(): LiveData<EphemeralTopic> {

--- a/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonViewModel.kt
@@ -25,7 +25,7 @@ class TopicLessonViewModel @Inject constructor(
   private val resourceHandler: AppLanguageResourceHandler,
   private val translationController: TranslationController
 ) {
-  private var internalProfileId: Int = -1
+  private lateinit var profileId: ProfileId
   private lateinit var topicId: String
   private lateinit var storyId: String
   private lateinit var topicStoryList: List<StorySummary>
@@ -42,10 +42,7 @@ class TopicLessonViewModel @Inject constructor(
   }
 
   private val topicResultLiveData: LiveData<AsyncResult<EphemeralTopic>> by lazy {
-    topicController.getTopic(
-      ProfileId.newBuilder().setInternalId(internalProfileId).build(),
-      topicId
-    ).toLiveData()
+    topicController.getTopic(profileId, topicId).toLiveData()
   }
 
   private fun processTopicResult(ephemeralResult: AsyncResult<EphemeralTopic>): EphemeralTopic {
@@ -80,8 +77,8 @@ class TopicLessonViewModel @Inject constructor(
     return itemList
   }
 
-  fun setInternalProfileId(internalProfileId: Int) {
-    this.internalProfileId = internalProfileId
+  fun setInternalProfileId(profileId: ProfileId) {
+    this.profileId = profileId
   }
 
   fun setTopicId(topicId: String) {

--- a/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonViewModel.kt
@@ -77,7 +77,7 @@ class TopicLessonViewModel @Inject constructor(
     return itemList
   }
 
-  fun setInternalProfileId(profileId: ProfileId) {
+  fun setProfileId(profileId: ProfileId) {
     this.profileId = profileId
   }
 

--- a/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragment.kt
@@ -38,13 +38,12 @@ class TopicLessonsFragment :
 
     /** Returns a new [TopicLessonsFragment]. */
     fun newInstance(
-      internalProfileId: Int,
+      profileId: ProfileId,
       classroomId: String,
       topicId: String,
       storyId: String
     ): TopicLessonsFragment {
 
-      val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
       val args = TopicLessonsFragmentArguments.newBuilder().apply {
         this.classroomId = classroomId
         this.topicId = topicId
@@ -88,7 +87,9 @@ class TopicLessonsFragment :
       }
       isDefaultStoryExpanded = stateArgs?.isDefaultStoryExpanded ?: false
     }
-    val internalProfileId = arguments?.extractCurrentUserProfileId()?.internalId ?: -1
+    val profileId =
+      arguments?.extractCurrentUserProfileId() ?: ProfileId.newBuilder().setInternalId(-1).build()
+
     val args = arguments?.getProto(
       TOPIC_LESSONS_FRAGMENT_ARGUMENTS_KEY,
       TopicLessonsFragmentArguments.getDefaultInstance()
@@ -105,7 +106,7 @@ class TopicLessonsFragment :
       container,
       currentExpandedChapterListIndex,
       this as ExpandedChapterListIndexListener,
-      internalProfileId,
+      profileId,
       classroomId,
       topicId,
       storyId,

--- a/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragment.kt
@@ -88,7 +88,7 @@ class TopicLessonsFragment :
       isDefaultStoryExpanded = stateArgs?.isDefaultStoryExpanded ?: false
     }
     val profileId =
-      arguments?.extractCurrentUserProfileId() ?: ProfileId.newBuilder().setInternalId(-1).build()
+      arguments?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
 
     val args = arguments?.getProto(
       TOPIC_LESSONS_FRAGMENT_ARGUMENTS_KEY,

--- a/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragment.kt
@@ -87,8 +87,7 @@ class TopicLessonsFragment :
       }
       isDefaultStoryExpanded = stateArgs?.isDefaultStoryExpanded ?: false
     }
-    val profileId =
-      arguments?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
+    val profileId = arguments?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
 
     val args = arguments?.getProto(
       TOPIC_LESSONS_FRAGMENT_ARGUMENTS_KEY,

--- a/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
@@ -278,7 +278,12 @@ class TopicLessonsFragmentPresenter @Inject constructor(
   }
 
   fun storySummaryClicked(storySummary: StorySummary) {
-    routeToStoryListener.routeToStory(profileId.internalId, classroomId, topicId, storySummary.storyId)
+    routeToStoryListener.routeToStory(
+      internalProfileId = profileId.internalId,
+      classroomId = classroomId,
+      topicId = topicId,
+      storyId = storySummary.storyId
+    )
   }
 
   fun selectChapterSummary(

--- a/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
@@ -54,7 +54,7 @@ class TopicLessonsFragmentPresenter @Inject constructor(
   private var currentExpandedChapterListIndex: Int? = null
 
   private lateinit var binding: TopicLessonsFragmentBinding
-  private var internalProfileId: Int = -1
+  private lateinit var profileId: ProfileId
   private lateinit var classroomId: String
   private lateinit var topicId: String
   private lateinit var storyId: String
@@ -69,13 +69,13 @@ class TopicLessonsFragmentPresenter @Inject constructor(
     container: ViewGroup?,
     currentExpandedChapterListIndex: Int?,
     expandedChapterListIndexListener: ExpandedChapterListIndexListener,
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
     isDefaultStoryExpanded: Boolean
   ): View? {
-    this.internalProfileId = internalProfileId
+    this.profileId = profileId
     this.classroomId = classroomId
     this.topicId = topicId
     this.storyId = storyId
@@ -93,7 +93,7 @@ class TopicLessonsFragmentPresenter @Inject constructor(
       this.viewModel = topicLessonViewModel
     }
 
-    topicLessonViewModel.setInternalProfileId(internalProfileId)
+    topicLessonViewModel.setInternalProfileId(profileId)
     topicLessonViewModel.setTopicId(topicId)
     topicLessonViewModel.setStoryId(storyId)
 
@@ -278,7 +278,7 @@ class TopicLessonsFragmentPresenter @Inject constructor(
   }
 
   fun storySummaryClicked(storySummary: StorySummary) {
-    routeToStoryListener.routeToStory(internalProfileId, classroomId, topicId, storySummary.storyId)
+    routeToStoryListener.routeToStory(profileId.internalId, classroomId, topicId, storySummary.storyId)
   }
 
   fun selectChapterSummary(
@@ -286,9 +286,6 @@ class TopicLessonsFragmentPresenter @Inject constructor(
     explorationId: String,
     chapterPlayState: ChapterPlayState
   ) {
-    val profileId = ProfileId.newBuilder().apply {
-      internalId = internalProfileId
-    }.build()
     val canHavePartialProgressSaved =
       when (chapterPlayState) {
         ChapterPlayState.IN_PROGRESS_SAVED, ChapterPlayState.IN_PROGRESS_NOT_SAVED,
@@ -373,21 +370,21 @@ class TopicLessonsFragmentPresenter @Inject constructor(
       !canHavePartialProgressSaved -> {
         // Only explorations that have been completed can't be saved, so replay the lesson.
         explorationDataController.replayExploration(
-          internalProfileId, classroomId, topicId, storyId, explorationId
+          profileId.internalId, classroomId, topicId, storyId, explorationId
         )
       }
       hadProgress -> {
         // If there was progress, either the checkpoint was never saved, failed to save, or failed
         // to be retrieved. In all cases, this is a restart.
         explorationDataController.restartExploration(
-          internalProfileId, classroomId, topicId, storyId, explorationId
+          profileId.internalId, classroomId, topicId, storyId, explorationId
         )
       }
       else -> {
         // If there's no progress and it was never completed, then it's a new play through (or the
         // user is very low on device memory).
         explorationDataController.startPlayingNewExploration(
-          internalProfileId, classroomId, topicId, storyId, explorationId
+          profileId.internalId, classroomId, topicId, storyId, explorationId
         )
       }
     }

--- a/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
@@ -93,7 +93,7 @@ class TopicLessonsFragmentPresenter @Inject constructor(
       this.viewModel = topicLessonViewModel
     }
 
-    topicLessonViewModel.setInternalProfileId(profileId)
+    topicLessonViewModel.setProfileId(profileId)
     topicLessonViewModel.setTopicId(topicId)
     topicLessonViewModel.setStoryId(storyId)
 

--- a/app/src/main/java/org/oppia/android/app/topic/practice/TopicPracticeFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/practice/TopicPracticeFragment.kt
@@ -26,9 +26,7 @@ class TopicPracticeFragment : InjectableFragment() {
     const val TOPIC_PRACTICE_FRAGMENT_STATE_KEY = "TopicPracticeFragment.state"
 
     /** Returns a new [TopicPracticeFragment]. */
-    fun newInstance(internalProfileId: Int, topicId: String): TopicPracticeFragment {
-
-      val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
+    fun newInstance(profileId: ProfileId, topicId: String): TopicPracticeFragment {
       val args = TopicPracticeFragmentArguments.newBuilder().apply {
         this.topicId = topicId
       }.build()
@@ -70,7 +68,8 @@ class TopicPracticeFragment : InjectableFragment() {
       TOPIC_PRACTICE_FRAGMENT_ARGUMENTS_KEY,
       TopicPracticeFragmentArguments.getDefaultInstance()
     )
-    val internalProfileId = arguments?.extractCurrentUserProfileId()?.internalId ?: -1
+    val profileId = arguments?.extractCurrentUserProfileId() ?: ProfileId.newBuilder()
+      .setInternalId(-1).build()
     val topicId = checkNotNull(args?.topicId) {
       "Expected topic ID to be included in arguments for TopicPracticeFragment."
     }
@@ -80,7 +79,7 @@ class TopicPracticeFragment : InjectableFragment() {
       container,
       selectedIdList,
       selectedSkillId,
-      internalProfileId,
+      profileId,
       topicId
     )
   }

--- a/app/src/main/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentPresenter.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import org.oppia.android.app.fragment.FragmentScope
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.recyclerview.BindableAdapter
 import org.oppia.android.app.topic.RouteToQuestionPlayerListener
 import org.oppia.android.app.topic.practice.practiceitemviewmodel.TopicPracticeFooterViewModel
@@ -19,7 +20,6 @@ import org.oppia.android.databinding.TopicPracticeHeaderViewBinding
 import org.oppia.android.databinding.TopicPracticeSubtopicBinding
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import javax.inject.Inject
-import org.oppia.android.app.model.ProfileId
 
 /** The presenter for [TopicPracticeFragment]. */
 @FragmentScope

--- a/app/src/main/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentPresenter.kt
@@ -19,6 +19,7 @@ import org.oppia.android.databinding.TopicPracticeHeaderViewBinding
 import org.oppia.android.databinding.TopicPracticeSubtopicBinding
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import javax.inject.Inject
+import org.oppia.android.app.model.ProfileId
 
 /** The presenter for [TopicPracticeFragment]. */
 @FragmentScope
@@ -42,12 +43,12 @@ class TopicPracticeFragmentPresenter @Inject constructor(
     container: ViewGroup?,
     subtopicList: ArrayList<Int>,
     selectedSkillId: HashMap<Int, MutableList<String>>,
-    internalProfileId: Int,
+    profileId: ProfileId,
     topicId: String
   ): View? {
     this.topicId = topicId
     viewModel.setTopicId(this.topicId)
-    viewModel.setInternalProfileId(internalProfileId)
+    viewModel.setInternalProfileId(profileId)
 
     selectedSubtopicIdList = subtopicList
     skillIdHashMap = selectedSkillId

--- a/app/src/main/java/org/oppia/android/app/topic/practice/TopicPracticeViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/practice/TopicPracticeViewModel.kt
@@ -26,13 +26,10 @@ class TopicPracticeViewModel @Inject constructor(
 ) : ObservableViewModel() {
   private val itemViewModelList: MutableList<TopicPracticeItemViewModel> = ArrayList()
   private lateinit var topicId: String
-  private var internalProfileId: Int = -1
+  private lateinit var profileId: ProfileId
 
   private val topicResultLiveData: LiveData<AsyncResult<EphemeralTopic>> by lazy {
-    topicController.getTopic(
-      ProfileId.newBuilder().setInternalId(internalProfileId).build(),
-      topicId
-    ).toLiveData()
+    topicController.getTopic(profileId, topicId).toLiveData()
   }
 
   private val topicLiveData: LiveData<EphemeralTopic> by lazy { getTopicList() }
@@ -49,8 +46,8 @@ class TopicPracticeViewModel @Inject constructor(
     this.topicId = topicId
   }
 
-  fun setInternalProfileId(internalProfileId: Int) {
-    this.internalProfileId = internalProfileId
+  fun setInternalProfileId(profileId: ProfileId) {
+    this.profileId = profileId
   }
 
   private fun processTopicResult(ephemeralResult: AsyncResult<EphemeralTopic>): EphemeralTopic {

--- a/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionFragment.kt
@@ -50,8 +50,7 @@ class TopicRevisionFragment : InjectableFragment(), RevisionSubtopicSelector {
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View? {
-    val profileId =
-      arguments?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
+    val profileId = arguments?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
 
     val args = arguments?.getProto(
       TOPIC_REVISION_FRAGMENT_ARGUMENTS_KEY,

--- a/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionFragment.kt
@@ -26,8 +26,7 @@ class TopicRevisionFragment : InjectableFragment(), RevisionSubtopicSelector {
     const val TOPIC_REVISION_FRAGMENT_TAG = "TOPIC_REVISION_FRAGMENT_TAG"
 
     /** Returns a new [TopicRevisionFragment]. */
-    fun newInstance(internalProfileId: Int, topicId: String): TopicRevisionFragment {
-      val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
+    fun newInstance(profileId: ProfileId, topicId: String): TopicRevisionFragment {
       val args = TopicRevisionFragmentArguments.newBuilder().setTopicId(topicId).build()
       return TopicRevisionFragment().apply {
         arguments = Bundle().apply {
@@ -51,7 +50,9 @@ class TopicRevisionFragment : InjectableFragment(), RevisionSubtopicSelector {
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View? {
-    val internalProfileId = arguments?.extractCurrentUserProfileId()?.internalId ?: -1
+    val profileId =
+      arguments?.extractCurrentUserProfileId() ?: ProfileId.newBuilder().setInternalId(-1).build()
+
     val args = arguments?.getProto(
       TOPIC_REVISION_FRAGMENT_ARGUMENTS_KEY,
       TopicRevisionFragmentArguments.getDefaultInstance()
@@ -63,7 +64,7 @@ class TopicRevisionFragment : InjectableFragment(), RevisionSubtopicSelector {
     return topicReviewFragmentPresenter.handleCreateView(
       inflater,
       container,
-      internalProfileId,
+      profileId,
       topicId
     )
   }

--- a/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionFragment.kt
@@ -51,7 +51,7 @@ class TopicRevisionFragment : InjectableFragment(), RevisionSubtopicSelector {
     savedInstanceState: Bundle?
   ): View? {
     val profileId =
-      arguments?.extractCurrentUserProfileId() ?: ProfileId.newBuilder().setInternalId(-1).build()
+      arguments?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
 
     val args = arguments?.getProto(
       TOPIC_REVISION_FRAGMENT_ARGUMENTS_KEY,

--- a/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentPresenter.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
 import org.oppia.android.R
 import org.oppia.android.app.fragment.FragmentScope
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.Subtopic
 import org.oppia.android.app.recyclerview.BindableAdapter
 import org.oppia.android.app.topic.RouteToRevisionCardListener
@@ -15,7 +16,6 @@ import org.oppia.android.app.topic.revision.revisionitemviewmodel.TopicRevisionI
 import org.oppia.android.databinding.TopicRevisionFragmentBinding
 import org.oppia.android.databinding.TopicRevisionSummaryViewBinding
 import javax.inject.Inject
-import org.oppia.android.app.model.ProfileId
 
 /** The presenter for [TopicRevisionFragment]. */
 @FragmentScope

--- a/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentPresenter.kt
@@ -15,6 +15,7 @@ import org.oppia.android.app.topic.revision.revisionitemviewmodel.TopicRevisionI
 import org.oppia.android.databinding.TopicRevisionFragmentBinding
 import org.oppia.android.databinding.TopicRevisionSummaryViewBinding
 import javax.inject.Inject
+import org.oppia.android.app.model.ProfileId
 
 /** The presenter for [TopicRevisionFragment]. */
 @FragmentScope
@@ -25,7 +26,7 @@ class TopicRevisionFragmentPresenter @Inject constructor(
   private val singleTypeBuilderFactory: BindableAdapter.SingleTypeBuilder.Factory
 ) : RevisionSubtopicSelector {
   private lateinit var binding: TopicRevisionFragmentBinding
-  private var internalProfileId: Int = -1
+  private lateinit var profileId: ProfileId
   private lateinit var topicId: String
   private val routeToReviewListener = activity as RouteToRevisionCardListener
   private var subtopicListSize: Int? = null
@@ -33,10 +34,10 @@ class TopicRevisionFragmentPresenter @Inject constructor(
   fun handleCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
-    internalProfileId: Int,
+    profileId: ProfileId,
     topicId: String
   ): View? {
-    this.internalProfileId = internalProfileId
+    this.profileId = profileId
     this.topicId = topicId
     binding = TopicRevisionFragmentBinding.inflate(
       inflater,
@@ -45,7 +46,7 @@ class TopicRevisionFragmentPresenter @Inject constructor(
     )
 
     viewModel.setTopicId(this.topicId)
-    viewModel.setInternalProfileId(this.internalProfileId)
+    viewModel.setInternalProfileId(this.profileId)
 
     binding.revisionRecyclerView.apply {
       adapter = createRecyclerViewAdapter()
@@ -66,7 +67,7 @@ class TopicRevisionFragmentPresenter @Inject constructor(
 
   override fun onTopicRevisionSummaryClicked(subtopic: Subtopic) {
     routeToReviewListener.routeToRevisionCard(
-      internalProfileId,
+      profileId,
       topicId,
       subtopic.subtopicId,
       checkNotNull(subtopicListSize) { "Subtopic list size not found." }

--- a/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentPresenter.kt
@@ -46,7 +46,7 @@ class TopicRevisionFragmentPresenter @Inject constructor(
     )
 
     viewModel.setTopicId(this.topicId)
-    viewModel.setInternalProfileId(this.profileId)
+    viewModel.setProfileId(this.profileId)
 
     binding.revisionRecyclerView.apply {
       adapter = createRecyclerViewAdapter()

--- a/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionViewModel.kt
@@ -72,7 +72,7 @@ class TopicRevisionViewModel @Inject constructor(
     this.topicId = topicId
   }
 
-  fun setInternalProfileId(internalProfileId: Int) {
-    this.profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
+  fun setInternalProfileId(profileId: ProfileId) {
+    this.profileId = profileId
   }
 }

--- a/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revision/TopicRevisionViewModel.kt
@@ -72,7 +72,7 @@ class TopicRevisionViewModel @Inject constructor(
     this.topicId = topicId
   }
 
-  fun setInternalProfileId(profileId: ProfileId) {
+  fun setProfileId(profileId: ProfileId) {
     this.profileId = profileId
   }
 }

--- a/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivity.kt
@@ -43,7 +43,7 @@ class RevisionCardActivity :
         RevisionCardActivityParams.getDefaultInstance()
       )
 
-      val internalProfileId = intent.extractCurrentUserProfileId().internalId
+      val profileId = intent.extractCurrentUserProfileId()
       val topicId = checkNotNull(args.topicId) {
         "Expected topic ID to be included in intent for RevisionCardActivity."
       }
@@ -51,7 +51,7 @@ class RevisionCardActivity :
       val subtopicListSize = args?.subtopicListSize ?: -1
 
       revisionCardActivityPresenter.handleOnCreate(
-        internalProfileId,
+        profileId,
         topicId,
         subtopicId,
         subtopicListSize
@@ -79,12 +79,11 @@ class RevisionCardActivity :
     /** Returns a new [Intent] to route to [RevisionCardActivity]. */
     fun createRevisionCardActivityIntent(
       context: Context,
-      internalProfileId: Int,
+      profileId: ProfileId,
       topicId: String,
       subtopicId: Int,
       subtopicListSize: Int
     ): Intent {
-      val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
       val args = RevisionCardActivityParams.newBuilder().apply {
         this.topicId = topicId
         this.subtopicId = subtopicId
@@ -99,7 +98,7 @@ class RevisionCardActivity :
   }
 
   override fun routeToRevisionCard(
-    internalProfileId: Int,
+    profileId: ProfileId,
     topicId: String,
     subtopicId: Int,
     subtopicListSize: Int
@@ -107,7 +106,7 @@ class RevisionCardActivity :
     startActivity(
       createRevisionCardActivityIntent(
         this,
-        internalProfileId,
+        profileId,
         topicId,
         subtopicId,
         subtopicListSize

--- a/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityPresenter.kt
@@ -51,7 +51,7 @@ class RevisionCardActivityPresenter @Inject constructor(
   private var subtopicListSize: Int = 0
 
   fun handleOnCreate(
-    internalProfileId: Int,
+    profileId: ProfileId,
     topicId: String,
     subtopicId: Int,
     subtopicListSize: Int
@@ -60,7 +60,7 @@ class RevisionCardActivityPresenter @Inject constructor(
       activity,
       R.layout.revision_card_activity
     )
-    profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
+    this.profileId = profileId
     this.topicId = topicId
     this.subtopicId = subtopicId
     this.subtopicListSize = subtopicListSize

--- a/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardViewModel.kt
@@ -47,7 +47,7 @@ class RevisionCardViewModel private constructor(
   /** Called when the previous navigation card is clicked. */
   fun onPreviousCardClicked() {
     routeToReviewListener.routeToRevisionCard(
-      profileId.internalId,
+      profileId,
       topicId,
       subtopicId - 1,
       subtopicListSize
@@ -57,7 +57,7 @@ class RevisionCardViewModel private constructor(
   /** Called when the next navigation card is clicked. */
   fun onNextCardClicked() {
     routeToReviewListener.routeToRevisionCard(
-      profileId.internalId,
+      profileId,
       topicId,
       subtopicId + 1,
       subtopicListSize

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
@@ -177,7 +177,7 @@ class TopicFragmentTest {
   @field:[Inject EnableExtraTopicTabsUi]
   lateinit var enableExtraTopicTabsUi: PlatformParameterValue<Boolean>
 
-  private val internalProfileId = 0
+  private val profileId = ProfileId.newBuilder().setInternalId(0).build()
   private val TOPIC_NAME = "Fractions"
 
   @Before
@@ -196,7 +196,7 @@ class TopicFragmentTest {
   fun testTopicFragment_toolbarTitle_isDisplayedSuccessfully() {
     initializeApplicationComponent(enableExtraTabsUi = false)
     launchTopicActivityIntent(
-      internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
+      profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.topic_toolbar_title)).check(matches(withText("Topic: Fractions")))
@@ -209,7 +209,7 @@ class TopicFragmentTest {
     markSpotlightSeen(FIRST_CHAPTER)
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
       )
     ).use {
       // Mark lessons spotlight seen.
@@ -219,7 +219,7 @@ class TopicFragmentTest {
 
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
@@ -232,7 +232,7 @@ class TopicFragmentTest {
     initializeApplicationComponent(false)
     activityTestRule.launchActivity(
       createTopicActivityIntent(
-        internalProfileId,
+        profileId,
         TEST_CLASSROOM_ID_1,
         FRACTIONS_TOPIC_ID
       )
@@ -247,7 +247,7 @@ class TopicFragmentTest {
     markSpotlightSeen(TOPIC_LESSON_TAB)
     activityTestRule.launchActivity(
       createTopicPlayStoryActivityIntent(
-        internalProfileId,
+        profileId,
         TEST_CLASSROOM_ID_1,
         FRACTIONS_TOPIC_ID,
         FRACTIONS_STORY_ID_0
@@ -262,7 +262,7 @@ class TopicFragmentTest {
     initializeApplicationComponent(false)
     launch<TopicActivity>(
       createTopicPlayStoryActivityIntent(
-        internalProfileId,
+        profileId,
         TEST_CLASSROOM_ID_1,
         FRACTIONS_TOPIC_ID,
         FRACTIONS_STORY_ID_0
@@ -277,7 +277,7 @@ class TopicFragmentTest {
 
     launch<TopicActivity>(
       createTopicPlayStoryActivityIntent(
-        internalProfileId,
+        profileId,
         TEST_CLASSROOM_ID_1,
         FRACTIONS_TOPIC_ID,
         FRACTIONS_STORY_ID_0
@@ -293,14 +293,13 @@ class TopicFragmentTest {
     initializeApplicationComponent(false)
     markSpotlightSeen(FIRST_CHAPTER)
     markSpotlightSeen(TOPIC_LESSON_TAB)
-    val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
     storyProgressTestHelper.markCompletedFractionsStory0Exp0(profileId, false)
     storyProgressTestHelper.markCompletedRatiosStory0Exp0(profileId, false)
     storyProgressTestHelper.markCompletedRatiosStory1Exp0(profileId, false)
     testCoroutineDispatchers.runCurrent()
     launch<TopicActivity>(
       createTopicPlayStoryActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
@@ -316,7 +315,7 @@ class TopicFragmentTest {
     markSpotlightSeen(FIRST_CHAPTER)
     launch<TopicActivity>(
       createTopicPlayStoryActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
@@ -329,14 +328,13 @@ class TopicFragmentTest {
     initializeApplicationComponent(false)
     markSpotlightSeen(TOPIC_LESSON_TAB)
     markSpotlightSeen(FIRST_CHAPTER)
-    val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
     fakeOppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_UPTIME_MILLIS)
     storyProgressTestHelper.markCompletedFractionsStory0Exp0(profileId, false)
     storyProgressTestHelper.markCompletedRatiosStory0Exp0(profileId, false)
     storyProgressTestHelper.markCompletedRatiosStory1Exp0(profileId, false)
     launch<TopicActivity>(
       createTopicPlayStoryActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
@@ -346,7 +344,7 @@ class TopicFragmentTest {
 
     launch<TopicActivity>(
       createTopicPlayStoryActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
       )
     ).use {
       testCoroutineDispatchers.runCurrent()
@@ -361,7 +359,7 @@ class TopicFragmentTest {
     fakeAccessibilityService.setScreenReaderEnabled(false)
     activityTestRule.launchActivity(
       createTopicActivityIntent(
-        internalProfileId,
+        profileId,
         TEST_CLASSROOM_ID_1,
         FRACTIONS_TOPIC_ID
       )
@@ -384,7 +382,7 @@ class TopicFragmentTest {
     fakeAccessibilityService.setScreenReaderEnabled(true)
     activityTestRule.launchActivity(
       createTopicActivityIntent(
-        internalProfileId,
+        profileId,
         TEST_CLASSROOM_ID_1,
         FRACTIONS_TOPIC_ID
       )
@@ -407,7 +405,7 @@ class TopicFragmentTest {
     fakeAccessibilityService.setScreenReaderEnabled(false)
     activityTestRule.launchActivity(
       createTopicActivityIntent(
-        internalProfileId,
+        profileId,
         TEST_CLASSROOM_ID_1,
         FRACTIONS_TOPIC_ID
       )
@@ -429,7 +427,7 @@ class TopicFragmentTest {
     fakeAccessibilityService.setScreenReaderEnabled(true)
     activityTestRule.launchActivity(
       createTopicActivityIntent(
-        internalProfileId,
+        profileId,
         TEST_CLASSROOM_ID_1,
         FRACTIONS_TOPIC_ID
       )
@@ -449,7 +447,7 @@ class TopicFragmentTest {
     initializeApplicationComponent(false)
     activityTestRule.launchActivity(
       createTopicActivityIntent(
-        internalProfileId,
+        profileId,
         TEST_CLASSROOM_ID_1,
         FRACTIONS_TOPIC_ID
       )
@@ -461,7 +459,7 @@ class TopicFragmentTest {
   @Test
   fun testTopicFragment_showsTopicFragmentWithMultipleTabs() {
     initializeApplicationComponent(enableExtraTabsUi = false)
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       onView(withId(R.id.topic_tabs_container)).perform(click()).check(matches(isDisplayed()))
     }
   }
@@ -469,7 +467,7 @@ class TopicFragmentTest {
   @Test
   fun testTopicFragment_swipePage_hasSwipedPage() {
     initializeApplicationComponent(enableExtraTabsUi = false)
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       onView(withId(R.id.topic_tabs_viewpager)).check(matches(isDisplayed()))
       onView(withId(R.id.topic_tabs_viewpager)).perform(swipeLeft())
       verifyTabTitleAtPosition(position = 1)
@@ -479,7 +477,7 @@ class TopicFragmentTest {
   @Test
   fun testTopicFragment_enableExtraTabs_infoTopicTab_isDisplayedInTabLayout() {
     initializeApplicationComponent(enableExtraTabsUi = true)
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       onView(
         withText(
           TopicTab.getTabForPosition(
@@ -494,7 +492,7 @@ class TopicFragmentTest {
   @Test
   fun testTopicFragment_disableExtraTabs_infoTopicTab_isNotDisplayedInTabLayout() {
     initializeApplicationComponent(enableExtraTabsUi = false)
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       onView(withText(TopicTab.getTabForPosition(position = INFO_TAB_POSITION, true).name))
         .check(doesNotExist())
     }
@@ -504,7 +502,7 @@ class TopicFragmentTest {
   fun testTopicFragment_disableExtraTabs_defaultTabIsLessons() {
     initializeApplicationComponent(enableExtraTabsUi = false)
     launchTopicPlayStoryActivityIntent(
-      internalProfileId,
+      profileId,
       TEST_CLASSROOM_ID_1,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0
@@ -517,7 +515,7 @@ class TopicFragmentTest {
   fun testTopicFragment_enableExtraTabs_defaultTabIsLessons() {
     initializeApplicationComponent(enableExtraTabsUi = true)
     launchTopicPlayStoryActivityIntent(
-      internalProfileId,
+      profileId,
       TEST_CLASSROOM_ID_1,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0
@@ -529,7 +527,7 @@ class TopicFragmentTest {
   @Test
   fun testTopicFragment_disableExtraTabs_clickOnLessonsTab_showsPlayTabSelected() {
     initializeApplicationComponent(enableExtraTabsUi = false)
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       clickTabAtPosition(position = LESSON_TAB_POSITION_EXTRA_TABS_DISABLED)
       verifyTabTitleAtPosition(position = LESSON_TAB_POSITION_EXTRA_TABS_DISABLED)
     }
@@ -539,7 +537,7 @@ class TopicFragmentTest {
   fun testTopicFragment_clickOnLessonsTab_showsPlayTabWithContentMatched() {
     initializeApplicationComponent(enableExtraTabsUi = true)
     markAllSpotlightsSeen()
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       testCoroutineDispatchers.runCurrent()
       clickTabAtPosition(position = LESSON_TAB_POSITION)
       testCoroutineDispatchers.runCurrent()
@@ -555,7 +553,7 @@ class TopicFragmentTest {
   @Test
   fun testTopicFragment_practiceTabEnabled_practiceTopicTabIsDisplayedInTabLayout() {
     initializeApplicationComponent(enableExtraTabsUi = true)
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       val practiceTab =
         TopicTab.getTabForPosition(position = PRACTICE_TAB_POSITION, enableExtraTopicTabsUi.value)
       onView(withText(practiceTab.name)).check(
@@ -573,7 +571,7 @@ class TopicFragmentTest {
   @Test
   fun testTopicFragment_disableExtraTabs_practiceTopicTabIsNotDisplayedInTabLayout() {
     initializeApplicationComponent(enableExtraTabsUi = false)
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       // Unconditionally retrieve the practice tab name since this test is verifying that it's not
       // enabled.
       val practiceTab =
@@ -585,7 +583,7 @@ class TopicFragmentTest {
   @Test
   fun testTopicFragment_disableExtraTabs_configChange_practiceTopicTabIsNotDisplayed() {
     initializeApplicationComponent(enableExtraTabsUi = false)
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       onView(isRoot()).perform(orientationLandscape())
       testCoroutineDispatchers.runCurrent()
 
@@ -601,7 +599,7 @@ class TopicFragmentTest {
   @Test
   fun testTopicFragment_enableExtraTabs_clickOnPracticeTab_showsPracticeTabSelected() {
     initializeApplicationComponent(enableExtraTabsUi = true)
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       clickTabAtPosition(position = PRACTICE_TAB_POSITION)
       verifyTabTitleAtPosition(position = PRACTICE_TAB_POSITION)
     }
@@ -611,7 +609,7 @@ class TopicFragmentTest {
   fun testTopicFragment_enableExtraTabs_clickOnPracticeTab_showsPracticeTabWithContentMatched() {
     initializeApplicationComponent(enableExtraTabsUi = true)
     markAllSpotlightsSeen()
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       testCoroutineDispatchers.runCurrent()
       clickTabAtPosition(position = PRACTICE_TAB_POSITION)
       testCoroutineDispatchers.runCurrent()
@@ -627,7 +625,7 @@ class TopicFragmentTest {
   @Test
   fun testTopicFragment_clickOnReviewTab_showsReviewTabSelected() {
     initializeApplicationComponent(enableExtraTabsUi = false)
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       clickTabAtPosition(position = REVISION_TAB_POSITION_EXTRA_TABS_DISABLED)
       verifyTabTitleAtPosition(position = REVISION_TAB_POSITION_EXTRA_TABS_DISABLED)
     }
@@ -637,7 +635,7 @@ class TopicFragmentTest {
   fun testTopicFragment_clickOnReviewTab_showsReviewTabWithContentMatched() {
     initializeApplicationComponent(enableExtraTabsUi = false)
     markAllSpotlightsSeen()
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       testCoroutineDispatchers.runCurrent()
       clickTabAtPosition(position = REVISION_TAB_POSITION_EXTRA_TABS_DISABLED)
       testCoroutineDispatchers.runCurrent()
@@ -653,7 +651,7 @@ class TopicFragmentTest {
   @Test
   fun testTopicFragment_enableExtraTabs_clickOnReviewTab_thenInfoTab_showsInfoTab() {
     initializeApplicationComponent(enableExtraTabsUi = true)
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       clickTabAtPosition(position = REVISION_TAB_POSITION)
       clickTabAtPosition(position = INFO_TAB_POSITION)
       verifyTabTitleAtPosition(position = INFO_TAB_POSITION)
@@ -663,7 +661,7 @@ class TopicFragmentTest {
   @Test
   fun enableExtraTabs_clickOnReviewTab_thenInfoTab_showsInfoTabWithContentMatched() {
     initializeApplicationComponent(enableExtraTabsUi = true)
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       testCoroutineDispatchers.runCurrent()
       clickTabAtPosition(position = REVISION_TAB_POSITION)
       testCoroutineDispatchers.runCurrent()
@@ -680,7 +678,7 @@ class TopicFragmentTest {
   @Test
   fun testTopicFragment_clickOnLessonsTab_configChange_showsSameTabAndItsContent() {
     initializeApplicationComponent(enableExtraTabsUi = false)
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       testCoroutineDispatchers.runCurrent()
       clickTabAtPosition(position = LESSON_TAB_POSITION_EXTRA_TABS_DISABLED)
       onView(isRoot()).perform(orientationLandscape())
@@ -699,7 +697,7 @@ class TopicFragmentTest {
   fun enableExtraTabs_clickOnPracticeTab_configChange_showsSameTabAndItsContent() {
     initializeApplicationComponent(enableExtraTabsUi = true)
     markAllSpotlightsSeen()
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       testCoroutineDispatchers.runCurrent()
       clickTabAtPosition(position = PRACTICE_TAB_POSITION)
       testCoroutineDispatchers.runCurrent()
@@ -725,7 +723,7 @@ class TopicFragmentTest {
   fun testTopicFragment_clickOnReviewTab_configChange_showsSameTabAndItsContent() {
     initializeApplicationComponent(enableExtraTabsUi = false)
     markAllSpotlightsSeen()
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       testCoroutineDispatchers.runCurrent()
       clickTabAtPosition(position = REVISION_TAB_POSITION_EXTRA_TABS_DISABLED)
       onView(isRoot()).perform(orientationLandscape())
@@ -744,7 +742,7 @@ class TopicFragmentTest {
   fun testTopicFragment_enableExtraTabs_configChange_showsDefaultTabAndItsContent() {
     initializeApplicationComponent(enableExtraTabsUi = true)
     launchTopicPlayStoryActivityIntent(
-      internalProfileId,
+      profileId,
       TEST_CLASSROOM_ID_1,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0
@@ -765,7 +763,7 @@ class TopicFragmentTest {
   fun testTopicFragment_disableExtraTabs_configChange_showsDefaultTabAndItsContent() {
     initializeApplicationComponent(enableExtraTabsUi = false)
     launchTopicPlayStoryActivityIntent(
-      internalProfileId,
+      profileId,
       TEST_CLASSROOM_ID_1,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0
@@ -787,7 +785,7 @@ class TopicFragmentTest {
     initializeApplicationComponent(enableExtraTabsUi = true)
     markAllSpotlightsSeen()
     launchTopicPlayStoryActivityIntent(
-      internalProfileId,
+      profileId,
       TEST_CLASSROOM_ID_1,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0
@@ -817,7 +815,7 @@ class TopicFragmentTest {
     initializeApplicationComponent(enableExtraTabsUi = false)
     markAllSpotlightsSeen()
     launchTopicPlayStoryActivityIntent(
-      internalProfileId,
+      profileId,
       TEST_CLASSROOM_ID_1,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0
@@ -834,7 +832,7 @@ class TopicFragmentTest {
     initializeApplicationComponent(enableExtraTabsUi = false)
     markAllSpotlightsSeen()
     launchTopicPlayStoryActivityIntent(
-      internalProfileId,
+      profileId,
       TEST_CLASSROOM_ID_1,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0
@@ -854,7 +852,7 @@ class TopicFragmentTest {
     initializeApplicationComponent(enableExtraTabsUi = false)
     markAllSpotlightsSeen()
     launchTopicPlayStoryActivityIntent(
-      internalProfileId,
+      profileId,
       TEST_CLASSROOM_ID_1,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0
@@ -876,7 +874,7 @@ class TopicFragmentTest {
     initializeApplicationComponent(enableExtraTabsUi = true)
     markAllSpotlightsSeen()
     launchTopicPlayStoryActivityIntent(
-      internalProfileId,
+      profileId,
       TEST_CLASSROOM_ID_1,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0
@@ -896,7 +894,7 @@ class TopicFragmentTest {
     initializeApplicationComponent(enableExtraTabsUi = true)
     markAllSpotlightsSeen()
     launchTopicPlayStoryActivityIntent(
-      internalProfileId,
+      profileId,
       TEST_CLASSROOM_ID_1,
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0
@@ -915,13 +913,13 @@ class TopicFragmentTest {
    * Creates TopicActivity Intent without a storyId
    */
   private fun createTopicActivityIntent(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String
   ): Intent {
     return TopicActivity.createTopicActivityIntent(
       ApplicationProvider.getApplicationContext(),
-      internalProfileId,
+      profileId,
       classroomId,
       topicId
     )
@@ -933,14 +931,14 @@ class TopicFragmentTest {
    * launch TopicActivity from Promoted stories.
    */
   private fun createTopicPlayStoryActivityIntent(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String
   ): Intent {
     return TopicActivity.createTopicPlayStoryActivityIntent(
       ApplicationProvider.getApplicationContext(),
-      internalProfileId,
+      profileId,
       classroomId,
       topicId,
       storyId
@@ -952,11 +950,11 @@ class TopicFragmentTest {
    * This simulates opening a topic from All topics list.
    */
   private fun launchTopicActivityIntent(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String
   ): ActivityScenario<TopicActivity> {
-    return launch(createTopicActivityIntent(internalProfileId, classroomId, topicId))
+    return launch(createTopicActivityIntent(profileId, classroomId, topicId))
   }
 
   /**
@@ -964,13 +962,13 @@ class TopicFragmentTest {
    * This simulates opening a topic from Promoted stories.
    */
   private fun launchTopicPlayStoryActivityIntent(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String
   ): ActivityScenario<TopicActivity> {
     return launch<TopicActivity>(
-      createTopicPlayStoryActivityIntent(internalProfileId, classroomId, topicId, storyId)
+      createTopicPlayStoryActivityIntent(profileId, classroomId, topicId, storyId)
     ).also { testCoroutineDispatchers.runCurrent() }
   }
 
@@ -1024,9 +1022,6 @@ class TopicFragmentTest {
   }
 
   private fun markSpotlightSeen(feature: Spotlight.FeatureCase) {
-    val profileId = ProfileId.newBuilder()
-      .setInternalId(internalProfileId)
-      .build()
     spotlightStateController.markSpotlightViewed(profileId, feature)
     testCoroutineDispatchers.runCurrent()
   }

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/info/TopicInfoFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/info/TopicInfoFragmentTest.kt
@@ -47,6 +47,7 @@ import org.oppia.android.app.application.ApplicationStartupListenerModule
 import org.oppia.android.app.application.testing.TestingBuildFlavorModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.topic.TopicActivity
@@ -159,7 +160,7 @@ class TopicInfoFragmentTest {
   )
 
   private val topicThumbnail = R.drawable.lesson_thumbnail_graphic_child_with_fractions_homework
-  private val internalProfileId = 0
+  private val profileId = ProfileId.newBuilder().setInternalId(0).build()
 
   @Before
   fun setUp() {
@@ -180,7 +181,7 @@ class TopicInfoFragmentTest {
   @Test
   fun testTopicInfoFragment_loadFragment_checkTopicName_isCorrect() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID,
       topicId = TEST_TOPIC_ID
     ).use {
@@ -192,7 +193,7 @@ class TopicInfoFragmentTest {
   @Test
   fun testTopicInfoFragment_loadFragmentWithTestTopicId1_checkTopicDescription_isCorrect() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID,
       topicId = TEST_TOPIC_ID
     ).use {
@@ -214,7 +215,7 @@ class TopicInfoFragmentTest {
     activityTestRule.launchActivity(
       createTopicActivityIntent(
         context = context,
-        internalProfileId = internalProfileId,
+        profileId = profileId,
         classroomId = TEST_CLASSROOM_ID,
         topicId = TEST_TOPIC_ID
       )
@@ -234,7 +235,7 @@ class TopicInfoFragmentTest {
     activityTestRule.launchActivity(
       createTopicActivityIntent(
         context = context,
-        internalProfileId = internalProfileId,
+        profileId = profileId,
         classroomId = TEST_CLASSROOM_ID,
         topicId = TEST_TOPIC_ID
       )
@@ -252,7 +253,7 @@ class TopicInfoFragmentTest {
   @Test
   fun testTopicInfoFragment_loadFragment_configurationChange_checkTopicThumbnail_isCorrect() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID,
       topicId = TEST_TOPIC_ID
     ).use {
@@ -264,7 +265,7 @@ class TopicInfoFragmentTest {
   @Test
   fun testTopicInfoFragment_loadFragment_checkTopicThumbnail_hasCorrectScaleType() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID,
       topicId = TEST_TOPIC_ID
     ).use {
@@ -280,7 +281,7 @@ class TopicInfoFragmentTest {
   @Test
   fun testTopicInfoFragment_loadFragment_configurationChange_checkTopicName_isCorrect() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID,
       topicId = TEST_TOPIC_ID
     ).use {
@@ -302,7 +303,7 @@ class TopicInfoFragmentTest {
   @Test
   fun testTopicInfoFragment_loadFragment_configurationLandscape_isCorrect() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID,
       topicId = TEST_TOPIC_ID
     ).use {
@@ -316,7 +317,7 @@ class TopicInfoFragmentTest {
   @RunOn(TestPlatform.ESPRESSO) // TODO(#2057): Enable for Robolectric.
   fun testTopicInfoFragment_loadFragment_configurationLandscape_imageViewNotDisplayed() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID,
       topicId = TEST_TOPIC_ID
     ).use {
@@ -329,7 +330,7 @@ class TopicInfoFragmentTest {
   @RunOn(TestPlatform.ESPRESSO) // TODO(#2057): Enable for Robolectric.
   fun testTopicInfoFragment_loadFragment_checkDefaultTopicDescriptionLines_fiveLinesVisible() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID,
       topicId = RATIOS_TOPIC_ID
     ).use {
@@ -348,7 +349,7 @@ class TopicInfoFragmentTest {
   @RunOn(TestPlatform.ESPRESSO) // TODO(#2057): Enable for Robolectric.
   fun testTopicInfoFragment_loadFragment_moreThanFiveLines_seeMoreIsVisible() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID,
       topicId = RATIOS_TOPIC_ID
     ).use {
@@ -367,7 +368,7 @@ class TopicInfoFragmentTest {
   @RunOn(TestPlatform.ESPRESSO) // TODO(#2057): Enable for Robolectric.
   fun testTopicInfoFragment_loadFragment_seeMoreIsVisible_and_fiveLinesVisible() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID,
       topicId = RATIOS_TOPIC_ID
     ).use {
@@ -393,7 +394,7 @@ class TopicInfoFragmentTest {
   @RunOn(TestPlatform.ESPRESSO) // TODO(#2057): Enable for Robolectric.
   fun testTopicInfoFragment_loadFragment_clickSeeMore_seeLessVisible() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID,
       topicId = RATIOS_TOPIC_ID
     ).use {
@@ -413,7 +414,7 @@ class TopicInfoFragmentTest {
   @RunOn(TestPlatform.ESPRESSO) // TODO(#2057): Enable for Robolectric.
   fun testTopicInfoFragment_loadFragment_seeMoreIsVisible() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID,
       topicId = RATIOS_TOPIC_ID
     ).use {
@@ -427,7 +428,7 @@ class TopicInfoFragmentTest {
   @RunOn(TestPlatform.ESPRESSO) // TODO(#2057): Enable for Robolectric.
   fun testTopicInfoFragment_loadFragment_clickSeeMore_textChangesToSeeLess() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID,
       topicId = RATIOS_TOPIC_ID
     ).use {
@@ -439,14 +440,14 @@ class TopicInfoFragmentTest {
   }
 
   private fun launchTopicActivityIntent(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String
   ): ActivityScenario<TopicActivity> {
     val intent =
       TopicActivity.createTopicActivityIntent(
         ApplicationProvider.getApplicationContext(),
-        internalProfileId,
+        profileId,
         classroomId,
         topicId
       )

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
@@ -178,7 +178,7 @@ class TopicLessonsFragmentTest {
 
   @field:[Inject EnableExtraTopicTabsUi]
   lateinit var enableExtraTopicTabsUiValue: PlatformParameterValue<Boolean>
-  
+
   private lateinit var profileId: ProfileId
 
   @Before

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
@@ -178,8 +178,7 @@ class TopicLessonsFragmentTest {
 
   @field:[Inject EnableExtraTopicTabsUi]
   lateinit var enableExtraTopicTabsUiValue: PlatformParameterValue<Boolean>
-
-  private val internalProfileId = 0
+  
   private lateinit var profileId: ProfileId
 
   @Before
@@ -188,7 +187,7 @@ class TopicLessonsFragmentTest {
     Intents.init()
     setUpTestApplicationComponent()
     testCoroutineDispatchers.registerIdlingResource()
-    profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
+    profileId = ProfileId.newBuilder().setInternalId(0).build()
     fakeOppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_UPTIME_MILLIS)
     markAllSpotlightsSeen()
   }
@@ -207,7 +206,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_storyName_isCorrect() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -219,7 +218,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_chapterCountTextMultiple_isCorrect() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -235,7 +234,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -251,7 +250,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -267,7 +266,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -287,7 +286,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -302,7 +301,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_noStoryProgress_contentDescriptionIsCorrect() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -322,7 +321,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -334,7 +333,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_configurationChange_storyName_isCorrect() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -348,7 +347,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_configurationLandscape_storyName_isCorrect() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -360,7 +359,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_clickStoryItem_opensStoryActivityWithCorrectIntent() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -380,7 +379,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_chapterListIsNotVisible() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       onView(withId(R.id.chapter_recycler_view)).check(doesNotExist())
@@ -391,7 +390,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_chapterNotStartedIsCorrectlyDisplayed() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -410,7 +409,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_chapterLockedIsCorrectlyDisplayed() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -429,7 +428,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_chapterIsLocked_contentDescriptionIsCorrect() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -461,7 +460,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -484,7 +483,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -516,7 +515,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -540,7 +539,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -567,7 +566,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_configChange_chapterLockedIsCorrectlyDisplayed() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -591,7 +590,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -616,7 +615,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -636,7 +635,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_configChange_chapterNotStartedIsCorrectlyDisplayed() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -656,7 +655,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_default_arrowDown() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -678,7 +677,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_clickExpandListIcon_chapterListIsVisible() {
     launch<TopicActivity>(
       createTopicPlayStoryActivityIntent(
-        internalProfileId,
+        profileId,
         TEST_CLASSROOM_ID_1,
         RATIOS_TOPIC_ID,
         RATIOS_STORY_ID_0
@@ -709,7 +708,7 @@ class TopicLessonsFragmentTest {
     testCoroutineDispatchers.runCurrent()
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -730,7 +729,7 @@ class TopicLessonsFragmentTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = ProfileId.newBuilder().apply { internalId = internalProfileId }.build()
+        profileId = profileId
         parentScreen = ExplorationActivityParams.ParentScreen.TOPIC_SCREEN_LESSONS_TAB
         checkpoint = ExplorationCheckpoint.newBuilder().apply {
           explorationTitle = "What is a Fraction?"
@@ -765,7 +764,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -786,7 +785,7 @@ class TopicLessonsFragmentTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = ProfileId.newBuilder().apply { internalId = internalProfileId }.build()
+        profileId = profileId
         isCheckpointingEnabled = true
         parentScreen = ExplorationActivityParams.ParentScreen.TOPIC_SCREEN_LESSONS_TAB
       }.build()
@@ -803,7 +802,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadFractionsTopic_clickChap_chapterMarkedAsNotStarted_opensExpAct() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -824,7 +823,7 @@ class TopicLessonsFragmentTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = ProfileId.newBuilder().apply { internalId = internalProfileId }.build()
+        profileId = profileId
         isCheckpointingEnabled = true
         parentScreen = ExplorationActivityParams.ParentScreen.TOPIC_SCREEN_LESSONS_TAB
       }.build()
@@ -846,7 +845,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -867,7 +866,7 @@ class TopicLessonsFragmentTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = ProfileId.newBuilder().apply { internalId = internalProfileId }.build()
+        profileId = profileId
         isCheckpointingEnabled = true
         parentScreen = ExplorationActivityParams.ParentScreen.TOPIC_SCREEN_LESSONS_TAB
       }.build()
@@ -889,7 +888,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -909,7 +908,7 @@ class TopicLessonsFragmentTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = ProfileId.newBuilder().apply { internalId = internalProfileId }.build()
+        profileId = profileId
         isCheckpointingEnabled = false
         parentScreen = ExplorationActivityParams.ParentScreen.TOPIC_SCREEN_LESSONS_TAB
       }.build()
@@ -926,7 +925,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_clickExpandListIconIndex1_clickExpandListIconIndex2_chapterListForIndex1IsNotDisplayed() { // ktlint-disable max-line-length
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -951,7 +950,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_clickExpandListIconIndex2_clickExpandListIconIndex1_chapterListForIndex2IsNotDisplayed() { // ktlint-disable max-line-length
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -974,7 +973,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_clickExpandListIconIndex1_configurationChange_chapterListIsVisible() { // ktlint-disable max-line-length
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -996,7 +995,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_clickExpandListIconIndex1_configurationLandscape_chapterListIsVisible() { // ktlint-disable max-line-length
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -1020,7 +1019,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -1039,7 +1038,7 @@ class TopicLessonsFragmentTest {
     )
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -1055,7 +1054,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRecentStory_default_chapterListIsVisible() {
     launch<TopicActivity>(
       createTopicPlayStoryActivityIntent(
-        internalProfileId,
+        profileId,
         TEST_CLASSROOM_ID_1,
         RATIOS_TOPIC_ID,
         RATIOS_STORY_ID_0
@@ -1076,7 +1075,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRecentStory_clickExpandIcon_chapterListIsNotVisible() {
     launch<TopicActivity>(
       createTopicPlayStoryActivityIntent(
-        internalProfileId,
+        profileId,
         TEST_CLASSROOM_ID_1,
         RATIOS_TOPIC_ID,
         RATIOS_STORY_ID_0
@@ -1098,7 +1097,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRecentStory_clickExpandIcon_land_chapterListIsNotVisible() {
     launch<TopicActivity>(
       createTopicPlayStoryActivityIntent(
-        internalProfileId,
+        profileId,
         TEST_CLASSROOM_ID_1,
         RATIOS_TOPIC_ID,
         RATIOS_STORY_ID_0
@@ -1122,7 +1121,7 @@ class TopicLessonsFragmentTest {
   fun testLessonsPlayFragment_loadRatiosTopic_checkDropDownIconWithScreenReader_isClickable() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
       )
     ).use {
       fakeAccessibilityService.setScreenReaderEnabled(true)
@@ -1144,7 +1143,7 @@ class TopicLessonsFragmentTest {
   fun testLessonPlayFragment_loadRatiosTopic_checkDropDownIconWithoutScreenReader_isNotClickable() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -1165,7 +1164,7 @@ class TopicLessonsFragmentTest {
   fun testLessonPlayFragment_loadRatiosTopic_checkStoryContainerWithScreenReader_isNotClickable() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
       )
     ).use {
       fakeAccessibilityService.setScreenReaderEnabled(true)
@@ -1187,7 +1186,7 @@ class TopicLessonsFragmentTest {
   fun testLessonPlayFragment_loadRatiosTopic_checkStoryContainerWithoutScreenReader_isClickable() {
     launch<TopicActivity>(
       createTopicActivityIntent(
-        internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
+        profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID
       )
     ).use {
       clickLessonTab()
@@ -1214,27 +1213,27 @@ class TopicLessonsFragmentTest {
   }
 
   private fun createTopicActivityIntent(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String
   ): Intent {
     return TopicActivity.createTopicActivityIntent(
       ApplicationProvider.getApplicationContext(),
-      internalProfileId,
+      profileId,
       classroomId,
       topicId
     )
   }
 
   private fun createTopicPlayStoryActivityIntent(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String
   ): Intent {
     return TopicActivity.createTopicPlayStoryActivityIntent(
       ApplicationProvider.getApplicationContext(),
-      internalProfileId,
+      profileId,
       classroomId,
       topicId,
       storyId

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/practice/TopicPracticeFragmentTest.kt
@@ -132,7 +132,7 @@ class TopicPracticeFragmentTest {
   val oppiaTestRule = OppiaTestRule()
 
   private var skillIdList = ArrayList<String>()
-  private val internalProfileId = 0
+  private val profileId = ProfileId.newBuilder().setInternalId(0).build()
 
   @Inject
   lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
@@ -166,7 +166,7 @@ class TopicPracticeFragmentTest {
 
   @Test
   fun testTopicPracticeFragment_loadFragment_displaySubtopics_startButtonIsInactive() {
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
       onView(
         atPositionOnView(
@@ -202,7 +202,7 @@ class TopicPracticeFragmentTest {
 
   @Test
   fun testTopicPracticeFragment_loadFragment_selectSubtopics_isSuccessful() {
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
       clickPracticeItem(position = 1, targetViewId = R.id.subtopic_check_box)
       onView(
@@ -225,7 +225,7 @@ class TopicPracticeFragmentTest {
 
   @Test
   fun testTopicPracticeFragment_loadFragment_selectSubtopics_startButtonIsActive() {
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
       clickPracticeItem(position = 1, targetViewId = R.id.subtopic_check_box)
       testCoroutineDispatchers.runCurrent()
@@ -242,7 +242,7 @@ class TopicPracticeFragmentTest {
 
   @Test
   fun testTopicPracticeFragment_loadFragment_selectSubtopics_thenDeselect_selectsCorrectTopic() {
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
       clickPracticeItem(position = 1, targetViewId = R.id.subtopic_check_box)
       clickPracticeItem(position = 1, targetViewId = R.id.subtopic_check_box)
@@ -258,7 +258,7 @@ class TopicPracticeFragmentTest {
 
   @Test
   fun testTopicPracticeFragment_loadFragment_selectSubtopics_thenDeselect_startButtonIsInactive() {
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
       clickPracticeItem(position = 1, targetViewId = R.id.subtopic_check_box)
       clickPracticeItem(position = 1, targetViewId = R.id.subtopic_check_box)
@@ -277,7 +277,7 @@ class TopicPracticeFragmentTest {
   @Test
   fun testTopicPracticeFragment_loadFragment_selectSubtopics_clickStartButton_skillListTransferSuccessfully() { // ktlint-disable max-line-length
     testCoroutineDispatchers.unregisterIdlingResource()
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
       clickPracticeItem(position = 1, targetViewId = R.id.subtopic_check_box)
       scrollToPosition(position = 5)
@@ -290,7 +290,7 @@ class TopicPracticeFragmentTest {
 
   @Test
   fun testTopicPracticeFragment_loadFragment_selectSkills_configurationChange_skillsAreSelected() {
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
       clickPracticeItem(position = 1, targetViewId = R.id.subtopic_check_box)
       testCoroutineDispatchers.runCurrent()
@@ -307,7 +307,7 @@ class TopicPracticeFragmentTest {
 
   @Test
   fun testTopicPracticeFragment_loadFragment_configurationChange_startButtonRemainsInactive() {
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
       scrollToPosition(position = 5)
       testCoroutineDispatchers.runCurrent()
@@ -332,7 +332,7 @@ class TopicPracticeFragmentTest {
 
   @Test
   fun testTopicPracticeFragment_loadFragment_selectSkills_configChange_startButtonRemainsActive() {
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
       clickPracticeItem(position = 1, targetViewId = R.id.subtopic_check_box)
       onView(isRoot()).perform(orientationLandscape())
@@ -350,7 +350,7 @@ class TopicPracticeFragmentTest {
 
   @Test
   fun testTopicPracticeFragment_loadFragment_changeOrientation_titleIsCorrect() {
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use {
       clickPracticeTab()
       onView(
         atPositionOnView(
@@ -383,14 +383,14 @@ class TopicPracticeFragmentTest {
   }
 
   private fun launchTopicActivityIntent(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String
   ): ActivityScenario<TopicActivity> {
     val intent =
       TopicActivity.createTopicActivityIntent(
         ApplicationProvider.getApplicationContext(),
-        internalProfileId,
+        profileId,
         classroomId,
         topicId
       )
@@ -429,7 +429,6 @@ class TopicPracticeFragmentTest {
   }
 
   private fun markAllSpotlightsSeen() {
-    val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
     spotlightStateController.markSpotlightViewed(profileId, TOPIC_LESSON_TAB)
     testCoroutineDispatchers.runCurrent()
     spotlightStateController.markSpotlightViewed(profileId, TOPIC_REVISION_TAB)

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revision/TopicRevisionFragmentTest.kt
@@ -145,7 +145,7 @@ class TopicRevisionFragmentTest {
   lateinit var enableExtraTopicTabsUi: PlatformParameterValue<Boolean>
 
   private val subtopicThumbnail = R.drawable.topic_fractions_01
-  private val internalProfileId = 0
+  private val profileId = ProfileId.newBuilder().setInternalId(0).build()
 
   @Before
   fun setUp() {
@@ -169,7 +169,7 @@ class TopicRevisionFragmentTest {
   @Test
   fun testTopicRevisionFragment_loadFragment_displayRevisionTopics_isSuccessful() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID_1,
       topicId = FRACTIONS_TOPIC_ID
     ).use {
@@ -183,7 +183,7 @@ class TopicRevisionFragmentTest {
   @Test
   fun testTopicRevisionFragment_loadFragment_selectRevisionTopics_opensRevisionCardActivity() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID_1,
       topicId = FRACTIONS_TOPIC_ID
     ).use {
@@ -203,7 +203,7 @@ class TopicRevisionFragmentTest {
   @Test
   fun testTopicRevisionFragment_loadFragment_checkTopicThumbnail_isCorrect() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID_1,
       topicId = FRACTIONS_TOPIC_ID
     ).use {
@@ -228,7 +228,7 @@ class TopicRevisionFragmentTest {
   @Test
   fun testTopicPracticeFragment_loadFragment_configurationChange_revisionSubtopicsAreDisplayed() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID_1,
       topicId = FRACTIONS_TOPIC_ID
     ).use {
@@ -243,7 +243,7 @@ class TopicRevisionFragmentTest {
   @Test
   fun testTopicRevisionFragment_loadFragment_configurationChange_checkTopicThumbnail_isCorrect() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID_1,
       topicId = FRACTIONS_TOPIC_ID
     ).use {
@@ -269,7 +269,7 @@ class TopicRevisionFragmentTest {
   @Test
   fun testTopicRevisionFragment_loadFragment_checkTopicThumbnail_hasCorrectScaleType() {
     launchTopicActivityIntent(
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = TEST_CLASSROOM_ID_1,
       topicId = FRACTIONS_TOPIC_ID
     ).use {
@@ -286,7 +286,6 @@ class TopicRevisionFragmentTest {
   }
 
   private fun markAllSpotlightsSeen() {
-    val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
     spotlightStateController.markSpotlightViewed(profileId, TOPIC_LESSON_TAB)
     testCoroutineDispatchers.runCurrent()
     spotlightStateController.markSpotlightViewed(profileId, TOPIC_REVISION_TAB)
@@ -296,26 +295,26 @@ class TopicRevisionFragmentTest {
   }
 
   private fun createTopicActivityIntent(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String
   ): Intent {
     return TopicActivity.createTopicActivityIntent(
       context = ApplicationProvider.getApplicationContext(),
-      internalProfileId = internalProfileId,
+      profileId = profileId,
       classroomId = classroomId,
       topicId = topicId
     )
   }
 
   private fun launchTopicActivityIntent(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String
   ): ActivityScenario<TopicActivity> {
     return launch(
       createTopicActivityIntent(
-        internalProfileId = internalProfileId,
+        profileId = profileId,
         classroomId = classroomId,
         topicId = topicId
       )

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityTest.kt
@@ -162,9 +162,10 @@ class RevisionCardActivityTest {
 
   @Test
   fun testActivity_createIntent_verifyScreenNameInIntent() {
+    val profileId = ProfileId.newBuilder().setInternalId(1).build()
     val currentScreenName = RevisionCardActivity.createRevisionCardActivityIntent(
       context,
-      1,
+      profileId,
       FRACTIONS_TOPIC_ID,
       1,
       FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -424,19 +425,19 @@ class RevisionCardActivityTest {
     subtopicId: Int
   ): ActivityScenario<RevisionCardActivity> {
     val scenario = ActivityScenario.launch<RevisionCardActivity>(
-      createRevisionCardActivityIntent(profileId.internalId, topicId, subtopicId)
+      createRevisionCardActivityIntent(profileId, topicId, subtopicId)
     )
     testCoroutineDispatchers.runCurrent()
     return scenario
   }
 
   private fun createRevisionCardActivityIntent(
-    internalProfileId: Int,
+    profileId: ProfileId,
     topicId: String,
     subtopicId: Int
   ) = RevisionCardActivity.createRevisionCardActivityIntent(
     context,
-    internalProfileId,
+    profileId,
     topicId,
     subtopicId,
     FRACTIONS_SUBTOPIC_LIST_SIZE

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentTest.kt
@@ -195,7 +195,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         subtopicId = 2,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -217,7 +217,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         subtopicId = 2,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -240,7 +240,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         subtopicId = 2,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -262,7 +262,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         subtopicId = 2,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -284,7 +284,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         subtopicId = 2,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -308,7 +308,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         subtopicId = 2,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -329,7 +329,7 @@ class RevisionCardFragmentTest {
     launch<ExplorationActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         SUBTOPIC_TOPIC_ID,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -350,7 +350,7 @@ class RevisionCardFragmentTest {
     launch<ExplorationActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         TEST_TOPIC_ID_0,
         SUBTOPIC_TOPIC_ID,
         1
@@ -366,7 +366,7 @@ class RevisionCardFragmentTest {
     launch<ExplorationActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         SUBTOPIC_TOPIC_ID,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -383,7 +383,7 @@ class RevisionCardFragmentTest {
     launch<ExplorationActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         SUBTOPIC_TOPIC_ID,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -413,7 +413,7 @@ class RevisionCardFragmentTest {
     launch<ExplorationActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         SUBTOPIC_TOPIC_ID,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -443,7 +443,7 @@ class RevisionCardFragmentTest {
     launch<ExplorationActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         SUBTOPIC_TOPIC_ID,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -466,7 +466,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         SUBTOPIC_TOPIC_ID,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -484,7 +484,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         SUBTOPIC_TOPIC_ID_2,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -504,7 +504,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         FRACTIONS_SUBTOPIC_TOPIC_ID_0,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -524,7 +524,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         FRACTIONS_SUBTOPIC_TOPIC_ID_1,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -544,7 +544,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         FRACTIONS_SUBTOPIC_TOPIC_ID_3,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -565,7 +565,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         FRACTIONS_SUBTOPIC_TOPIC_ID_1,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -591,7 +591,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         FRACTIONS_SUBTOPIC_TOPIC_ID_1,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -617,7 +617,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         SUBTOPIC_TOPIC_ID,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -638,7 +638,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         SUBTOPIC_TOPIC_ID_2,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -659,7 +659,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         subtopicId = 2,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -678,7 +678,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         subtopicId = 2,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -700,7 +700,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         subtopicId = 2,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -725,7 +725,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         subtopicId = 2,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -754,7 +754,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         "test_topic_id_0",
         subtopicId = 1,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -775,7 +775,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         "test_topic_id_0",
         subtopicId = 1,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -800,7 +800,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         "test_topic_id_0",
         subtopicId = 1,
         FRACTIONS_SUBTOPIC_LIST_SIZE
@@ -818,7 +818,7 @@ class RevisionCardFragmentTest {
     launch<RevisionCardActivity>(
       createRevisionCardActivityIntent(
         context,
-        profileId.internalId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         subtopicId = 2,
         FRACTIONS_SUBTOPIC_LIST_SIZE

--- a/app/src/test/java/org/oppia/android/app/topic/info/TopicInfoFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/topic/info/TopicInfoFragmentLocalTest.kt
@@ -24,6 +24,7 @@ import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.model.EventLog
 import org.oppia.android.app.model.EventLog.Context.ActivityContextCase.OPEN_INFO_TAB
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.topic.TopicActivity
@@ -100,7 +101,7 @@ class TopicInfoFragmentLocalTest {
   @Inject lateinit var fakeAnalyticsEventLogger: FakeAnalyticsEventLogger
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
 
-  private val internalProfileId = 0
+  private val profileId = ProfileId.newBuilder().setInternalId(0).build()
 
   @Before
   fun setUp() {
@@ -110,7 +111,7 @@ class TopicInfoFragmentLocalTest {
   @Test
   fun testTopicInfoFragment_onLaunch_logsEvent() {
     TestPlatformParameterModule.forceEnableExtraTopicTabsUi(true)
-    launchTopicActivityIntent(internalProfileId, TEST_CLASSROOM_ID, TEST_TOPIC_ID).use {
+    launchTopicActivityIntent(profileId = profileId, TEST_CLASSROOM_ID, TEST_TOPIC_ID).use {
       testCoroutineDispatchers.runCurrent()
       val event = fakeAnalyticsEventLogger.getMostRecentEvent()
 
@@ -121,14 +122,14 @@ class TopicInfoFragmentLocalTest {
   }
 
   private fun launchTopicActivityIntent(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String
   ): ActivityScenario<TopicActivity> {
     val intent =
       TopicActivity.createTopicActivityIntent(
         ApplicationProvider.getApplicationContext(),
-        internalProfileId,
+        profileId,
         classroomId,
         topicId
       )

--- a/app/src/test/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentLocalTest.kt
@@ -22,8 +22,8 @@ import org.oppia.android.app.application.ApplicationStartupListenerModule
 import org.oppia.android.app.application.testing.TestingBuildFlavorModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
-import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.EventLog
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.topic.TopicActivity

--- a/app/src/test/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentLocalTest.kt
@@ -22,6 +22,7 @@ import org.oppia.android.app.application.ApplicationStartupListenerModule
 import org.oppia.android.app.application.testing.TestingBuildFlavorModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.EventLog
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
@@ -100,7 +101,7 @@ class TopicLessonsFragmentLocalTest {
   @Inject lateinit var fakeAnalyticsEventLogger: FakeAnalyticsEventLogger
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
 
-  private val internalProfileId = 0
+  private val profileId = ProfileId.newBuilder().setInternalId(0).build()
 
   @Before
   fun setUp() {
@@ -110,7 +111,7 @@ class TopicLessonsFragmentLocalTest {
   @Test
   fun testTopicLessonsFragment_onLaunch_logsEvent() {
     launchTopicActivityIntent(
-      internalProfileId, TEST_CLASSROOM_ID, TEST_TOPIC_ID, TEST_STORY_ID
+      profileId, TEST_CLASSROOM_ID, TEST_TOPIC_ID, TEST_STORY_ID
     ).use {
       testCoroutineDispatchers.runCurrent()
       val event = fakeAnalyticsEventLogger.getMostRecentEvent()
@@ -123,7 +124,7 @@ class TopicLessonsFragmentLocalTest {
   }
 
   private fun launchTopicActivityIntent(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String
@@ -131,7 +132,7 @@ class TopicLessonsFragmentLocalTest {
     val intent =
       TopicActivity.createTopicPlayStoryActivityIntent(
         ApplicationProvider.getApplicationContext(),
-        internalProfileId,
+        profileId,
         classroomId,
         topicId,
         storyId

--- a/app/src/test/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityLocalTest.kt
@@ -85,6 +85,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
+import org.oppia.android.app.model.ProfileId
 
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
@@ -98,7 +99,7 @@ class RevisionCardActivityLocalTest {
   @Inject lateinit var fakeAnalyticsEventLogger: FakeAnalyticsEventLogger
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
 
-  private val internalProfileId = 1
+  private val profileId = ProfileId.newBuilder().setInternalId(1).build()
   private val fractionsSubtopicListSize: Int = 4
 
   @Before
@@ -111,7 +112,7 @@ class RevisionCardActivityLocalTest {
     ActivityScenario.launch<RevisionCardActivity>(
       RevisionCardActivity.createRevisionCardActivityIntent(
         ApplicationProvider.getApplicationContext(),
-        internalProfileId,
+        profileId,
         FRACTIONS_TOPIC_ID,
         SUBTOPIC_TOPIC_ID,
         fractionsSubtopicListSize

--- a/app/src/test/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityLocalTest.kt
@@ -24,6 +24,7 @@ import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.model.EventLog
 import org.oppia.android.app.model.EventLog.Context.ActivityContextCase.OPEN_REVISION_CARD
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.translation.testing.ActivityRecreatorTestModule
@@ -85,7 +86,6 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
-import org.oppia.android.app.model.ProfileId
 
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
### Fixes part of #4865 

This PR aim to refactor `topic` package to use `ProfileId`
Changes include all topic fragments, presenters, and TopicActivity
Also updated the test classes.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
