### PR TITLE
Fix: Update drawer selection on back navigation (#6042)

### DIFF
--- a/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragment.kt
@@ -64,7 +64,12 @@ class NavigationDrawerFragment :
     navigationDrawerFragmentPresenter.highlightDeveloperOptionsItem()
   }
 
-  override fun unhighlightSwitchProfileMenuItem() {
     navigationDrawerFragmentPresenter.unhighlightSwitchProfileMenuItem()
   }
+
+  override fun onResume() {
+    super.onResume()
+    navigationDrawerFragmentPresenter.handleOnResume()
+  }
+
 }

--- a/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
@@ -474,6 +474,19 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
     }
   }
 
+  /**
+   * Re-checks the current menu item in the navigation drawer. This is needed when the user returns
+   * to this fragment from another activity (like Administrator Controls) where the selection might
+   * have been cleared.
+   */
+  fun handleOnResume() {
+     if (this::binding.isInitialized && previousMenuItemId != null && previousMenuItemId != 0 && previousMenuItemId != -1) {
+       binding.fragmentDrawerNavView.menu.getItem(
+         NavigationDrawerItem.valueFromNavId(previousMenuItemId!!).ordinal
+       ).isChecked = true
+     }
+  }
+
   private fun checkIfPreviousActivityShouldGetFinished(currentMenuItemId: Int): Boolean {
     if (previousMenuItemId != null &&
       (previousMenuItemId == 0 || previousMenuItemId == -1) &&


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
