### PR TITLE
Fix #5981: Option Screen goes blank when user select the preferred audio language as Hindi

### DIFF
--- a/app/src/main/java/org/oppia/android/app/onboarding/AudioLanguageFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/AudioLanguageFragmentPresenter.kt
@@ -175,7 +175,10 @@ class AudioLanguageFragmentPresenter @Inject constructor(
         when (result) {
           is AsyncResult.Success -> {
             if (parentScreen == ParentScreen.OPTIONS_SCREEN) {
-              updateAudioLanguage(getAudioLanguageFromOppiaLanguage(selectedLanguage))
+              updateAudioLanguage(
+                audioLanguageSelectionViewModel
+                  .getAudioLanguageFromOppiaLanguage(selectedLanguage)
+              )
             }
           }
           is AsyncResult.Failure ->
@@ -196,18 +199,6 @@ class AudioLanguageFragmentPresenter @Inject constructor(
         parentActivity.optionActivityPresenter.updateAudioLanguage(audioLanguage)
       is AudioLanguageActivity ->
         parentActivity.audioLanguageActivityPresenter.setLanguageSelected(audioLanguage)
-    }
-  }
-
-  private fun getAudioLanguageFromOppiaLanguage(oppiaLanguage: OppiaLanguage): AudioLanguage {
-    return when (oppiaLanguage) {
-      OppiaLanguage.UNRECOGNIZED, OppiaLanguage.LANGUAGE_UNSPECIFIED, OppiaLanguage.HINGLISH,
-      OppiaLanguage.PORTUGUESE, OppiaLanguage.SWAHILI -> AudioLanguage.AUDIO_LANGUAGE_UNSPECIFIED
-      OppiaLanguage.ARABIC -> AudioLanguage.ARABIC_LANGUAGE
-      OppiaLanguage.ENGLISH -> AudioLanguage.ENGLISH_AUDIO_LANGUAGE
-      OppiaLanguage.HINDI -> AudioLanguage.HINDI_AUDIO_LANGUAGE
-      OppiaLanguage.BRAZILIAN_PORTUGUESE -> AudioLanguage.BRAZILIAN_PORTUGUESE_LANGUAGE
-      OppiaLanguage.NIGERIAN_PIDGIN -> AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE
     }
   }
 

--- a/app/src/main/java/org/oppia/android/app/options/AudioLanguageFragmentPresenterV1.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AudioLanguageFragmentPresenterV1.kt
@@ -7,7 +7,6 @@ import androidx.fragment.app.Fragment
 import org.oppia.android.app.databinding.databinding.AudioLanguageFragmentBinding
 import org.oppia.android.app.databinding.databinding.AudioLanguageItemBinding
 import org.oppia.android.app.model.AudioLanguage
-import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.recyclerview.BindableAdapter
 import javax.inject.Inject
 
@@ -26,24 +25,6 @@ class AudioLanguageFragmentPresenterV1 @Inject constructor(
     container: ViewGroup?,
     audioLanguage: AudioLanguage
   ): View {
-
-    audioLanguageSelectionViewModel.supportedOppiaLanguagesLiveData.observe(
-      fragment,
-      { languages ->
-        val supportedAudioLanguages = languages.filter { language ->
-          when (language) {
-            OppiaLanguage.UNRECOGNIZED,
-            OppiaLanguage.LANGUAGE_UNSPECIFIED,
-            OppiaLanguage.HINGLISH,
-            OppiaLanguage.PORTUGUESE,
-            OppiaLanguage.SWAHILI -> false
-            else -> true
-          }
-        }
-        audioLanguageSelectionViewModel.setSupportedAudioLanguages(supportedAudioLanguages)
-      }
-    )
-
     return AudioLanguageFragmentBinding.inflate(
       inflater,
       container,

--- a/app/src/main/java/org/oppia/android/app/options/AudioLanguageFragmentPresenterV1.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AudioLanguageFragmentPresenterV1.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.Fragment
 import org.oppia.android.app.databinding.databinding.AudioLanguageFragmentBinding
 import org.oppia.android.app.databinding.databinding.AudioLanguageItemBinding
 import org.oppia.android.app.model.AudioLanguage
+import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.recyclerview.BindableAdapter
 import javax.inject.Inject
 
@@ -25,6 +26,24 @@ class AudioLanguageFragmentPresenterV1 @Inject constructor(
     container: ViewGroup?,
     audioLanguage: AudioLanguage
   ): View {
+
+    audioLanguageSelectionViewModel.supportedOppiaLanguagesLiveData.observe(
+      fragment,
+      { languages ->
+        val supportedAudioLanguages = languages.filter { language ->
+          when (language) {
+            OppiaLanguage.UNRECOGNIZED,
+            OppiaLanguage.LANGUAGE_UNSPECIFIED,
+            OppiaLanguage.HINGLISH,
+            OppiaLanguage.PORTUGUESE,
+            OppiaLanguage.SWAHILI -> false
+            else -> true
+          }
+        }
+        audioLanguageSelectionViewModel.setSupportedAudioLanguages(supportedAudioLanguages)
+      }
+    )
+
     return AudioLanguageFragmentBinding.inflate(
       inflater,
       container,

--- a/app/src/main/java/org/oppia/android/app/options/AudioLanguageFragmentPresenterV1.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AudioLanguageFragmentPresenterV1.kt
@@ -33,6 +33,7 @@ class AudioLanguageFragmentPresenterV1 @Inject constructor(
       audioLanguageSelectionViewModel.selectedLanguage.value = audioLanguage
       audioLanguageRecyclerView.apply {
         viewModel = audioLanguageSelectionViewModel
+        lifecycleOwner = fragment
         adapter = createRecyclerViewAdapter()
       }
     }.root

--- a/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
@@ -27,6 +27,7 @@ class AudioLanguageSelectionViewModel @Inject constructor(
   private val oppiaLogger: OppiaLogger
 ) : ObservableViewModel() {
   private lateinit var profileId: ProfileId
+  private lateinit var supportedAudioLanguages: List<OppiaLanguage>
 
   /** An [ObservableField] to bind the resolved audio language to the dropdown text. */
   val selectedAudioLanguage = ObservableField(OppiaLanguage.LANGUAGE_UNSPECIFIED)
@@ -52,16 +53,6 @@ class AudioLanguageSelectionViewModel @Inject constructor(
   /** The [AudioLanguage] currently selected in the radio button list. */
   val selectedLanguage = MutableLiveData<AudioLanguage>()
 
-  /** The list of [AudioLanguageItemViewModel]s which can be bound to a recycler view. */
-  val recyclerViewAudioLanguageList: List<AudioLanguageItemViewModel> by lazy {
-    val languages = AudioLanguage.values().filter { it !in IGNORED_AUDIO_LANGUAGES }
-    val sortedLanguages = languages.sortedWith(
-      compareBy<AudioLanguage> { it != AudioLanguage.ENGLISH_AUDIO_LANGUAGE }
-        .thenBy { appLanguageResourceHandler.computeLocalizedDisplayName(it) }
-    )
-    sortedLanguages.map(::createItemViewModel)
-  }
-
   /** Sets the list of audio languages supported by the app based on [OppiaLanguage]. */
   val supportedOppiaLanguagesLiveData: LiveData<List<OppiaLanguage>> by lazy {
     Transformations.map(
@@ -82,6 +73,19 @@ class AudioLanguageSelectionViewModel @Inject constructor(
     }
   }
 
+  /** The list of [AudioLanguageItemViewModel]s which can be bound to a recycler view. */
+  val recyclerViewAudioLanguageList: List<AudioLanguageItemViewModel> by lazy {
+    val sortedLanguages = supportedAudioLanguages
+      .sortedWith(
+        compareBy<OppiaLanguage> { it != OppiaLanguage.ENGLISH }
+          .thenBy { appLanguageResourceHandler.computeLocalizedDisplayName(it) }
+      )
+
+    sortedLanguages
+      .map { getAudioLanguageFromOppiaLanguage(it) }
+      .map(::createItemViewModel)
+  }
+
   private val languagePreselectionProvider: DataProvider<OppiaLanguage> by lazy {
     translationController.getAudioLanguagePreselection(profileId)
   }
@@ -89,6 +93,24 @@ class AudioLanguageSelectionViewModel @Inject constructor(
   /** Receives and sets the current profileId in this viewModel. */
   fun updateProfileId(profileId: ProfileId) {
     this.profileId = profileId
+  }
+
+  /** Maps an [OppiaLanguage] to an [AudioLanguage]. */
+  fun getAudioLanguageFromOppiaLanguage(oppiaLanguage: OppiaLanguage): AudioLanguage {
+    return when (oppiaLanguage) {
+      OppiaLanguage.UNRECOGNIZED, OppiaLanguage.LANGUAGE_UNSPECIFIED, OppiaLanguage.HINGLISH,
+      OppiaLanguage.PORTUGUESE, OppiaLanguage.SWAHILI -> AudioLanguage.AUDIO_LANGUAGE_UNSPECIFIED
+      OppiaLanguage.ARABIC -> AudioLanguage.ARABIC_LANGUAGE
+      OppiaLanguage.ENGLISH -> AudioLanguage.ENGLISH_AUDIO_LANGUAGE
+      OppiaLanguage.HINDI -> AudioLanguage.HINDI_AUDIO_LANGUAGE
+      OppiaLanguage.BRAZILIAN_PORTUGUESE -> AudioLanguage.BRAZILIAN_PORTUGUESE_LANGUAGE
+      OppiaLanguage.NIGERIAN_PIDGIN -> AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE
+    }
+  }
+
+  /** Sets the list of audio languages supported by the app. */
+  fun setSupportedAudioLanguages(languages: List<OppiaLanguage>) {
+    this.supportedAudioLanguages = languages
   }
 
   private fun createItemViewModel(language: AudioLanguage): AudioLanguageItemViewModel {

--- a/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
@@ -54,11 +54,11 @@ class AudioLanguageSelectionViewModel @Inject constructor(
 
   /** Sets the list of audio languages supported by the app based on [OppiaLanguage]. */
   // TODO(#6020): Replace getSupportedAppLanguages with an audio languages specific API.
-  val supportedOppiaLanguagesLiveData: LiveData<List<OppiaLanguage>> by lazy {
+  val supportedOppiaLanguagesLiveData: LiveData<List<OppiaLanguage>> =
     Transformations.map(
       translationController.getSupportedAppLanguages().toLiveData()
     ) { supportedLanguagesResult ->
-      return@map when (supportedLanguagesResult) {
+      when (supportedLanguagesResult) {
         is AsyncResult.Failure -> {
           oppiaLogger.e(
             "AudioLanguageFragment",
@@ -71,7 +71,6 @@ class AudioLanguageSelectionViewModel @Inject constructor(
         is AsyncResult.Success -> supportedLanguagesResult.value
       }
     }
-  }
 
   /** The list of [AudioLanguageItemViewModel]s which can be bound to a recycler view. */
   val recyclerViewAudioLanguageList: LiveData<List<AudioLanguageItemViewModel>> =

--- a/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
@@ -10,6 +10,7 @@ import org.oppia.android.app.model.AudioLanguage
 import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.translation.AppLanguageResourceHandler
+import org.oppia.android.app.viewmodel.ObservableArrayList
 import org.oppia.android.app.viewmodel.ObservableViewModel
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.translation.TranslationController
@@ -74,17 +75,30 @@ class AudioLanguageSelectionViewModel @Inject constructor(
   }
 
   /** The list of [AudioLanguageItemViewModel]s which can be bound to a recycler view. */
-  val recyclerViewAudioLanguageList: List<AudioLanguageItemViewModel> by lazy {
-    val sortedLanguages = supportedAudioLanguages
-      .sortedWith(
+  val recyclerViewAudioLanguageList: ObservableArrayList<AudioLanguageItemViewModel>
+    get() = _recyclerViewAudioLanguageList
+
+  init {
+    supportedOppiaLanguagesLiveData.observeForever { languages ->
+      val sortedLanguages = (languages ?: emptyList()).sortedWith(
         compareBy<OppiaLanguage> { it != OppiaLanguage.ENGLISH }
           .thenBy { appLanguageResourceHandler.computeLocalizedDisplayName(it) }
       )
 
-    sortedLanguages
-      .map { getAudioLanguageFromOppiaLanguage(it) }
-      .map(::createItemViewModel)
+      _recyclerViewAudioLanguageList.apply {
+        clear()
+        addAll(
+          sortedLanguages
+            .map(::getAudioLanguageFromOppiaLanguage)
+            .filter { it !in IGNORED_AUDIO_LANGUAGES }
+            .map(::createItemViewModel)
+        )
+      }
+    }
   }
+
+  private val _recyclerViewAudioLanguageList =
+    ObservableArrayList<AudioLanguageItemViewModel>()
 
   private val languagePreselectionProvider: DataProvider<OppiaLanguage> by lazy {
     translationController.getAudioLanguagePreselection(profileId)
@@ -106,11 +120,6 @@ class AudioLanguageSelectionViewModel @Inject constructor(
       OppiaLanguage.BRAZILIAN_PORTUGUESE -> AudioLanguage.BRAZILIAN_PORTUGUESE_LANGUAGE
       OppiaLanguage.NIGERIAN_PIDGIN -> AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE
     }
-  }
-
-  /** Sets the list of audio languages supported by the app. */
-  fun setSupportedAudioLanguages(languages: List<OppiaLanguage>) {
-    this.supportedAudioLanguages = languages
   }
 
   private fun createItemViewModel(language: AudioLanguage): AudioLanguageItemViewModel {

--- a/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
@@ -10,7 +10,6 @@ import org.oppia.android.app.model.AudioLanguage
 import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.translation.AppLanguageResourceHandler
-import org.oppia.android.app.viewmodel.ObservableArrayList
 import org.oppia.android.app.viewmodel.ObservableViewModel
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.translation.TranslationController
@@ -28,7 +27,6 @@ class AudioLanguageSelectionViewModel @Inject constructor(
   private val oppiaLogger: OppiaLogger
 ) : ObservableViewModel() {
   private lateinit var profileId: ProfileId
-  private lateinit var supportedAudioLanguages: List<OppiaLanguage>
 
   /** An [ObservableField] to bind the resolved audio language to the dropdown text. */
   val selectedAudioLanguage = ObservableField(OppiaLanguage.LANGUAGE_UNSPECIFIED)
@@ -75,30 +73,20 @@ class AudioLanguageSelectionViewModel @Inject constructor(
   }
 
   /** The list of [AudioLanguageItemViewModel]s which can be bound to a recycler view. */
-  val recyclerViewAudioLanguageList: ObservableArrayList<AudioLanguageItemViewModel>
-    get() = _recyclerViewAudioLanguageList
-
-  init {
-    supportedOppiaLanguagesLiveData.observeForever { languages ->
-      val sortedLanguages = (languages ?: emptyList()).sortedWith(
+  val recyclerViewAudioLanguageList: LiveData<List<AudioLanguageItemViewModel>> =
+    Transformations.map(supportedOppiaLanguagesLiveData) { languages ->
+      // Order starting with English in the list, then alphabetically by the localized name of the
+      // language to match what is done by the Android OS.
+      val sortedLanguages = languages.sortedWith(
         compareBy<OppiaLanguage> { it != OppiaLanguage.ENGLISH }
           .thenBy { appLanguageResourceHandler.computeLocalizedDisplayName(it) }
       )
 
-      _recyclerViewAudioLanguageList.apply {
-        clear()
-        addAll(
-          sortedLanguages
-            .map(::getAudioLanguageFromOppiaLanguage)
-            .filter { it !in IGNORED_AUDIO_LANGUAGES }
-            .map(::createItemViewModel)
-        )
-      }
+      sortedLanguages
+        .map(::getAudioLanguageFromOppiaLanguage)
+        .filter { it !in IGNORED_AUDIO_LANGUAGES }
+        .map(::createItemViewModel)
     }
-  }
-
-  private val _recyclerViewAudioLanguageList =
-    ObservableArrayList<AudioLanguageItemViewModel>()
 
   private val languagePreselectionProvider: DataProvider<OppiaLanguage> by lazy {
     translationController.getAudioLanguagePreselection(profileId)

--- a/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
@@ -53,6 +53,7 @@ class AudioLanguageSelectionViewModel @Inject constructor(
   val selectedLanguage = MutableLiveData<AudioLanguage>()
 
   /** Sets the list of audio languages supported by the app based on [OppiaLanguage]. */
+  // TODO(#6020): Replace getSupportedAppLanguages with an audio languages specific API.
   val supportedOppiaLanguagesLiveData: LiveData<List<OppiaLanguage>> by lazy {
     Transformations.map(
       translationController.getSupportedAppLanguages().toLiveData()

--- a/app/src/main/res/layout-sw600dp/audio_language_fragment.xml
+++ b/app/src/main/res/layout-sw600dp/audio_language_fragment.xml
@@ -18,5 +18,5 @@
     android:paddingBottom="@dimen/audio_language_recycler_view_padding_bottom"
     android:scrollbars="none"
     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-    app:list="@{viewModel.recyclerViewAudioLanguageList}" />
+    app:data="@{viewModel.recyclerViewAudioLanguageList}" />
 </layout>

--- a/app/src/main/res/layout/audio_language_fragment.xml
+++ b/app/src/main/res/layout/audio_language_fragment.xml
@@ -22,7 +22,7 @@
       android:paddingBottom="@dimen/audio_language_recycler_view_padding_bottom"
       android:scrollbars="none"
       app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-      app:list="@{viewModel.recyclerViewAudioLanguageList}" />
+      app:data="@{viewModel.recyclerViewAudioLanguageList}" />
 
     <View
       android:id="@+id/toolbar_shadow_view"

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
@@ -133,6 +133,8 @@ import javax.inject.Singleton
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(application = AudioLanguageFragmentTest.TestApplication::class)
 class AudioLanguageFragmentTest {
+  // TODO(#6022): Add tests for validating that when an unsupported language was previously
+  //  selected, it goes back to English
   private companion object {
     private const val ENGLISH_BUTTON_INDEX = 0
     private const val NIGERIAN_PIDGIN_BUTTON_INDEX = 1

--- a/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
@@ -297,6 +297,7 @@ class TranslationController @Inject constructor(
   fun getAudioTranslationContentLocale(
     profileId: ProfileId
   ): DataProvider<OppiaLocale.ContentLocale> {
+    // TODO(#6020): Replace getSupportedAppLanguages with an audio languages specific API.
     val resolvedLanguageProvider =
       getAudioTranslationContentLanguageSelection(profileId).combineWith(
         getSupportedAppLanguages(), SUPPORTED_AUDIO_LANGUAGES_DATA_PROVIDER_ID

--- a/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
@@ -3,6 +3,7 @@ package org.oppia.android.domain.translation
 import com.google.protobuf.MessageLite
 import org.oppia.android.app.model.AppLanguageSelection
 import org.oppia.android.app.model.AudioTranslationLanguageSelection
+import org.oppia.android.app.model.AudioTranslationLanguageSelection.SelectionTypeCase
 import org.oppia.android.app.model.LanguageSupportDefinition
 import org.oppia.android.app.model.LanguageSupportDefinition.LanguageId.LanguageTypeCase.IETF_BCP47_ID
 import org.oppia.android.app.model.LanguageSupportDefinition.LanguageId.LanguageTypeCase.LANGUAGETYPE_NOT_SET
@@ -301,7 +302,9 @@ class TranslationController @Inject constructor(
         getSupportedAppLanguages(), SUPPORTED_AUDIO_LANGUAGES_DATA_PROVIDER_ID
       ) { audioLanguageSelection, supportedAppLanguages ->
         // Before a profile sets an audio language, LANGUAGE_UNSPECIFIED is always returned.
+        // In some cases, a language might not be supported but has a fallback configured.
         if (audioLanguageSelection.selectedLanguage in supportedAppLanguages ||
+          audioLanguageSelection.selectionTypeCase == SelectionTypeCase.USE_APP_LANGUAGE ||
           audioLanguageSelection.selectedLanguage == OppiaLanguage.LANGUAGE_UNSPECIFIED
         ) {
           audioLanguageSelection
@@ -450,10 +453,9 @@ class TranslationController @Inject constructor(
     audioLanguageSelection: AudioTranslationLanguageSelection
   ): LanguageResolutionStatus {
     return when (audioLanguageSelection.selectionTypeCase) {
-      AudioTranslationLanguageSelection.SelectionTypeCase.SELECTED_LANGUAGE ->
+      SelectionTypeCase.SELECTED_LANGUAGE ->
         LanguageResolutionStatus.Resolved(audioLanguageSelection.selectedLanguage)
-      AudioTranslationLanguageSelection.SelectionTypeCase.USE_APP_LANGUAGE,
-      AudioTranslationLanguageSelection.SelectionTypeCase.SELECTIONTYPE_NOT_SET, null ->
+      SelectionTypeCase.USE_APP_LANGUAGE, SelectionTypeCase.SELECTIONTYPE_NOT_SET, null ->
         computeAppLanguage(appLanguageSelection)
     }
   }

--- a/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
@@ -301,8 +301,9 @@ class TranslationController @Inject constructor(
         getSupportedAppLanguages(), SUPPORTED_AUDIO_LANGUAGES_DATA_PROVIDER_ID
       ) { audioLanguageSelection, supportedAppLanguages ->
         // Before a profile sets an audio language, LANGUAGE_UNSPECIFIED is always returned.
-        if (audioLanguageSelection.selectedLanguage in supportedAppLanguages
-          || audioLanguageSelection.selectedLanguage == OppiaLanguage.LANGUAGE_UNSPECIFIED) {
+        if (audioLanguageSelection.selectedLanguage in supportedAppLanguages ||
+          audioLanguageSelection.selectedLanguage == OppiaLanguage.LANGUAGE_UNSPECIFIED
+        ) {
           audioLanguageSelection
         } else {
           AudioTranslationLanguageSelection.newBuilder()

--- a/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
@@ -51,6 +51,7 @@ private const val AUDIO_TRANSLATION_CONTENT_LANG_RES_DATA_PROVIDER_ID =
   "audio_translation_content_language_resolution"
 private const val AUDIO_TRANSLATION_CONTENT_SELECTION_DATA_PROVIDER_ID =
   "audio_translation_content_selection"
+private const val SUPPORTED_AUDIO_LANGUAGES_DATA_PROVIDER_ID = "supported_audio_languages"
 private const val UPDATE_AUDIO_TRANSLATION_CONTENT_DATA_PROVIDER_ID =
   "update_audio_translation_content"
 private const val PROFILE_AUDIO_LANGUAGE_PROVIDER_ID = "profile_audio_language"
@@ -297,10 +298,23 @@ class TranslationController @Inject constructor(
   ): DataProvider<OppiaLocale.ContentLocale> {
     val resolvedLanguageProvider =
       getAudioTranslationContentLanguageSelection(profileId).combineWith(
-        getAppLanguageSelection(profileId), AUDIO_TRANSLATION_CONTENT_LANG_RES_DATA_PROVIDER_ID
-      ) { audioLanguageSelection, appLanguageSelection ->
-        computeAudioTranslationContentLanguage(appLanguageSelection, audioLanguageSelection)
+        getSupportedAppLanguages(), SUPPORTED_AUDIO_LANGUAGES_DATA_PROVIDER_ID
+      ) { audioLanguageSelection, supportedAppLanguages ->
+        // Before a profile sets an audio language, LANGUAGE_UNSPECIFIED is always returned.
+        if (audioLanguageSelection.selectedLanguage in supportedAppLanguages
+          || audioLanguageSelection.selectedLanguage == OppiaLanguage.LANGUAGE_UNSPECIFIED) {
+          audioLanguageSelection
+        } else {
+          AudioTranslationLanguageSelection.newBuilder()
+            .setSelectedLanguage(OppiaLanguage.ENGLISH)
+            .build()
+        }
       }
+        .combineWith(
+          getAppLanguageSelection(profileId), AUDIO_TRANSLATION_CONTENT_LANG_RES_DATA_PROVIDER_ID
+        ) { audioLanguageSelection, appLanguageSelection ->
+          computeAudioTranslationContentLanguage(appLanguageSelection, audioLanguageSelection)
+        }
     return getSystemLanguage().combineWithAsync(
       resolvedLanguageProvider, AUDIO_TRANSLATION_CONTENT_LOCALE_DATA_PROVIDER_ID
     ) { systemLanguage, resolutionStatus ->

--- a/domain/src/test/java/org/oppia/android/domain/translation/TranslationControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/translation/TranslationControllerTest.kt
@@ -1042,19 +1042,6 @@ class TranslationControllerTest {
   }
 
   @Test
-  fun testGetAudioLanguage_updateLanguageToHinglish_returnsEnglish() {
-    forceDefaultLocale(Locale.ROOT)
-    ensureAudioTranslationsLanguageIsUpdatedTo(PROFILE_ID_0, HINGLISH)
-
-    val languageProvider = translationController.getAudioTranslationContentLanguage(PROFILE_ID_0)
-
-    val language = monitorFactory.waitForNextSuccessfulResult(languageProvider)
-    // Supported languages are [ARABIC, ENGLISH, HINDI, BRAZILIAN_PORTUGUESE, SWAHILI, NIGERIAN_PIDGIN]
-    // Attempting to update to HINGLISH should fall back to ENGLISH
-    assertThat(language).isEqualTo(ENGLISH)
-  }
-
-  @Test
   fun testGetAudioLanguage_updateLanguageToUseApp_returnsAppLanguage() {
     // First, initialize the language to Hindi before overwriting to use the app language.
     ensureAudioTranslationsLanguageIsUpdatedTo(PROFILE_ID_0, HINDI)
@@ -1161,6 +1148,21 @@ class TranslationControllerTest {
     assertThat(context.languageDefinition.language).isEqualTo(BRAZILIAN_PORTUGUESE)
     // This region comes from the default locale.
     assertThat(context.regionDefinition.region).isEqualTo(BRAZIL)
+  }
+
+  @Test
+  fun testGetAudioLocale_updateLanguageToHinglish_returnsEnglishLocale() {
+    forceDefaultLocale(Locale.ROOT)
+    ensureAudioTranslationsLanguageIsUpdatedTo(PROFILE_ID_0, HINGLISH)
+
+    val localeProvider = translationController.getAudioTranslationContentLocale(PROFILE_ID_0)
+
+    val locale = monitorFactory.waitForNextSuccessfulResult(localeProvider)
+    val context = locale.localeContext
+    assertThat(context.usageMode).isEqualTo(AUDIO_TRANSLATIONS)
+    assertThat(context.languageDefinition.language).isEqualTo(ENGLISH)
+    // This region comes from the default locale.
+    assertThat(context.regionDefinition.region).isEqualTo(REGION_UNSPECIFIED)
   }
 
   @Test

--- a/domain/src/test/java/org/oppia/android/domain/translation/TranslationControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/translation/TranslationControllerTest.kt
@@ -25,6 +25,7 @@ import org.oppia.android.app.model.OppiaLanguage.ARABIC
 import org.oppia.android.app.model.OppiaLanguage.BRAZILIAN_PORTUGUESE
 import org.oppia.android.app.model.OppiaLanguage.ENGLISH
 import org.oppia.android.app.model.OppiaLanguage.HINDI
+import org.oppia.android.app.model.OppiaLanguage.HINGLISH
 import org.oppia.android.app.model.OppiaLanguage.LANGUAGE_UNSPECIFIED
 import org.oppia.android.app.model.OppiaLanguage.NIGERIAN_PIDGIN
 import org.oppia.android.app.model.OppiaLanguage.PORTUGUESE
@@ -1038,6 +1039,19 @@ class TranslationControllerTest {
 
     val language = monitorFactory.waitForNextSuccessfulResult(languageProvider)
     assertThat(language).isEqualTo(HINDI)
+  }
+
+  @Test
+  fun testGetAudioLanguage_updateLanguageToHinglish_returnsEnglish() {
+    forceDefaultLocale(Locale.ROOT)
+    ensureAudioTranslationsLanguageIsUpdatedTo(PROFILE_ID_0, HINGLISH)
+
+    val languageProvider = translationController.getAudioTranslationContentLanguage(PROFILE_ID_0)
+
+    val language = monitorFactory.waitForNextSuccessfulResult(languageProvider)
+    // Supported languages are [ARABIC, ENGLISH, HINDI, BRAZILIAN_PORTUGUESE, SWAHILI, NIGERIAN_PIDGIN]
+    // Attempting to update to HINGLISH should fall back to ENGLISH
+    assertThat(language).isEqualTo(ENGLISH)
   }
 
   @Test


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix #5981

The current implementation of the Audio Langauge Selection UI relies on the `AudioLanguage` enum to display a list of ausio langauges. This is problematic because some audio languages are not supported in prod.

This PR changes the supported audio languages list to be displayed to be derived from the supported `OppiaLanguage`s list. This means that the list will vary for dev or prod depending on the definitions in `supported_languages.textproto`.

An in-place migration has also been added in `TranslationController` to help users who had previously selected a language that is now unsupported due to configuration changes, recover gracefully.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing

|Before|After|
|---|---|
|https://github.com/user-attachments/assets/f69cb01b-2bf6-4b97-9990-97e0d3348b9b| https://github.com/user-attachments/assets/fce3e8d7-61d7-49d3-8ea2-2271bc5900c9|






