### PR TITLE
Fix #5761: Create shared oppia-android.bazelproject.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -250,6 +250,7 @@ WORKSPACE @oppia/android-app-infrastructure-reviewers
 *.bazel @oppia/android-app-infrastructure-reviewers
 .bazelrc @oppia/android-app-infrastructure-reviewers
 .bazelversion @oppia/android-app-infrastructure-reviewers
+oppia-android.bazelproject @oppia/android-app-infrastructure-reviewers
 /tools/android/ @oppia/android-app-infrastructure-reviewers
 /tools/kotlin/ @oppia/android-app-infrastructure-reviewers
 

--- a/oppia-android.bazelproject
+++ b/oppia-android.bazelproject
@@ -1,0 +1,27 @@
+# This file describes the shared configuration for developing Oppia Android using the Bazel IntelliJ
+# plugin. Note that this file should be imported rather than used directly. It can be extended in
+# local .bazelproject files to add additional target directories for syncing, as needed.
+
+directories:
+  .
+  
+derive_targets_from_directories: false
+
+targets:
+  //:oppia_dev_binary
+  //app/src/main/... 
+  //domain/src/main/... 
+  //testing/src/main/... 
+  //utility/src/main/... 
+  //data/src/main/... 
+  //model/...
+  
+additional_languages:
+  java
+  kotlin
+
+android_sdk_platform: android-34
+
+shard_sync: true
+
+java_language_level: 11


### PR DESCRIPTION
## Explanation
Fixes #5761

This PR introduces a shared `.bazelproject` file to ensure that we can more easily control recommended syncing configurations across everyone who uses the IntelliJ Bazel plugin. Such cases where this is especially useful:
- Target SDK updates (we can now essentially soft force developers to newer SDK versions).
- When syncing becomes more efficient or correct (e.g. after modularization we should be able to remove syncing the AAB binary target which could halve the syncing time).

This shared file will be able to be used through an `import` directive as described here: https://ij.bazel.build/docs/project-views.html#import. I believe that developers can override settings in their local bazelproject file if they need to (for instance to add more targets to sync).

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- Infrastructure-only fix.