### PR TITLE
Fix part of #5732: Introduce feature flag for Flashback

### DIFF
--- a/config/src/java/org/oppia/android/config/platform/feature_flags.textproto
+++ b/config/src/java/org/oppia/android/config/platform/feature_flags.textproto
@@ -63,3 +63,8 @@ feature_flag_definition {
   remote_server_name: "enable_multiple_classrooms"
   default_is_enabled: false
 }
+feature_flag_definition {
+  id: FLASHBACK_SUPPORT
+  remote_server_name: "android_enable_flashback_support"
+  default_is_enabled: false
+}

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/FeatureFlagBindingModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/FeatureFlagBindingModule.kt
@@ -8,6 +8,7 @@ import org.oppia.android.util.platformparameter.EnableDownloadsSupport
 import org.oppia.android.util.platformparameter.EnableEditAccountsOptionsUi
 import org.oppia.android.util.platformparameter.EnableExtraTopicTabsUi
 import org.oppia.android.util.platformparameter.EnableFastLanguageSwitchingInLesson
+import org.oppia.android.util.platformparameter.EnableFlashbackSupport
 import org.oppia.android.util.platformparameter.EnableInteractionConfigChangeStateRetention
 import org.oppia.android.util.platformparameter.EnableLearnerStudyAnalytics
 import org.oppia.android.util.platformparameter.EnableLoggingLearnerStudyIds
