### PR TITLE
Fixes part of #5345: Fixes restarting of download on config change.

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/DeveloperOptionsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/DeveloperOptionsFragmentTest.kt
@@ -110,7 +110,6 @@ import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
-import org.robolectric.shadows.ShadowLog
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -626,26 +625,6 @@ class DeveloperOptionsFragmentTest {
     val cause = performException.cause
     assertThat(cause).isInstanceOf(SecurityException::class.java)
     assertThat(cause?.message).contains("System.exit()")
-  }
-
-  @Test
-  fun testDeveloperOptionsFragment_clickDownload_configChange_downloadDoesnotRestarts() {
-    launch<DeveloperOptionsTestActivity>(
-      createDeveloperOptionsTestActivityIntent(internalProfileId)
-    ).use {
-      testCoroutineDispatchers.runCurrent()
-
-      scrollToPosition(position = 2)
-      onView(withId(R.id.force_download_button)).perform(click())
-      testCoroutineDispatchers.runCurrent()
-      onView(isRoot()).perform(orientationLandscape())
-
-      val logs = ShadowLog.getLogs()
-      val platformParamLogs = logs.filter { it.tag == "PlatformParameterController" }
-      assertThat(
-        platformParamLogs.count { it.msg.contains("Calling Force Download of remote parameters") }
-      ).isEqualTo(1)
-    }
   }
 
   private fun createDeveloperOptionsTestActivityIntent(internalProfileId: Int): Intent {

--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/DeveloperOptionsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/DeveloperOptionsFragmentTest.kt
@@ -110,6 +110,7 @@ import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowLog
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -625,6 +626,26 @@ class DeveloperOptionsFragmentTest {
     val cause = performException.cause
     assertThat(cause).isInstanceOf(SecurityException::class.java)
     assertThat(cause?.message).contains("System.exit()")
+  }
+
+  @Test
+  fun testDeveloperOptionsFragment_clickDownload_configChange_downloadDoesnotRestarts() {
+    launch<DeveloperOptionsTestActivity>(
+      createDeveloperOptionsTestActivityIntent(internalProfileId)
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+
+      scrollToPosition(position = 2)
+      onView(withId(R.id.force_download_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+      onView(isRoot()).perform(orientationLandscape())
+
+      val logs = ShadowLog.getLogs()
+      val platformParamLogs = logs.filter { it.tag == "PlatformParameterController" }
+      assertThat(
+        platformParamLogs.count { it.msg.contains("Calling Force Download of remote parameters") }
+      ).isEqualTo(1)
+    }
   }
 
   private fun createDeveloperOptionsTestActivityIntent(internalProfileId: Int): Intent {

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImpl.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImpl.kt
@@ -74,14 +74,16 @@ class PlatformParameterControllerDebugImpl @Inject constructor(
   }
 
   override fun downloadRemoteParameters(): DataProvider<Unit> {
-    oppiaLogger.d("PlatformParameterController", "Calling Force Download of remote parameters")
     return dataProviders.createInMemoryDataProviderAsync(DOWNLOAD_REMOTE_PARAMETERS_PROVIDER_ID) {
-      ongoingDownloadTask?.cancel()
-      ongoingDownloadTask = CoroutineScope(backgroundCoroutineDispatcher).async {
-        // TODO(#5950): Replace with actual logic to force-download remote parameters.
+      if (ongoingDownloadTask == null || ongoingDownloadTask?.isCancelled == true) {
+        oppiaLogger.d("PlatformParameterController", "Calling Force Download of remote parameters")
+        ongoingDownloadTask?.cancel()
+        ongoingDownloadTask = CoroutineScope(backgroundCoroutineDispatcher).async {
+          // TODO(#5950): Replace with actual logic to force-download remote parameters.
+          oppiaLogger.d("PlatformParameterController", "Download finished successfully.")
+        }
       }
       ongoingDownloadTask?.await()
-      oppiaLogger.d("PlatformParameterController", "Download finished successfully.")
       return@createInMemoryDataProviderAsync AsyncResult.Success(Unit)
     }
   }

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImpl.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImpl.kt
@@ -74,9 +74,7 @@ class PlatformParameterControllerDebugImpl @Inject constructor(
     }
   }
 
-  override fun downloadRemoteParameters(): DataProvider<Unit> {
-    return downloadRemoteParametersProvider
-  }
+  override fun downloadRemoteParameters() = downloadRemoteParametersProvider
 
   /** Cancels any ongoing remote parameter download. */
   fun cancelRemoteParameterDownload(): Boolean {
@@ -252,9 +250,8 @@ class PlatformParameterControllerDebugImpl @Inject constructor(
 
   private fun downloadRemoteParametersInternal(): DataProvider<Unit> {
     return dataProviders.createInMemoryDataProviderAsync(DOWNLOAD_REMOTE_PARAMETERS_PROVIDER_ID) {
-      if (ongoingDownloadTask == null || ongoingDownloadTask?.isCancelled == true) {
+      if (ongoingDownloadTask == null) {
         oppiaLogger.d("PlatformParameterController", "Calling Force Download of remote parameters")
-        ongoingDownloadTask?.cancel()
         ongoingDownloadTask = CoroutineScope(backgroundCoroutineDispatcher).async {
           // TODO(#5950): Replace with actual logic to force-download remote parameters.
           oppiaLogger.d("PlatformParameterController", "Download finished successfully.")

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImpl.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImpl.kt
@@ -44,6 +44,7 @@ class PlatformParameterControllerDebugImpl @Inject constructor(
   // Note that the 'by lazy' here guarantees thread-safe and singleton initialization.
   private val initializationDeferred by lazy { loadParametersInternalAsync() }
   private val parametersAreLoadedFlow by lazy { MutableStateFlow(false) }
+  private val downloadRemoteParametersProvider by lazy { downloadRemoteParametersInternal() }
   private var ongoingDownloadTask: Deferred<Unit>? = null
 
   init {
@@ -74,18 +75,7 @@ class PlatformParameterControllerDebugImpl @Inject constructor(
   }
 
   override fun downloadRemoteParameters(): DataProvider<Unit> {
-    return dataProviders.createInMemoryDataProviderAsync(DOWNLOAD_REMOTE_PARAMETERS_PROVIDER_ID) {
-      if (ongoingDownloadTask == null || ongoingDownloadTask?.isCancelled == true) {
-        oppiaLogger.d("PlatformParameterController", "Calling Force Download of remote parameters")
-        ongoingDownloadTask?.cancel()
-        ongoingDownloadTask = CoroutineScope(backgroundCoroutineDispatcher).async {
-          // TODO(#5950): Replace with actual logic to force-download remote parameters.
-          oppiaLogger.d("PlatformParameterController", "Download finished successfully.")
-        }
-      }
-      ongoingDownloadTask?.await()
-      return@createInMemoryDataProviderAsync AsyncResult.Success(Unit)
-    }
+    return downloadRemoteParametersProvider
   }
 
   /** Cancels any ongoing remote parameter download. */
@@ -257,6 +247,21 @@ class PlatformParameterControllerDebugImpl @Inject constructor(
 
       // Let observers know that parameters have been initialized.
       parametersAreLoadedFlow.value = true
+    }
+  }
+
+  private fun downloadRemoteParametersInternal(): DataProvider<Unit> {
+    return dataProviders.createInMemoryDataProviderAsync(DOWNLOAD_REMOTE_PARAMETERS_PROVIDER_ID) {
+      if (ongoingDownloadTask == null || ongoingDownloadTask?.isCancelled == true) {
+        oppiaLogger.d("PlatformParameterController", "Calling Force Download of remote parameters")
+        ongoingDownloadTask?.cancel()
+        ongoingDownloadTask = CoroutineScope(backgroundCoroutineDispatcher).async {
+          // TODO(#5950): Replace with actual logic to force-download remote parameters.
+          oppiaLogger.d("PlatformParameterController", "Download finished successfully.")
+        }
+      }
+      ongoingDownloadTask?.await()
+      return@createInMemoryDataProviderAsync AsyncResult.Success(Unit)
     }
   }
 

--- a/domain/src/test/java/org/oppia/android/domain/devoptions/ForceDownloadRemoteParametersControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/devoptions/ForceDownloadRemoteParametersControllerTest.kt
@@ -67,6 +67,18 @@ class ForceDownloadRemoteParametersControllerTest {
     assertThat(result).isEqualTo(true)
   }
 
+  @Test
+  fun testDownloadRemoteParameters_secondInvocation_returnsSameInstance() {
+    setUpTestApplicationComponent()
+
+    val firstProvider = forceDownloadRemoteParametersController.downloadRemoteParameters()
+    val secondProvider = forceDownloadRemoteParametersController.downloadRemoteParameters()
+    testCoroutineDispatchers.runCurrent()
+
+    // Multiple calls to downloadRemoteParameters() should yield the same DataProvider instance.
+    assertThat(secondProvider).isEqualTo(firstProvider)
+  }
+
   private fun setUpTestApplicationComponent() {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }

--- a/domain/src/test/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImplTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImplTest.kt
@@ -1138,6 +1138,19 @@ class PlatformParameterControllerDebugImplTest {
     assertThat(ephemeralNewUiFlag?.currentValue)
       .isEqualTo(TEST_REMOTE_MULTIPLE_CLASSROOMS)
   }
+
+  @Test
+  fun testDownloadRemoteParameters_withMultipleProviders_isOfSameInstance() {
+    setUpTestApplicationComponent()
+    testCoroutineDispatchers.runCurrent()
+
+    val firstProvider = platformParameterControllerDebugImpl.downloadRemoteParameters()
+    val secondProvider = platformParameterControllerDebugImpl.downloadRemoteParameters()
+    testCoroutineDispatchers.runCurrent()
+
+    assertThat(secondProvider).isSameInstanceAs(firstProvider)
+  }
+
   // Populates the remote DB with test feature flag for MULTIPLE_CLASSROOMS.
   private fun addTestRemoteFeatureFlagToDatabase(
     component: TestApplicationComponent,

--- a/domain/src/test/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImplTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImplTest.kt
@@ -1140,15 +1140,15 @@ class PlatformParameterControllerDebugImplTest {
   }
 
   @Test
-  fun testDownloadRemoteParameters_withMultipleProviders_isOfSameInstance() {
+  fun testDownloadRemoteParameters_secondInvocation_returnsSameInstance() {
     setUpTestApplicationComponent()
-    testCoroutineDispatchers.runCurrent()
 
     val firstProvider = platformParameterControllerDebugImpl.downloadRemoteParameters()
     val secondProvider = platformParameterControllerDebugImpl.downloadRemoteParameters()
     testCoroutineDispatchers.runCurrent()
 
-    assertThat(secondProvider).isSameInstanceAs(firstProvider)
+    // Multiple calls to downloadRemoteParameters() should yield the same DataProvider instance.
+    assertThat(secondProvider).isEqualTo(firstProvider)
   }
 
   // Populates the remote DB with test feature flag for MULTIPLE_CLASSROOMS.


### PR DESCRIPTION
Fixes part of #5345:
This pull request updates the logic for downloading remote platform parameters in `PlatformParameterControllerDebugImpl`. The main change is that logging for the download process now only occurs when a new download is actually initiated, and not every time the method is called.

Improvements to download logic and logging:

* In `PlatformParameterControllerDebugImpl.kt`, changed the placement of logging statements so that "Calling Force Download of remote parameters" and "Download finished successfully." are logged only when a new download task is started, preventing duplicate logs when a download is already in progress.
Added a check :
```kotlin
   if (ongoingDownloadTask == null || ongoingDownloadTask?.isCancelled == true) {
```
To simulate actual download behaviour and verify that on config change download doesn't restarts please repalace:
```
 // TODO(#5950): Replace with actual logic to force-download remote parameters.
```
with

```kotlin
delay(3000)
```
#### Evaluation Points:

1. Rotating the device while the downloads dialog is open and actively downloading does not causes it to restart the call from scratch. [Video](https://github.com/user-attachments/assets/40aa156d-240f-4ae7-85c9-8538db102700)
2. Rotating the device when the ‘successfully downloaded’ dialog is open does not causes the download to start again.
[Video](https://github.com/user-attachments/assets/728c30b2-16c8-476b-9063-7571b63f96c4)



</div></b>

#### Screenrecording:

##### Before

[Screencast from 2025-09-09 14-46-31.webm](https://github.com/user-attachments/assets/40aa156d-240f-4ae7-85c9-8538db102700)

##### After

[Screencast from 2025-09-09 09-42-16.webm](https://github.com/user-attachments/assets/95c4dd7a-6098-453f-a94e-6a4ebdb4afe8)



## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).