### PR TITLE
fix preferred audio settings #5783 

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/audio/AudioFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/audio/AudioFragmentPresenter.kt
@@ -188,6 +188,15 @@ class AudioFragmentPresenter @Inject constructor(
   fun languageSelected(language: String) {
     if (audioViewModel.selectedLanguageCode != language) {
       audioViewModel.setAudioLanguageCode(language)
+      val audioLanguage = when (language) {
+        "hi" -> AudioLanguage.HINDI_AUDIO_LANGUAGE
+        "pt", "pt-br" -> AudioLanguage.BRAZILIAN_PORTUGUESE_LANGUAGE
+        "ar" -> AudioLanguage.ARABIC_LANGUAGE
+        "pcm" -> AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE
+        else -> AudioLanguage.ENGLISH_AUDIO_LANGUAGE
+      }
+      profileManagementController.updateAudioLanguage(profileId, audioLanguage)
+        .toLiveData().observe(fragment) { }
     }
   }
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - When user update the language during a lesson this PR changes the audio in the preferred audio setting

https://github.com/user-attachments/assets/a07706a2-0051-49b0-9afc-8b2a8d5042c8


  - "Fixes #5783:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ X] The PR title and explanation each start with "Fix #5783
- [ X] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ X] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ X] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ X] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ X] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

