### PR TITLE
Fix #5354: Replaced single-threaded scope with Actor

### DIFF
--- a/utility/src/main/java/org/oppia/android/util/data/InMemoryBlockingCache.kt
+++ b/utility/src/main/java/org/oppia/android/util/data/InMemoryBlockingCache.kt
@@ -4,16 +4,16 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.actor
-import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
 import org.oppia.android.util.threading.BlockingDispatcher
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ObsoleteCoroutinesApi
-import kotlinx.coroutines.withContext
 
 /**
  * An in-memory cache that provides blocking CRUD operations such that each operation is guaranteed to operate exactly
@@ -256,7 +256,8 @@ class InMemoryBlockingCache<T : Any> private constructor(
    * be called regardless of the state of the cache, and whose return value will be returned in this method's
    * [Deferred].
    */
-  fun maybeForceDeleteAsync(shouldDelete: suspend (T?) -> Boolean): Deferred<Boolean> = scope.async {
+  fun maybeForceDeleteAsync(shouldDelete: suspend (T?) -> Boolean): Deferred<Boolean>
+  = scope.async {
     CompletableDeferred<Boolean>().also { deferred ->
       actor.send(MaybeForceDelete(shouldDelete, deferred))
     }.await()

--- a/utility/src/main/java/org/oppia/android/util/data/InMemoryBlockingCache.kt
+++ b/utility/src/main/java/org/oppia/android/util/data/InMemoryBlockingCache.kt
@@ -123,6 +123,7 @@ class InMemoryBlockingCache<T : Any> private constructor(
 
   private val state = State(initialValue, null, changeObserver)
 
+  @OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
   private val actor = scope.actor<Pair<CacheOp<T, Any?>, Channel<Result<Any?>>>>(
     capacity = Channel.UNLIMITED
   ) {

--- a/utility/src/main/java/org/oppia/android/util/data/InMemoryBlockingCache.kt
+++ b/utility/src/main/java/org/oppia/android/util/data/InMemoryBlockingCache.kt
@@ -31,6 +31,7 @@ class InMemoryBlockingCache<T : Any> private constructor(
   private var value: T? = initialValue
   private val scope = CoroutineScope(SupervisorJob() + blockingDispatcher)
   private var changeObserver: suspend (T?, T?) -> Unit = { _, _ -> }
+
   private sealed class CacheOp<T, R> {
     abstract suspend fun execute(state: State<T>): R
 

--- a/utility/src/main/java/org/oppia/android/util/data/InMemoryBlockingCache.kt
+++ b/utility/src/main/java/org/oppia/android/util/data/InMemoryBlockingCache.kt
@@ -3,7 +3,10 @@ package org.oppia.android.util.data
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.actor
 import org.oppia.android.util.threading.BlockingDispatcher
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -20,29 +23,139 @@ class InMemoryBlockingCache<T : Any> private constructor(
   blockingDispatcher: CoroutineDispatcher,
   initialValue: T?
 ) {
-  private val blockingScope = CoroutineScope(blockingDispatcher)
 
   /**
    * The value of the cache. Note that this does not require a lock since it's only ever accessed via the blocking
    * dispatcher's single thread.
    */
   private var value: T? = initialValue
-
+  private val scope = CoroutineScope(SupervisorJob() + blockingDispatcher)
   private var changeObserver: suspend (T?, T?) -> Unit = { _, _ -> }
+  private sealed class CacheOp<T, R> {
+    abstract suspend fun execute(state: State<T>): R
+
+    data class Create<T>(val value: T) : CacheOp<T, T>() {
+      override suspend fun execute(state: State<T>): T {
+        state.value = value
+        state.changeObserver(state.previousValue, value)
+        state.previousValue = value
+        return value
+      }
+    }
+
+    data class CreateIfAbsent<T>(val generate: suspend () -> T) : CacheOp<T, T>() {
+      override suspend fun execute(state: State<T>): T {
+        if (state.value == null) {
+          val newValue = generate()
+          state.value = newValue
+          state.changeObserver(state.previousValue, newValue)
+          state.previousValue = newValue
+        }
+        return checkNotNull(state.value)
+      }
+    }
+
+    class Read<T>(val dummy: Boolean = true) : CacheOp<T, T?>() {
+      override suspend fun execute(state: State<T>): T? = state.value
+    }
+
+    class ReadIfPresent<T>(val dummy: Boolean = true) : CacheOp<T, T>() {
+      override suspend fun execute(state: State<T>): T {
+        return checkNotNull(state.value) {
+          "Expected to read the cache only after it's been created"
+        }
+      }
+    }
+
+    data class Update<T>(val transform: suspend (T?) -> T) : CacheOp<T, T>() {
+      override suspend fun execute(state: State<T>): T {
+        val newValue = transform(state.value)
+        state.value = newValue
+        state.changeObserver(state.previousValue, newValue)
+        state.previousValue = newValue
+        return newValue
+      }
+    }
+
+    data class UpdateIfPresent<T>(val transform: suspend (T) -> T) : CacheOp<T, T>() {
+      override suspend fun execute(state: State<T>): T {
+        val currentValue = checkNotNull(state.value) {
+          "Expected to update the cache only after it's been created"
+        }
+        val newValue = transform(currentValue)
+        state.value = newValue
+        state.changeObserver(state.previousValue, newValue)
+        state.previousValue = newValue
+        return newValue
+      }
+    }
+
+    data class UpdateWithCustom<T, V>(
+      val transform: suspend (T) -> Pair<T, V>
+    ) : CacheOp<T, V>() {
+      override suspend fun execute(state: State<T>): V {
+        val currentValue = checkNotNull(state.value) {
+          "Expected to update the cache only after it's been created"
+        }
+        val (newValue, result) = transform(currentValue)
+        state.value = newValue
+        state.changeObserver(state.previousValue, newValue)
+        state.previousValue = newValue
+        return result
+      }
+    }
+
+    class Delete<T>(val dummy: Boolean = true) : CacheOp<T, Unit>() {
+      override suspend fun execute(state: State<T>) {
+        state.changeObserver(state.value, null)
+        state.previousValue = state.value
+        state.value = null
+      }
+    }
+  }
+
+  private class State<T>(
+    var value: T?,
+    var previousValue: T?,
+    var changeObserver: suspend (T?, T?) -> Unit
+  )
+
+  private val state = State(initialValue, null, changeObserver)
+
+  private val actor = scope.actor<Pair<CacheOp<T, Any?>, Channel<Result<Any?>>>>(
+    capacity = Channel.UNLIMITED
+  ) {
+    for ((op, resultChannel) in channel) {
+      try {
+        val result = op.execute(state)
+        resultChannel.send(Result.success(result))
+      } catch (e: Exception) {
+        resultChannel.send(Result.failure(e))
+      } finally {
+        resultChannel.close()
+      }
+    }
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private suspend fun <R> submitOperation(op: CacheOp<T, R>): R {
+    val resultChannel = Channel<Result<Any?>>()
+    actor.send(op as CacheOp<T, Any?> to resultChannel)
+    val result = resultChannel.receive() as Result<R>
+    return result.getOrThrow()
+  }
 
   /** Registers an observer that is called synchronously whenever this cache's contents are changed. */
-  fun observeChanges(changeObserver: suspend (T?, T?) -> Unit) {
-    this.changeObserver = changeObserver
+  fun observeChanges(observer: suspend (T?, T?) -> Unit) {
+    state.changeObserver = observer
   }
 
   /**
    * Returns a [Deferred] that, upon completion, guarantees that the cache has been recreated and initialized to the
    * specified value. The [Deferred] will be passed the most up-to-date state of the cache.
    */
-  fun createAsync(newValue: T): Deferred<T> {
-    return blockingScope.async {
-      setCache(newValue)
-    }
+  fun createAsync(newValue: T): Deferred<T> = scope.async {
+    submitOperation(CacheOp.Create(newValue))
   }
 
   /**
@@ -50,30 +163,24 @@ class InMemoryBlockingCache<T : Any> private constructor(
    * state (if defined), or calling the provided generator to create a new state and initialize the cache to that state.
    * The provided function must be thread-safe and should have no side effects.
    */
-  fun createIfAbsentAsync(generate: suspend () -> T): Deferred<T> {
-    return blockingScope.async {
-      setCache(value ?: generate())
-    }
+  fun createIfAbsentAsync(generate: suspend () -> T): Deferred<T> = scope.async {
+    submitOperation(CacheOp.CreateIfAbsent(generate))
   }
 
   /**
    * Returns a [Deferred] that will provide the most-up-to-date value stored in the cache, or null if it's not yet
    * initialized.
    */
-  fun readAsync(): Deferred<T?> {
-    return blockingScope.async {
-      value
-    }
+  fun readAsync(): Deferred<T?> = scope.async {
+    submitOperation(CacheOp.Read())
   }
 
   /**
    * Returns a [Deferred] similar to [readAsync], except this assumes the cache to have been created already otherwise
    * an exception will be thrown.
    */
-  fun readIfPresentAsync(): Deferred<T> {
-    return blockingScope.async {
-      checkNotNull(value) { "Expected to read the cache only after it's been created" }
-    }
+  fun readIfPresentAsync(): Deferred<T> = scope.async {
+    submitOperation(CacheOp.ReadIfPresent())
   }
 
   /**
@@ -82,39 +189,23 @@ class InMemoryBlockingCache<T : Any> private constructor(
    * side effects. This function is safe to call regardless of whether the cache has been created, meaning it can be
    * used also to initialize the cache.
    */
-  fun updateAsync(update: suspend (T?) -> T): Deferred<T> {
-    return blockingScope.async {
-      setCache(update(value))
-    }
+  fun updateAsync(transform: suspend (T?) -> T): Deferred<T> = scope.async {
+    submitOperation(CacheOp.Update(transform))
   }
 
   /**
    * Returns a [Deferred] in the same way as [updateAsync], excepted this update is expected to occur after cache
    * creation otherwise an exception will be thrown.
    */
-  fun updateIfPresentAsync(update: suspend (T) -> T): Deferred<T> {
-    return blockingScope.async {
-      setCache(
-        update(
-          checkNotNull(value) {
-            "Expected to update the cache only after it's been created"
-          }
-        )
-      )
-    }
+  fun updateIfPresentAsync(transform: suspend (T) -> T): Deferred<T> = scope.async {
+    submitOperation(CacheOp.UpdateIfPresent(transform))
   }
 
   /** See [updateIfPresentAsync]. Returns a custom deferred result. */
-  fun <V> updateWithCustomChannelIfPresentAsync(update: suspend (T) -> Pair<T, V>): Deferred<V> {
-    return blockingScope.async {
-      val (updatedValue, customResult) = update(
-        checkNotNull(value) {
-          "Expected to update the cache only after it's been created"
-        }
-      )
-      setCache(updatedValue)
-      customResult
-    }
+  fun <V> updateWithCustomChannelIfPresentAsync(
+    transform: suspend (T) -> Pair<T, V>
+  ): Deferred<V> = scope.async {
+    submitOperation(CacheOp.UpdateWithCustom(transform))
   }
 
   /**
@@ -122,19 +213,17 @@ class InMemoryBlockingCache<T : Any> private constructor(
    * function is expected to update the cache in-place and return a custom value to propagate to the result of the
    * [Deferred] object.
    */
-  fun <O> updateInPlaceIfPresentAsync(update: suspend (T) -> O): Deferred<O> {
-    return blockingScope.async {
-      update(checkNotNull(value) { "Expected to update the cache only after it's been created" })
-    }
+  fun <O> updateInPlaceIfPresentAsync(transform: suspend (T) -> O): Deferred<O> = scope.async {
+    transform(
+      checkNotNull(state.value) { "Expected to update the cache only after it's been created" }
+    )
   }
 
   /**
    * Returns a [Deferred] that executes when this cache has been fully cleared, or if it's already been cleared.
    */
-  fun deleteAsync(): Deferred<Unit> {
-    return blockingScope.async {
-      clearCache()
-    }
+  fun deleteAsync(): Deferred<Unit> = scope.async {
+    submitOperation(CacheOp.Delete())
   }
 
   /**
@@ -143,14 +232,12 @@ class InMemoryBlockingCache<T : Any> private constructor(
    *
    * Note that the provided function will not be called if the cache is already cleared.
    */
-  fun maybeDeleteAsync(shouldDelete: suspend (T) -> Boolean): Deferred<Boolean> {
-    return blockingScope.async {
-      val valueSnapshot = value
-      if (valueSnapshot != null && shouldDelete(valueSnapshot)) {
-        clearCache()
-        true
-      } else false
-    }
+  fun maybeDeleteAsync(shouldDelete: suspend (T) -> Boolean): Deferred<Boolean> = scope.async {
+    val valueSnapshot = state.value
+    if (valueSnapshot != null && shouldDelete(valueSnapshot)) {
+      submitOperation(CacheOp.Delete())
+      true
+    } else false
   }
 
   /**
@@ -158,27 +245,13 @@ class InMemoryBlockingCache<T : Any> private constructor(
    * be called regardless of the state of the cache, and whose return value will be returned in this method's
    * [Deferred].
    */
-  fun maybeForceDeleteAsync(shouldDelete: suspend (T?) -> Boolean): Deferred<Boolean> {
-    return blockingScope.async {
-      if (shouldDelete(value)) {
-        clearCache()
+  fun maybeForceDeleteAsync(shouldDelete: suspend (T?) -> Boolean): Deferred<Boolean> =
+    scope.async {
+      if (shouldDelete(state.value)) {
+        submitOperation(CacheOp.Delete())
         true
       } else false
     }
-  }
-
-  private suspend fun setCache(newValue: T): T {
-    val oldValue = value
-    value = newValue
-    changeObserver(oldValue, newValue)
-    return newValue
-  }
-
-  private suspend fun clearCache() {
-    val oldValue = value
-    value = null
-    changeObserver(oldValue, null)
-  }
 
   /** An injectable factory for [InMemoryBlockingCache]es. */
   @Singleton

--- a/utility/src/main/java/org/oppia/android/util/data/InMemoryBlockingCache.kt
+++ b/utility/src/main/java/org/oppia/android/util/data/InMemoryBlockingCache.kt
@@ -256,12 +256,12 @@ class InMemoryBlockingCache<T : Any> private constructor(
    * be called regardless of the state of the cache, and whose return value will be returned in this method's
    * [Deferred].
    */
-  fun maybeForceDeleteAsync(shouldDelete: suspend (T?) -> Boolean): Deferred<Boolean>
-  = scope.async {
-    CompletableDeferred<Boolean>().also { deferred ->
-      actor.send(MaybeForceDelete(shouldDelete, deferred))
-    }.await()
-  }
+  fun maybeForceDeleteAsync(shouldDelete: suspend (T?) -> Boolean):
+    Deferred<Boolean> = scope.async {
+      CompletableDeferred<Boolean>().also { deferred ->
+        actor.send(MaybeForceDelete(shouldDelete, deferred))
+      }.await()
+    }
   private suspend fun notifyChange(oldValue: T?, newValue: T?) {
     withContext(Dispatchers.Main) {
       changeObserver(oldValue, newValue)

--- a/utility/src/main/java/org/oppia/android/util/data/InMemoryBlockingCache.kt
+++ b/utility/src/main/java/org/oppia/android/util/data/InMemoryBlockingCache.kt
@@ -1,15 +1,19 @@
 package org.oppia.android.util.data
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.actor
+import kotlinx.coroutines.async
 import org.oppia.android.util.threading.BlockingDispatcher
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.withContext
 
 /**
  * An in-memory cache that provides blocking CRUD operations such that each operation is guaranteed to operate exactly
@@ -23,133 +27,135 @@ class InMemoryBlockingCache<T : Any> private constructor(
   blockingDispatcher: CoroutineDispatcher,
   initialValue: T?
 ) {
+  private val scope = CoroutineScope(blockingDispatcher + SupervisorJob())
 
   /**
    * The value of the cache. Note that this does not require a lock since it's only ever accessed via the blocking
    * dispatcher's single thread.
    */
   private var value: T? = initialValue
-  private val scope = CoroutineScope(SupervisorJob() + blockingDispatcher)
   private var changeObserver: suspend (T?, T?) -> Unit = { _, _ -> }
 
-  private sealed class CacheOp<T, R> {
-    abstract suspend fun execute(state: State<T>): R
+  private sealed class CacheOp<out T : Any, R> {
+    abstract val response: CompletableDeferred<R>
+    abstract suspend fun execute(cache: InMemoryBlockingCache<@UnsafeVariance T>)
+  }
 
-    data class Create<T>(val value: T) : CacheOp<T, T>() {
-      override suspend fun execute(state: State<T>): T {
-        state.value = value
-        state.changeObserver(state.previousValue, value)
-        state.previousValue = value
-        return value
+  private class Create<T : Any>(
+    val newValue: T,
+    override val response: CompletableDeferred<T>
+  ) : CacheOp<T, T>() {
+    override suspend fun execute(cache: InMemoryBlockingCache<T>) {
+      response.complete(cache.setCache(newValue))
+    }
+  }
+
+  private class CreateIfAbsent<T : Any>(
+    val generate: suspend () -> T,
+    override val response: CompletableDeferred<T>
+  ) : CacheOp<T, T>() {
+    override suspend fun execute(cache: InMemoryBlockingCache<T>) {
+      response.complete(cache.setCache(cache.value ?: generate()))
+    }
+  }
+
+  private class Read<T : Any>(
+    override val response: CompletableDeferred<T?>
+  ) : CacheOp<T, T?>() {
+    override suspend fun execute(cache: InMemoryBlockingCache<T>) {
+      response.complete(cache.value)
+    }
+  }
+
+  private class Update<T : Any>(
+    val update: suspend (T?) -> T,
+    override val response: CompletableDeferred<T>
+  ) : CacheOp<T, T>() {
+    override suspend fun execute(cache: InMemoryBlockingCache<T>) {
+      response.complete(cache.setCache(update(cache.value)))
+    }
+  }
+
+  private class UpdateIfPresent<T : Any>(
+    val update: suspend (T) -> T,
+    override val response: CompletableDeferred<T>
+  ) : CacheOp<T, T>() {
+    override suspend fun execute(cache: InMemoryBlockingCache<T>) {
+      val currentValue = checkNotNull(cache.value) {
+        "Expected to update the cache only after it's been created"
       }
+      response.complete(cache.setCache(update(currentValue)))
     }
+  }
 
-    data class CreateIfAbsent<T>(val generate: suspend () -> T) : CacheOp<T, T>() {
-      override suspend fun execute(state: State<T>): T {
-        if (state.value == null) {
-          val newValue = generate()
-          state.value = newValue
-          state.changeObserver(state.previousValue, newValue)
-          state.previousValue = newValue
-        }
-        return checkNotNull(state.value)
+  private class UpdateWithCustomChannel<T : Any, V>(
+    val update: suspend (T) -> Pair<T, V>,
+    override val response: CompletableDeferred<V>
+  ) : CacheOp<T, V>() {
+    override suspend fun execute(cache: InMemoryBlockingCache<T>) {
+      val currentValue = checkNotNull(cache.value) {
+        "Expected to update the cache only after it's been created"
       }
+      val (newValue, result) = update(currentValue)
+      cache.setCache(newValue)
+      response.complete(result)
     }
+  }
 
-    class Read<T>(val dummy: Boolean = true) : CacheOp<T, T?>() {
-      override suspend fun execute(state: State<T>): T? = state.value
+  private class Delete<T : Any>(
+    override val response: CompletableDeferred<Unit>
+  ) : CacheOp<T, Unit>() {
+    override suspend fun execute(cache: InMemoryBlockingCache<T>) {
+      cache.clearCache()
+      response.complete(Unit)
     }
+  }
 
-    class ReadIfPresent<T>(val dummy: Boolean = true) : CacheOp<T, T>() {
-      override suspend fun execute(state: State<T>): T {
-        return checkNotNull(state.value) {
-          "Expected to read the cache only after it's been created"
-        }
-      }
-    }
-
-    data class Update<T>(val transform: suspend (T?) -> T) : CacheOp<T, T>() {
-      override suspend fun execute(state: State<T>): T {
-        val newValue = transform(state.value)
-        state.value = newValue
-        state.changeObserver(state.previousValue, newValue)
-        state.previousValue = newValue
-        return newValue
-      }
-    }
-
-    data class UpdateIfPresent<T>(val transform: suspend (T) -> T) : CacheOp<T, T>() {
-      override suspend fun execute(state: State<T>): T {
-        val currentValue = checkNotNull(state.value) {
-          "Expected to update the cache only after it's been created"
-        }
-        val newValue = transform(currentValue)
-        state.value = newValue
-        state.changeObserver(state.previousValue, newValue)
-        state.previousValue = newValue
-        return newValue
-      }
-    }
-
-    data class UpdateWithCustom<T, V>(
-      val transform: suspend (T) -> Pair<T, V>
-    ) : CacheOp<T, V>() {
-      override suspend fun execute(state: State<T>): V {
-        val currentValue = checkNotNull(state.value) {
-          "Expected to update the cache only after it's been created"
-        }
-        val (newValue, result) = transform(currentValue)
-        state.value = newValue
-        state.changeObserver(state.previousValue, newValue)
-        state.previousValue = newValue
-        return result
-      }
-    }
-
-    class Delete<T>(val dummy: Boolean = true) : CacheOp<T, Unit>() {
-      override suspend fun execute(state: State<T>) {
-        state.changeObserver(state.value, null)
-        state.previousValue = state.value
-        state.value = null
+  private class MaybeDelete<T : Any>(
+    val shouldDelete: suspend (T) -> Boolean,
+    override val response: CompletableDeferred<Boolean>
+  ) : CacheOp<T, Boolean>() {
+    override suspend fun execute(cache: InMemoryBlockingCache<T>) {
+      val valueSnapshot = cache.value
+      if (valueSnapshot != null && shouldDelete(valueSnapshot)) {
+        cache.clearCache()
+        response.complete(true)
+      } else {
+        response.complete(false)
       }
     }
   }
 
-  private class State<T>(
-    var value: T?,
-    var previousValue: T?,
-    var changeObserver: suspend (T?, T?) -> Unit
-  )
+  private class MaybeForceDelete<T : Any>(
+    val shouldDelete: suspend (T?) -> Boolean,
+    override val response: CompletableDeferred<Boolean>
+  ) : CacheOp<T, Boolean>() {
+    override suspend fun execute(cache: InMemoryBlockingCache<T>) {
+      if (shouldDelete(cache.value)) {
+        cache.clearCache()
+        response.complete(true)
+      } else {
+        response.complete(false)
+      }
+    }
+  }
 
-  private val state = State(initialValue, null, changeObserver)
-
-  @OptIn(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
-  private val actor = scope.actor<Pair<CacheOp<T, Any?>, Channel<Result<Any?>>>>(
+  @OptIn(ObsoleteCoroutinesApi::class)
+  private val actor = scope.actor<CacheOp<T, *>>(
     capacity = Channel.UNLIMITED
   ) {
-    for ((op, resultChannel) in channel) {
+    for (msg in channel) {
       try {
-        val result = op.execute(state)
-        resultChannel.send(Result.success(result))
+        msg.execute(this@InMemoryBlockingCache)
       } catch (e: Exception) {
-        resultChannel.send(Result.failure(e))
-      } finally {
-        resultChannel.close()
+        msg.response.completeExceptionally(e)
       }
     }
-  }
-
-  @Suppress("UNCHECKED_CAST")
-  private suspend fun <R> submitOperation(op: CacheOp<T, R>): R {
-    val resultChannel = Channel<Result<Any?>>()
-    actor.send(op as CacheOp<T, Any?> to resultChannel)
-    val result = resultChannel.receive() as Result<R>
-    return result.getOrThrow()
   }
 
   /** Registers an observer that is called synchronously whenever this cache's contents are changed. */
-  fun observeChanges(observer: suspend (T?, T?) -> Unit) {
-    state.changeObserver = observer
+  fun observeChanges(changeObserver: suspend (T?, T?) -> Unit) {
+    this.changeObserver = changeObserver
   }
 
   /**
@@ -157,7 +163,9 @@ class InMemoryBlockingCache<T : Any> private constructor(
    * specified value. The [Deferred] will be passed the most up-to-date state of the cache.
    */
   fun createAsync(newValue: T): Deferred<T> = scope.async {
-    submitOperation(CacheOp.Create(newValue))
+    CompletableDeferred<T>().also { deferred ->
+      actor.send(Create(newValue, deferred))
+    }.await()
   }
 
   /**
@@ -166,7 +174,9 @@ class InMemoryBlockingCache<T : Any> private constructor(
    * The provided function must be thread-safe and should have no side effects.
    */
   fun createIfAbsentAsync(generate: suspend () -> T): Deferred<T> = scope.async {
-    submitOperation(CacheOp.CreateIfAbsent(generate))
+    CompletableDeferred<T>().also { deferred ->
+      actor.send(CreateIfAbsent(generate, deferred))
+    }.await()
   }
 
   /**
@@ -174,7 +184,9 @@ class InMemoryBlockingCache<T : Any> private constructor(
    * initialized.
    */
   fun readAsync(): Deferred<T?> = scope.async {
-    submitOperation(CacheOp.Read())
+    CompletableDeferred<T?>().also { deferred ->
+      actor.send(Read(deferred))
+    }.await()
   }
 
   /**
@@ -182,7 +194,9 @@ class InMemoryBlockingCache<T : Any> private constructor(
    * an exception will be thrown.
    */
   fun readIfPresentAsync(): Deferred<T> = scope.async {
-    submitOperation(CacheOp.ReadIfPresent())
+    val deferred = CompletableDeferred<T?>()
+    actor.send(Read(deferred))
+    checkNotNull(deferred.await()) { "Expected to read the cache only after it's been created" }
   }
 
   /**
@@ -191,41 +205,38 @@ class InMemoryBlockingCache<T : Any> private constructor(
    * side effects. This function is safe to call regardless of whether the cache has been created, meaning it can be
    * used also to initialize the cache.
    */
-  fun updateAsync(transform: suspend (T?) -> T): Deferred<T> = scope.async {
-    submitOperation(CacheOp.Update(transform))
+  fun updateAsync(update: suspend (T?) -> T): Deferred<T> = scope.async {
+    CompletableDeferred<T>().also { deferred ->
+      actor.send(Update(update, deferred))
+    }.await()
   }
 
   /**
    * Returns a [Deferred] in the same way as [updateAsync], excepted this update is expected to occur after cache
    * creation otherwise an exception will be thrown.
    */
-  fun updateIfPresentAsync(transform: suspend (T) -> T): Deferred<T> = scope.async {
-    submitOperation(CacheOp.UpdateIfPresent(transform))
+  fun updateIfPresentAsync(update: suspend (T) -> T): Deferred<T> = scope.async {
+    CompletableDeferred<T>().also { deferred ->
+      actor.send(UpdateIfPresent(update, deferred))
+    }.await()
   }
 
   /** See [updateIfPresentAsync]. Returns a custom deferred result. */
   fun <V> updateWithCustomChannelIfPresentAsync(
-    transform: suspend (T) -> Pair<T, V>
+    update: suspend (T) -> Pair<T, V>
   ): Deferred<V> = scope.async {
-    submitOperation(CacheOp.UpdateWithCustom(transform))
-  }
-
-  /**
-   * Returns a [Deferred] in the same way and for the same conditions as [updateIfPresentAsync] except the provided
-   * function is expected to update the cache in-place and return a custom value to propagate to the result of the
-   * [Deferred] object.
-   */
-  fun <O> updateInPlaceIfPresentAsync(transform: suspend (T) -> O): Deferred<O> = scope.async {
-    transform(
-      checkNotNull(state.value) { "Expected to update the cache only after it's been created" }
-    )
+    CompletableDeferred<V>().also { deferred ->
+      actor.send(UpdateWithCustomChannel(update, deferred))
+    }.await()
   }
 
   /**
    * Returns a [Deferred] that executes when this cache has been fully cleared, or if it's already been cleared.
    */
   fun deleteAsync(): Deferred<Unit> = scope.async {
-    submitOperation(CacheOp.Delete())
+    CompletableDeferred<Unit>().also { deferred ->
+      actor.send(Delete(deferred))
+    }.await()
   }
 
   /**
@@ -235,11 +246,9 @@ class InMemoryBlockingCache<T : Any> private constructor(
    * Note that the provided function will not be called if the cache is already cleared.
    */
   fun maybeDeleteAsync(shouldDelete: suspend (T) -> Boolean): Deferred<Boolean> = scope.async {
-    val valueSnapshot = state.value
-    if (valueSnapshot != null && shouldDelete(valueSnapshot)) {
-      submitOperation(CacheOp.Delete())
-      true
-    } else false
+    CompletableDeferred<Boolean>().also { deferred ->
+      actor.send(MaybeDelete(shouldDelete, deferred))
+    }.await()
   }
 
   /**
@@ -247,20 +256,34 @@ class InMemoryBlockingCache<T : Any> private constructor(
    * be called regardless of the state of the cache, and whose return value will be returned in this method's
    * [Deferred].
    */
-  fun maybeForceDeleteAsync(shouldDelete: suspend (T?) -> Boolean): Deferred<Boolean> =
-    scope.async {
-      if (shouldDelete(state.value)) {
-        submitOperation(CacheOp.Delete())
-        true
-      } else false
+  fun maybeForceDeleteAsync(shouldDelete: suspend (T?) -> Boolean): Deferred<Boolean> = scope.async {
+    CompletableDeferred<Boolean>().also { deferred ->
+      actor.send(MaybeForceDelete(shouldDelete, deferred))
+    }.await()
+  }
+  private suspend fun notifyChange(oldValue: T?, newValue: T?) {
+    withContext(Dispatchers.Main) {
+      changeObserver(oldValue, newValue)
     }
+  }
+  private suspend fun setCache(newValue: T): T {
+    val oldValue = value
+    value = newValue
+    notifyChange(oldValue, newValue)
+    return newValue
+  }
+
+  private suspend fun clearCache() {
+    val oldValue = value
+    value = null
+    changeObserver(oldValue, null)
+  }
 
   /** An injectable factory for [InMemoryBlockingCache]es. */
   @Singleton
   class Factory @Inject constructor(
     @BlockingDispatcher private val blockingDispatcher: CoroutineDispatcher
   ) {
-    /** Returns a new [InMemoryBlockingCache] with, optionally, the specified initial value. */
     fun <T : Any> create(initialValue: T? = null): InMemoryBlockingCache<T> {
       return InMemoryBlockingCache(blockingDispatcher, initialValue)
     }

--- a/utility/src/test/java/org/oppia/android/util/data/InMemoryBlockingCacheTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/data/InMemoryBlockingCacheTest.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/utility/src/test/java/org/oppia/android/util/data/InMemoryBlockingCacheTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/data/InMemoryBlockingCacheTest.kt
@@ -12,8 +12,10 @@ import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -62,6 +64,29 @@ class InMemoryBlockingCacheTest {
   @Before
   fun setUp() {
     setUpTestApplicationComponent()
+  }
+
+  @Test
+  fun testSequentiality() = runBlocking {
+    val first = Job()
+    val second = Job()
+
+    val cache = cacheFactory.create<String>()
+    val firstUpdate = cache.updateAsync {
+      first.join()
+      "first"
+    }
+    val secondUpdate = cache.updateAsync {
+      second.join()
+      "second"
+    }
+    second.complete()
+    testCoroutineDispatchers.advanceUntilIdle()
+    first.complete()
+    testCoroutineDispatchers.advanceUntilIdle()
+    firstUpdate.await()
+    secondUpdate.await()
+    assertThat(awaitCompletion(cache.readAsync())).isEqualTo("second")
   }
 
   @Test

--- a/utility/src/test/java/org/oppia/android/util/data/InMemoryBlockingCacheTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/data/InMemoryBlockingCacheTest.kt
@@ -67,7 +67,7 @@ class InMemoryBlockingCacheTest {
   }
 
   @Test
-  fun testSequentiality() = runBlocking {
+  fun testSequentially_updatesExecuteInOrder() {
     val first = Job()
     val second = Job()
 
@@ -80,12 +80,15 @@ class InMemoryBlockingCacheTest {
       second.join()
       "second"
     }
+
     second.complete()
     testCoroutineDispatchers.advanceUntilIdle()
+
     first.complete()
     testCoroutineDispatchers.advanceUntilIdle()
-    firstUpdate.await()
-    secondUpdate.await()
+
+    awaitCompletion(firstUpdate)
+    awaitCompletion(secondUpdate)
     assertThat(awaitCompletion(cache.readAsync())).isEqualTo("second")
   }
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix #5354 
This PR addresses the issue where `InMemoryBlockingCache` was not guaranteed to process CRUD operations sequentially due to limitations in using a single-threaded dispatcher. The implementation has been updated to use an `Actor`, which ensures strict sequential processing of operations, thereby improving thread safety and atomicity.

- Replaced the single-threaded dispatcher-based coroutine scope with an `Actor`.
- Updated the internal state management logic to process CRUD operations exclusively within the `Actor`.
- Ensured all operations (create, read, update, delete) are processed in the correct order and no race conditions occur.


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

