### PR TITLE
Update repository 'vacation' mode reminders for end-of-year 2025

### DIFF
--- a/.devbots/vacation.yml
+++ b/.devbots/vacation.yml
@@ -9,4 +9,4 @@ issue-comment: >
     Thanks for filing this issue! Please note that some team members
     are currently taking time off to recharge, so it might be a
     while before we respond to or triage this issue.
-period: 2021-11-19 - 2021-12-06
+period: 2025-12-19 - 2026-01-05


### PR DESCRIPTION
## Explanation
Updates the repository's 'vacation mode' to send automated replies to both new issues and PRs from 19 December 2025 to 05 January 2026 due to reduced team reviewer and triage coverage during that time period.

Note that we'll still have some folks coming in and out during that time, but we won't have consistent reviewer coverage until after the new year.

## Essential Checklist
- [ ] ~The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)~
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- This is a developer workflow change that only impacts GitHub.
