### PR TITLE
Fix #5658: Update WORKSPACE Java resolution order

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,19 @@ android_sdk_repository(
     build_tools_version = BUILD_TOOLS_VERSION,
 )
 
+# The rules_java contains the java_lite_proto_library rule used in the model module.
+http_archive(
+    name = "rules_java",
+    sha256 = HTTP_DEPENDENCY_VERSIONS["rules_java"]["sha"],
+    url = "https://github.com/bazelbuild/rules_java/releases/download/{0}/rules_java-{0}.tar.gz".format(HTTP_DEPENDENCY_VERSIONS["rules_java"]["version"]),
+)
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+rules_java_toolchains()
+
 # Oppia's backend proto API definitions.
 git_repository(
     name = "oppia_proto_api",
@@ -74,19 +87,6 @@ bind(
     name = "proto_java_toolchain",
     actual = "//tools:java_toolchain",
 )
-
-# The rules_java contains the java_lite_proto_library rule used in the model module.
-http_archive(
-    name = "rules_java",
-    sha256 = HTTP_DEPENDENCY_VERSIONS["rules_java"]["sha"],
-    url = "https://github.com/bazelbuild/rules_java/releases/download/{0}/rules_java-{0}.tar.gz".format(HTTP_DEPENDENCY_VERSIONS["rules_java"]["version"]),
-)
-
-load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
-
-rules_java_dependencies()
-
-rules_java_toolchains()
 
 # The rules_proto contains the proto_library rule used in the model module.
 http_archive(


### PR DESCRIPTION
## Explanation
Fixes #5658

It seems that there was an incompatibility introduced with older ``rules_java`` in the AS Bazel plugin (see https://github.com/bazelbuild/intellij/issues/6474 for a related issue, though I'm unsure as to the exact change in the plugin that caused this).

The fix essentially moves the app's ``rules_java`` initialization (which _is_ compatible with the plugin) to be before initializing ``oppia_proto_api`` since that uses an old version of ``rules_java``: https://github.com/oppia/oppia-proto-api/blob/f6d167c5de636edf941e366dc9a6ca6b2bf20e89/repo/versions.bzl#L35-L39. Since the WORKSPACE resolves as "first declaration wins" the order swap fixes the issue without introducing any cross-dependency incompatibilities.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- this is an infrastructure change only.