### PR TITLE
Fix #5807, #6015: Fix flashbacks & item selection classifier

### DIFF
--- a/domain/src/main/assets/test_exp_id_2.textproto
+++ b/domain/src/main/assets/test_exp_id_2.textproto
@@ -1269,7 +1269,7 @@ states {
       }
     }
     recorded_voiceovers {
-      key: "default_outcome"
+      key: "default_outcome_id_with_extras_because_this_is_valid"
       value {
       }
     }
@@ -1370,7 +1370,7 @@ states {
       }
     }
     written_translations {
-      key: "default_outcome"
+      key: "default_outcome_id_with_extras_because_this_is_valid"
       value {
         translation_mapping {
           key: "pt"
@@ -1547,7 +1547,7 @@ states {
         dest_state_name: "RatioInput"
         feedback {
           html: "<p>Not correct</p>"
-          content_id: "default_outcome"
+          content_id: "default_outcome_id_with_extras_because_this_is_valid"
         }
       }
       customization_args {

--- a/domain/src/main/java/org/oppia/android/domain/classify/rules/itemselectioninput/ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProvider.kt
+++ b/domain/src/main/java/org/oppia/android/domain/classify/rules/itemselectioninput/ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProvider.kt
@@ -10,8 +10,9 @@ import org.oppia.android.domain.util.getContentIdSet
 import javax.inject.Inject
 
 /**
- * Provider for a classifier that determines whether an item selection answer does not contain any
- * of a set of options per the item selection input interaction.
+ * Provider for a classifier that determines whether an item selection answer does not contain at
+ * least one element of a set of options per the item selection input interaction, that is, this
+ * classifier only matches if an answer contains all of the input options (plus optional extras).
  *
  * https://github.com/oppia/oppia/blob/37285a/extensions/interactions/ItemSelectionInput/directives/item-selection-input-rules.service.ts#L41
  */
@@ -34,5 +35,5 @@ class ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProvider
     answer: SetOfTranslatableHtmlContentIds,
     input: SetOfTranslatableHtmlContentIds,
     classificationContext: ClassificationContext
-  ): Boolean = answer.getContentIdSet().intersect(input.getContentIdSet()).isEmpty()
+  ): Boolean = (input.getContentIdSet() - answer.getContentIdSet()).isNotEmpty()
 }

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
@@ -1278,7 +1278,7 @@ class ExplorationProgressController @Inject constructor(
       !outcome.labelledAsCorrectAnswer &&
       !doesInteractionAutoContinue(outcome.state.interaction.id) &&
       !linkedSkillId.isNullOrEmpty() &&
-      outcome.feedback.contentId.equals("default_outcome") &&
+      outcome.isDefaultOutcome &&
       !stateDeck.wasFlashbackPreviouslyOffered() &&
       stateDeck.hasFlashbackState(linkedSkillId)
   }

--- a/domain/src/main/java/org/oppia/android/domain/state/StateGraph.kt
+++ b/domain/src/main/java/org/oppia/android/domain/state/StateGraph.kt
@@ -27,6 +27,7 @@ class StateGraph constructor(
       .setFeedback(outcome.feedback)
       .setLabelledAsCorrectAnswer(outcome.labelledAsCorrect)
       .setState(currentState)
+      .setIsDefaultOutcome(outcome == currentState.interaction.defaultOutcome)
     when {
       outcome.refresherExplorationId.isNotEmpty() ->
         answerOutcomeBuilder.refresherExplorationId = outcome.refresherExplorationId

--- a/domain/src/test/java/org/oppia/android/domain/classify/rules/itemselectioninput/ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProviderTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/classify/rules/itemselectioninput/ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProviderTest.kt
@@ -19,22 +19,11 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /** Tests for [ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProvider]. */
-@Suppress("PrivatePropertyName") // Truly immutable constants can be named in CONSTANT_CASE.
+@Suppress("FunctionName") // FunctionName: test names are conventionally named with underscores.
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(manifest = Config.NONE)
 class ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProviderTest {
-
-  private val ITEM_SET_12345 =
-    createSetOfTranslatableHtmlContentIds("test1", "test2", "test3", "test4", "test5")
-  private val ITEM_SET_1 = createSetOfTranslatableHtmlContentIds("test1")
-  private val ITEM_SET_16 = createSetOfTranslatableHtmlContentIds("test1", "test6")
-  private val ITEM_SET_12 = createSetOfTranslatableHtmlContentIds("test1", "test2")
-  private val ITEM_SET_126 = createSetOfTranslatableHtmlContentIds("test1", "test2", "test6")
-  private val ITEM_SET_EMPTY = createSetOfTranslatableHtmlContentIds()
-  private val ITEM_SET_6 = createSetOfTranslatableHtmlContentIds("test6")
-  private val DIFFERENT_INTERACTION_OBJECT_TYPE = createInt(value = 0)
-
   @Inject
   internal lateinit var itemSelectionInputDesNotContainAtLeastOneOfRuleClassifierProvider:
     ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProvider
@@ -49,116 +38,232 @@ class ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProviderTest {
   }
 
   @Test
-  fun testItemSet_setAnswer_inputIsASubset_answerContainsInput() {
-    val inputs = mapOf("x" to ITEM_SET_1)
+  fun testMatches_emptyAnswer_emptyInput_returnsFalse() {
+    val inputs = mapOf("x" to createSetOfTranslatableHtmlContentIds())
 
     val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
-      answer = ITEM_SET_12345,
+      answer = createSetOfTranslatableHtmlContentIds(),
       inputs = inputs,
       classificationContext = ClassificationContext()
     )
 
+    // There's nothing to miss from the input so this is never a match.
     assertThat(matches).isFalse()
   }
 
   @Test
-  fun testItemSet_setAnswer_inputHasOneElementInSet_answerContainsInput() {
-    val inputs = mapOf("x" to ITEM_SET_16)
+  fun testMatches_emptyAnswer_singletonInput_returnsTrue() {
+    val inputs = mapOf("x" to createSetOfTranslatableHtmlContentIds("test1"))
 
     val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
-      answer = ITEM_SET_12345,
+      answer = createSetOfTranslatableHtmlContentIds(),
       inputs = inputs,
       classificationContext = ClassificationContext()
     )
 
-    assertThat(matches).isFalse()
-  }
-
-  @Test
-  fun testItemSet_setAnswer_inputHasTwoElementsInSetNoneExtra_answerContainsInput() {
-    val inputs = mapOf("x" to ITEM_SET_12)
-
-    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
-      answer = ITEM_SET_12345,
-      inputs = inputs,
-      classificationContext = ClassificationContext()
-    )
-
-    assertThat(matches).isFalse()
-  }
-
-  @Test
-  fun testItemSet_setAnswer_inputHasTwoElementsInSetOneExtra_answerContainsInput() {
-    val inputs = mapOf("x" to ITEM_SET_126)
-
-    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
-      answer = ITEM_SET_12345,
-      inputs = inputs,
-      classificationContext = ClassificationContext()
-    )
-
-    assertThat(matches).isFalse()
-  }
-
-  @Test
-  fun testItemSet_setAnswer_inputIsEmptySet_answerDoesNotContainInput() {
-    val inputs = mapOf("x" to ITEM_SET_EMPTY)
-
-    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
-      answer = ITEM_SET_12345,
-      inputs = inputs,
-      classificationContext = ClassificationContext()
-    )
-
+    // Answer is missing 'test1'.
     assertThat(matches).isTrue()
   }
 
   @Test
-  fun testItemSet_setAnswer_inputIsExclusiveOfSet_answerDoesNotContainInput() {
-    val inputs = mapOf("x" to ITEM_SET_6)
+  fun testMatches_singletonAnswer_emptyInput_returnsFalse() {
+    val inputs = mapOf("x" to createSetOfTranslatableHtmlContentIds())
 
     val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
-      answer = ITEM_SET_12345,
+      answer = createSetOfTranslatableHtmlContentIds("test1"),
       inputs = inputs,
       classificationContext = ClassificationContext()
     )
 
-    assertThat(matches).isTrue()
-  }
-
-  @Test
-  fun testItemSet_setAnswerIsEmpty_inputIsNonEmpty_answerDoesNotContainInput() {
-    val inputs = mapOf("x" to ITEM_SET_12345)
-
-    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
-      answer = ITEM_SET_EMPTY,
-      inputs = inputs,
-      classificationContext = ClassificationContext()
-    )
-
-    assertThat(matches).isTrue()
-  }
-
-  @Test
-  fun testItemSet_setAnswer_inputIsASuperset_answerContainsInput() {
-    val inputs = mapOf("x" to ITEM_SET_12345)
-
-    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
-      answer = ITEM_SET_12,
-      inputs = inputs,
-      classificationContext = ClassificationContext()
-    )
-
+    // There's nothing to miss from the input so this is never a match.
     assertThat(matches).isFalse()
   }
 
   @Test
