### PR TITLE
Fix #6029: Update `//scripts:download_lessons` CLI arguments for CI workflow

### DIFF
--- a/.github/workflows/lesson_checks.yml
+++ b/.github/workflows/lesson_checks.yml
@@ -55,4 +55,5 @@ jobs:
             cache_mode=none \
             $(pwd)/release_assets/cache \
             $(pwd)/release_assets/pinned_versions.textproto \
+            false \
             -Werror


### PR DESCRIPTION
## Explanation
Fixes #6029

This updates the CI arguments for the asset download script run weekly in CI. The script was updated to include an argument for also downloading questions.

Note that this cannot be easily tested without first merging it, but at this point it's been demonstrated that this is precisely the failure running in the workflow and this command line works locally.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- This only affects a diagnostic CI workflow.