### PR TITLE
Fix #5712: Add resetLocale() function to AppLanguageLocaleHandler

### DIFF
--- a/app/src/main/java/org/oppia/android/app/translation/AppLanguageLocaleHandler.kt
+++ b/app/src/main/java/org/oppia/android/app/translation/AppLanguageLocaleHandler.kt
@@ -76,6 +76,12 @@ class AppLanguageLocaleHandler @Inject constructor(
     verifyDisplayLocaleIsInitialized()
     return displayLocale
   }
+  /**
+   * Resets the locale to the system default.
+   *
+   * If the locale is not initialized, it initializes it using the likely default app string locale context.
+   * Otherwise, it updates the locale with the default values.
+   */
   fun resetLocale() {
     if (!isInitialized()) {
       // Initialize with system default locale if not already set

--- a/app/src/main/java/org/oppia/android/app/translation/AppLanguageLocaleHandler.kt
+++ b/app/src/main/java/org/oppia/android/app/translation/AppLanguageLocaleHandler.kt
@@ -76,6 +76,21 @@ class AppLanguageLocaleHandler @Inject constructor(
     verifyDisplayLocaleIsInitialized()
     return displayLocale
   }
+  fun resetLocale() {
+    if (!isInitialized()) {
+      // Initialize with system default locale if not already set
+      initializeLocale(
+        localeController.reconstituteDisplayLocale(
+          localeController.getLikelyDefaultAppStringLocaleContext()
+        )
+      )
+    } else {
+      // If already initialized, just update the locale
+      displayLocale = localeController.reconstituteDisplayLocale(
+        localeController.getLikelyDefaultAppStringLocaleContext()
+      )
+    }
+  }
 
   private fun verifyDisplayLocaleIsInitialized() {
     check(isInitialized()) {


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

This PR introduces a new resetLocale() function to the AppLanguageLocaleHandler. Currently, there's no standard mechanism to reset the locale across the app.

Additionally, there is no direct way for other classes to trigger a locale reset when needed. By adding a resetLocale() function to AppLanguageLocaleHandler, any class that requires a locale reset can utilize this function, ensuring a consistent and centralized approach to locale management. This implementation solves the issue by:

-Ensuring the locale is properly initialized before attempting a reset.
-Reconstituting and updating the display locale using the default app string locale context from the --LocaleController.
-Providing a convenient and reusable method that allows any class to reset the locale when needed.

Fixes #5712


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #5712 : " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