-  fun testItemSet_inputIsMissing_throwsException() {
-    val inputs = mapOf("y" to ITEM_SET_1)
+  fun testMatches_singletonAnswer_singletonInput_different_returnsTrue() {
+    val inputs = mapOf("x" to createSetOfTranslatableHtmlContentIds("test1"))
 
-    val exception = assertThrows<IllegalStateException>() {
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = createSetOfTranslatableHtmlContentIds("test2"),
+      inputs = inputs,
+      classificationContext = ClassificationContext()
+    )
+
+    // Answer is missing 'test1'.
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testMatches_singletonAnswer_singletonInput_same_returnsFalse() {
+    val inputs = mapOf("x" to createSetOfTranslatableHtmlContentIds("test1"))
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = createSetOfTranslatableHtmlContentIds("test1"),
+      inputs = inputs,
+      classificationContext = ClassificationContext()
+    )
+
+    // Answer is contains 'test1' (the only input element, so none of input's elements are absent).
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testMatches_answerWithTwoElems_inputWithTwoElems_distinct_returnsTrue() {
+    val inputs = mapOf("x" to createSetOfTranslatableHtmlContentIds("test1", "test2"))
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = createSetOfTranslatableHtmlContentIds("test3", "test4"),
+      inputs = inputs,
+      classificationContext = ClassificationContext()
+    )
+
+    // All of input's elements are absent.
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testMatches_answerWithTwoElems_inputWithTwoElems_oneCommon_returnsTrue() {
+    val inputs = mapOf("x" to createSetOfTranslatableHtmlContentIds("test1", "test2"))
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = createSetOfTranslatableHtmlContentIds("test1", "test4"),
+      inputs = inputs,
+      classificationContext = ClassificationContext()
+    )
+
+    // 'test2' is still missing.
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testMatches_answerWithTwoElems_inputWithTwoElems_bothCommon_returnsFalse() {
+    val inputs = mapOf("x" to createSetOfTranslatableHtmlContentIds("test1", "test2"))
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = createSetOfTranslatableHtmlContentIds("test1", "test2"),
+      inputs = inputs,
+      classificationContext = ClassificationContext()
+    )
+
+    // All of the input's elements are present in the answer.
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testMatches_multiElemAnswer_multiElemInput_answerIsSubset_returnsTrue() {
+    val inputs = mapOf(
+      "x" to createSetOfTranslatableHtmlContentIds("test1", "test2", "test3", "test4")
+    )
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = createSetOfTranslatableHtmlContentIds("test1", "test2", "test4"),
+      inputs = inputs,
+      classificationContext = ClassificationContext()
+    )
+
+    // 'test3' is still missing in the answer.
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testMatches_multiElemAnswer_multiElemInput_answerIsSubset_diffOrders_returnsTrue() {
+    val inputs = mapOf(
+      "x" to createSetOfTranslatableHtmlContentIds("test2", "test4", "test1", "test3")
+    )
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = createSetOfTranslatableHtmlContentIds("test4", "test1", "test2"),
+      inputs = inputs,
+      classificationContext = ClassificationContext()
+    )
+
+    // 'test3' is still missing in the answer.
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testMatches_multiElemAnswer_multiElemInput_answerHasMultipleCommonToInput_returnsTrue() {
+    val inputs = mapOf(
+      "x" to createSetOfTranslatableHtmlContentIds("test1", "test2", "test3", "test4")
+    )
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = createSetOfTranslatableHtmlContentIds("test1", "test2", "test4", "test5", "test6"),
+      inputs = inputs,
+      classificationContext = ClassificationContext()
+    )
+
+    // 'test3' is still missing in the answer.
+    assertThat(matches).isTrue()
+  }
+
+  @Test
+  fun testMatches_multiElemAnswer_multiElemInput_inputIsSubset_returnsFalse() {
+    val inputs = mapOf("x" to createSetOfTranslatableHtmlContentIds("test2", "test3", "test4"))
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = createSetOfTranslatableHtmlContentIds("test1", "test2", "test3", "test4", "test5"),
+      inputs = inputs,
+      classificationContext = ClassificationContext()
+    )
+
+    // All of the input's elements are present in the answer.
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testMatches_multiElemAnswer_multiElemInput_inputIsSubset_diffOrder_returnsFalse() {
+    val inputs = mapOf("x" to createSetOfTranslatableHtmlContentIds("test4", "test2", "test3"))
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = createSetOfTranslatableHtmlContentIds("test2", "test3", "test4", "test5", "test1"),
+      inputs = inputs,
+      classificationContext = ClassificationContext()
+    )
+
+    // All of the input's elements are present in the answer.
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testMatches_multiElemAnswer_multiElemInput_allMatch_returnsFalse() {
+    val inputs = mapOf(
+      "x" to createSetOfTranslatableHtmlContentIds("test1", "test2", "test3", "test4")
+    )
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = createSetOfTranslatableHtmlContentIds("test1", "test2", "test3", "test4"),
+      inputs = inputs,
+      classificationContext = ClassificationContext()
+    )
+
+    // All of the input's elements are present in the answer.
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testMatches_multiElemAnswer_multiElemInput_allMatch_diffOrder_returnsFalse() {
+    val inputs = mapOf(
+      "x" to createSetOfTranslatableHtmlContentIds("test2", "test4", "test3", "test1")
+    )
+
+    val matches = inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
+      answer = createSetOfTranslatableHtmlContentIds("test4", "test1", "test3", "test2"),
+      inputs = inputs,
+      classificationContext = ClassificationContext()
+    )
+
+    // All of the input's elements are present in the answer.
+    assertThat(matches).isFalse()
+  }
+
+  @Test
+  fun testMatches_inputIsMissing_throwsException() {
+    val inputs = mapOf("y" to createSetOfTranslatableHtmlContentIds("test1"))
+
+    val exception = assertThrows<IllegalStateException> {
       inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
-        answer = ITEM_SET_12345,
+        answer = createSetOfTranslatableHtmlContentIds("test1"),
         inputs = inputs,
         classificationContext = ClassificationContext()
       )
@@ -170,12 +275,12 @@ class ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProviderTest {
   }
 
   @Test
-  fun testItemSet_inputHasTheWrongType_throwsException() {
-    val inputs = mapOf("x" to DIFFERENT_INTERACTION_OBJECT_TYPE)
+  fun testMatches_inputHasTheWrongType_throwsException() {
+    val inputs = mapOf("x" to createInt(value = 0))
 
-    val exception = assertThrows<IllegalStateException>() {
+    val exception = assertThrows<IllegalStateException> {
       inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
-        answer = ITEM_SET_12345,
+        answer = createSetOfTranslatableHtmlContentIds("test1"),
         inputs = inputs,
         classificationContext = ClassificationContext()
       )
@@ -187,12 +292,12 @@ class ItemSelectionInputDoesNotContainAtLeastOneOfRuleClassifierProviderTest {
   }
 
   @Test
-  fun testItemSet_answerHasTheWrongType_throwsException() {
-    val inputs = mapOf("x" to ITEM_SET_12345)
+  fun testMatches_answerHasTheWrongType_throwsException() {
+    val inputs = mapOf("x" to createSetOfTranslatableHtmlContentIds("test1"))
 
-    val exception = assertThrows<IllegalStateException>() {
+    val exception = assertThrows<IllegalStateException> {
       inputDoesNotContainAtLeastOneOfRuleClassifier.matches(
-        answer = DIFFERENT_INTERACTION_OBJECT_TYPE,
+        answer = createInt(value = 0),
         inputs = inputs,
         classificationContext = ClassificationContext()
       )

--- a/model/src/main/proto/exploration.proto
+++ b/model/src/main/proto/exploration.proto
@@ -357,6 +357,9 @@ message AnswerOutcome {
   // needing to synchronize with other data providers).
   State state = 3;
 
+  // Whether this corresponds the the default outcome option for a state interaction.
+  bool is_default_outcome = 8;
+
   // One of several destinations the learner should be routed to as a result of submitting this answer.
   oneof destination {
     // Indicates that the learner should not progress past the current state.


### PR DESCRIPTION
## Explanation

Fixes #5807
Fixes #6015

This PR fixes #5807 by correcting the logic for the `DoesNotContainAtLeastOneOf` classifier for the `ItemSelectionInput` interaction. https://github.com/oppia/oppia-android/issues/5807#issuecomment-3564634024 provides a more detailed explanation for what the underlying issue was. The new logic has been confirmed against the exact tests Oppia web uses for its implementation (seen here: https://github.com/oppia/oppia/blob/6c6196618e892a817162f972cf1d933f33d69c34/extensions/interactions/ItemSelectionInput/directives/item-selection-input-rules.service.spec.ts#L79-L108). Note that the new tests have been largely rewritten to correctly represent the expected behaviors and have been verified to:
- Fail with the old logic.
- Pass with the new logic.
- Pass with the exact same logic Oppia web uses (https://github.com/oppia/oppia/blob/6c6196618e892a817162f972cf1d933f33d69c34/extensions/interactions/ItemSelectionInput/directives/item-selection-input-rules.service.ts#L64).

This PR fixes #6015 by correcting an incorrect assumption in the original implementation of flashbacks: that all default outcomes have the exact content ID 'default_outcome'. This may have been true in the past but it's definitely not true with how Oppia web manages translations for an exploration (content IDs must be unique at the exploration level). The new logic passes along an actual property to indicate default outcome state (as checked against the actual default outcome). Note that this is tested by updating the primary test lesson for flashbacks to use a different default outcome content ID (and this has been verified to cause the existing tests to fail).

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
Flashbacks isn't a UI change in this PR though this PR does allow that UI-facing feature to be enabled.