### PR TITLE
Fix #5749: Add support for checking lesson compatibility weekly

### DIFF
--- a/.github/workflows/lesson_checks.yml
+++ b/.github/workflows/lesson_checks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   check_lesson_compatibility:
     name: Check production lesson conversion
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up JDK 11
         uses: actions/setup-java@v1

--- a/.github/workflows/lesson_checks.yml
+++ b/.github/workflows/lesson_checks.yml
@@ -1,0 +1,68 @@
+# Contains jobs corresponding to verify Oppia lesson compatibility.
+
+name: Checks for Oppia Lesson Compatibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 02 * * 1"
+
+jobs:
+  check_lesson_compatibility:
+    name: Check production lesson conversion
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Set up Bazel
+        uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: 6.5.0
+
+      # This checks out the actual true develop branch separately to ensure that the stats check is
+      # run from the latest develop rather than the base branch (which might be different for
+      # chained PRs).
+      - name: Check out introduce-asset-download-script branch
+        uses: actions/checkout@v4
+        with:
+          ref: introduce-asset-download-script
+          path: develop
+
+      - name: Set up build environment
+        uses: ./develop/.github/actions/set-up-android-bazel-build-environment
+
+      - name: Extract production API key
+        env:
+          BAZEL_REMOTE_CACHE_URL: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
+        run: |
+          echo "$BAZEL_REMOTE_CACHE_URL" > prod_server.key
+
+      - name: Check Bazel environment
+        run: |
+          cd develop
+          bazel info
+
+      - name: Download lesson version list
+        run: |
+          bazel run //scripts:download_lesson_list -- \
+            https://www.oppia.org \
+            https://storage.googleapis.com \
+            oppiaserver-resources \
+            $(pwd)/../prod_server.key \
+            $(pwd)/release_assets/pinned_versions.textproto
+
+      - name: Download lessons and verify conversion
+        run: |
+          bazel run //scripts:download_lessons -- \
+            https://www.oppia.org \
+            https://storage.googleapis.com \
+            oppiaserver-resources \
+            $(pwd)/../prod_server.key \
+            $(pwd)/release_assets/assets \
+            cache_mode=none \
+            $(pwd)/release_assets/cache \
+            $(pwd)/release_assets/pinned_versions.textproto \
+            -Werror

--- a/.github/workflows/lesson_checks.yml
+++ b/.github/workflows/lesson_checks.yml
@@ -30,11 +30,12 @@ jobs:
       - name: Set up build environment
         uses: ./.github/actions/set-up-android-bazel-build-environment
 
-      - name: Extract production API key
+      - name: Prepare environment
         env:
           PROD_SERVER_LESSON_SECRET: ${{ secrets.PROD_SERVER_LESSON_SECRET }}
         run: |
           echo "$PROD_SERVER_LESSON_SECRET" > prod_server.key
+          mkdir release_assets
 
       - name: Check Bazel environment
         run: bazel info

--- a/.github/workflows/lesson_checks.yml
+++ b/.github/workflows/lesson_checks.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: introduce-asset-download-script
-          path: develop
 
       - name: Set up build environment
         uses: ./develop/.github/actions/set-up-android-bazel-build-environment
@@ -41,9 +40,7 @@ jobs:
           echo "$PROD_SERVER_LESSON_SECRET" > prod_server.key
 
       - name: Check Bazel environment
-        run: |
-          cd develop
-          bazel info
+        run: bazel info
 
       - name: Download lesson version list
         run: |
@@ -51,7 +48,7 @@ jobs:
             https://www.oppia.org \
             https://storage.googleapis.com \
             oppiaserver-resources \
-            $(pwd)/../prod_server.key \
+            $(pwd)/prod_server.key \
             $(pwd)/release_assets/pinned_versions.textproto
 
       - name: Download lessons and verify conversion
@@ -60,7 +57,7 @@ jobs:
             https://www.oppia.org \
             https://storage.googleapis.com \
             oppiaserver-resources \
-            $(pwd)/../prod_server.key \
+            $(pwd)/prod_server.key \
             $(pwd)/release_assets/assets \
             cache_mode=none \
             $(pwd)/release_assets/cache \

--- a/.github/workflows/lesson_checks.yml
+++ b/.github/workflows/lesson_checks.yml
@@ -22,16 +22,13 @@ jobs:
         with:
           version: 6.5.0
 
-      # This checks out the actual true develop branch separately to ensure that the stats check is
-      # run from the latest develop rather than the base branch (which might be different for
-      # chained PRs).
       - name: Check out introduce-asset-download-script branch
         uses: actions/checkout@v4
         with:
           ref: introduce-asset-download-script
 
       - name: Set up build environment
-        uses: ./develop/.github/actions/set-up-android-bazel-build-environment
+        uses: ./.github/actions/set-up-android-bazel-build-environment
 
       - name: Extract production API key
         env:

--- a/.github/workflows/lesson_checks.yml
+++ b/.github/workflows/lesson_checks.yml
@@ -36,9 +36,9 @@ jobs:
 
       - name: Extract production API key
         env:
-          BAZEL_REMOTE_CACHE_URL: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
+          PROD_SERVER_LESSON_SECRET: ${{ secrets.PROD_SERVER_LESSON_SECRET }}
         run: |
-          echo "$BAZEL_REMOTE_CACHE_URL" > prod_server.key
+          echo "$PROD_SERVER_LESSON_SECRET" > prod_server.key
 
       - name: Check Bazel environment
         run: |


### PR DESCRIPTION
## Explanation
Fixes #5749

This PR introduces support for, once per week (Mondays at 2:30am GMT), attempting to download the list of lessons and failing if any conversion errors occur (support for this was introduced in the asset download script in 0252fc8fd5b246e56a3a34c88018eda2bf3a09f3 and 0bec9004cdb6faaa899d8b03162bce6b750d47de). There are currently over 6000 issues that need fixing, so it's expected that this is a cron job that will be failing for some time as the content team works through the failures, and the web team introduces checks to help prevent some of these classes of failures from regressing.

https://github.com/BenHenning/oppia-android/actions/runs/13843084590/job/38735087365 demonstrates a failure when issues are detected:

![image](https://github.com/user-attachments/assets/ced33349-f83e-40bf-9613-368fdb8c1c1f)

Note that the actual exception thrown is caught as a GitHub actions annotation, but fortunately it doesn't have any critically important information as all the actual errors are printed to standard output.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- This is a CI infrastructure change.