### PR TITLE
Fix part of #2747: Disable Gradle in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,6 @@ name: Unit Tests (Robolectric -- Gradle)
 # events or push events in the develop branch.
 on:
   workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      # Push events on develop branch
-      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}


### PR DESCRIPTION
## Explanation
Fix part of #2747.

In order to unblock #5604, this PR disables Gradle in CI completely. This is an extreme mitigation to the issues discovered as part of that PR, but please see https://github.com/oppia/oppia-android/pull/5628#issuecomment-2564494780 and that PR's main description for a detailed account of the attempt to migrate to the latest versions of Gradle. It seems that the best path forward both for this upcoming release and long-term is to outright remove Gradle, even though Bazel is not completely developer ready. The alternative (keeping a broken version of Gradle for several months as we migrate dependencies) seems far too disruptive, and not ideal in the long-term since we want to move away from having two build systems, anyway.

Please note that I will remove the required Gradle CI checks once the PR is approved (so that it can be merged).

This change and the eventual removal of Gradle has been announced in the CLaM chat. We'll need to reach out to specific newer team members in the new year once we actually perform the removal and update corresponding documentation.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
This is an infrastructure only change.