### PR TITLE
Fix #6004: Submit Button in Admin Auth not Working

### DIFF
--- a/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivity.kt
@@ -28,7 +28,8 @@ class AdminAuthActivity : InjectableSystemLocalizedAppCompatActivity() {
       colorRgb: Int,
       adminPinEnum: Int
     ): Intent {
-      val profileId = ProfileId.newBuilder().apply { this.internalId = internalProfileId }.build()
+      // TODO(#5440): Ensure the ProfileId is valid.
+      val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
       val args = AdminAuthActivityParams.newBuilder().apply {
         this.adminPin = adminPin
         this.colorRgb = colorRgb

--- a/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivityPresenter.kt
@@ -103,12 +103,16 @@ class AdminAuthActivityPresenter @Inject constructor(
             }
           }
           AdminAuthEnum.PROFILE_ADD_PROFILE.value -> {
-            activity.startActivity(
-              AddProfileActivity.createAddProfileActivityIntent(
-                context, args?.colorRgb ?: -10710042
-              )
-            )
-            activity.finish()
+            profileManagementController.loginToProfile(profileId).toLiveData().observe(activity) {
+              if (it is AsyncResult.Success) {
+                activity.startActivity(
+                  AddProfileActivity.createAddProfileActivityIntent(
+                    context, args?.colorRgb ?: -10710042
+                  )
+                )
+                activity.finish()
+              }
+            }
           }
         }
       } else if (inputPin.length == adminPin.length) {

--- a/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivityPresenter.kt
@@ -9,7 +9,6 @@ import org.oppia.android.app.activity.ActivityScope
 import org.oppia.android.app.administratorcontrols.AdministratorControlsActivity
 import org.oppia.android.app.databinding.databinding.AdminAuthActivityBinding
 import org.oppia.android.app.model.AdminAuthActivityParams
-import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.profile.AdminAuthActivity.Companion.ADMIN_AUTH_ACTIVITY_PARAMS_KEY
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.ui.R
@@ -31,7 +30,6 @@ class AdminAuthActivityPresenter @Inject constructor(
   private val profileManagementController: ProfileManagementController,
 ) {
   private lateinit var binding: AdminAuthActivityBinding
-  private var profileId = ProfileId.getDefaultInstance()
   private val args by lazy {
     activity.intent.getProtoExtra(
       ADMIN_AUTH_ACTIVITY_PARAMS_KEY,
@@ -51,7 +49,6 @@ class AdminAuthActivityPresenter @Inject constructor(
     val adminPin = checkNotNull(args?.adminPin) {
       "Expected AdminAuthActivity.admin_auth_admin_pin to be in intent extras."
     }
-    profileId = activity.intent.extractCurrentUserProfileId()
     binding.apply {
       lifecycleOwner = activity
       viewModel = authViewModel
@@ -84,6 +81,7 @@ class AdminAuthActivityPresenter @Inject constructor(
     }
 
     binding.adminAuthSubmitButton.setOnClickListener {
+      val profileId = activity.intent.extractCurrentUserProfileId()
       val inputPin = binding.adminAuthInputPinEditText.text.toString()
       if (inputPin.isEmpty()) {
         return@setOnClickListener

--- a/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivityPresenter.kt
@@ -9,6 +9,7 @@ import org.oppia.android.app.activity.ActivityScope
 import org.oppia.android.app.administratorcontrols.AdministratorControlsActivity
 import org.oppia.android.app.databinding.databinding.AdminAuthActivityBinding
 import org.oppia.android.app.model.AdminAuthActivityParams
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.profile.AdminAuthActivity.Companion.ADMIN_AUTH_ACTIVITY_PARAMS_KEY
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.ui.R
@@ -30,6 +31,7 @@ class AdminAuthActivityPresenter @Inject constructor(
   private val profileManagementController: ProfileManagementController,
 ) {
   private lateinit var binding: AdminAuthActivityBinding
+  private var profileId = ProfileId.getDefaultInstance()
   private val args by lazy {
     activity.intent.getProtoExtra(
       ADMIN_AUTH_ACTIVITY_PARAMS_KEY,
@@ -49,6 +51,7 @@ class AdminAuthActivityPresenter @Inject constructor(
     val adminPin = checkNotNull(args?.adminPin) {
       "Expected AdminAuthActivity.admin_auth_admin_pin to be in intent extras."
     }
+    profileId = activity.intent.extractCurrentUserProfileId()
     binding.apply {
       lifecycleOwner = activity
       viewModel = authViewModel
@@ -88,7 +91,6 @@ class AdminAuthActivityPresenter @Inject constructor(
       if (inputPin == adminPin) {
         when (args?.adminPinEnum ?: 0) {
           AdminAuthEnum.PROFILE_ADMIN_CONTROLS.value -> {
-            val profileId = activity.intent.extractCurrentUserProfileId()
             profileManagementController.loginToProfile(profileId).toLiveData().observe(activity) {
               if (it is AsyncResult.Success) {
                 activity.startActivity(
@@ -101,17 +103,12 @@ class AdminAuthActivityPresenter @Inject constructor(
             }
           }
           AdminAuthEnum.PROFILE_ADD_PROFILE.value -> {
-            val profileId = activity.intent.extractCurrentUserProfileId()
-            profileManagementController.loginToProfile(profileId).toLiveData().observe(activity) {
-              if (it is AsyncResult.Success) {
-                activity.startActivity(
-                  AddProfileActivity.createAddProfileActivityIntent(
-                    context, args?.colorRgb ?: -10710042
-                  )
-                )
-                activity.finish()
-              }
-            }
+            activity.startActivity(
+              AddProfileActivity.createAddProfileActivityIntent(
+                context, args?.colorRgb ?: -10710042
+              )
+            )
+            activity.finish()
           }
         }
       } else if (inputPin.length == adminPin.length) {

--- a/app/src/main/java/org/oppia/android/app/profile/ProfileChooserFragmentPresenterV1.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/ProfileChooserFragmentPresenterV1.kt
@@ -194,7 +194,7 @@ class ProfileChooserFragmentPresenterV1 @Inject constructor(
           AdminAuthActivity.createAdminAuthActivityIntent(
             activity,
             chooserViewModel.adminPin,
-            -1,
+            chooserViewModel.adminProfileId.internalId,
             selectUniqueRandomColor(),
             AdminAuthEnum.PROFILE_ADD_PROFILE.value
           )

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
@@ -64,6 +64,7 @@ import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.test.R
 import org.oppia.android.app.translation.AppLanguageLocaleHandler
 import org.oppia.android.app.translation.testing.ActivityRecreatorTestModule
+import org.oppia.android.app.utility.EspressoTestsMatchers.hasProtoExtra
 import org.oppia.android.app.utility.OrientationChangeAction.Companion.orientationLandscape
 import org.oppia.android.data.backends.gae.NetworkConfigProdModule
 import org.oppia.android.data.backends.gae.RetrofitModule
@@ -617,6 +618,7 @@ class ProfileChooserFragmentTest {
       ).perform(click())
       intended(hasComponent(AdminAuthActivity::class.java.name))
       intended(hasExtraWithKey(ADMIN_AUTH_ACTIVITY_PARAMS_KEY))
+      intended(hasProtoExtra(PROFILE_ID_INTENT_DECORATOR, testProfileId))
     }
   }
 
@@ -1132,6 +1134,7 @@ class ProfileChooserFragmentTest {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_button)).perform(click())
       intended(hasComponent(AdminAuthActivity::class.java.name))
+      intended(hasProtoExtra(PROFILE_ID_INTENT_DECORATOR, testProfileId))
     }
   }
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->

## Explanation

Fix #6004:

#5955 introduced a change that requires the admin to be logged in before being able to add a profile. For reasons why this was needed, please see https://github.com/oppia/oppia-android/issues/5906. This change exposed a bug in the navigation logic for creating the `AdminAuthActivity` intent from the Profile Chooser. The profile Id provided was -1, an invalid profile, instead of the actual admin profile. This caused the login flow to fail, since no matching profile was found. 

This PR fixes the bug by passing in the admin's profile.

Tests have been modified to verify the value of the profileId passed. 

This fix can be made more robust by the implementation of https://github.com/oppia/oppia-android/issues/5440.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing

### Proof of the tests failing before the fix
<img width="1395" height="701" alt="Screenshot 2025-11-24 at 01 23 25" src="https://github.com/user-attachments/assets/69aa03ab-4e96-45af-87b8-98d83d203250" />

### Videos
|Before|After|
|---|---|
|https://github.com/user-attachments/assets/0c7bacf1-e4b8-420e-8a1a-52de3a6213bb|https://github.com/user-attachments/assets/8badd9c2-cd78-4f93-95e4-1269728091b3|



