### PR TITLE
Fix #5983: Restrict Fractions Lesson to accept only exact 1/2 answer

### DIFF
--- a/domain/src/main/assets/test_exp_id_2.json
+++ b/domain/src/main/assets/test_exp_id_2.json
@@ -496,14 +496,7 @@
                   "denominator": 2
                 }
               }
-            },
-              {
-                "rule_type": "HasIntegerPartEqualTo",
-                "inputs": {
-                  "x": 1
-                }
-              }
-            ],
+            }],
             "outcome": {
               "dest": "MultipleChoice",
               "feedback": {

--- a/domain/src/main/assets/test_exp_id_2.textproto
+++ b/domain/src/main/assets/test_exp_id_2.textproto
@@ -805,15 +805,6 @@ states {
           }
           rule_type: "IsExactlyEqualTo"
         }
-        rule_specs {
-         input {
-          key: "x"
-            value {
-             signed_int: 1
-              }
-             }
-           rule_type: "HasIntegerPartEqualTo"
-         }
       }
       solution {
         answer_is_exclusive: true

--- a/domain/src/test/java/org/oppia/android/domain/util/StateRetrieverTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/util/StateRetrieverTest.kt
@@ -630,32 +630,6 @@ class StateRetrieverTest {
     assertThat(state.linkedSkillId).isEqualTo("test_skill_id_2")
   }
 
-  @Test
-  fun testParseState_withFractionInputInteraction_parsesRuleHasIntegerPartEqualToRuleSpec() {
-    val state = loadStateFromJson(
-      stateName = "Fractions",
-      explorationName = TEST_EXPLORATION_ID_2
-    )
-
-    val ruleSpecMap = state.interaction.answerGroupsList
-      .flatMap(AnswerGroup::getRuleSpecsList)
-      .associateBy(RuleSpec::getRuleType)
-    assertThat(ruleSpecMap).containsKey("HasIntegerPartEqualTo")
-  }
-
-  @Test
-  fun testParseState_withFractionInput_parsesRuleHasIntegerPartEqualToValueAtX() {
-    val state = loadStateFromJson(
-      stateName = "Fractions",
-      explorationName = TEST_EXPLORATION_ID_2
-    )
-
-    val ruleSpecMap = lookUpRuleSpec(state, "HasIntegerPartEqualTo")
-    val expectedInputInteractionObject =
-      InteractionObject.newBuilder().setSignedInt(1).build()
-    assertThat(ruleSpecMap.inputMap["x"]).isEqualTo(expectedInputInteractionObject)
-  }
-
   /**
    * Return the first [RuleSpec] in the specified [State] matching the specified rule type, or fails
    * if one cannot be found.


### PR DESCRIPTION
## Explanation

Fix #5983 : This PR fixes a bug in the Fractions Lesson test exploration where the question "What fraction represents half of something?" was incorrectly accepting answers like `1`, `1 1/2`, `1 5/6`, etc.

### Root Cause
The answer group in `test_exp_id_2` had two rules combined with OR logic:
1. `IsExactlyEqualTo` with value `1/2` (correct)
2. `HasIntegerPartEqualTo` with value `1` (incorrect for this question)

Since any fraction with an integer part of 1 matched the second rule, incorrect answers were being accepted.

### Changes Made
- Removed the `HasIntegerPartEqualTo` rule from the Fractions question in `test_exp_id_2.json` and `test_exp_id_2.textproto`
- Removed related tests in `StateRetrieverTest.kt` that tested parsing of the removed rule

### Testing
After this fix:
- `1/2` → Accepted
-  `0 1/2` → Accepted  
-  `1` → Rejected (was incorrectly accepted before)
-  `1 5/6` → Rejected (was incorrectly accepted before)

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).