### PR TITLE
Fix #5784: Standardize audio and app language list ordering

### DIFF
--- a/app/src/main/java/org/oppia/android/app/options/AppLanguageSelectionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AppLanguageSelectionViewModel.kt
@@ -40,7 +40,8 @@ class AppLanguageSelectionViewModel @Inject constructor(
       is AsyncResult.Success -> {
         val sortedLanguages = asyncResultAppLanguageListData.value.sortedWith(
           compareBy<OppiaLanguage> { it != OppiaLanguage.ENGLISH }
-            .thenBy { appLanguageResourceHandler.computeLocalizedDisplayName(it) })
+            .thenBy { appLanguageResourceHandler.computeLocalizedDisplayName(it) }
+        )
 
         sortedLanguages.map {
           AppLanguageItemViewModel(

--- a/app/src/main/java/org/oppia/android/app/options/AppLanguageSelectionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AppLanguageSelectionViewModel.kt
@@ -38,7 +38,11 @@ class AppLanguageSelectionViewModel @Inject constructor(
   ): List<AppLanguageItemViewModel> {
     return when (asyncResultAppLanguageListData) {
       is AsyncResult.Success -> {
-        asyncResultAppLanguageListData.value.map {
+        val sortedLanguages = asyncResultAppLanguageListData.value.sortedWith(
+          compareBy<OppiaLanguage> { it != OppiaLanguage.ENGLISH }
+            .thenBy { appLanguageResourceHandler.computeLocalizedDisplayName(it) })
+
+        sortedLanguages.map {
           AppLanguageItemViewModel(
             it,
             appLanguageResourceHandler.computeLocalizedDisplayName(it),

--- a/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
@@ -54,7 +54,12 @@ class AudioLanguageSelectionViewModel @Inject constructor(
 
   /** The list of [AudioLanguageItemViewModel]s which can be bound to a recycler view. */
   val recyclerViewAudioLanguageList: List<AudioLanguageItemViewModel> by lazy {
-    AudioLanguage.values().filter { it !in IGNORED_AUDIO_LANGUAGES }.map(::createItemViewModel)
+    val languages = AudioLanguage.values().filter { it !in IGNORED_AUDIO_LANGUAGES }
+    val sortedLanguages = languages.sortedWith(
+      compareBy<AudioLanguage> { it != AudioLanguage.ENGLISH_AUDIO_LANGUAGE }
+        .thenBy { appLanguageResourceHandler.computeLocalizedDisplayName(it) }
+    )
+    sortedLanguages.map(::createItemViewModel)
   }
 
   /** Sets the list of audio languages supported by the app based on [OppiaLanguage]. */

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AppLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AppLanguageFragmentTest.kt
@@ -240,6 +240,30 @@ class AppLanguageFragmentTest {
   }
 
   @Test
+  fun testAppLanguage_englishIsFirstThenAlphabetical() {
+    launch(OptionsActivity::class.java).use {
+      it.onActivity { activity ->
+        val fragment = activity.supportFragmentManager
+          .findFragmentByTag(TAG_APP_LANGUAGE_FRAGMENT) as AppLanguageFragment
+        testCoroutineDispatchers.runCurrent()
+        fragment.requireView().requestLayout()
+      }
+      onView(withId(R.id.language_recycler_view))
+        .perform(
+          scrollToPosition<RecyclerView.ViewHolder>(0)
+        ).check(
+          matches(
+            atPositionOnView(
+              0,
+              withText("English"),
+              R.id.language_radio_button
+            )
+          )
+        )
+    }
+  }
+
+  @Test
   fun testFragment_fragmentLoaded_verifyCorrectArgumentsPassed() {
     setUpTestWithOnboardingV2Disabled()
     launch<AppLanguageActivity>(createAppLanguageActivityIntent(OppiaLanguage.ENGLISH))

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AppLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AppLanguageFragmentTest.kt
@@ -5,12 +5,14 @@ import android.content.Context
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onData
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 import androidx.test.espresso.matcher.RootMatchers.withDecorView
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
@@ -114,8 +116,6 @@ import org.robolectric.annotation.LooperMode
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
-import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 
 /** Tests for [AppLanguageFragment]. */
 @RunWith(AndroidJUnit4::class)

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AppLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AppLanguageFragmentTest.kt
@@ -114,6 +114,8 @@ import org.robolectric.annotation.LooperMode
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 
 /** Tests for [AppLanguageFragment]. */
 @RunWith(AndroidJUnit4::class)
@@ -123,8 +125,8 @@ import javax.inject.Singleton
 class AppLanguageFragmentTest {
 
   private companion object {
-    private const val ENGLISH_BUTTON_INDEX = 1
-    private const val KISWAHILI_BUTTON_INDEX = 4
+    private const val ENGLISH_BUTTON_INDEX = 0
+    private const val KISWAHILI_BUTTON_INDEX = 1
     private const val PORTUGUESE_BUTTON_INDEX = 3
 
     private val BRAZIL_PORTUGUESE_LOCALE = Locale("pt", "BR")
@@ -241,25 +243,69 @@ class AppLanguageFragmentTest {
 
   @Test
   fun testAppLanguage_englishIsFirstThenAlphabetical() {
-    launch(OptionsActivity::class.java).use {
-      it.onActivity { activity ->
-        val fragment = activity.supportFragmentManager
-          .findFragmentByTag(TAG_APP_LANGUAGE_FRAGMENT) as AppLanguageFragment
-        testCoroutineDispatchers.runCurrent()
-        fragment.requireView().requestLayout()
-      }
+    setUpTestWithOnboardingV2Disabled()
+    launch<AppLanguageActivity>(createAppLanguageActivityIntent(OppiaLanguage.ENGLISH)).use {
+      testCoroutineDispatchers.runCurrent()
+
       onView(withId(R.id.language_recycler_view))
-        .perform(
-          scrollToPosition<RecyclerView.ViewHolder>(0)
-        ).check(
-          matches(
-            atPositionOnView(
-              0,
-              withText("English"),
-              R.id.language_radio_button
-            )
-          )
+        .perform(scrollToPosition<RecyclerView.ViewHolder>(0))
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.language_recycler_view,
+          position = 0,
+          targetViewId = R.id.language_text_view
         )
+      ).check(matches(withText("English")))
+
+      onView(withId(R.id.language_recycler_view))
+        .perform(scrollToPosition<RecyclerView.ViewHolder>(1))
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.language_recycler_view,
+          position = 1,
+          targetViewId = R.id.language_text_view
+        )
+      ).check(matches(withText("Kiswahili")))
+
+      onView(withId(R.id.language_recycler_view))
+        .perform(scrollToPosition<RecyclerView.ViewHolder>(2))
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.language_recycler_view,
+          position = 2,
+          targetViewId = R.id.language_text_view
+        )
+      ).check(matches(withText("Naijá")))
+
+      onView(withId(R.id.language_recycler_view))
+        .perform(scrollToPosition<RecyclerView.ViewHolder>(3))
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.language_recycler_view,
+          position = 3,
+          targetViewId = R.id.language_text_view
+        )
+      ).check(matches(withText("Português")))
+
+      onView(withId(R.id.language_recycler_view))
+        .perform(scrollToPosition<RecyclerView.ViewHolder>(4))
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.language_recycler_view,
+          position = 4,
+          targetViewId = R.id.language_text_view
+        )
+      ).check(matches(withText("العربية")))
+
+      onView(withId(R.id.language_recycler_view))
+        .perform(scrollToPosition<RecyclerView.ViewHolder>(5))
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.language_recycler_view,
+          position = 5,
+          targetViewId = R.id.language_text_view
+        )
+      ).check(matches(withText("हिन्दी")))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
@@ -3,6 +3,7 @@ package org.oppia.android.app.options
 import android.app.Application
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
@@ -12,6 +13,7 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.pressBack
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
@@ -123,8 +125,6 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
-import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 
 /** Tests for [AudioLanguageFragment]. */
 // Function name: test names are conventionally named with underscores.

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
@@ -123,6 +123,8 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
 import javax.inject.Singleton
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 
 /** Tests for [AudioLanguageFragment]. */
 // Function name: test names are conventionally named with underscores.
@@ -133,8 +135,8 @@ import javax.inject.Singleton
 class AudioLanguageFragmentTest {
   private companion object {
     private const val ENGLISH_BUTTON_INDEX = 0
+    private const val NIGERIAN_PIDGIN_BUTTON_INDEX = 1
     private const val PORTUGUESE_BUTTON_INDEX = 2
-    private const val NIGERIAN_PIDGIN_BUTTON_INDEX = 4
   }
 
   @get:Rule
@@ -249,31 +251,59 @@ class AudioLanguageFragmentTest {
 
   @Test
   fun testAudioLanguage_englishIsFirstThenAlphabetical() {
-    topicController.getTopic(
-      ProfileId.newBuilder().setInternalId(0).build(),
-      TEST_TOPIC_ID_0
-    ).observeForever(mockTopicLiveDataObserver)
-    testCoroutineDispatchers.runCurrent()
-
-    launch<OptionsActivity>(
-      createAudioLanguageActivityIntent(
-        profileId.internalId,
-        TEST_TOPIC_ID_0
-      )
-    ).use {
+    initializeTestApplicationComponent(enableOnboardingFlowV2 = false)
+    launchActivityWithLanguage(ENGLISH_AUDIO_LANGUAGE).use {
       testCoroutineDispatchers.runCurrent()
-      onView(withId(R.id.language_recycler_view))
-        .perform(
-          scrollToPosition<RecyclerView.ViewHolder>(0)
-        ).check(
-          matches(
-            atPositionOnView(
-              0,
-              withText("English"),
-              R.id.language_radio_button
-            )
-          )
+
+      onView(withId(R.id.audio_language_recycler_view))
+        .perform(scrollToPosition<RecyclerView.ViewHolder>(0))
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.audio_language_recycler_view,
+          position = 0,
+          targetViewId = R.id.language_text_view
         )
+      ).check(matches(withText("English")))
+
+      onView(withId(R.id.audio_language_recycler_view))
+        .perform(scrollToPosition<RecyclerView.ViewHolder>(1))
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.audio_language_recycler_view,
+          position = 1,
+          targetViewId = R.id.language_text_view
+        )
+      ).check(matches(withText("Naijá")))
+
+      onView(withId(R.id.audio_language_recycler_view))
+        .perform(scrollToPosition<RecyclerView.ViewHolder>(2))
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.audio_language_recycler_view,
+          position = 2,
+          targetViewId = R.id.language_text_view
+        )
+      ).check(matches(withText("Português")))
+
+      onView(withId(R.id.audio_language_recycler_view))
+        .perform(scrollToPosition<RecyclerView.ViewHolder>(3))
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.audio_language_recycler_view,
+          position = 3,
+          targetViewId = R.id.language_text_view
+        )
+      ).check(matches(withText("العربية")))
+
+      onView(withId(R.id.audio_language_recycler_view))
+        .perform(scrollToPosition<RecyclerView.ViewHolder>(4))
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.audio_language_recycler_view,
+          position = 4,
+          targetViewId = R.id.language_text_view
+        )
+      ).check(matches(withText("हिन्दी")))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
@@ -248,6 +248,36 @@ class AudioLanguageFragmentTest {
   }
 
   @Test
+  fun testAudioLanguage_englishIsFirstThenAlphabetical() {
+    topicController.getTopic(
+      ProfileId.newBuilder().setInternalId(0).build(),
+      TEST_TOPIC_ID_0
+    ).observeForever(mockTopicLiveDataObserver)
+    testCoroutineDispatchers.runCurrent()
+
+    launch<OptionsActivity>(
+      createAudioLanguageActivityIntent(
+        profileId.internalId,
+        TEST_TOPIC_ID_0
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(withId(R.id.language_recycler_view))
+        .perform(
+          scrollToPosition<RecyclerView.ViewHolder>(0)
+        ).check(
+          matches(
+            atPositionOnView(
+              0,
+              withText("English"),
+              R.id.language_radio_button
+            )
+          )
+        )
+    }
+  }
+
+  @Test
   fun testAudioLanguage_onboardingV2Enabled_allViewsAreDisplayed() {
     launchV2FlowWithLanguage(ENGLISH_AUDIO_LANGUAGE, LEARNER_INTRO_SCREEN).use {
       onView(withId(R.id.audio_language_text)).check(


### PR DESCRIPTION
## Explanation
Fix #5784 

Before, the list of text and audio languages was bad sorted, so, as was proposed, I sorted the languages in alphabetic form, excluding the English from that sort and applying that as the first language.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only

| Before (Inconsistent Sort) | After (Standardized Sort) |
| :--- | :--- |
| [Video](https://github.com/user-attachments/assets/1f9704cc-40f1-47f5-aa65-65dc36bc53fe) | [Video](https://github.com/user-attachments/assets/3b8d0539-cda9-4fcd-9387-9092a8123115) |