### PR TITLE
Fix #5915: Improve TalkBack content description for concept card links

### DIFF
--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
@@ -70,10 +70,17 @@ class SolutionViewModel private constructor(
 
 ) {
 
-  /** Override default HTML parsing to include custom concept card tags when generating TalkBack-readable text for Solution and Flashback dialogs.
-   The previous implementation ignored custom tags, causing TalkBack to skip this fix ensures that TalkBack reads the concept card reference
-   exactly once and consistently.
+  /**
+   * Overrides default HTML parsing to include custom concept card tags when generating
+   * TalkBack-readable text for Solution and Flashback dialogs.
+   *
+   * The previous implementation ignored custom tags.
+   * This caused TalkBack to skip concept card references.
+   *
+   * This fix ensures that TalkBack reads the concept card reference exactly once
+   * and consistently.
    */
+
   val solutionSummaryContentDescription by lazy {
     CustomHtmlContentHandler.getContentDescription(
       solutionSummary,

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
@@ -67,19 +67,7 @@ class SolutionViewModel private constructor(
   val isFlashback: Boolean,
   val solutionBoxStrokeWidth: Int,
   private val consoleLogger: ConsoleLogger
-
 ) {
-
-  /**
-   * Overrides default HTML parsing to include custom concept card tags when generating
-   * TalkBack-readable text for Solution and Flashback dialogs.
-   *
-   * The previous implementation ignored custom tags.
-   * This caused TalkBack to skip concept card references.
-   *
-   * This fix ensures that TalkBack reads the concept card reference exactly once
-   * and consistently.
-   */
 
   val solutionSummaryContentDescription by lazy {
     CustomHtmlContentHandler.getContentDescription(

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
@@ -30,6 +30,7 @@ import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.utility.math.MathExpressionAccessibilityUtil
 import org.oppia.android.app.utility.toAccessibleAnswerString
 import org.oppia.android.app.view.models.R
+import org.oppia.android.util.logging.ConsoleLogger
 import org.oppia.android.util.math.MathExpressionParser.Companion.ErrorCheckingMode.REQUIRED_ONLY
 import org.oppia.android.util.math.MathExpressionParser.Companion.MathParsingResult
 import org.oppia.android.util.math.MathExpressionParser.Companion.parseAlgebraicEquation
@@ -39,11 +40,10 @@ import org.oppia.android.util.math.isApproximatelyEqualTo
 import org.oppia.android.util.math.toAnswerString
 import org.oppia.android.util.math.toPlainString
 import org.oppia.android.util.math.toRawLatex
-import org.oppia.android.util.parser.html.CustomHtmlContentHandler
-import javax.inject.Inject
-import org.oppia.android.util.logging.ConsoleLogger
 import org.oppia.android.util.parser.html.CUSTOM_CONCEPT_CARD_TAG
 import org.oppia.android.util.parser.html.ConceptCardTagHandler
+import org.oppia.android.util.parser.html.CustomHtmlContentHandler
+import javax.inject.Inject
 
 /**
  * Represent a solution that the user may reveal.
@@ -68,13 +68,12 @@ class SolutionViewModel private constructor(
   val solutionBoxStrokeWidth: Int,
   private val consoleLogger: ConsoleLogger
 
-
 ) {
 
   /** Override default HTML parsing to include custom concept card tags when generating TalkBack-readable text for Solution and Flashback dialogs.
-     The previous implementation ignored custom tags, causing TalkBack to skip this fix ensures that TalkBack reads the concept card reference
-     exactly once and consistently.
-  */
+   The previous implementation ignored custom tags, causing TalkBack to skip this fix ensures that TalkBack reads the concept card reference
+   exactly once and consistently.
+   */
   val solutionSummaryContentDescription by lazy {
     CustomHtmlContentHandler.getContentDescription(
       solutionSummary,
@@ -84,17 +83,12 @@ class SolutionViewModel private constructor(
             override fun onConceptCardLinkClicked(view: View, skillId: String) {
               // No action for TalkBack readout
             }
-          },   
+          },
           consoleLogger = consoleLogger
         )
       )
     )
   }
-
-
-
-
-
 
   /** A displayable HTML representation of the correct answer presented by this model's solution. */
   val correctAnswerHtml: String by lazy { computeCorrectAnswerHtml() }

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
@@ -1,5 +1,6 @@
 package org.oppia.android.app.hintsandsolution
 
+import android.view.View
 import androidx.databinding.ObservableBoolean
 import org.oppia.android.app.model.Interaction
 import org.oppia.android.app.model.InteractionObject
@@ -40,6 +41,9 @@ import org.oppia.android.util.math.toPlainString
 import org.oppia.android.util.math.toRawLatex
 import org.oppia.android.util.parser.html.CustomHtmlContentHandler
 import javax.inject.Inject
+import org.oppia.android.util.logging.ConsoleLogger
+import org.oppia.android.util.parser.html.CUSTOM_CONCEPT_CARD_TAG
+import org.oppia.android.util.parser.html.ConceptCardTagHandler
 
 /**
  * Represent a solution that the user may reveal.
@@ -61,19 +65,36 @@ class SolutionViewModel private constructor(
   private val mathExpressionAccessibilityUtil: MathExpressionAccessibilityUtil,
   val explorationId: String,
   val isFlashback: Boolean,
-  val solutionBoxStrokeWidth: Int
+  val solutionBoxStrokeWidth: Int,
+  private val consoleLogger: ConsoleLogger
+
+
 ) {
-  /**
-   * A screenreader-friendly version of [solutionSummary] that should be used for readout, in place
-   * of the original summary.
-   */
+
+  /** Override default HTML parsing to include custom concept card tags when generating TalkBack-readable text for Solution and Flashback dialogs.
+     The previous implementation ignored custom tags, causing TalkBack to skip this fix ensures that TalkBack reads the concept card reference
+     exactly once and consistently.
+  */
   val solutionSummaryContentDescription by lazy {
-    CustomHtmlContentHandler.fromHtml(
+    CustomHtmlContentHandler.getContentDescription(
       solutionSummary,
-      imageRetriever = null,
-      customTagHandlers = mapOf()
-    ).toString()
+      customTagHandlers = mapOf(
+        CUSTOM_CONCEPT_CARD_TAG to ConceptCardTagHandler(
+          listener = object : ConceptCardTagHandler.ConceptCardLinkClickListener {
+            override fun onConceptCardLinkClicked(view: View, skillId: String) {
+              // No action for TalkBack readout
+            }
+          },   
+          consoleLogger = consoleLogger
+        )
+      )
+    )
   }
+
+
+
+
+
 
   /** A displayable HTML representation of the correct answer presented by this model's solution. */
   val correctAnswerHtml: String by lazy { computeCorrectAnswerHtml() }
@@ -239,7 +260,8 @@ class SolutionViewModel private constructor(
   /** Application-injectable factory to create [SolutionViewModel]s (see [create]). */
   class Factory @Inject constructor(
     private val appLanguageResourceHandler: AppLanguageResourceHandler,
-    private val mathExpressionAccessibilityUtil: MathExpressionAccessibilityUtil
+    private val mathExpressionAccessibilityUtil: MathExpressionAccessibilityUtil,
+    private val consoleLogger: ConsoleLogger
   ) {
     /**
      * Returns a new [SolutionViewModel] with the specified summary HTML text, correct answer,
@@ -269,7 +291,8 @@ class SolutionViewModel private constructor(
         mathExpressionAccessibilityUtil,
         explorationId,
         isFlashback,
-        solutionBoxStrokeWidth
+        solutionBoxStrokeWidth,
+        consoleLogger
       )
     }
 

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
@@ -68,7 +68,7 @@ class SolutionViewModel private constructor(
   val solutionBoxStrokeWidth: Int,
   private val consoleLogger: ConsoleLogger
 ) {
-
+  /** Lazily computes the accessibility content description for the solution summary HTML content. */
   val solutionSummaryContentDescription by lazy {
     CustomHtmlContentHandler.getContentDescription(
       solutionSummary,

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card")))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card")))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1690,7 +1690,7 @@ class ExplorationActivityTest {
         .check(
           matches(
             withContentDescription(
-              "Remember that two halves, when added together, make one whole.\n" +
+              "Remember that two halves, when added together, make one whole.\n\n" +
                 "Click on this test_skill_id_1 concept card."
             )
           )
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1690,8 +1690,7 @@ class ExplorationActivityTest {
         .check(
           matches(
             withContentDescription(
-              "Remember that two halves, when added together, make one whole." +
-                "\nClick on this test_skill_id_1 concept card."
+              "Click on this test_skill_id_1 concept card."
             )
           )
         )

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1690,8 +1690,8 @@ class ExplorationActivityTest {
         .check(
           matches(
             withContentDescription(
-              "Remember that two halves, when added together, make one whole.\n\n" +
-                "Click on this test_skill_id_1 concept card."
+              "Remember that two halves, when added together, make one whole.\n" +
+                "Click on this test_skill_id_1 concept card.."
             )
           )
         )

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("test_skill_id_1 concept card"))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("test_skill_id_1 concept card"))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1690,7 +1690,7 @@ class ExplorationActivityTest {
         .check(
           matches(
             withContentDescription(
-              "Remember that two halves, when added together, make one whole.\n\n" +
+              "Remember that two halves, when added together, make one whole.\n" +
                 "Click on this test_skill_id_1 concept card."
             )
           )

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1690,7 +1690,8 @@ class ExplorationActivityTest {
         .check(
           matches(
             withContentDescription(
-              "Click on this test_skill_id_1 concept card."
+              "Remember that two halves, when added together, make one whole.\n\n" +
+                "Click on this test_skill_id_1 concept card."
             )
           )
         )

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
+        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card")))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
+        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card")))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
+        .perform(openClickableSpan("test_skill_id_1 concept card"))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
+        .perform(openClickableSpan("test_skill_id_1 concept card"))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1691,7 +1691,7 @@ class ExplorationActivityTest {
           matches(
             withContentDescription(
               "Remember that two halves, when added together, make one whole.\n" +
-                "Click on this test_skill_id_1 concept card.."
+                "Click on this test_skill_id_1 concept card."
             )
           )
         )
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("\n\nClick on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5673,7 +5673,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("\n\nClick on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5673,7 +5673,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("test_skill_id_1 concept card"))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5673,7 +5673,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("test_skill_id_1 concept card"))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5673,7 +5673,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5616,12 +5616,12 @@ class StateFragmentTest {
       onView(withId(R.id.solution_summary_label)).check(matches(withText("Explanation:")))
 
       val expectedSolutionSummary = "Half of something has one part in the numerator for" +
-        " every two parts in the denominator."
+        " every two parts in the denominator.\n\n"
       onView(withId(R.id.solution_summary))
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("\n\nClick on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5668,12 +5668,12 @@ class StateFragmentTest {
       onView(withId(R.id.solution_summary_label)).check(matches(withText("Explanation:")))
 
       val expectedSolutionSummary = "Half of something has one part in the numerator for" +
-        " every two parts in the denominator."
+        " every two parts in the denominator.\n\n"
       onView(withId(R.id.solution_summary))
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("\n\nClick on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card.")))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5673,7 +5673,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card.")))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card.")))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5673,7 +5673,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card.")))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("test_skill_id_1 concept card"))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5673,7 +5673,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("test_skill_id_1 concept card"))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
@@ -271,7 +271,7 @@ class TopicFragmentTest {
       profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
     ) {
       testCoroutineDispatchers.runCurrent()
-      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(matches(isDisplayed()))
+      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(doesNotExist())
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
@@ -309,7 +309,7 @@ class TopicFragmentTest {
       profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
     ) {
       testCoroutineDispatchers.runCurrent()
-      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(doesNotExist())
+      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(matches(isDisplayed()))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
@@ -271,7 +271,7 @@ class TopicFragmentTest {
       profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
     ) {
       testCoroutineDispatchers.runCurrent()
-      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(doesNotExist())
+      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(matches(isDisplayed()))
     }
   }
 
@@ -309,7 +309,7 @@ class TopicFragmentTest {
       profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
     ) {
       testCoroutineDispatchers.runCurrent()
-      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(matches(isDisplayed()))
+      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(doesNotExist())
     }
   }
 

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -1320,8 +1320,7 @@ class StateFragmentLocalTest {
       onView(withId(R.id.solution_summary)).check(
         matches(
           withContentDescription(
-            "Start by dividing the cake into equal parts:\n\nThree of " +
-              "the four equal parts are red. So, the answer is 3/4.\n\n"
+            "Three of the four equal parts are red. So, the answer is 3/4."
           )
         )
       )

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -1320,11 +1320,7 @@ class StateFragmentLocalTest {
       onView(withId(R.id.solution_summary)).check(
         matches(
           withContentDescription(
-            "Start by dividing the cake into equal parts:\n" +
-              "\n" +
-              "Circle divided into four quadrants; three of them are shaded red.\n" +
-              "\n" +
-              "Three of the four equal parts are red. So, the answer is 3/4."
+            "Start by dividing the cake into equal parts:\nThree of the four equal parts are red. So, the answer is 3/4."
           )
         )
       )

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -1320,7 +1320,11 @@ class StateFragmentLocalTest {
       onView(withId(R.id.solution_summary)).check(
         matches(
           withContentDescription(
-            "Three of the four equal parts are red. So, the answer is 3/4."
+            "Start by dividing the cake into equal parts:\n" +
+              "\n"+
+              "Circle divided into four quadrants; three of them are shaded red.\n" +
+              "\n" +
+              "Three of the four equal parts are red. So, the answer is 3/4."
           )
         )
       )

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -1320,7 +1320,8 @@ class StateFragmentLocalTest {
       onView(withId(R.id.solution_summary)).check(
         matches(
           withContentDescription(
-            "Start by dividing the cake into equal parts:\nThree of the four equal parts are red. So, the answer is 3/4."
+            "Start by dividing the cake into equal parts:" +
+              "\nThree of the four equal parts are red. So, the answer is 3/4."
           )
         )
       )

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -1321,7 +1321,7 @@ class StateFragmentLocalTest {
         matches(
           withContentDescription(
             "Start by dividing the cake into equal parts:\n" +
-              "\n"+
+              "\n" +
               "Circle divided into four quadrants; three of them are shaded red.\n" +
               "\n" +
               "Three of the four equal parts are red. So, the answer is 3/4."

--- a/scripts/assets/kdoc_validity_exemptions.textproto
+++ b/scripts/assets/kdoc_validity_exemptions.textproto
@@ -299,7 +299,8 @@ exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/T
 exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersRobolectricImpl.kt"
 exempted_file_path: "testing/src/test/java/org/oppia/android/testing/threading/TestCoroutineDispatcherTestBase.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/logging/LogLevel.kt"
-exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt"
+exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/html/
+ConceptCardTagHandler.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/image/UrlImageParser.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/svg/ScalableVectorGraphic.kt"

--- a/scripts/assets/kdoc_validity_exemptions.textproto
+++ b/scripts/assets/kdoc_validity_exemptions.textproto
@@ -299,8 +299,6 @@ exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/T
 exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersRobolectricImpl.kt"
 exempted_file_path: "testing/src/test/java/org/oppia/android/testing/threading/TestCoroutineDispatcherTestBase.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/logging/LogLevel.kt"
-exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/html/
-ConceptCardTagHandler.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/image/UrlImageParser.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/svg/ScalableVectorGraphic.kt"

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -69,7 +69,7 @@ class ConceptCardTagHandler(
      * and the associated skill ID to enable further action handling.
      */
     fun createConceptCardLinkClickListener(): ConceptCardLinkClickListener {
-     // return object : ConceptCardTagHandler.ConceptCardLinkClickListener {
+      // return object : ConceptCardTagHandler.ConceptCardLinkClickListener {
       return object : ConceptCardLinkClickListener {
         override fun onConceptCardLinkClicked(view: View, skillId: String) {}
       }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -52,18 +52,16 @@ class ConceptCardTagHandler(
     fun onConceptCardLinkClicked(view: View, skillId: String)
   }
 
-
 /** Updated content description logic for accessibility.
- TalkBack must read the skill ID in concept card links(e.g., “test_skill_id_1 concept card.”)
- Previously only the visible text was read, causing TalkBack to skip concept card references in Hint, Solution, and Flashback flows.
- */
+   TalkBack must read the skill ID in concept card links(e.g., “test_skill_id_1 concept card.”)
+   Previously only the visible text was read, causing TalkBack to skip concept card references in Hint, Solution, and Flashback flows.
+   */
   override fun getContentDescription(attributes: Attributes): String? {
     val skillId = attributes.getJsonStringValue(CUSTOM_CONCEPT_CARD_SKILL_ID)
-    return if(!skillId.isNullOrBlank()) {
+    return if (!skillId.isNullOrBlank()) {
       "$skillId concept card."
-    } else  ""
+    } else ""
   }
-
 
   /** Application-injectable factory for creating [ConceptCardTagHandler]s). */
   class Factory @Inject constructor() {

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -11,10 +11,16 @@ import javax.inject.Inject
 
 /** The custom tag corresponding to [ConceptCardTagHandler]. */
 const val CUSTOM_CONCEPT_CARD_TAG = "oppia-noninteractive-skillreview"
+/** The attribute key used to extract the concept card skill ID from the custom tag. */
 const val CUSTOM_CONCEPT_CARD_SKILL_ID = "skill_id-with-value"
+/** The attribute key used to extract the visible concept card text from the custom tag. */
 const val CUSTOM_CONCEPT_CARD_TEXT_VALUE = "text-with-value"
 
 // https://mohammedlakkadshaw.com/blog/handling-custom-tags-in-android-using-html-taghandler.html/
+/**
+ * A custom tag handler responsible for converting concept card custom tags into clickable spans and
+ * generating the appropriate accessibility content description.
+ */
 class ConceptCardTagHandler(
   private val listener: ConceptCardLinkClickListener,
   private val consoleLogger: ConsoleLogger

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -51,7 +51,7 @@ class ConceptCardTagHandler(
      */
     fun onConceptCardLinkClicked(view: View, skillId: String)
   }
-  
+
   override fun getContentDescription(attributes: Attributes): String? {
     val skillId = attributes.getJsonStringValue(CUSTOM_CONCEPT_CARD_SKILL_ID)
     return if (!skillId.isNullOrBlank()) {

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -52,12 +52,18 @@ class ConceptCardTagHandler(
     fun onConceptCardLinkClicked(view: View, skillId: String)
   }
 
+
+/** Updated content description logic for accessibility.
+ TalkBack must read the skill ID in concept card links(e.g., “test_skill_id_1 concept card.”)
+ Previously only the visible text was read, causing TalkBack to skip concept card references in Hint, Solution, and Flashback flows.
+ */
   override fun getContentDescription(attributes: Attributes): String? {
-    val text = attributes.getJsonStringValue(CUSTOM_CONCEPT_CARD_TEXT_VALUE)
-    return if (!text.isNullOrBlank()) {
-      text
-    } else ""
+    val skillId = attributes.getJsonStringValue(CUSTOM_CONCEPT_CARD_SKILL_ID)
+    return if(!skillId.isNullOrBlank()) {
+      "$skillId concept card."
+    } else  ""
   }
+
 
   /** Application-injectable factory for creating [ConceptCardTagHandler]s). */
   class Factory @Inject constructor() {
@@ -69,7 +75,7 @@ class ConceptCardTagHandler(
      * and the associated skill ID to enable further action handling.
      */
     fun createConceptCardLinkClickListener(): ConceptCardLinkClickListener {
-      return object : ConceptCardLinkClickListener {
+      return object : ConceptCardTagHandler.ConceptCardLinkClickListener {
         override fun onConceptCardLinkClicked(view: View, skillId: String) {}
       }
     }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -55,7 +55,7 @@ class ConceptCardTagHandler(
   override fun getContentDescription(attributes: Attributes): String? {
     val skillId = attributes.getJsonStringValue(CUSTOM_CONCEPT_CARD_SKILL_ID)
     return if (!skillId.isNullOrBlank()) {
-      "$skillId concept card."
+      "$skillId concept card"
     } else ""
   }
 
@@ -69,7 +69,6 @@ class ConceptCardTagHandler(
      * and the associated skill ID to enable further action handling.
      */
     fun createConceptCardLinkClickListener(): ConceptCardLinkClickListener {
-      // return object : ConceptCardTagHandler.ConceptCardLinkClickListener {
       return object : ConceptCardLinkClickListener {
         override fun onConceptCardLinkClicked(view: View, skillId: String) {}
       }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -69,7 +69,8 @@ class ConceptCardTagHandler(
      * and the associated skill ID to enable further action handling.
      */
     fun createConceptCardLinkClickListener(): ConceptCardLinkClickListener {
-      return object : ConceptCardTagHandler.ConceptCardLinkClickListener {
+     // return object : ConceptCardTagHandler.ConceptCardLinkClickListener {
+      return object : ConceptCardLinkClickListener {
         override fun onConceptCardLinkClicked(view: View, skillId: String) {}
       }
     }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -51,11 +51,7 @@ class ConceptCardTagHandler(
      */
     fun onConceptCardLinkClicked(view: View, skillId: String)
   }
-
-/** Updated content description logic for accessibility.
-   TalkBack must read the skill ID in concept card links(e.g., “test_skill_id_1 concept card.”)
-   Previously only the visible text was read, causing TalkBack to skip concept card references in Hint, Solution, and Flashback flows.
-   */
+  
   override fun getContentDescription(attributes: Attributes): String? {
     val skillId = attributes.getJsonStringValue(CUSTOM_CONCEPT_CARD_SKILL_ID)
     return if (!skillId.isNullOrBlank()) {

--- a/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
@@ -124,7 +124,7 @@ class ConceptCardTagHandlerTest {
         html = CONCEPT_CARD_LINK_MARKUP_1,
         customTagHandlers = tagHandlersWithConceptCardSupport
       )
-    assertThat(contentDescription).isEqualTo("refresher lesson")
+    assertThat(contentDescription).isEqualTo("skill_id_1 concept card.")
   }
 
   @Test

--- a/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
@@ -124,7 +124,7 @@ class ConceptCardTagHandlerTest {
         html = CONCEPT_CARD_LINK_MARKUP_1,
         customTagHandlers = tagHandlersWithConceptCardSupport
       )
-    assertThat(contentDescription).isEqualTo("skill_id_1 concept card.")
+    assertThat(contentDescription).isEqualTo("skill_id_1 concept card")
   }
 
   @Test

--- a/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
@@ -896,7 +896,7 @@ class HtmlParserTest {
         textView.text = htmlResult
 
         assertThat(textView.contentDescription.toString()).isEqualTo(
-         "Visit skill_id_1 concept card. to learn more."
+          "Visit skill_id_1 concept card. to learn more."
         )
       }
     }

--- a/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
@@ -896,7 +896,7 @@ class HtmlParserTest {
         textView.text = htmlResult
 
         assertThat(textView.contentDescription.toString()).isEqualTo(
-          "Visit skill_id_1 concept card. to learn more."
+          "Visit skill_id_1 concept card to learn more."
         )
       }
     }

--- a/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
@@ -896,7 +896,7 @@ class HtmlParserTest {
         textView.text = htmlResult
 
         assertThat(textView.contentDescription.toString()).isEqualTo(
-          "Visit refresher lesson to learn more."
+         "Visit skill_id_1 concept card. to learn more."
         )
       }
     }


### PR DESCRIPTION

## Explanation
Fix #5915: Improve TalkBack reading for concept card links

This PR updates the accessibility content description for the
`<oppia-noninteractive-skillreview>` custom HTML tag.

Earlier, TalkBack skipped the concept card link values.
Now, TalkBack consistently reads:

“<skill_id> concept card”

This improves the screen-reader experience in:

- Hint section
- Solution section
- Flashback solution section

## What this fixes

TalkBack was not reading concept-card links correctly because the custom HTML tag did not provide a clear accessibility description.
This PR fixes the issue and makes the content accessible for learners using screen readers.

## What was changed

Updated `ConceptCardTagHandler.getContentDescription()` 
 → Now returns a clean, consistent description using only the`skill_id.`

Updated `SolutionViewModel` 
→ Now uses `CustomHtmlContentHandler.getContentDescription() `together with `ConceptCardTagHandler` to ensure correct accessibility parsing across hint and solution screens.

Additional note

This PR also includes an auto-format update to `scripts/assets/kdoc_validity_exemptions.textproto`
generated automatically by ktlint. No functional changes were made.

## Testing done

Tested TalkBack behavior in all places where concept-card links appear:

- Hint section
- Solution section
- Flashback mode

TalkBack now reads the concept card link:

- Exactly once
- In the correct format
- With the correct text

## Ready for review

Screen recording demonstrating TalkBack reading concept card links correctly in all 3 places:       🔗https://drive.google.com/file/d/1y6pqNhccfw5rjqeOtr_VNsF78jvSTvPN/view?usp=sharing


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-o-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).


