### PR TITLE
Fix #5601: Version upgrade for actions/cache

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -48,7 +48,7 @@ jobs:
       # with Bazel since Bazel can share the most recent cache from an unrelated build and still
       # benefit from incremental build performance (assuming that actions/cache aggressively removes
       # older caches due to the 5GB cache limit size & Bazel's large cache size).
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -191,7 +191,7 @@ jobs:
       # with Bazel since Bazel can share the most recent cache from an unrelated build and still
       # benefit from incremental build performance (assuming that actions/cache aggressively removes
       # older caches due to the 5GB cache limit size & Bazel's large cache size).
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -325,7 +325,7 @@ jobs:
       # with Bazel since Bazel can share the most recent cache from an unrelated build and still
       # benefit from incremental build performance (assuming that actions/cache aggressively removes
       # older caches due to the 5GB cache limit size & Bazel's large cache size).
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -459,7 +459,7 @@ jobs:
       # with Bazel since Bazel can share the most recent cache from an unrelated build and still
       # benefit from incremental build performance (assuming that actions/cache aggressively removes
       # older caches due to the 5GB cache limit size & Bazel's large cache size).
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -580,7 +580,7 @@ jobs:
       # with Bazel since Bazel can share the most recent cache from an unrelated build and still
       # benefit from incremental build performance (assuming that actions/cache aggressively removes
       # older caches due to the 5GB cache limit size & Bazel's large cache size).
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           version: 6.5.0
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: scripts_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -130,7 +130,7 @@ jobs:
         with:
           version: 6.5.0
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: scripts_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -178,7 +178,7 @@ jobs:
       # with Bazel since Bazel can share the most recent cache from an unrelated build and still
       # benefit from incremental build performance (assuming that actions/cache aggressively removes
       # older caches due to the 5GB cache limit size & Bazel's large cache size).
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: test_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -285,7 +285,7 @@ jobs:
         with:
           version: 6.5.0
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: scripts_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         os: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ~/.gradle
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-jars-{{ checksum "build.gradle" }}

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -115,7 +115,7 @@ jobs:
         with:
           version: 6.5.0
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: scripts_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -126,7 +126,7 @@ jobs:
       # with Bazel since Bazel can share the most recent cache from an unrelated build and still
       # benefit from incremental build performance (assuming that actions/cache aggressively removes
       # older caches due to the 5GB cache limit size & Bazel's large cache size).
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         id: cache
         with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           version: 6.5.0
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: scripts_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -121,7 +121,7 @@ jobs:
         with:
           version: 6.5.0
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: scripts_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -163,7 +163,7 @@ jobs:
       # with Bazel since Bazel can share the most recent cache from an unrelated build and still
       # benefit from incremental build performance (assuming that actions/cache aggressively removes
       # older caches due to the 5GB cache limit size & Bazel's large cache size).
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: test_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,4 +1,5 @@
 name: Deploy to Wiki
+
 on:
   pull_request:
     paths:

--- a/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
@@ -47,7 +47,6 @@ class CustomHtmlContentHandler private constructor(
     originalContentHandler?.characters(ch, start, length)
   }
 
-
   override fun endDocument() {
     originalContentHandler?.endDocument()
     originalContentHandler = null // There's nothing left to read.

--- a/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
@@ -47,6 +47,7 @@ class CustomHtmlContentHandler private constructor(
     originalContentHandler?.characters(ch, start, length)
   }
 
+
   override fun endDocument() {
     originalContentHandler?.endDocument()
     originalContentHandler = null // There's nothing left to read.


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix #5601 

This PR updates the workflow to upgrade from `actions/cache@v2`, which has been deprecated, to `actions/cache@v4`.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
