### PR TITLE
fixes: Change ProfileId defaulting to be an invalid profile

### DIFF
--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivity.kt
@@ -76,7 +76,8 @@ class AdministratorControlsActivity :
       // TODO(#661): Change the default fragment in the right hand side to be EditAccount fragment in the case of multipane controls.
       PROFILE_LIST_FRAGMENT
     }
-    val selectedProfileId = intent?.extractCurrentUserProfileId() ?: ProfileId.newBuilder().setLoggedOut(true).build()
+    val selectedProfileId = intent?.extractCurrentUserProfileId() ?:
+      ProfileId.newBuilder().setLoggedOut(true).build()
 
     administratorControlsActivityPresenter.handleOnCreate(
       extraControlsTitle,

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivity.kt
@@ -76,8 +76,8 @@ class AdministratorControlsActivity :
       // TODO(#661): Change the default fragment in the right hand side to be EditAccount fragment in the case of multipane controls.
       PROFILE_LIST_FRAGMENT
     }
-    val selectedProfileId = intent?.extractCurrentUserProfileId() ?:
-      ProfileId.newBuilder().setLoggedOut(true).build()
+    val selectedProfileId = intent?.extractCurrentUserProfileId() ?: ProfileId
+      .cnewBuilder().setLoggedOut(true).build()
 
     administratorControlsActivityPresenter.handleOnCreate(
       extraControlsTitle,

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivity.kt
@@ -76,7 +76,7 @@ class AdministratorControlsActivity :
       // TODO(#661): Change the default fragment in the right hand side to be EditAccount fragment in the case of multipane controls.
       PROFILE_LIST_FRAGMENT
     }
-    val selectedProfileId = intent?.extractCurrentUserProfileId() ?: ProfileId.getDefaultInstance()
+    val selectedProfileId = intent?.extractCurrentUserProfileId() ?: ProfileId.newBuilder().setLoggedOut(true).build()
 
     administratorControlsActivityPresenter.handleOnCreate(
       extraControlsTitle,

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityPresenter.kt
@@ -70,8 +70,8 @@ class AdministratorControlsActivityPresenter @Inject constructor(
         APP_VERSION_FRAGMENT -> activity.loadAppVersion()
         PROFILE_EDIT_FRAGMENT -> selectedProfileId.let { profileId ->
           Log.d("profile", profileId.loggedOut.toString())
-          if(!profileId.loggedOut){
-            Log.d("profile",profileId.internalId.toString())
+          if (!profileId.loggedOut) {
+            Log.d("profile", profileId.internalId.toString())
           }
           if (extraControlsTitle != null) {
             activity.loadProfileEdit(profileId = profileId, profileName = extraControlsTitle)

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityPresenter.kt
@@ -1,6 +1,7 @@
 package org.oppia.android.app.administratorcontrols
 
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
@@ -31,7 +32,7 @@ class AdministratorControlsActivityPresenter @Inject constructor(
   private lateinit var binding: AdministratorControlsActivityBinding
 
   private lateinit var lastLoadedFragment: String
-  private var selectedProfileId: ProfileId = ProfileId.getDefaultInstance()
+  private var selectedProfileId: ProfileId = ProfileId.newBuilder().setLoggedOut(true).build()
   private lateinit var extraControlsTitle: String
   private var isProfileDeletionDialogVisible: Boolean = false
 
@@ -68,9 +69,13 @@ class AdministratorControlsActivityPresenter @Inject constructor(
         PROFILE_LIST_FRAGMENT -> activity.loadProfileList()
         APP_VERSION_FRAGMENT -> activity.loadAppVersion()
         PROFILE_EDIT_FRAGMENT -> selectedProfileId.let { profileId ->
+          Log.d("profile", profileId.loggedOut.toString())
+          if(!profileId.loggedOut){
+            Log.d("profile",profileId.internalId.toString())
+          }
           if (extraControlsTitle != null) {
             activity.loadProfileEdit(profileId = profileId, profileName = extraControlsTitle)
-            if (isProfileDeletionDialogVisible && profileId.internalId != 0) {
+            if (isProfileDeletionDialogVisible && !profileId.loggedOut) {
               val fragment = activity.supportFragmentManager.findFragmentById(
                 R.id.administrator_controls_fragment_multipane_placeholder
               )

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -133,7 +133,12 @@ message ProfileId {
    * Unique ID used to identify a single profile.
    * Should not be used directory outside of the profile system.
    */
-  int32 internal_id = 1;
+  reserved 1;
+  oneof type {
+    int32 internal_id = 2;
+    // Boolean if user is logged_out or not.
+    bool logged_out = 3;
+  }
 }
 
 // Used in BindableAdapter for ProfileChooserFragment.

--- a/utility/src/main/java/org/oppia/android/util/profile/CurrentUserProfileIdIntentDecorator.kt
+++ b/utility/src/main/java/org/oppia/android/util/profile/CurrentUserProfileIdIntentDecorator.kt
@@ -30,7 +30,7 @@ object CurrentUserProfileIdIntentDecorator {
   fun Intent.extractCurrentUserProfileId(): ProfileId {
     return getProtoExtra(
       PROFILE_ID_INTENT_DECORATOR,
-      ProfileId.getDefaultInstance()
+      ProfileId.newBuilder().setLoggedOut(true).build()
     )
   }
 
@@ -39,7 +39,9 @@ object CurrentUserProfileIdIntentDecorator {
    * [extractCurrentUserProfileId] should be used for retrieving the [ProfileId] later.
    */
   fun Bundle.decorateWithUserProfileId(profileId: ProfileId) {
-    putProto(PROFILE_ID_BUNDLE_DECORATOR, profileId)
+    if(!profileId.loggedOut) {
+      putProto(PROFILE_ID_BUNDLE_DECORATOR, profileId)
+    }
   }
 
   /**
@@ -49,7 +51,7 @@ object CurrentUserProfileIdIntentDecorator {
   fun Bundle.extractCurrentUserProfileId(): ProfileId {
     return getProto(
       PROFILE_ID_BUNDLE_DECORATOR,
-      ProfileId.getDefaultInstance()
+      ProfileId.newBuilder().setLoggedOut(true).build()
     )
   }
 }

--- a/utility/src/main/java/org/oppia/android/util/profile/CurrentUserProfileIdIntentDecorator.kt
+++ b/utility/src/main/java/org/oppia/android/util/profile/CurrentUserProfileIdIntentDecorator.kt
@@ -39,7 +39,7 @@ object CurrentUserProfileIdIntentDecorator {
    * [extractCurrentUserProfileId] should be used for retrieving the [ProfileId] later.
    */
   fun Bundle.decorateWithUserProfileId(profileId: ProfileId) {
-    if(!profileId.loggedOut) {
+    if (!profileId.loggedOut) {
       putProto(PROFILE_ID_BUNDLE_DECORATOR, profileId)
     }
   }


### PR DESCRIPTION
## Explanation
fixes : 5482

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
