### PR TITLE
Fixes #5883 and part of #5345 : Keyboard opening automaticaly in Platform Parameter dashboard disabled.

### DIFF
--- a/app/src/main/res/layout/platform_parameter_item.xml
+++ b/app/src/main/res/layout/platform_parameter_item.xml
@@ -75,6 +75,7 @@
         android:layout_marginTop="8dp"
         android:gravity="center"
         android:textAlignment="center"
+        app:errorMessage="@{viewModel.inputErrorMsg}"
         android:visibility="@{viewModel.isTextInputMode ? View.VISIBLE : View.GONE}"
         app:errorIconDrawable="@null"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/platform_parameters_fragment.xml
+++ b/app/src/main/res/layout/platform_parameters_fragment.xml
@@ -41,6 +41,8 @@
     <FrameLayout
       android:layout_width="0dp"
       android:layout_height="0dp"
+      android:descendantFocusability="beforeDescendants"
+      android:focusableInTouchMode="true"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
@@ -51,8 +53,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:clipToPadding="false"
-        android:descendantFocusability="beforeDescendants"
-        android:focusableInTouchMode="true"
         android:overScrollMode="never"
         android:paddingBottom="40dp"
         android:scrollbars="none"

--- a/app/src/main/res/layout/platform_parameters_fragment.xml
+++ b/app/src/main/res/layout/platform_parameters_fragment.xml
@@ -52,6 +52,7 @@
         android:layout_height="match_parent"
         android:clipToPadding="false"
         android:descendantFocusability="beforeDescendants"
+        android:focusableInTouchMode="true"
         android:overScrollMode="never"
         android:paddingBottom="40dp"
         android:scrollbars="none"

--- a/app/src/main/res/layout/platform_parameters_fragment.xml
+++ b/app/src/main/res/layout/platform_parameters_fragment.xml
@@ -51,6 +51,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:clipToPadding="false"
+        android:descendantFocusability="beforeDescendants"
         android:overScrollMode="never"
         android:paddingBottom="40dp"
         android:scrollbars="none"

--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentTest.kt
@@ -493,6 +493,10 @@ class PlatformParametersFragmentTest {
           targetViewId = R.id.platform_parameter_input_edit_text
         )
       ).check(matches(not(hasFocus())))
+
+      onView(
+        withId(R.id.platform_parameters_container)
+      ).check(matches(hasFocus()))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentTest.kt
@@ -3,6 +3,7 @@ package org.oppia.android.app.devoptions.platformparameters
 import android.app.Application
 import android.content.Context
 import android.graphics.drawable.GradientDrawable
+import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario.launch
@@ -474,6 +475,18 @@ class PlatformParametersFragmentTest {
         position = 0,
         expectedValue = expectedValue
       )
