### PR TITLE
Fix #4655: Improve TalkBack behavior in onboarding screen

### DIFF
--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenterV1.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenterV1.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.LinearLayout
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.widget.ViewPager2
 import org.oppia.android.R
@@ -81,6 +82,17 @@ class OnboardingFragmentPresenterV1 @Inject constructor(
           positionOffset: Float,
           positionOffsetPixels: Int
         ) {
+          if (positionOffsetPixels == 0 && position > 0) {
+            binding.onboardingSlideViewPager.apply {
+              contentDescription = getViewPagerContentAndDescription(position)
+              announceForAccessibility(contentDescription)
+
+              performAccessibilityAction(
+                AccessibilityNodeInfoCompat.ACTION_ACCESSIBILITY_FOCUS,
+                null
+              )
+            }
+          }
         }
 
         override fun onPageSelected(position: Int) {
@@ -94,6 +106,24 @@ class OnboardingFragmentPresenterV1 @Inject constructor(
           onboardingStatusBarColorUpdate(position)
         }
       })
+  }
+
+  private fun getViewPagerContentAndDescription(position: Int): String {
+    val slideTitle = when (position) {
+      1 -> resourceHandler.getStringInLocale(R.string.onboarding_slide_1_title)
+      2 -> resourceHandler.getStringInLocale(R.string.onboarding_slide_2_title)
+      3 -> resourceHandler.getStringInLocale(R.string.onboarding_slide_3_title)
+      else -> ""
+    }
+
+    val slideDescription = when (position) {
+      1 -> resourceHandler.getStringInLocale(R.string.onboarding_slide_1_description)
+      2 -> resourceHandler.getStringInLocale(R.string.onboarding_slide_2_description)
+      3 -> resourceHandler.getStringInLocale(R.string.onboarding_slide_3_description)
+      else -> ""
+    }
+
+    return "$slideTitle, $slideDescription"
   }
 
   private fun createViewPagerAdapter(): BindableAdapter<OnboardingViewPagerViewModel> {


### PR DESCRIPTION
### Explanation  
This PR Fixes : #4655 And Ensures TalkBack announces the new onboarding slide after a transition by:  

- Verified accessibility actions (`ACTION_ACCESSIBILITY_FOCUS`) are triggered to ensure focus consistency.  
- Ensured the `ViewPager2` requests accessibility focus after slide transitions, enabling TalkBack to announce the new slide.  


---

### Essential Checklist  
- [x] The PR title and explanation start with "Fix #4655: ".  
- [x] The PR adheres to the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).  
- [x] The branch is not called "develop" and is up-to-date with "develop".  
- [x] The PR includes only necessary changes, avoiding unrelated code changes.  
- [x] Reviewers have been assigned correctly ([guidance here](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).  

After Changes : 

https://github.com/user-attachments/assets/1f083350-1506-4979-8bde-8f25d2e91931