@@ -88,6 +89,11 @@ class FeatureFlagBindingModule {
   @EnableMultipleClassrooms
   fun provideEnableMultipleClassrooms(processState: PlatformParameterProcessState) =
     processState.retrieveFeatureFlag(FeatureFlagId.MULTIPLE_CLASSROOMS)
+
+  @Provides
+  @EnableFlashbackSupport
+  fun provideEnableFlashbackSupport(processState: PlatformParameterProcessState) =
+    processState.retrieveFeatureFlag(FeatureFlagId.FLASHBACK_SUPPORT)
 
   private companion object {
     private fun PlatformParameterProcessState.retrieveFeatureFlag(

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/FeatureFlagsMapBindingModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/FeatureFlagsMapBindingModule.kt
@@ -9,6 +9,7 @@ import org.oppia.android.util.platformparameter.EnableDownloadsSupport
 import org.oppia.android.util.platformparameter.EnableEditAccountsOptionsUi
 import org.oppia.android.util.platformparameter.EnableExtraTopicTabsUi
 import org.oppia.android.util.platformparameter.EnableFastLanguageSwitchingInLesson
+import org.oppia.android.util.platformparameter.EnableFlashbackSupport
 import org.oppia.android.util.platformparameter.EnableInteractionConfigChangeStateRetention
 import org.oppia.android.util.platformparameter.EnableLearnerStudyAnalytics
 import org.oppia.android.util.platformparameter.EnableLoggingLearnerStudyIds
@@ -125,5 +126,13 @@ interface FeatureFlagsMapBindingModule {
   @FeatureFlagIdKey(FeatureFlagId.MULTIPLE_CLASSROOMS)
   fun bindMultipleClassrooms(
     @EnableMultipleClassrooms param: PlatformParameterValue<Boolean>
+  ): PlatformParameterValue<Boolean>
+
+  @Binds
+  @IntoMap
+  @FeatureFlags
+  @FeatureFlagIdKey(FeatureFlagId.FLASHBACK_SUPPORT)
+  fun bindFlashbackSupport(
+    @EnableFlashbackSupport param: PlatformParameterValue<Boolean>
   ): PlatformParameterValue<Boolean>
 }

--- a/domain/src/test/java/org/oppia/android/domain/oppialogger/analytics/FeatureFlagsLoggerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/oppialogger/analytics/FeatureFlagsLoggerTest.kt
@@ -141,7 +141,7 @@ class FeatureFlagsLoggerTest {
 
   @Test
   fun testLogFeatureFlags_correctNumberOfFeatureFlagsIsLogged() {
-    val expectedFeatureFlagCount = 13
+    val expectedFeatureFlagCount = 14
 
     featureFlagsLogger.logAllFeatureFlags(TEST_SESSION_ID)
     testCoroutineDispatchers.runCurrent()
@@ -166,6 +166,7 @@ class FeatureFlagsLoggerTest {
   @Iteration("nps_survey", "index=10", "flagId=NPS_SURVEY")
   @Iteration("onboarding_flow_v2", "index=11", "flagId=ONBOARDING_FLOW_V2")
   @Iteration("multiple_classrooms", "index=12", "flagId=MULTIPLE_CLASSROOMS")
+  @Iteration("flashback_support", "index=13", "flagId=FLASHBACK_SUPPORT")
   fun testLogFeatureFlags_allFeatureFlagIdsAreLogged() {
     featureFlagsLogger.logAllFeatureFlags(TEST_SESSION_ID)
 

--- a/model/src/main/proto/platform_parameter.proto
+++ b/model/src/main/proto/platform_parameter.proto
@@ -139,6 +139,10 @@ enum FeatureFlagId {
   // Corresponds to a new version of the home screen that supports multiple classrooms (such as
   // mathematics and science).
   MULTIPLE_CLASSROOMS = 15;
+
+  // Corresponds to a feature that enables a UI for quick revision when a learner answers a specific
+  // question incorrectly.
+  FLASHBACK_SUPPORT = 16;
 }
 
 // Corresponds to a compile-time definition of a platform parameter which is a mechanism by which to

--- a/testing/src/main/java/org/oppia/android/testing/platformparameter/TestPlatformParameterModule.kt
+++ b/testing/src/main/java/org/oppia/android/testing/platformparameter/TestPlatformParameterModule.kt
@@ -7,6 +7,7 @@ import org.oppia.android.app.model.FeatureFlagId.DOWNLOADS_SUPPORT
 import org.oppia.android.app.model.FeatureFlagId.EDIT_ACCOUNTS_OPTIONS_UI
 import org.oppia.android.app.model.FeatureFlagId.EXTRA_TOPIC_TABS_UI
 import org.oppia.android.app.model.FeatureFlagId.FAST_LANGUAGE_SWITCHING_IN_LESSON
+import org.oppia.android.app.model.FeatureFlagId.FLASHBACK_SUPPORT
 import org.oppia.android.app.model.FeatureFlagId.LEARNER_STUDY_ANALYTICS
 import org.oppia.android.app.model.FeatureFlagId.LOGGING_LEARNER_STUDY_IDS
 import org.oppia.android.app.model.FeatureFlagId.MULTIPLE_CLASSROOMS
@@ -107,6 +108,10 @@ class TestPlatformParameterModule {
 
     fun forceEnableAppAndOsDeprecation(value: Boolean) {
       TestPlatformParameterConfigRetriever.setFlagOverride(APP_AND_OS_DEPRECATION, value)
+    }
+
+    fun forceEnableFlashbackSupport(value: Boolean) {
+      TestPlatformParameterConfigRetriever.setFlagOverride(FLASHBACK_SUPPORT, value)
     }
 
     fun reset() {

--- a/utility/src/main/java/org/oppia/android/util/platformparameter/FeatureFlagConstants.kt
+++ b/utility/src/main/java/org/oppia/android/util/platformparameter/FeatureFlagConstants.kt
@@ -180,12 +180,12 @@ const val ENABLE_MULTIPLE_CLASSROOMS = "enable_multiple_classrooms"
 /** Default value of the feature flag corresponding to [EnableMultipleClassrooms]. */
 const val ENABLE_MULTIPLE_CLASSROOMS_DEFAULT_VALUE = true
 
-/** Qualifier for the feature flag that toggles the new multiple classrooms. */
+/** Qualifier for the feature flag that toggles the new flashback support. */
 @Qualifier
 annotation class EnableFlashbackSupport
 
-/** Name of the feature flag that toggles the new multiple classrooms. */
+/** Name of the feature flag that toggles the new flashback support. */
 const val ENABLE_FLASHBACK_SUPPORT = "android_enable_flashback_support"
 
-/** Default value of the feature flag corresponding to [EnableMultipleClassrooms]. */
+/** Default value of the feature flag corresponding to [EnableFlashbackSupport]. */
 const val ENABLE_FLASHBACK_SUPPORT_DEFAULT_VALUE = false

--- a/utility/src/main/java/org/oppia/android/util/platformparameter/FeatureFlagConstants.kt
+++ b/utility/src/main/java/org/oppia/android/util/platformparameter/FeatureFlagConstants.kt
@@ -179,3 +179,13 @@ const val ENABLE_MULTIPLE_CLASSROOMS = "enable_multiple_classrooms"
 
 /** Default value of the feature flag corresponding to [EnableMultipleClassrooms]. */
 const val ENABLE_MULTIPLE_CLASSROOMS_DEFAULT_VALUE = true
+
+/** Qualifier for the feature flag that toggles the new multiple classrooms. */
+@Qualifier
+annotation class EnableFlashbackSupport
+
+/** Name of the feature flag that toggles the new multiple classrooms. */
+const val ENABLE_FLASHBACK_SUPPORT = "android_enable_flashback_support"
+
+/** Default value of the feature flag corresponding to [EnableMultipleClassrooms]. */
+const val ENABLE_FLASHBACK_SUPPORT_DEFAULT_VALUE = false


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fixes part of #5732 
- Introduce feature flag for Flashback


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
