### PR TITLE
Fix #5959 Profiles Flicker issue

### DIFF
--- a/app/src/main/java/org/oppia/android/app/databinding/ImageViewBindingAdapters.java
+++ b/app/src/main/java/org/oppia/android/app/databinding/ImageViewBindingAdapters.java
@@ -7,10 +7,6 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.databinding.BindingAdapter;
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.DataSource;
-import com.bumptech.glide.load.engine.GlideException;
-import com.bumptech.glide.request.RequestListener;
-import com.bumptech.glide.request.target.Target;
 import org.oppia.android.app.databinding.adapters.R;
 import org.oppia.android.app.model.ChapterPlayState;
 import org.oppia.android.app.model.ProfileAvatar;
@@ -44,34 +40,16 @@ public final class ImageViewBindingAdapters {
   public static void setProfileImage(ImageView imageView, ProfileAvatar profileAvatar) {
     if (profileAvatar != null) {
       if (profileAvatar.getAvatarTypeCase() == ProfileAvatar.AvatarTypeCase.AVATAR_COLOR_RGB) {
-        Glide.with(imageView.getContext())
-            .load(R.drawable.ic_default_avatar)
-            .listener(new RequestListener<Drawable>() {
-              @Override
-              public boolean onLoadFailed(
-                  GlideException e,
-                  Object model,
-                  Target<Drawable> target,
-                  boolean isFirstResource) {
-                return false;
-              }
-
-              @Override
-              public boolean onResourceReady(
-                  Drawable resource,
-                  Object model,
-                  Target<Drawable> target,
-                  DataSource dataSource,
-                  boolean isFirstResource
-              ) {
-                imageView.setColorFilter(
-                    profileAvatar.getAvatarColorRgb(),
-                    PorterDuff.Mode.DST_OVER
-                );
-                return false;
-              }
-            }).into(imageView);
+        // Clear any pending Glide request from a recycled ViewHolder and load the default avatar
+        // synchronously.
+        Glide.with(imageView.getContext()).clear(imageView);
+        imageView.setImageResource(R.drawable.ic_default_avatar);
+        imageView.setColorFilter(
+                profileAvatar.getAvatarColorRgb(),
+                PorterDuff.Mode.DST_OVER
+        );
       } else {
+        imageView.clearColorFilter();
         Glide.with(imageView.getContext())
             .load(profileAvatar.getAvatarImageUri())
             .placeholder(R.drawable.ic_default_avatar)

--- a/app/src/main/java/org/oppia/android/app/recyclerview/BindableAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/recyclerview/BindableAdapter.kt
@@ -211,6 +211,7 @@ class BindableAdapter<T : Any> internal constructor(
             // Attaching lifecycleOwner before view model initialization can sometimes cause a
             // NullPointerException because data might not be attached to the views yet.
             binding.lifecycleOwner = lifecycleOwner
+            binding.executePendingBindings()
           }
         }
       }
@@ -337,6 +338,7 @@ class BindableAdapter<T : Any> internal constructor(
             // Attaching lifecycleOwner before view model initialization can sometimes cause a
             // NullPointerException because data might not be attached to the views yet.
             binding.lifecycleOwner = lifecycleOwner
+            binding.executePendingBindings()
           }
         }
       }


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
  - "Fixes #5959 " in the explanation so that GitHub can auto-close the issue
 -  Reuse view holders for items with the same stable ID, preventing full rebinds that cause UI flicker.
  - when this PR is merged - Cleaner and Smoother UI transitions during Profile Selection
  
  

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
- Mobile 

https://github.com/user-attachments/assets/3e294808-df92-46ff-ab3e-6bcf2e2e3142

-Tablet

https://github.com/user-attachments/assets/9a91995f-8559-46c6-8dcf-f71065c231c5

 - BindableAdapterTest Result 
 
<img width="1920" height="1080" alt="Screenshot from 2026-01-02 22-09-49" src="https://github.com/user-attachments/assets/ab6e8df5-d06d-4da3-bead-bc8bd79cd72c" />



<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
