### PR TITLE
Fix #5631: Fix thumbnail loading for multiple classrooms

### DIFF
--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
@@ -66,6 +66,7 @@ import org.oppia.android.domain.translation.TranslationController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.locale.OppiaLocale
+import org.oppia.android.util.parser.html.ClassroomHtmlParserEntityType
 import org.oppia.android.util.parser.html.StoryHtmlParserEntityType
 import org.oppia.android.util.parser.html.TopicHtmlParserEntityType
 import org.oppia.android.util.platformparameter.EnableOnboardingFlowV2
@@ -84,6 +85,7 @@ class ClassroomListFragmentPresenter @Inject constructor(
   private val topicListController: TopicListController,
   private val classroomController: ClassroomController,
   private val oppiaLogger: OppiaLogger,
+  @ClassroomHtmlParserEntityType private val classroomEntityType: String,
   @TopicHtmlParserEntityType private val topicEntityType: String,
   @StoryHtmlParserEntityType private val storyEntityType: String,
   private val resourceHandler: AppLanguageResourceHandler,
@@ -120,6 +122,7 @@ class ClassroomListFragmentPresenter @Inject constructor(
       profileManagementController,
       topicListController,
       classroomController,
+      classroomEntityType,
       topicEntityType,
       storyEntityType,
       resourceHandler,

--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListViewModel.kt
@@ -40,6 +40,7 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders.Companion.combineWith
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.parser.html.ClassroomHtmlParserEntityType
 import org.oppia.android.util.parser.html.StoryHtmlParserEntityType
 import org.oppia.android.util.parser.html.TopicHtmlParserEntityType
 
@@ -57,6 +58,7 @@ class ClassroomListViewModel(
   private val profileManagementController: ProfileManagementController,
   private val topicListController: TopicListController,
   private val classroomController: ClassroomController,
+  @ClassroomHtmlParserEntityType private val classroomEntityType: String,
   @TopicHtmlParserEntityType private val topicEntityType: String,
   @StoryHtmlParserEntityType private val storyEntityType: String,
   private val resourceHandler: AppLanguageResourceHandler,
@@ -270,6 +272,7 @@ class ClassroomListViewModel(
         ClassroomSummaryViewModel(
           fragment as ClassroomSummaryClickListener,
           ephemeralClassroomSummary,
+          classroomEntityType,
           translationController
         )
       }

--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListViewModel.kt
@@ -40,9 +40,6 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders.Companion.combineWith
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
-import org.oppia.android.util.parser.html.ClassroomHtmlParserEntityType
-import org.oppia.android.util.parser.html.StoryHtmlParserEntityType
-import org.oppia.android.util.parser.html.TopicHtmlParserEntityType
 
 private const val PROFILE_AND_PROMOTED_ACTIVITY_COMBINED_PROVIDER_ID =
   "profile+promotedActivityList"
@@ -58,9 +55,9 @@ class ClassroomListViewModel(
   private val profileManagementController: ProfileManagementController,
   private val topicListController: TopicListController,
   private val classroomController: ClassroomController,
-  @ClassroomHtmlParserEntityType private val classroomEntityType: String,
-  @TopicHtmlParserEntityType private val topicEntityType: String,
-  @StoryHtmlParserEntityType private val storyEntityType: String,
+  private val classroomEntityType: String,
+  private val topicEntityType: String,
+  private val storyEntityType: String,
   private val resourceHandler: AppLanguageResourceHandler,
   private val dateTimeUtil: DateTimeUtil,
   private val translationController: TranslationController

--- a/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
@@ -1,0 +1,19 @@
+package org.oppia.android.app.classroom
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ThumbnailImage(modifier: Modifier = Modifier, imageResId: Int) {
+  Image(
+    painter = painterResource(id = imageResId),
+    contentDescription = null,
+    modifier = modifier.size(100.dp),
+    contentScale = ContentScale.Crop
+  )
+}

--- a/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
@@ -14,7 +14,7 @@ fun ThumbnailImage(
   lessonThumbnail: LessonThumbnail?,
   modifier: Modifier = Modifier,
 ) {
-  // TODO(#5422): Migrate to jetpack compose.
+  // TODO(#5422): Migrate to Jetpack Compose once the Glide Compose library becomes compatible.
   AndroidView(
     modifier = modifier.fillMaxSize(),
     factory = { context ->

--- a/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
@@ -1,162 +1,28 @@
 package org.oppia.android.app.classroom
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
-import org.oppia.android.R
+import androidx.compose.ui.viewinterop.AndroidView
+import org.oppia.android.app.customview.LessonThumbnailImageView
 import org.oppia.android.app.model.LessonThumbnail
-import org.oppia.android.app.model.LessonThumbnailGraphic
-import org.oppia.android.domain.oppialogger.OppiaLogger
-import org.oppia.android.util.locale.OppiaLocale
-import org.oppia.android.util.parser.image.ImageLoader
-import org.oppia.android.util.parser.image.ImageTransformation
 
 @Composable
 fun ThumbnailImage(
-  modifier: Modifier = Modifier,
   entityId: String,
   entityType: String,
   lessonThumbnail: LessonThumbnail?,
-  isBlurred: Boolean,
-  imageLoader: ImageLoader,
-  resourceBucketName: String,
-  thumbnailDownloadUrlTemplate: String,
-  gcsPrefix: String,
-  oppiaLogger: OppiaLogger,
-  machineLocale: OppiaLocale.MachineLocale
+  modifier: Modifier = Modifier,
 ) {
-  val context = LocalContext.current
-
-  // Determine the background color and scale type
-  val backgroundColor = remember(lessonThumbnail) {
-    lessonThumbnail?.backgroundColorRgb?.toLong()?.let {
-      (0xff000000L or it).toInt()
-    } ?: 0xff000000.toInt()
-  }
-  val transformations = if (isBlurred) listOf(ImageTransformation.BLUR) else listOf()
-
-  Box(
-    modifier = modifier
-      .background(Color(backgroundColor))
-      .fillMaxSize()
-  ) {
-    if (lessonThumbnail != null) {
-      val filename = lessonThumbnail.thumbnailFilename
-      if (filename.isNotEmpty()) {
-        val imageUrl = remember(filename, entityId, entityType) {
-          machineLocale.run {
-            val formattedName = thumbnailDownloadUrlTemplate.formatForMachines(
-              entityType,
-              entityId,
-              filename
-            )
-            "$gcsPrefix/$resourceBucketName/$formattedName"
-          }
-        }
-
-        // Load image using ImageLoader
-        /*ImageLoaderComposable(
-          imageUrl = imageUrl,
-          transformations = transformations,
-          imageLoader = imageLoader,
-          oppiaLogger = oppiaLogger*//*
-        )*/
-      } else {
-        // Load drawable resource
-        val drawableRes = getDrawableResource(lessonThumbnail)
-        Image(
-          painter = painterResource(id = drawableRes),
-          contentDescription = null,
-          modifier = Modifier.fillMaxSize(),
-          contentScale = ContentScale.Fit
-        )
+  AndroidView(
+    modifier = modifier.fillMaxSize(),
+    factory = { context ->
+      // Creates view
+      LessonThumbnailImageView(context).apply {
+        setLessonThumbnail(lessonThumbnail)
+        setEntityId(entityId)
+        setEntityType(entityType)
       }
     }
-  }
-}
-
-/*@Composable
-private fun ImageLoaderComposable(
-  imageUrl: String,
-  transformations: List<ImageTransformation>,
-  imageLoader: ImageLoader,
-  oppiaLogger: OppiaLogger
-) {
-  LaunchedEffect(imageUrl) {
-    try {
-      // Use the image loader to fetch the image
-      imageLoader.loadBitmap(imageUrl, object : ImageViewTa {
-        override fun onBitmapLoaded(bitmap: Bitmap?) {
-          // Handle successful image loading
-        }
-
-        override fun onBitmapFailed(errorDrawable: Drawable?) {
-          // Handle image loading failure
-          oppiaLogger.e("LessonThumbnailImage", "Image loading failed")
-        }
-      }, transformations)
-    } catch (e: Exception) {
-      oppiaLogger.e("LessonThumbnailImage", "Error loading image", e)
-    }
-  }
-}*/
-
-/** Retrieves the drawable resource ID for the lesson thumbnail based on its graphic type. */
-private fun getDrawableResource(lessonThumbnail: LessonThumbnail): Int {
-  return when (lessonThumbnail.thumbnailGraphic) {
-    LessonThumbnailGraphic.BAKER ->
-      R.drawable.lesson_thumbnail_graphic_baker
-    LessonThumbnailGraphic.CHILD_WITH_BOOK ->
-      R.drawable.lesson_thumbnail_graphic_child_with_book
-    LessonThumbnailGraphic.CHILD_WITH_CUPCAKES ->
-      R.drawable.lesson_thumbnail_graphic_child_with_cupcakes
-    LessonThumbnailGraphic.CHILD_WITH_FRACTIONS_HOMEWORK ->
-      R.drawable.lesson_thumbnail_graphic_child_with_fractions_homework
-    LessonThumbnailGraphic.DUCK_AND_CHICKEN ->
-      R.drawable.lesson_thumbnail_graphic_duck_and_chicken
-    LessonThumbnailGraphic.PERSON_WITH_PIE_CHART ->
-      R.drawable.lesson_thumbnail_graphic_person_with_pie_chart
-    LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION ->
-      R.drawable.topic_fractions_01
-    LessonThumbnailGraphic.WRITING_FRACTIONS ->
-      R.drawable.topic_fractions_02
-    LessonThumbnailGraphic.EQUIVALENT_FRACTIONS ->
-      R.drawable.topic_fractions_03
-    LessonThumbnailGraphic.MIXED_NUMBERS_AND_IMPROPER_FRACTIONS ->
-      R.drawable.topic_fractions_04
-    LessonThumbnailGraphic.COMPARING_FRACTIONS ->
-      R.drawable.topic_fractions_05
-    LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS ->
-      R.drawable.topic_fractions_06
-    LessonThumbnailGraphic.MULTIPLYING_FRACTIONS ->
-      R.drawable.topic_fractions_07
-    LessonThumbnailGraphic.DIVIDING_FRACTIONS ->
-      R.drawable.topic_fractions_08
-    LessonThumbnailGraphic.DERIVE_A_RATIO ->
-      R.drawable.topic_ratios_01
-    LessonThumbnailGraphic.WHAT_IS_A_FRACTION ->
-      R.drawable.topic_fractions_01
-    LessonThumbnailGraphic.FRACTION_OF_A_GROUP ->
-      R.drawable.topic_fractions_02
-    LessonThumbnailGraphic.ADDING_FRACTIONS ->
-      R.drawable.topic_fractions_03
-    LessonThumbnailGraphic.MIXED_NUMBERS ->
-      R.drawable.topic_fractions_04
-    LessonThumbnailGraphic.SCIENCE_CLASSROOM ->
-      R.drawable.ic_science
-    LessonThumbnailGraphic.MATHS_CLASSROOM ->
-      R.drawable.ic_maths
-    LessonThumbnailGraphic.ENGLISH_CLASSROOM ->
-      R.drawable.ic_english
-    else ->
-      R.drawable.topic_fractions_01
-  }
+  )
 }

--- a/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
@@ -7,6 +7,19 @@ import androidx.compose.ui.viewinterop.AndroidView
 import org.oppia.android.app.customview.LessonThumbnailImageView
 import org.oppia.android.app.model.LessonThumbnail
 
+/**
+ * A composable function that displays a lesson thumbnail image using a custom Android view.
+ *
+ * This function integrates the [LessonThumbnailImageView] within a Compose layout, allowing it
+ * to render a lesson thumbnail image based on the provided parameters. The implementation
+ * currently relies on a traditional Android View approach due to compatibility issues with the
+ * Glide Compose library.
+ *
+ * @param entityId The unique identifier for the entity associated with the thumbnail.
+ * @param entityType The type of the entity (e.g., classroom, topic, story).
+ * @param lessonThumbnail The [LessonThumbnail] containing metadata required to load the image.
+ * @param modifier The [Modifier] to be applied to the layout, defaulting to [Modifier].
+ */
 @Composable
 fun ThumbnailImage(
   entityId: String,

--- a/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
@@ -15,10 +15,10 @@ import org.oppia.android.app.model.LessonThumbnail
  * currently relies on a traditional Android View approach due to compatibility issues with the
  * Glide Compose library.
  *
- * @param entityId The unique identifier for the entity associated with the thumbnail.
- * @param entityType The type of the entity (e.g., classroom, topic, story).
- * @param lessonThumbnail The [LessonThumbnail] containing metadata required to load the image.
- * @param modifier The [Modifier] to be applied to the layout, defaulting to [Modifier].
+ * @param entityId the unique identifier for the entity associated with the thumbnail
+ * @param entityType the type of the entity (e.g., classroom, topic, story)
+ * @param lessonThumbnail the [LessonThumbnail] containing metadata required to load the image
+ * @param modifier the [Modifier] to be applied to the layout, defaulting to [Modifier]
  */
 @Composable
 fun ThumbnailImage(

--- a/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
@@ -23,6 +23,11 @@ fun ThumbnailImage(
         setEntityId(entityId)
         setEntityType(entityType)
       }
+    },
+    update = { view ->
+      view.setLessonThumbnail(lessonThumbnail)
+      view.setEntityId(entityId)
+      view.setEntityType(entityType)
     }
   )
 }

--- a/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
@@ -1,19 +1,162 @@
 package org.oppia.android.app.classroom
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.dp
+import org.oppia.android.R
+import org.oppia.android.app.model.LessonThumbnail
+import org.oppia.android.app.model.LessonThumbnailGraphic
+import org.oppia.android.domain.oppialogger.OppiaLogger
+import org.oppia.android.util.locale.OppiaLocale
+import org.oppia.android.util.parser.image.ImageLoader
+import org.oppia.android.util.parser.image.ImageTransformation
 
 @Composable
-fun ThumbnailImage(modifier: Modifier = Modifier, imageResId: Int) {
-  Image(
-    painter = painterResource(id = imageResId),
-    contentDescription = null,
-    modifier = modifier.size(100.dp),
-    contentScale = ContentScale.Crop
-  )
+fun ThumbnailImage(
+  modifier: Modifier = Modifier,
+  entityId: String,
+  entityType: String,
+  lessonThumbnail: LessonThumbnail?,
+  isBlurred: Boolean,
+  imageLoader: ImageLoader,
+  resourceBucketName: String,
+  thumbnailDownloadUrlTemplate: String,
+  gcsPrefix: String,
+  oppiaLogger: OppiaLogger,
+  machineLocale: OppiaLocale.MachineLocale
+) {
+  val context = LocalContext.current
+
+  // Determine the background color and scale type
+  val backgroundColor = remember(lessonThumbnail) {
+    lessonThumbnail?.backgroundColorRgb?.toLong()?.let {
+      (0xff000000L or it).toInt()
+    } ?: 0xff000000.toInt()
+  }
+  val transformations = if (isBlurred) listOf(ImageTransformation.BLUR) else listOf()
+
+  Box(
+    modifier = modifier
+      .background(Color(backgroundColor))
+      .fillMaxSize()
+  ) {
+    if (lessonThumbnail != null) {
+      val filename = lessonThumbnail.thumbnailFilename
+      if (filename.isNotEmpty()) {
+        val imageUrl = remember(filename, entityId, entityType) {
+          machineLocale.run {
+            val formattedName = thumbnailDownloadUrlTemplate.formatForMachines(
+              entityType,
+              entityId,
+              filename
+            )
+            "$gcsPrefix/$resourceBucketName/$formattedName"
+          }
+        }
+
+        // Load image using ImageLoader
+        /*ImageLoaderComposable(
+          imageUrl = imageUrl,
+          transformations = transformations,
+          imageLoader = imageLoader,
+          oppiaLogger = oppiaLogger*//*
+        )*/
+      } else {
+        // Load drawable resource
+        val drawableRes = getDrawableResource(lessonThumbnail)
+        Image(
+          painter = painterResource(id = drawableRes),
+          contentDescription = null,
+          modifier = Modifier.fillMaxSize(),
+          contentScale = ContentScale.Fit
+        )
+      }
+    }
+  }
+}
+
+/*@Composable
+private fun ImageLoaderComposable(
+  imageUrl: String,
+  transformations: List<ImageTransformation>,
+  imageLoader: ImageLoader,
+  oppiaLogger: OppiaLogger
+) {
+  LaunchedEffect(imageUrl) {
+    try {
+      // Use the image loader to fetch the image
+      imageLoader.loadBitmap(imageUrl, object : ImageViewTa {
+        override fun onBitmapLoaded(bitmap: Bitmap?) {
+          // Handle successful image loading
+        }
+
+        override fun onBitmapFailed(errorDrawable: Drawable?) {
+          // Handle image loading failure
+          oppiaLogger.e("LessonThumbnailImage", "Image loading failed")
+        }
+      }, transformations)
+    } catch (e: Exception) {
+      oppiaLogger.e("LessonThumbnailImage", "Error loading image", e)
+    }
+  }
+}*/
+
+/** Retrieves the drawable resource ID for the lesson thumbnail based on its graphic type. */
+private fun getDrawableResource(lessonThumbnail: LessonThumbnail): Int {
+  return when (lessonThumbnail.thumbnailGraphic) {
+    LessonThumbnailGraphic.BAKER ->
+      R.drawable.lesson_thumbnail_graphic_baker
+    LessonThumbnailGraphic.CHILD_WITH_BOOK ->
+      R.drawable.lesson_thumbnail_graphic_child_with_book
+    LessonThumbnailGraphic.CHILD_WITH_CUPCAKES ->
+      R.drawable.lesson_thumbnail_graphic_child_with_cupcakes
+    LessonThumbnailGraphic.CHILD_WITH_FRACTIONS_HOMEWORK ->
+      R.drawable.lesson_thumbnail_graphic_child_with_fractions_homework
+    LessonThumbnailGraphic.DUCK_AND_CHICKEN ->
+      R.drawable.lesson_thumbnail_graphic_duck_and_chicken
+    LessonThumbnailGraphic.PERSON_WITH_PIE_CHART ->
+      R.drawable.lesson_thumbnail_graphic_person_with_pie_chart
+    LessonThumbnailGraphic.IDENTIFYING_THE_PARTS_OF_A_FRACTION ->
+      R.drawable.topic_fractions_01
+    LessonThumbnailGraphic.WRITING_FRACTIONS ->
+      R.drawable.topic_fractions_02
+    LessonThumbnailGraphic.EQUIVALENT_FRACTIONS ->
+      R.drawable.topic_fractions_03
+    LessonThumbnailGraphic.MIXED_NUMBERS_AND_IMPROPER_FRACTIONS ->
+      R.drawable.topic_fractions_04
+    LessonThumbnailGraphic.COMPARING_FRACTIONS ->
+      R.drawable.topic_fractions_05
+    LessonThumbnailGraphic.ADDING_AND_SUBTRACTING_FRACTIONS ->
+      R.drawable.topic_fractions_06
+    LessonThumbnailGraphic.MULTIPLYING_FRACTIONS ->
+      R.drawable.topic_fractions_07
+    LessonThumbnailGraphic.DIVIDING_FRACTIONS ->
+      R.drawable.topic_fractions_08
+    LessonThumbnailGraphic.DERIVE_A_RATIO ->
+      R.drawable.topic_ratios_01
+    LessonThumbnailGraphic.WHAT_IS_A_FRACTION ->
+      R.drawable.topic_fractions_01
+    LessonThumbnailGraphic.FRACTION_OF_A_GROUP ->
+      R.drawable.topic_fractions_02
+    LessonThumbnailGraphic.ADDING_FRACTIONS ->
+      R.drawable.topic_fractions_03
+    LessonThumbnailGraphic.MIXED_NUMBERS ->
+      R.drawable.topic_fractions_04
+    LessonThumbnailGraphic.SCIENCE_CLASSROOM ->
+      R.drawable.ic_science
+    LessonThumbnailGraphic.MATHS_CLASSROOM ->
+      R.drawable.ic_maths
+    LessonThumbnailGraphic.ENGLISH_CLASSROOM ->
+      R.drawable.ic_english
+    else ->
+      R.drawable.topic_fractions_01
+  }
 }

--- a/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt
@@ -14,10 +14,10 @@ fun ThumbnailImage(
   lessonThumbnail: LessonThumbnail?,
   modifier: Modifier = Modifier,
 ) {
+  // TODO(#5422): Migrate to jetpack compose.
   AndroidView(
     modifier = modifier.fillMaxSize(),
     factory = { context ->
-      // Creates view
       LessonThumbnailImageView(context).apply {
         setLessonThumbnail(lessonThumbnail)
         setEntityId(entityId)

--- a/app/src/main/java/org/oppia/android/app/classroom/classroomlist/ClassroomList.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/classroomlist/ClassroomList.kt
@@ -2,7 +2,6 @@ package org.oppia.android.app.classroom.classroomlist
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -23,14 +22,13 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.integerResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.oppia.android.R
-import org.oppia.android.app.classroom.getDrawableResource
+import org.oppia.android.app.classroom.ThumbnailImage
 import org.oppia.android.app.home.classroomlist.ClassroomSummaryViewModel
 
 /** Test tag for the classroom list. */
@@ -103,14 +101,10 @@ fun ClassroomCard(
       horizontalAlignment = Alignment.CenterHorizontally,
     ) {
       AnimatedVisibility(visible = !isSticky) {
-        Image(
-          painter = painterResource(
-            id = classroomSummaryViewModel
-              .classroomSummary
-              .classroomThumbnail
-              .getDrawableResource()
-          ),
-          contentDescription = classroomSummaryViewModel.title,
+        ThumbnailImage(
+          entityId = classroomSummaryViewModel.classroomSummary.classroomId,
+          entityType = classroomSummaryViewModel.entityType,
+          lessonThumbnail = classroomSummaryViewModel.classroomSummary.classroomThumbnail,
           modifier = Modifier
             .testTag("${CLASSROOM_CARD_ICON_TEST_TAG}_${classroomSummaryViewModel.title}")
             .padding(bottom = dimensionResource(id = R.dimen.classrooms_card_icon_padding_bottom))

--- a/app/src/main/java/org/oppia/android/app/classroom/promotedlist/ComingSoonTopicList.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/promotedlist/ComingSoonTopicList.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource

--- a/app/src/main/java/org/oppia/android/app/classroom/promotedlist/ComingSoonTopicList.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/promotedlist/ComingSoonTopicList.kt
@@ -1,6 +1,5 @@
 package org.oppia.android.app.classroom.promotedlist
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -22,7 +21,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -31,7 +29,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.oppia.android.R
-import org.oppia.android.app.classroom.getDrawableResource
+import org.oppia.android.app.classroom.ThumbnailImage
 import org.oppia.android.app.home.promotedlist.ComingSoonTopicListViewModel
 import org.oppia.android.app.home.promotedlist.ComingSoonTopicsViewModel
 import org.oppia.android.util.locale.OppiaLocale
@@ -104,12 +102,10 @@ fun ComingSoonTopicCard(
       Column(
         verticalArrangement = Arrangement.Center,
       ) {
-        Image(
-          painter = painterResource(
-            id = comingSoonTopicsViewModel.topicSummary.lessonThumbnail.getDrawableResource()
-          ),
-          contentDescription = "Picture of a " +
-            "${comingSoonTopicsViewModel.topicSummary.lessonThumbnail.thumbnailGraphic.name}.",
+        ThumbnailImage(
+          entityId = comingSoonTopicsViewModel.topicSummary.topicId,
+          entityType = comingSoonTopicsViewModel.entityType,
+          lessonThumbnail = comingSoonTopicsViewModel.topicSummary.lessonThumbnail,
           modifier = Modifier
             .aspectRatio(4f / 3f)
             .background(

--- a/app/src/main/java/org/oppia/android/app/classroom/promotedlist/ComingSoonTopicList.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/promotedlist/ComingSoonTopicList.kt
@@ -106,17 +106,7 @@ fun ComingSoonTopicCard(
           entityId = comingSoonTopicsViewModel.topicSummary.topicId,
           entityType = comingSoonTopicsViewModel.entityType,
           lessonThumbnail = comingSoonTopicsViewModel.topicSummary.lessonThumbnail,
-          modifier = Modifier
-            .aspectRatio(4f / 3f)
-            .background(
-              Color(
-                (
-                  0xff000000L or
-                    comingSoonTopicsViewModel
-                      .topicSummary.lessonThumbnail.backgroundColorRgb.toLong()
-                  ).toInt()
-              )
-            )
+          modifier = Modifier.aspectRatio(4f / 3f)
         )
         ComingSoonTopicCardTextSection(comingSoonTopicsViewModel)
       }

--- a/app/src/main/java/org/oppia/android/app/classroom/promotedlist/PromotedStoryList.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/promotedlist/PromotedStoryList.kt
@@ -2,7 +2,6 @@ package org.oppia.android.app.classroom.promotedlist
 
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -27,7 +26,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -36,7 +34,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.oppia.android.R
-import org.oppia.android.app.classroom.getDrawableResource
+import org.oppia.android.app.classroom.ThumbnailImage
 import org.oppia.android.app.home.promotedlist.PromotedStoryListViewModel
 import org.oppia.android.app.home.promotedlist.PromotedStoryViewModel
 import org.oppia.android.util.locale.OppiaLocale
@@ -141,11 +139,10 @@ fun PromotedStoryCard(
     Column(
       modifier = cardColumnModifier
     ) {
-      Image(
-        painter = painterResource(
-          id = promotedStoryViewModel.promotedStory.lessonThumbnail.getDrawableResource()
-        ),
-        contentDescription = promotedStoryViewModel.storyTitle,
+      ThumbnailImage(
+        entityId = promotedStoryViewModel.promotedStory.storyId,
+        entityType = promotedStoryViewModel.entityType,
+        lessonThumbnail = promotedStoryViewModel.promotedStory.lessonThumbnail,
         modifier = Modifier
           .aspectRatio(16f / 9f)
           .background(

--- a/app/src/main/java/org/oppia/android/app/classroom/promotedlist/PromotedStoryList.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/promotedlist/PromotedStoryList.kt
@@ -143,16 +143,7 @@ fun PromotedStoryCard(
         entityId = promotedStoryViewModel.promotedStory.storyId,
         entityType = promotedStoryViewModel.entityType,
         lessonThumbnail = promotedStoryViewModel.promotedStory.lessonThumbnail,
-        modifier = Modifier
-          .aspectRatio(16f / 9f)
-          .background(
-            Color(
-              (
-                0xff000000L or
-                  promotedStoryViewModel.promotedStory.lessonThumbnail.backgroundColorRgb.toLong()
-                ).toInt()
-            )
-          )
+        modifier = Modifier.aspectRatio(16f / 9f)
       )
       Text(
         text = promotedStoryViewModel.nextChapterTitle,

--- a/app/src/main/java/org/oppia/android/app/classroom/promotedlist/PromotedStoryList.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/promotedlist/PromotedStoryList.kt
@@ -2,7 +2,6 @@ package org.oppia.android.app.classroom.promotedlist
 
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -22,7 +21,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource

--- a/app/src/main/java/org/oppia/android/app/classroom/topiclist/TopicCard.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/topiclist/TopicCard.kt
@@ -43,16 +43,7 @@ fun TopicCard(topicSummaryViewModel: TopicSummaryViewModel) {
         entityId = topicSummaryViewModel.topicSummary.topicId,
         entityType = topicSummaryViewModel.entityType,
         lessonThumbnail = topicSummaryViewModel.topicSummary.topicThumbnail,
-        modifier = Modifier
-          .aspectRatio(4f / 3f)
-          .background(
-            Color(
-              (
-                0xff000000L or
-                  topicSummaryViewModel.topicSummary.topicThumbnail.backgroundColorRgb.toLong()
-                ).toInt()
-            )
-          )
+        modifier = Modifier.aspectRatio(4f / 3f)
       )
       TopicCardTextSection(topicSummaryViewModel)
     }

--- a/app/src/main/java/org/oppia/android/app/classroom/topiclist/TopicCard.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/topiclist/TopicCard.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 import org.oppia.android.R
+import org.oppia.android.app.classroom.ThumbnailImage
 import org.oppia.android.app.classroom.getDrawableResource
 import org.oppia.android.app.home.topiclist.TopicSummaryViewModel
 
@@ -41,7 +42,22 @@ fun TopicCard(topicSummaryViewModel: TopicSummaryViewModel) {
     Column(
       verticalArrangement = Arrangement.Center,
     ) {
-      Image(
+      ThumbnailImage(
+        entityId = topicSummaryViewModel.topicSummary.topicId,
+        entityType = topicSummaryViewModel.entityType,
+        lessonThumbnail = topicSummaryViewModel.topicSummary.topicThumbnail,
+        modifier = Modifier
+          .aspectRatio(4f / 3f)
+          .background(
+            Color(
+              (
+                0xff000000L or
+                  topicSummaryViewModel.topicSummary.topicThumbnail.backgroundColorRgb.toLong()
+                ).toInt()
+            )
+          )
+      )
+      /*Image(
         painter = painterResource(
           id = topicSummaryViewModel.topicSummary.topicThumbnail.getDrawableResource()
         ),
@@ -57,7 +73,7 @@ fun TopicCard(topicSummaryViewModel: TopicSummaryViewModel) {
                 ).toInt()
             )
           )
-      )
+      )*/
       TopicCardTextSection(topicSummaryViewModel)
     }
   }

--- a/app/src/main/java/org/oppia/android/app/classroom/topiclist/TopicCard.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/topiclist/TopicCard.kt
@@ -11,7 +11,6 @@ import androidx.compose.material.Card
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.font.FontFamily

--- a/app/src/main/java/org/oppia/android/app/classroom/topiclist/TopicCard.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/topiclist/TopicCard.kt
@@ -1,6 +1,5 @@
 package org.oppia.android.app.classroom.topiclist
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -15,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -24,7 +22,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 import org.oppia.android.R
 import org.oppia.android.app.classroom.ThumbnailImage
-import org.oppia.android.app.classroom.getDrawableResource
 import org.oppia.android.app.home.topiclist.TopicSummaryViewModel
 
 /** Displays a card with the topic summary information. */
@@ -57,23 +54,6 @@ fun TopicCard(topicSummaryViewModel: TopicSummaryViewModel) {
             )
           )
       )
-      /*Image(
-        painter = painterResource(
-          id = topicSummaryViewModel.topicSummary.topicThumbnail.getDrawableResource()
-        ),
-        contentDescription = "Picture of a " +
-          "${topicSummaryViewModel.topicSummary.topicThumbnail.thumbnailGraphic.name}.",
-        modifier = Modifier
-          .aspectRatio(4f / 3f)
-          .background(
-            Color(
-              (
-                0xff000000L or
-                  topicSummaryViewModel.topicSummary.topicThumbnail.backgroundColorRgb.toLong()
-                ).toInt()
-            )
-          )
-      )*/
       TopicCardTextSection(topicSummaryViewModel)
     }
   }

--- a/app/src/main/java/org/oppia/android/app/customview/LessonThumbnailImageView.kt
+++ b/app/src/main/java/org/oppia/android/app/customview/LessonThumbnailImageView.kt
@@ -193,6 +193,12 @@ class LessonThumbnailImageView @JvmOverloads constructor(
         R.drawable.topic_fractions_03
       LessonThumbnailGraphic.MIXED_NUMBERS ->
         R.drawable.topic_fractions_04
+      LessonThumbnailGraphic.SCIENCE_CLASSROOM ->
+        R.drawable.ic_science
+      LessonThumbnailGraphic.MATHS_CLASSROOM ->
+        R.drawable.ic_maths
+      LessonThumbnailGraphic.ENGLISH_CLASSROOM ->
+        R.drawable.ic_english
       else ->
         R.drawable.topic_fractions_01
     }

--- a/app/src/main/java/org/oppia/android/app/home/classroomlist/ClassroomSummaryViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/home/classroomlist/ClassroomSummaryViewModel.kt
@@ -10,6 +10,7 @@ import java.util.Objects
 class ClassroomSummaryViewModel(
   private val classroomSummaryClickListener: ClassroomSummaryClickListener,
   ephemeralClassroomSummary: EphemeralClassroomSummary,
+  val entityType: String,
   translationController: TranslationController,
 ) : HomeItemViewModel() {
   /** The [ClassroomSummary] retrieved from the [EphemeralClassroomSummary]. */

--- a/scripts/assets/test_file_exemptions.textproto
+++ b/scripts/assets/test_file_exemptions.textproto
@@ -299,6 +299,10 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/classroom/topiclist/AllTopicsHeaderText.kt"
   test_file_not_required: true
 }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ExplorationHtmlParserEntityType.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ExplorationHtmlParserEntityType.kt
@@ -10,6 +10,10 @@ annotation class ExplorationHtmlParserEntityType
 @Qualifier
 annotation class ConceptCardHtmlParserEntityType
 
+/** Qualifier for injecting the entity type for classroom card. */
+@Qualifier
+annotation class ClassroomHtmlParserEntityType
+
 /** Qualifier for injecting the entity type for review card. */
 @Qualifier
 annotation class TopicHtmlParserEntityType

--- a/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParserEntityTypeModule.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParserEntityTypeModule.kt
@@ -19,6 +19,12 @@ class HtmlParserEntityTypeModule {
   }
 
   @Provides
+  @ClassroomHtmlParserEntityType
+  fun provideClassroomCardHtmlParserEntityType(): String {
+    return "classroom"
+  }
+
+  @Provides
   @TopicHtmlParserEntityType
   fun provideReviewCardHtmlParserEntityType(): String {
     return "topic"


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #5631

This PR introduces a new `ThumbnailImage` composable that integrates the `LessonThumbnailImageView` within a Compose layout. The changes include:

- Adding the basic structure for `ThumbnailImage` composable.
- Updating various UI components to use the new `ThumbnailImage` composable.
- Adding classroom thumbnail drawables to `LessonThumbnailImageView`.

Note: Initial attempts were made to use the Glide Compose library, but was found to be incompatible with other dependencies https://github.com/oppia/oppia-android/issues/5631#issuecomment-2570261190.

## Screenshots

|Light Mode|Dark Mode|
|--|--|
|![image](https://github.com/user-attachments/assets/84d7447e-cde1-4ef5-b08b-a05dce7c6243)|![image](https://github.com/user-attachments/assets/a37ad536-46be-470d-96b6-e953282bc800)|
|![image](https://github.com/user-attachments/assets/c4ad9439-d071-4b73-8c6b-f927a45e420b)|![image](https://github.com/user-attachments/assets/8e472114-5e97-4327-a13f-46cb31f739d9)|

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