+    }
+  }
+
+  @Test
+  fun testPlatformParametersFragment_opensDashboard_keyboardIsNotVisible() {
+    setUpTestApplicationComponent()
+    launch(PlatformParametersTestActivity::class.java).use {
+      testCoroutineDispatchers.runCurrent()
+      val inputMethodManager =
+        context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+      val isKeyboardVisible = inputMethodManager.isAcceptingText
+      assertThat(isKeyboardVisible).isFalse()
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentTest.kt
@@ -11,7 +11,6 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
-import androidx.test.espresso.matcher.ViewMatchers.hasFocus
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -475,28 +474,6 @@ class PlatformParametersFragmentTest {
         position = 0,
         expectedValue = expectedValue
       )
-    }
-  }
-
-  @Config(sdk = [27])
-  @Test
-  fun testPlatformParametersFragment_opensDashboard_keyboardIsNotVisible() {
-    setUpTestApplicationComponent()
-    launch(PlatformParametersTestActivity::class.java).use {
-      testCoroutineDispatchers.runCurrent()
-
-      scrollToPosition(1)
-      onView(
-        atPositionOnView(
-          recyclerViewId = R.id.platform_parameters_recycler_view,
-          position = 1,
-          targetViewId = R.id.platform_parameter_input_edit_text
-        )
-      ).check(matches(not(hasFocus())))
-
-      onView(
-        withId(R.id.platform_parameters_container)
-      ).check(matches(hasFocus()))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentTest.kt
@@ -3,7 +3,6 @@ package org.oppia.android.app.devoptions.platformparameters
 import android.app.Application
 import android.content.Context
 import android.graphics.drawable.GradientDrawable
-import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario.launch
@@ -12,6 +11,7 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
+import androidx.test.espresso.matcher.ViewMatchers.hasFocus
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -322,6 +322,7 @@ class PlatformParametersFragmentTest {
     }
   }
 
+  @Test
   fun testPlatformParametersFragment_removeTextFromInputBox_showsInvalidInputError() {
     setUpTestApplicationComponent()
     launch(PlatformParametersTestActivity::class.java).use {
@@ -335,12 +336,11 @@ class PlatformParametersFragmentTest {
           targetViewId = R.id.platform_parameter_input_edit_text
         )
       ).perform(editTextInputAction.replaceText(""))
-
       onView(
         atPositionOnView(
           recyclerViewId = R.id.platform_parameters_recycler_view,
           position = 7,
-          targetViewId = R.id.platform_parameter_input_edit_text
+          targetViewId = R.id.platform_parameter_input_layout
         )
       ).check(
         matches(
@@ -478,15 +478,21 @@ class PlatformParametersFragmentTest {
     }
   }
 
+  @Config(sdk = [27])
   @Test
   fun testPlatformParametersFragment_opensDashboard_keyboardIsNotVisible() {
     setUpTestApplicationComponent()
     launch(PlatformParametersTestActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
-      val inputMethodManager =
-        context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-      val isKeyboardVisible = inputMethodManager.isAcceptingText
-      assertThat(isKeyboardVisible).isFalse()
+
+      scrollToPosition(1)
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.platform_parameters_recycler_view,
+          position = 1,
+          targetViewId = R.id.platform_parameter_input_edit_text
+        )
+      ).check(matches(not(hasFocus())))
     }
   }
 

--- a/wiki/Wiki.md
+++ b/wiki/Wiki.md
@@ -93,5 +93,3 @@ If you change the wiki through the web interface at https://github.com/oppia/opp
 
 #### Demo Screenshot
 <img width="1074" alt="Screenshot wiki preview" src="https://user-images.githubusercontent.com/76530270/227737306-0bf3d5ef-ddcb-4886-b65b-a9c1ce1b4069.gif">
-
-<!-- TODO(#4933): Revise markdown instructions once a Java runtime override isn't needed anymore to render Markdown in Android Studio. -->

--- a/wiki/Wiki.md
+++ b/wiki/Wiki.md
@@ -93,3 +93,5 @@ If you change the wiki through the web interface at https://github.com/oppia/opp
 
 #### Demo Screenshot
 <img width="1074" alt="Screenshot wiki preview" src="https://user-images.githubusercontent.com/76530270/227737306-0bf3d5ef-ddcb-4886-b65b-a9c1ce1b4069.gif">
+
+<!-- TODO(#4933): Revise markdown instructions once a Java runtime override isn't needed anymore to render Markdown in Android Studio. -->


### PR DESCRIPTION
Fixes #5883 and part of #5345: 
This PR fixes the bug of keyboard opening automatically in the PlatformParameterDashboard.
Also `inputErrorMsg` was removed by mistake in one of the PRs have been added again.

#### Changes:
- `platform_parameters_fragment.xml` : Added `android:descendantFocusability="beforeDescendants"` to remove focus from the editText.
- `platform_parameter_item.xml` : Added `app:errorMessage="@{viewModel.inputErrorMsg}"` which may have removed earlier.
- `PlatformParametersFragmentTest` : Added test to verify behaviour.

#### Recording (Api 27)
[Screen_recording_20250714_121842.webm](https://github.com/user-attachments/assets/2cb3c81e-e0ac-4bec-8299-08f9fe88342a)


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
