### PR TITLE
Fix part of #5699: Enable workflow dispatching for wiki jobs

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,6 +1,7 @@
 name: Deploy to Wiki
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - 'wiki/**'


### PR DESCRIPTION
## Explanation

Fixes part of #5699 (even though it's already expected to be fixed).

This was missed in #5700. We can't verify the fixes from that PR without the ability to re-run the workflow outside of a PR (or until another PR that modifies the wiki is merged). It seems ideal to have the ability to force-refresh the wiki in this way, anyway.

Similar to #5700, this can't be easily verified until it's merged.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- This only affects GitHub actions wiki workflows.