### PR TITLE
Fix #5440: Change ProfileId defaulting to be an invalid profile

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
@@ -117,7 +117,10 @@ class StateFragmentPresenter @Inject constructor(
     explorationId: String,
     userAnswerState: UserAnswerState
   ): View? {
-    profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
+    profileId = ProfileId.newBuilder().apply {
+      if (internalProfileId != -1) internalId = internalProfileId
+      else loggedOut = true
+    }.build()
     this.topicId = topicId
     this.storyId = storyId
     this.explorationId = explorationId
@@ -307,10 +310,17 @@ class StateFragmentPresenter @Inject constructor(
   }
 
   private fun getAudioUiManager(): AudioUiManager? {
-    if (getAudioFragment() == null) {
-      val audioFragment: AudioFragment = AudioFragment.newInstance(profileId.internalId)
-      fragment.childFragmentManager.beginTransaction()
-        .add(R.id.audio_fragment_placeholder, audioFragment, TAG_AUDIO_FRAGMENT).commitNow()
+    when (profileId.typeCase) {
+      ProfileId.TypeCase.INTERNAL_ID -> {
+        if (getAudioFragment() == null) {
+          val audioFragment: AudioFragment = AudioFragment.newInstance(profileId.internalId)
+          fragment.childFragmentManager.beginTransaction()
+            .add(R.id.audio_fragment_placeholder, audioFragment, TAG_AUDIO_FRAGMENT).commitNow()
+        }
+      }
+      ProfileId.TypeCase.LOGGED_OUT,
+      ProfileId.TypeCase.TYPE_NOT_SET -> return null
+      else -> return null
     }
     return getAudioFragment() as? AudioUiManager
   }

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -129,11 +129,15 @@ message ProfileAvatar {
 
 // Opaque data structure to pass ID.
 message ProfileId {
-  /**
-   * Unique ID used to identify a single profile.
-   * Should not be used directory outside of the profile system.
-   */
-  int32 internal_id = 1;
+  reserved 1;
+  oneof type {
+    // Unique ID used to identify a single profile.
+    // Should not be used directory outside of the profile system.
+    int32 internal_id = 2;
+
+    // Indicates the user is logged out.
+    bool logged_out = 3;
+  }
 }
 
 // Used in BindableAdapter for ProfileChooserFragment.


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix #5440 : Change ProfileId defaulting to be an invalid profile

- changed profile id proto.
- changed use of profileid in org.oppia.android.app.player.state

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
