### PR TITLE
Fix #3245: Enable AccessibilityChecks for Espresso Tests

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/onboarding/CreateProfileFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/onboarding/CreateProfileFragmentTest.kt
@@ -89,7 +89,6 @@ import org.oppia.android.domain.oppialogger.loguploader.LogReportWorkerModule
 import org.oppia.android.domain.platformparameter.PlatformParameterSingletonModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
-import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
@@ -226,7 +225,6 @@ class CreateProfileFragmentTest {
   }
 
   @Test
-  @DisableAccessibilityChecks
   fun testFragment_continueButtonClicked_filledNickname_doesNotShowErrorText() {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))

--- a/app/src/sharedTest/java/org/oppia/android/app/story/StoryActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/story/StoryActivityTest.kt
@@ -80,7 +80,6 @@ import org.oppia.android.domain.topic.TEST_EXPLORATION_ID_2
 import org.oppia.android.domain.topic.TEST_STORY_ID_0
 import org.oppia.android.domain.topic.TEST_TOPIC_ID_0
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
-import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
@@ -176,8 +175,7 @@ class StoryActivityTest {
     assertThat(title).isEqualTo(context.getString(R.string.story_activity_title))
   }
 
-  @Test // TODO(#3245): Error -> URLSpan should be used in place of ClickableSpan
-  @DisableAccessibilityChecks
+  @Test
   fun clickOnStory_intentsToExplorationActivity() {
     launch<StoryActivity>(
       createStoryActivityIntent(

--- a/app/src/sharedTest/java/org/oppia/android/app/story/StoryFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/story/StoryFragmentTest.kt
@@ -115,7 +115,6 @@ import org.oppia.android.domain.topic.RATIOS_TOPIC_ID
 import org.oppia.android.domain.topic.TEST_STORY_ID_0
 import org.oppia.android.domain.topic.TEST_TOPIC_ID_0
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
-import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.firebase.TestAuthenticationModule
@@ -214,8 +213,7 @@ class StoryFragmentTest {
     Intents.release()
   }
 
-  @Test // TODO(#3245): Error -> URLSpan should be used in place of ClickableSpan
-  @DisableAccessibilityChecks
+  @Test
   fun testStoryFragment_clickOnToolbarNavigationButton_closeActivity() {
     activityTestRule.launchActivity(createFractionsStoryActivityIntent())
     testCoroutineDispatchers.runCurrent()
@@ -718,9 +716,7 @@ class StoryFragmentTest {
     }
   }
 
-  @Test // TODO(#3245): Error -> View falls below the minimum recommended size for touch targets and
-  // URLSpan should be used in place of ClickableSpan
-  @DisableAccessibilityChecks
+  @Test
   fun testStoryFragment_changeConfiguration_explorationStartCorrectly() {
     launch<StoryActivity>(createFractionsStoryActivityIntent()).use {
       testCoroutineDispatchers.runCurrent()

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/TextInputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/TextInputInteractionViewTestActivityTest.kt
@@ -68,7 +68,6 @@ import org.oppia.android.domain.platformparameter.PlatformParameterModule
 import org.oppia.android.domain.platformparameter.PlatformParameterSingletonModule
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
-import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.espresso.EditTextInputAction
@@ -132,8 +131,6 @@ class TextInputInteractionViewTestActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks // Disabled, as TextInputInteractionViewTestActivity is a test file and
-  // will not be used by user
   fun testTextInput_withNoInput_hasCorrectPendingAnswerType() {
     val activityScenario = ActivityScenario.launch(
       TextInputInteractionViewTestActivity::class.java
@@ -146,8 +143,6 @@ class TextInputInteractionViewTestActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks // Disabled, as TextInputInteractionViewTestActivity is a test file and
-  // will not be used by user
   fun testTextInput_withChar_hasCorrectPendingAnswer() {
     val activityScenario = ActivityScenario.launch(
       TextInputInteractionViewTestActivity::class.java
@@ -191,8 +186,6 @@ class TextInputInteractionViewTestActivityTest {
   }
 
   @Test
-  @DisableAccessibilityChecks // Disabled, as TextInputInteractionViewTestActivity is a test file and
-  // will not be used by user
   fun testTextInput_withBlankInput_submit_emptyInputErrorIsDisplayed() {
     ActivityScenario.launch(TextInputInteractionViewTestActivity::class.java).use {
       scrollToSubmitButton()


### PR DESCRIPTION
**Explanation**  
This PR Fix #3245 the issue of enabling accessibility checks in Espresso tests by removing the `DisableAccessibilityChecks` annotation from various test files. The changes are made in the following files:
- `CreateProfileFragmentTest.kt`
- `StoryActivityTest.kt`
- `StoryFragmentTest.kt`
- `TextInputInteractionViewTestActivityTest.kt`

By removing this annotation, the tests will now include accessibility checks during their execution, ensuring compliance with accessibility guidelines.

**Changes:**
- Removed `@DisableAccessibilityChecks` annotation from test functions.
- Updated the `testFragment_continueButtonClicked_filledNickname_doesNotShowErrorText` test in `CreateProfileFragmentTest.kt`.
- Removed `@DisableAccessibilityChecks` from multiple tests in `StoryActivityTest.kt`, `StoryFragmentTest.kt`, and `TextInputInteractionViewTestActivityTest.kt`.

**Fixes**:  
- **Fixes #3245** by enabling accessibility checks across multiple Espresso tests.

## Essential Checklist:
- [x] The PR title and explanation each start with "Fix #3245: ".
- [ ] Any changes to `scripts/assets` files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers.

**Screenshots/Tests:**

1. CreateProfileFragmentTest.kt

![Image](https://github.com/user-attachments/assets/6c5847c6-9d47-4228-9517-434d5c6a1d69)

2. StoryActivityTest.kt

![Image](https://github.com/user-attachments/assets/296ae093-8b54-4047-b543-68ef096d775c)

3. StoryFragmentTest.kt

![Image](https://github.com/user-attachments/assets/365a4ce6-a0d0-4e27-a47a-88f36edb7c42)

4. TextInputInteractionViewTestActivityTest.kt

![Image](https://github.com/user-attachments/assets/c97e9054-584a-4f7a-b545-f590cf5f1650)