### PR TITLE
Fix #5812: Fail early in PROTO mode if test or source mapping is missing in coverage script

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
@@ -63,7 +63,13 @@ fun main(vararg args: String) {
     .map { filePath ->
       when {
         filePath.endsWith("Test.kt") -> {
-          findSourceFile(File(repoRoot).absoluteFile, repoRoot, filePath)
+          val sourceFile = findSourceFile(File(repoRoot).absoluteFile, repoRoot, filePath)
+          if (sourceFile == null) {
+            // Return a special marker for failure, to be handled in the main logic
+            "__NO_SOURCE_FOUND__::$filePath"
+          } else {
+            sourceFile
+          }
         }
         filePath.endsWith(".kt") -> filePath
         else -> null
@@ -87,6 +93,16 @@ fun main(vararg args: String) {
   println("Using format: $reportFormat")
 
   for (filePath in filePathList) {
+    if (filePath.startsWith("__NO_SOURCE_FOUND__::")) {
+      val testFilePath = filePath.removePrefix("__NO_SOURCE_FOUND__::")
+      println("COVERAGE FAILURE REPORT:")
+      println("-----------------------")
+      println("Coverage Report Failure:")
+      println("------------------------")
+      println("Test Target: $testFilePath")
+      println("Failure Message: No source files found for test file: $testFilePath")
+      kotlin.system.exitProcess(1)
+    }
     check(File(repoRoot, filePath).exists()) {
       "File doesn't exist: $filePath."
     }

--- a/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
@@ -148,7 +148,15 @@ class RunCoverage(
     if (reportFormat == ReportFormat.PROTO) {
       filePathList.forEach { filePath ->
         val coverageReport = runCoverageForFile(filePath)
-
+        if (coverageReport.hasFailure()) {
+          println("COVERAGE FAILURE REPORT:")
+          println("-----------------------")
+          println("Coverage Report Failure:")
+          println("------------------------")
+          println("Test Target: $filePath")
+          println("Failure Message: ${coverageReport.failure.failureMessage}")
+          kotlin.system.exitProcess(1)
+        }
         val filePathDir = filePath.substringBeforeLast(".")
         val protoOutputPath = "$repoRoot/coverage_reports/$filePathDir/coverage_report.pb"
         val protoOutputFile = File(protoOutputPath)

--- a/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
@@ -165,13 +165,16 @@ class RunCoverage(
       filePathList.forEach { filePath ->
         val coverageReport = runCoverageForFile(filePath)
         if (coverageReport.hasFailure()) {
-          println("COVERAGE FAILURE REPORT:")
-          println("-----------------------")
-          println("Coverage Report Failure:")
-          println("------------------------")
-          println("Test Target: $filePath")
-          println("Failure Message: ${coverageReport.failure.failureMessage}")
-          kotlin.system.exitProcess(1)
+          val failureMessage = buildString {
+            appendLine("COVERAGE FAILURE REPORT:")
+            appendLine("-----------------------")
+            appendLine("Coverage Report Failure:")
+            appendLine("------------------------")
+            appendLine("Test Target: $filePath")
+            appendLine("Failure Message: ${coverageReport.failure.failureMessage}")
+          }
+          print(failureMessage)
+          error(failureMessage.trim())
         }
         val filePathDir = filePath.substringBeforeLast(".")
         val protoOutputPath = "$repoRoot/coverage_reports/$filePathDir/coverage_report.pb"

--- a/scripts/src/javatests/org/oppia/android/scripts/coverage/RunCoverageTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/coverage/RunCoverageTest.kt
@@ -2370,7 +2370,8 @@ class RunCoverageTest {
       )
     }
 
-    assertThat(exception).hasMessageThat().contains("No appropriate test file found for $sampleFile")
+    assertThat(exception).hasMessageThat()
+      .contains("No appropriate test file found for $sampleFile")
   }
 
   @Test
@@ -2379,7 +2380,8 @@ class RunCoverageTest {
     testBazelWorkspace.initEmptyWorkspace()
 
     // Create a test file without a corresponding source file
-    val testFileContent = """
+    val testFileContent =
+      """
       package com.example
       
       import org.junit.Assert.assertEquals
@@ -2391,7 +2393,7 @@ class RunCoverageTest {
           assertEquals(1, 1)
         }
       }
-    """.trimIndent()
+      """.trimIndent()
 
     val testFile = File(tempFolder.root, testFilePath)
     testFile.parentFile?.mkdirs()

--- a/scripts/src/javatests/org/oppia/android/scripts/coverage/RunCoverageTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/coverage/RunCoverageTest.kt
@@ -161,6 +161,33 @@ class RunCoverageTest {
   }
 
   @Test
+  fun testRunCoverage_withProtoReportFormat_savesCoverageReportProto() {
+    val filePath = "coverage/main/java/com/example/AddNums.kt"
+
+    testBazelWorkspace.initEmptyWorkspace()
+    testBazelWorkspace.addSourceAndTestFileWithContent(
+      filename = "AddNums",
+      testFilename = "AddNumsTest",
+      sourceContent = getAddNumsSourceContent(),
+      testContent = getAddNumsTestContent(),
+      sourceSubpackage = "coverage/main/java/com/example",
+      testSubpackage = "coverage/test/java/com/example"
+    )
+
+    main(
+      "${tempFolder.root}",
+      filePath,
+      "--format=Proto",
+      "--processTimeout=10"
+    )
+
+    val outputFilePath = "${tempFolder.root}" +
+      "$coverageDir/${filePath.removeSuffix(".kt")}/coverage_report.pb"
+
+    assertThat(File(outputFilePath).exists()).isTrue()
+  }
+
+  @Test
   fun testRunCoverage_reorderedArguments_generatesCoverageReport() {
     val filePath = "coverage/main/java/com/example/AddNums.kt"
 
@@ -2330,18 +2357,55 @@ class RunCoverageTest {
   }
 
   @Test
-  fun testRunCoverage_withProtoReportFormat_savesCoverageReportProto() {
+  fun testRunCoverage_withProtoReportFormat_missingTestFile_generatesFailureReport() {
     val sampleFile = "file.kt"
-    val outputFilePath = "${tempFolder.root}/coverage_reports/file/coverage_report.pb"
     testBazelWorkspace.initEmptyWorkspace()
     tempFolder.newFile(sampleFile)
-    main(
-      tempFolder.root.absolutePath,
-      sampleFile,
-      "--format=Proto"
-    )
 
-    assertThat(File(outputFilePath).exists()).isTrue()
+    val exception = assertThrows<IllegalStateException>() {
+      main(
+        tempFolder.root.absolutePath,
+        sampleFile,
+        "--format=Proto"
+      )
+    }
+
+    assertThat(exception).hasMessageThat().contains("No appropriate test file found for $sampleFile")
+  }
+
+  @Test
+  fun testRunCoverage_testFileWithNoSourceMapping_generatesFailureReport() {
+    val testFilePath = "coverage/test/java/com/example/AddNumsTest.kt"
+    testBazelWorkspace.initEmptyWorkspace()
+
+    // Create a test file without a corresponding source file
+    val testFileContent = """
+      package com.example
+      
+      import org.junit.Assert.assertEquals
+      import org.junit.Test
+      
+      class AddNumsTest {
+        @Test
+        fun testSumNumbers() {
+          assertEquals(1, 1)
+        }
+      }
+    """.trimIndent()
+
+    val testFile = File(tempFolder.root, testFilePath)
+    testFile.parentFile?.mkdirs()
+    testFile.writeText(testFileContent)
+
+    val exception = assertThrows<SecurityException>() {
+      main(
+        tempFolder.root.absolutePath,
+        testFilePath
+      )
+    }
+
+    // Bazel catches the System.exit() call and throws a SecurityException
+    assertThat(exception).hasMessageThat().contains("System.exit()")
   }
 
   private fun getExpectedMarkdownText(filePath: String): String {


### PR DESCRIPTION
## Explanation

Fixes #5812 :

This PR ensures that the coverage script fails early in PROTO mode if either a test file is missing for a source file or a source file is missing for a test file. It adds robust error handling for both mapping directions (source→test and test→source), providing clear error messages and exit codes.
As discussed  [here](https://github.com/oppia/oppia-android/issues/5780#issuecomment-2752627473) in #5780 

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

