### PR TITLE
Fixes #5967: Changed the test naming to more relevent in PlatformParameterControllerDebugImplTest.

### DIFF
--- a/domain/src/test/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImplTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImplTest.kt
@@ -406,7 +406,7 @@ class PlatformParameterControllerDebugImplTest {
   }
 
   @Test
-  fun testLoadEphemeralFeatureFlags_withOverrideAndNoRemote_returnsDefaultNonOverriddenValue() {
+  fun testLoadEphemeralFeatureFlags_withOverrideAndNoRemote_returnsDefaultForNonOverriddenValue() {
     TestPlatformParameterModule.forceEnableMultipleClassrooms(false)
     executeInPreviousAppInstance { testComponent ->
       addTestOverriddenFeatureFlagToDatabase(testComponent, true)
@@ -490,7 +490,7 @@ class PlatformParameterControllerDebugImplTest {
   }
 
   @Test
-  fun testLoadEphemeralFeatureFlags_withLocalOverrideAndRemote_returnsRemoteNonOverriddenValue() {
+  fun testLoadEphemeralFeatureFlags_withLocalOverrideAndRemote_returnRemoteForNonOverriddenValue() {
     TestPlatformParameterModule.forceEnableMultipleClassrooms(false)
     executeInPreviousAppInstance { testComponent ->
       addTestRemoteFeatureFlagToDatabase(testComponent, true)


### PR DESCRIPTION
Fixes #5967:
This pull request makes minor improvements to test method names in the `PlatformParameterControllerDebugImplTest` class to clarify their expected behaviors.

* Renamed test method to clarify that the default value is returned for non-overridden platform parameters when only an override exists and no remote value is present (`testLoadEphemeralFeatureFlags_withOverrideAndNoRemote_returnsDefaultForNonOverriddenValue`).
* Renamed test method to clarify that the remote value is returned for non-overridden platform parameters when both a local override and remote value exist (`testLoadEphemeralFeatureFlags_withLocalOverrideAndRemote_returnRemoteForNonOverriddenValue`).

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).