### PR TITLE
Fix Part of #4938: Add admin controls dialog (6/12)

### DIFF
--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsDialog.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsDialog.kt
@@ -1,0 +1,94 @@
+package org.oppia.android.app.administratorcontrols
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Card
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import org.oppia.android.app.ui.R
+
+@Composable
+fun AdministratorControlsDialog(onDismiss: () -> Unit) {
+  Dialog(onDismissRequest = onDismiss) {
+    Card(
+      shape = RoundedCornerShape(16.dp),
+      elevation = 8.dp,
+      modifier = Modifier.padding(12.dp)
+    ) {
+      Box(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(24.dp)
+      ) {
+
+        IconButton(
+          onClick = onDismiss,
+          modifier = Modifier.align(Alignment.TopEnd)
+        ) {
+          Icon(
+            imageVector = Icons.Default.Close,
+            contentDescription = "Close",
+            tint = colorResource(R.color.component_color_shared_black_background_color)
+          )
+        }
+
+        Column(
+          modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp),
+          horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+          Text(
+            text = "Welcome to the Administrator Controls Page!",
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold,
+            color = colorResource(R.color.component_color_onboarding_shared_green_color),
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = 12.dp)
+          )
+
+          Text(
+            text = "On this page, you can add new learners, or change the profile settings for " +
+              "all learners.",
+            fontSize = 18.sp,
+            color = colorResource(R.color.component_color_shared_primary_text_color),
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 16.dp)
+          )
+
+          Button(
+            onClick = onDismiss,
+            modifier = Modifier
+              .fillMaxWidth()
+              .padding(top = 24.dp),
+            colors = ButtonDefaults.buttonColors(
+              backgroundColor = colorResource(
+                R.color.component_color_onboarding_shared_green_color
+              )
+            ),
+          ) {
+            Text("OK, LET'S GO", fontWeight = FontWeight.Bold, color = Color.White)
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentPresenter.kt
@@ -1,11 +1,17 @@
 package org.oppia.android.app.administratorcontrols
 
+import android.app.Dialog
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.ViewTreeViewModelStoreOwner
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.savedstate.ViewTreeSavedStateRegistryOwner
 import org.oppia.android.app.administratorcontrols.administratorcontrolsitemviewmodel.AdministratorControlsAccountActionsViewModel
 import org.oppia.android.app.administratorcontrols.administratorcontrolsitemviewmodel.AdministratorControlsAppInformationViewModel
 import org.oppia.android.app.administratorcontrols.administratorcontrolsitemviewmodel.AdministratorControlsDownloadPermissionsViewModel
@@ -69,6 +75,9 @@ class AdministratorControlsFragmentPresenter @Inject constructor(
       this.viewModel = administratorControlsViewModel
       this.lifecycleOwner = fragment
     }
+
+    // TODO(4938): Only show this dialog on the first visit.
+    fragment.requireContext().showDialog()
 
     return binding.root
   }
@@ -186,6 +195,26 @@ class AdministratorControlsFragmentPresenter @Inject constructor(
       APP_VERSION_FRAGMENT -> 4
       else -> throw InvalidParameterException("Not a valid fragment in getSelectedFragmentIndex.")
     }
+  }
+
+  private fun Context.showDialog() {
+    val dialog = Dialog(this)
+
+    val composeView = ComposeView(this).apply {
+      ViewTreeLifecycleOwner.set(this, fragment.viewLifecycleOwner)
+      ViewTreeViewModelStoreOwner.set(this, fragment)
+      ViewTreeSavedStateRegistryOwner.set(this, fragment)
+
+      setContent {
+        AdministratorControlsDialog(
+          onDismiss = { dialog.dismiss() }
+        )
+      }
+    }
+
+    dialog.setContentView(composeView)
+    dialog.setCancelable(true)
+    dialog.show()
   }
 
   private enum class ViewType {

--- a/app/src/main/java/org/oppia/android/app/profile/ProfileLoginActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/ProfileLoginActivity.kt
@@ -6,10 +6,10 @@ import android.os.Bundle
 import org.oppia.android.app.activity.ActivityComponentImpl
 import org.oppia.android.app.activity.InjectableAutoLocalizedAppCompatActivity
 import org.oppia.android.app.model.ProfileId
-import org.oppia.android.app.model.ProfileType
 import org.oppia.android.app.model.ProfileLoginActivityParams
-import org.oppia.android.util.extensions.putProtoExtra
+import org.oppia.android.app.model.ProfileType
 import org.oppia.android.app.model.ScreenName
+import org.oppia.android.util.extensions.putProtoExtra
 import org.oppia.android.util.logging.CurrentAppScreenNameIntentDecorator.decorateWithScreenName
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.decorateWithUserProfileId
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
@@ -84,7 +84,6 @@ class ProfileLoginActivity :
           LoginFlow.OPEN_EXISTING_PROFILE.value
         )
       )
-
   }
 
   override fun routeToResetPinDialog(profileId: ProfileId, profileName: String) {

--- a/app/src/main/java/org/oppia/android/app/profile/ProfileLoginFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/ProfileLoginFragmentPresenter.kt
@@ -61,7 +61,6 @@ import org.oppia.android.app.home.HomeActivity
 import org.oppia.android.app.model.Profile
 import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.ProfileType
-import org.oppia.android.util.extensions.getProtoExtra
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.ui.R
 import org.oppia.android.domain.onboarding.AppStartupStateController
@@ -69,6 +68,7 @@ import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.extensions.getProtoExtra
 import org.oppia.android.util.platformparameter.EnableMultipleClassrooms
 import org.oppia.android.util.platformparameter.PlatformParameterValue
 import javax.inject.Inject

--- a/app/src/sharedTest/java/org/oppia/android/app/onboarding/CreateProfileFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/onboarding/CreateProfileFragmentTest.kt
@@ -190,7 +190,8 @@ class CreateProfileFragmentTest {
       onView(withId(R.id.create_profile_pin_constraint_layout))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
       onView(withId(R.id.add_profile_activity_pin_edit_text)).check(matches(isDisplayed()))
-      onView(withId(R.id.create_profile_activity_confirm_pin_edit_text)).check(matches(isDisplayed()))
+      onView(withId(R.id.create_profile_activity_confirm_pin_edit_text))
+        .check(matches(isDisplayed()))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileLoginFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileLoginFragmentTest.kt
@@ -50,7 +50,6 @@ import org.oppia.android.app.classroom.ClassroomListActivity
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.home.HomeActivity
-import org.oppia.android.app.onboarding.CreateProfileActivity
 import org.oppia.android.app.model.AppStartupState
 import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.onboarding.CreateProfileActivity


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
