### PR TITLE
Fix part of #5732: Implement domain logic to show flashback button

### DIFF
--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
@@ -698,15 +698,26 @@ class ExplorationProgressController @Inject constructor(
         val ephemeralState = computeBaseCurrentEphemeralState()
         when {
           answerOutcome.destinationCase == AnswerOutcome.DestinationCase.STATE_NAME -> {
-            endState()
-            val newState = explorationProgress.stateGraph.getState(answerOutcome.stateName)
-            explorationProgress.stateDeck.pushState(
-              newState,
-              prohibitSameStateName = true,
-              timestamp = startSessionTimeMs + continueButtonAnimationDelay,
-              isContinueButtonAnimationSeen = isContinueButtonAnimationSeen
-            )
-            hintHandler.finishState(newState)
+            val wasVisited = explorationProgress.stateDeck
+              .wasPreviouslyVisited(answerOutcome.stateName)
+
+            // Checks whether Learner submits wrong answer and destination name was previously
+            // visited by Learner.
+            if (!doesInteractionAutoContinue(answerOutcome.state.interaction.id) &&
+              !answerOutcome.labelledAsCorrectAnswer && wasVisited
+            ) {
+              explorationProgress.stateDeck.addFlashbackState(answerOutcome.stateName)
+            } else {
+              endState()
+              val newState = explorationProgress.stateGraph.getState(answerOutcome.stateName)
+              explorationProgress.stateDeck.pushState(
+                newState,
+                prohibitSameStateName = true,
+                timestamp = startSessionTimeMs + continueButtonAnimationDelay,
+                isContinueButtonAnimationSeen = isContinueButtonAnimationSeen
+              )
+              hintHandler.finishState(newState)
+            }
           }
           ephemeralState.stateTypeCase == EphemeralState.StateTypeCase.PENDING_STATE -> {
             // Schedule, or show immediately, a new hint or solution based on the current

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
@@ -698,13 +698,13 @@ class ExplorationProgressController @Inject constructor(
         val ephemeralState = computeBaseCurrentEphemeralState()
         when {
           answerOutcome.destinationCase == AnswerOutcome.DestinationCase.STATE_NAME -> {
-            val wasVisited = explorationProgress.stateDeck
-              .wasPreviouslyVisited(answerOutcome.stateName)
+            val wasVisitedBefore = explorationProgress.stateDeck
+              .wasStatePreviouslyVisited(answerOutcome.stateName)
 
-            // Checks whether Learner submits wrong answer and destination name was previously
-            // visited by Learner.
+            // Checks whether the learner submitted a wrong answer and the expected destination name
+            // was previously visited.
             if (!doesInteractionAutoContinue(answerOutcome.state.interaction.id) &&
-              !answerOutcome.labelledAsCorrectAnswer && wasVisited
+              !answerOutcome.labelledAsCorrectAnswer && wasVisitedBefore
             ) {
               explorationProgress.stateDeck.addFlashbackState(answerOutcome.stateName)
             } else {

--- a/domain/src/main/java/org/oppia/android/domain/state/StateDeck.kt
+++ b/domain/src/main/java/org/oppia/android/domain/state/StateDeck.kt
@@ -253,8 +253,8 @@ class StateDeck constructor(
   }
 
   /** Returns whether the given state was previously visited. */
-  fun wasPreviouslyVisited(stateName: String): Boolean {
-    return previousStates.asReversed().any { it.state.name == stateName }
+  fun wasStatePreviouslyVisited(stateName: String): Boolean {
+    return previousStates.any { it.state.name == stateName }
   }
 
   /**

--- a/domain/src/main/java/org/oppia/android/domain/state/StateDeck.kt
+++ b/domain/src/main/java/org/oppia/android/domain/state/StateDeck.kt
@@ -251,4 +251,25 @@ class StateDeck constructor(
   private fun isTopOfDeckTerminal(): Boolean {
     return isTopOfDeckTerminalChecker(pendingTopState)
   }
+
+  /** Returns whether the given state was previously visited. */
+  fun wasPreviouslyVisited(stateName: String): Boolean {
+    return previousStates.asReversed().any { it.state.name == stateName }
+  }
+
+  /**
+   * Updates the `state_name_to_revisit` field of the last [AnswerAndResponse] in the
+   * [currentDialogInteractions] list with the given [stateName].
+   */
+  fun addFlashbackState(stateName: String) {
+    if (currentDialogInteractions.isNotEmpty()) {
+      val lastIndex = currentDialogInteractions.lastIndex
+      val lastAnswerAndResponse = currentDialogInteractions[lastIndex]
+      val updatedAnswerAndResponse = lastAnswerAndResponse.toBuilder()
+        .setStateNameToRevisit(stateName)
+        .build()
+
+      currentDialogInteractions[lastIndex] = updatedAnswerAndResponse
+    }
+  }
 }

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
@@ -3347,7 +3347,6 @@ class ExplorationProgressControllerTest {
       .isEqualTo("Ratio shows relative relationship 2")
   }
 
-
   @Test
   fun testFlashback_onSubmit_wrongMultipleChoiceAnswers_noHintIsVisible() {
     startPlayingNewExploration(

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
@@ -3286,13 +3286,13 @@ class ExplorationProgressControllerTest {
   }
 
   @Test
-  fun testFlashback_onSubmit_wrongMultipleChoiceAnswer_returnsOutcomeWithTransition() {
+  fun testFlashback_onSubmitWrongMultipleChoiceAnswer_returnsFlashbackAttributes() {
     startPlayingNewExploration(
       TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, RATIOS_EXPLORATION_ID_0
     )
 
     waitForGetCurrentStateSuccessfulLoad()
-    navigateToFlashbackMultipleChoiceState()
+    playThroughToMultipleChoiceStateWithFlashbackDest()
 
     // Submit a wrong answer.
     val result = explorationProgressController.submitAnswer(createMultipleChoiceAnswer(1))
@@ -3309,13 +3309,13 @@ class ExplorationProgressControllerTest {
   }
 
   @Test
-  fun testFlashback_onSubmit_wrongMultipleChoiceAnswer_returnsPendingState() {
+  fun testFlashback_onSubmitWrongMultipleChoiceAnswer_returnsPendingState() {
     startPlayingNewExploration(
       TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, RATIOS_EXPLORATION_ID_0
     )
 
     waitForGetCurrentStateSuccessfulLoad()
-    navigateToFlashbackMultipleChoiceState()
+    playThroughToMultipleChoiceStateWithFlashbackDest()
 
     // Submit a wrong answer.
     val ephemeralState = submitAnswer(createMultipleChoiceAnswer(choiceIndex = 1))
@@ -3327,13 +3327,13 @@ class ExplorationProgressControllerTest {
   }
 
   @Test
-  fun testFlashback_onSubmit_wrongMultipleChoiceAnswer_verifyFlashbackStateName_isAdded() {
+  fun testFlashback_onSubmitWrongMultipleChoiceAnswer_verifyFlashbackStateNameIsAdded() {
     startPlayingNewExploration(
       TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, RATIOS_EXPLORATION_ID_0
     )
 
     waitForGetCurrentStateSuccessfulLoad()
-    navigateToFlashbackMultipleChoiceState()
+    playThroughToMultipleChoiceStateWithFlashbackDest()
 
     // Submit a wrong answer.
     val ephemeralState = submitAnswer(createMultipleChoiceAnswer(choiceIndex = 1))
@@ -3348,13 +3348,13 @@ class ExplorationProgressControllerTest {
   }
 
   @Test
-  fun testFlashback_onSubmit_wrongMultipleChoiceAnswers_noHintIsVisible() {
+  fun testFlashback_onSubmitWrongMultipleChoiceAnswers_noHintIsVisible() {
     startPlayingNewExploration(
       TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, RATIOS_EXPLORATION_ID_0
     )
 
     waitForGetCurrentStateSuccessfulLoad()
-    navigateToFlashbackMultipleChoiceState()
+    playThroughToMultipleChoiceStateWithFlashbackDest()
 
     // Submit 2 wrong answers.
     submitAnswer(createMultipleChoiceAnswer(choiceIndex = 1))
@@ -3373,7 +3373,7 @@ class ExplorationProgressControllerTest {
     )
 
     waitForGetCurrentStateSuccessfulLoad()
-    navigateToFlashbackMultipleChoiceState()
+    playThroughToMultipleChoiceStateWithFlashbackDest()
 
     // Submit a wrong answer.
     submitAnswer(createMultipleChoiceAnswer(choiceIndex = 1))
@@ -3396,7 +3396,7 @@ class ExplorationProgressControllerTest {
       .isEqualTo("Ratio shows relative relationship 2")
   }
 
-  private fun navigateToFlashbackMultipleChoiceState() {
+  private fun playThroughToMultipleChoiceStateWithFlashbackDest() {
     playThroughRatioExplorationState1()
     playThroughRatioExplorationState2()
     playThroughRatioExplorationState3()

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
@@ -76,6 +76,7 @@ import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.domain.topic.FRACTIONS_EXPLORATION_ID_0
 import org.oppia.android.domain.topic.FRACTIONS_STORY_ID_0
 import org.oppia.android.domain.topic.FRACTIONS_TOPIC_ID
+import org.oppia.android.domain.topic.RATIOS_EXPLORATION_ID_0
 import org.oppia.android.domain.topic.TEST_EXPLORATION_ID_13
 import org.oppia.android.domain.topic.TEST_EXPLORATION_ID_2
 import org.oppia.android.domain.topic.TEST_EXPLORATION_ID_4
@@ -3282,6 +3283,203 @@ class ExplorationProgressControllerTest {
     endExploration()
 
     assertThat(getAggregateTopicTime()).isEqualTo(sessionTime)
+  }
+
+  @Test
+  fun testFlashback_onSubmit_wrongMultipleChoiceAnswer_returnsOutcomeWithTransition() {
+    startPlayingNewExploration(
+      TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, RATIOS_EXPLORATION_ID_0
+    )
+
+    waitForGetCurrentStateSuccessfulLoad()
+    navigateToFlashbackMultipleChoiceState()
+
+    // Submit a wrong answer.
+    val result = explorationProgressController.submitAnswer(createMultipleChoiceAnswer(1))
+    // Verify that the answer submission was successful.
+    val answerOutcome = monitorFactory.waitForNextSuccessfulResult(result)
+
+    val expectedFeedback = "<p>No, that represents a ratio of orange puree to milk that is 3:1." +
+      " You want a ratio of 3:2.</p>\n\n<p>It looks like you might need a quick refresher on" +
+      " what a ratio is. Let's go back a few steps and learn from Uncle Berry again!</p>"
+
+    assertThat(answerOutcome.labelledAsCorrectAnswer).isEqualTo(false)
+    assertThat(answerOutcome.destinationCase).isEqualTo(AnswerOutcome.DestinationCase.STATE_NAME)
+    assertThat(answerOutcome.feedback.html).contains(expectedFeedback)
+  }
+
+  @Test
+  fun testFlashback_onSubmit_wrongMultipleChoiceAnswer_returnsPendingState() {
+    startPlayingNewExploration(
+      TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, RATIOS_EXPLORATION_ID_0
+    )
+
+    waitForGetCurrentStateSuccessfulLoad()
+    navigateToFlashbackMultipleChoiceState()
+
+    // Submit a wrong answer.
+    val ephemeralState = submitAnswer(createMultipleChoiceAnswer(choiceIndex = 1))
+
+    // Verify that the current state updates. It should stay pending, and the wrong answer should be
+    // appended.
+    assertThat(ephemeralState.stateTypeCase).isEqualTo(EphemeralState.StateTypeCase.PENDING_STATE)
+    assertThat(ephemeralState.pendingState.wrongAnswerCount).isEqualTo(1)
+  }
+
+  @Test
+  fun testFlashback_onSubmit_wrongMultipleChoiceAnswer_verifyFlashbackStateName_isAdded() {
+    startPlayingNewExploration(
+      TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, RATIOS_EXPLORATION_ID_0
+    )
+
+    waitForGetCurrentStateSuccessfulLoad()
+    navigateToFlashbackMultipleChoiceState()
+
+    // Submit a wrong answer.
+    val ephemeralState = submitAnswer(createMultipleChoiceAnswer(choiceIndex = 1))
+    // Access the first answer and response in the list.
+    val answerAndResponse = ephemeralState.pendingState.wrongAnswerList[0]
+
+    // Verify that there is exactly one wrong answer.
+    assertThat(ephemeralState.pendingState.wrongAnswerCount).isEqualTo(1)
+    // Verify answer and response contains the flashback state name.
+    assertThat(answerAndResponse.stateNameToRevisit)
+      .isEqualTo("Ratio shows relative relationship 2")
+  }
+
+
+  @Test
+  fun testFlashback_onSubmit_wrongMultipleChoiceAnswers_noHintIsVisible() {
+    startPlayingNewExploration(
+      TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, RATIOS_EXPLORATION_ID_0
+    )
+
+    waitForGetCurrentStateSuccessfulLoad()
+    navigateToFlashbackMultipleChoiceState()
+
+    // Submit 2 wrong answers.
+    submitAnswer(createMultipleChoiceAnswer(choiceIndex = 1))
+    val ephemeralState = submitAnswer(createMultipleChoiceAnswer(choiceIndex = 1))
+
+    // Verify that the helpIndex.IndexTypeCase is equal to INDEX_TYPE_NOT_SET because no hint
+    // is visible yet.
+    assertThat(ephemeralState.pendingState.helpIndex.indexTypeCase)
+      .isEqualTo(HelpIndex.IndexTypeCase.INDEXTYPE_NOT_SET)
+  }
+
+  @Test
+  fun testFlashback_submitWrongMultipleChoiceAnswer_resumeExploration_verifyCorrectPendingState() {
+    startPlayingNewExploration(
+      TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, RATIOS_EXPLORATION_ID_0
+    )
+
+    waitForGetCurrentStateSuccessfulLoad()
+    navigateToFlashbackMultipleChoiceState()
+
+    // Submit a wrong answer.
+    submitAnswer(createMultipleChoiceAnswer(choiceIndex = 1))
+    endExploration()
+
+    val checkpoint = retrieveExplorationCheckpoint(RATIOS_EXPLORATION_ID_0)
+    resumeExploration(
+      TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, RATIOS_EXPLORATION_ID_0, checkpoint
+    )
+    val ephemeralState = waitForGetCurrentStateSuccessfulLoad()
+    // Access the first answer and response in the list.
+    val answerAndResponse = ephemeralState.pendingState.wrongAnswerList[0]
+
+    assertThat(ephemeralState.stateTypeCase).isEqualTo(PENDING_STATE)
+    assertThat(ephemeralState.state.name).isEqualTo("Practice 6")
+    // Verify that there is exactly one wrong answer.
+    assertThat(ephemeralState.pendingState.wrongAnswerCount).isEqualTo(1)
+    // Verify answer and response contains the flashback state name.
+    assertThat(answerAndResponse.stateNameToRevisit)
+      .isEqualTo("Ratio shows relative relationship 2")
+  }
+
+  private fun navigateToFlashbackMultipleChoiceState() {
+    playThroughRatioExplorationState1()
+    playThroughRatioExplorationState2()
+    playThroughRatioExplorationState3()
+    playThroughRatioExplorationState4()
+    playThroughRatioExplorationState5()
+    playThroughRatioExplorationState6()
+    playThroughRatioExplorationState7()
+    playThroughRatioExplorationState8()
+    playThroughRatioExplorationState9()
+    playThroughRatioExplorationState10()
+    playThroughRatioExplorationState11()
+    playThroughRatioExplorationState12()
+    playThroughRatioExplorationState13()
+    playThroughRatioExplorationState14()
+    playThroughRatioExplorationState15()
+  }
+
+  private fun playThroughRatioExplorationState1(): EphemeralState {
+    return submitContinueButtonAnswerAndContinue()
+  }
+
+  private fun playThroughRatioExplorationState2(): EphemeralState {
+    return submitContinueButtonAnswerAndContinue()
+  }
+
+  private fun playThroughRatioExplorationState3(): EphemeralState {
+    return submitContinueButtonAnswerAndContinue()
+  }
+
+  private fun playThroughRatioExplorationState4(): EphemeralState {
+    return submitContinueButtonAnswerAndContinue()
+  }
+
+  private fun playThroughRatioExplorationState5(): EphemeralState {
+    return submitContinueButtonAnswerAndContinue()
+  }
+
+  private fun playThroughRatioExplorationState6(): EphemeralState {
+    submitTextInputAnswer("2 to 5")
+    return moveToNextState()
+  }
+
+  private fun playThroughRatioExplorationState7(): EphemeralState {
+    submitTextInputAnswer("3 to 1")
+    return moveToNextState()
+  }
+  private fun playThroughRatioExplorationState8(): EphemeralState {
+    submitTextInputAnswer("2:3")
+    return moveToNextState()
+  }
+
+  private fun playThroughRatioExplorationState9(): EphemeralState {
+    submitTextInputAnswer("5:2")
+    return moveToNextState()
+  }
+
+  private fun playThroughRatioExplorationState10(): EphemeralState {
+    return submitContinueButtonAnswerAndContinue()
+  }
+
+  private fun playThroughRatioExplorationState11(): EphemeralState {
+    submitMultipleChoiceAnswer(2)
+    return moveToNextState()
+  }
+
+  private fun playThroughRatioExplorationState12(): EphemeralState {
+    return submitContinueButtonAnswerAndContinue()
+  }
+
+  private fun playThroughRatioExplorationState13(): EphemeralState {
+    submitTextInputAnswer("1:4")
+    return moveToNextState()
+  }
+
+  private fun playThroughRatioExplorationState14(): EphemeralState {
+    submitTextInputAnswer("1:4")
+    return moveToNextState()
+  }
+
+  private fun playThroughRatioExplorationState15(): EphemeralState {
+    submitTextInputAnswer("2:1")
+    return moveToNextState()
   }
 
   private fun getAggregateTopicTime(): Long {

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
@@ -3348,7 +3348,7 @@ class ExplorationProgressControllerTest {
   }
 
   @Test
-  fun testFlashback_onSubmitWrongMultipleChoiceAnswers_noHintIsVisible() {
+  fun testController_enterTwoWrongAnswers_destinationStatePreviouslyVisited_noHintIsVisible() {
     startPlayingNewExploration(
       TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, RATIOS_EXPLORATION_ID_0
     )

--- a/model/src/main/proto/exploration.proto
+++ b/model/src/main/proto/exploration.proto
@@ -331,6 +331,10 @@ message AnswerAndResponse {
 
   // Whether the answer was labelled by the creator as correct.
   bool is_correct_answer = 3;
+
+  // Indicates that a flashback button should be shown. Contains the name of the state the learner
+  // can revisit.
+  string state_name_to_revisit = 4;
 }
 
 message AnswerOutcome {

--- a/model/src/main/proto/exploration.proto
+++ b/model/src/main/proto/exploration.proto
@@ -332,8 +332,8 @@ message AnswerAndResponse {
   // Whether the answer was labelled by the creator as correct.
   bool is_correct_answer = 3;
 
-  // Indicates that a flashback button should be shown. Contains the name of the state the learner
-  // can revisit.
+  // The name of the state the learner can revisit to review a concept. It's presence indicates that
+  // a flashback button should be shown.
   string state_name_to_revisit = 4;
 }
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixes part of #5732

- Add a new field to the AnswerAndResponse message in exploration.proto.
- Add a logic to detect flashbacks in ExplorationProgressController and add functions in StateDeck.
- Add relevant tests in ExplorationProgressControllerTest.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
