### PR TITLE
Fix #6006: Add Installation ID with copy option to App Version screen

### DIFF
--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -563,6 +563,7 @@ kt_android_library(
         "//utility/src/main/java/org/oppia/android/util/math:fraction_parser",
         "//utility/src/main/java/org/oppia/android/util/networking:network_connection_debug_util",
         "//utility/src/main/java/org/oppia/android/util/parser/html:html_parser",
+        "//app/src/main/java/org/oppia/android/app/utility/lifecycle:lifecycle_safe_timer_factory",
     ],
 )
 

--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -544,6 +544,7 @@ kt_android_library(
         ":resources",
         "//app/src/main/java/org/oppia/android/app/shim:intent_factory_shim",
         "//app/src/main/java/org/oppia/android/app/utility/datetime:date_time_util",
+        "//app/src/main/java/org/oppia/android/app/utility/lifecycle:lifecycle_safe_timer_factory",
         "//app/src/main/java/org/oppia/android/app/utility/math:math_expression_accessibility_util",
         "//app/src/main/java/org/oppia/android/app/viewmodel:observable_array_list",
         "//app/src/main/java/org/oppia/android/app/viewmodel:observable_view_model",
@@ -563,7 +564,6 @@ kt_android_library(
         "//utility/src/main/java/org/oppia/android/util/math:fraction_parser",
         "//utility/src/main/java/org/oppia/android/util/networking:network_connection_debug_util",
         "//utility/src/main/java/org/oppia/android/util/parser/html:html_parser",
-        "//app/src/main/java/org/oppia/android/app/utility/lifecycle:lifecycle_safe_timer_factory",
     ],
 )
 

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
@@ -1,8 +1,6 @@
 package org.oppia.android.app.administratorcontrols.appversion
 
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import androidx.databinding.ObservableField
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LiveData
@@ -19,6 +17,7 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.getLastUpdateTime
 import org.oppia.android.util.extensions.getVersionName
+import org.oppia.android.app.utility.lifecycle.LifecycleSafeTimerFactory
 import javax.inject.Inject
 
 private const val COPY_ICON_RESET_DELAY_MS = 2000L
@@ -31,12 +30,12 @@ class AppVersionViewModel @Inject constructor(
   private val clipboardController: ClipboardController,
   private val oppiaLogger: OppiaLogger,
   private val fragment: Fragment,
+  private val lifecycleSafeTimerFactory: LifecycleSafeTimerFactory,
   context: Context
 ) : ObservableViewModel() {
 
   private val versionName: String = context.getVersionName()
   private val lastUpdateDateTime = context.getLastUpdateTime()
-  private val handler = Handler(Looper.getMainLooper())
 
   /** Indicates whether the installation ID was recently copied. */
   val isInstallationIdCopied = ObservableField(false)
@@ -62,9 +61,9 @@ class AppVersionViewModel @Inject constructor(
       ).toLiveData().observe(fragment) { result ->
         if (result is AsyncResult.Success) {
           isInstallationIdCopied.set(true)
-          handler.postDelayed({
+          lifecycleSafeTimerFactory.createTimer(COPY_ICON_RESET_DELAY_MS).observe(fragment) {
             isInstallationIdCopied.set(false)
-          }, COPY_ICON_RESET_DELAY_MS)
+          }
         } else {
           oppiaLogger.w(
             "AppVersionViewModel",

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import org.oppia.android.app.fragment.FragmentScope
 import org.oppia.android.app.translation.AppLanguageResourceHandler
+import org.oppia.android.app.utility.lifecycle.LifecycleSafeTimerFactory
 import org.oppia.android.app.view.models.R
 import org.oppia.android.app.viewmodel.ObservableViewModel
 import org.oppia.android.domain.clipboard.ClipboardController
@@ -17,7 +18,6 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.getLastUpdateTime
 import org.oppia.android.util.extensions.getVersionName
-import org.oppia.android.app.utility.lifecycle.LifecycleSafeTimerFactory
 import javax.inject.Inject
 
 private const val COPY_ICON_RESET_DELAY_MS = 2000L

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
@@ -1,24 +1,79 @@
 package org.oppia.android.app.administratorcontrols.appversion
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import androidx.databinding.ObservableField
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import org.oppia.android.app.fragment.FragmentScope
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.view.models.R
 import org.oppia.android.app.viewmodel.ObservableViewModel
+import org.oppia.android.domain.clipboard.ClipboardController
+import org.oppia.android.domain.oppialogger.LoggingIdentifierController
+import org.oppia.android.domain.oppialogger.OppiaLogger
+import org.oppia.android.util.data.AsyncResult
+import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.getLastUpdateTime
 import org.oppia.android.util.extensions.getVersionName
 import javax.inject.Inject
+
+private const val COPY_ICON_RESET_DELAY_MS = 2000L
 
 /** [ViewModel] for [AppVersionFragment]. */
 @FragmentScope
 class AppVersionViewModel @Inject constructor(
   private val resourceHandler: AppLanguageResourceHandler,
+  private val loggingIdentifierController: LoggingIdentifierController,
+  private val clipboardController: ClipboardController,
+  private val oppiaLogger: OppiaLogger,
+  private val fragment: Fragment,
   context: Context
 ) : ObservableViewModel() {
 
   private val versionName: String = context.getVersionName()
   private val lastUpdateDateTime = context.getLastUpdateTime()
+  private val handler = Handler(Looper.getMainLooper())
+
+  /** Indicates whether the installation ID was recently copied. */
+  val isInstallationIdCopied = ObservableField(false)
+
+  /** The device installation ID. */
+  val installationId: LiveData<String?> by lazy {
+    Transformations.map(
+      loggingIdentifierController.getInstallationId().toLiveData()
+    ) { result ->
+      (result as? AsyncResult.Success)?.value
+    }
+  }
+
+  /** Copies the specified installation ID (if non-null) to the user's clipboard. */
+  fun copyInstallationId(installationId: String?) {
+    installationId?.let {
+      val appName = resourceHandler.getStringInLocale(R.string.app_name)
+      clipboardController.setCurrentClip(
+        resourceHandler.getStringInLocaleWithWrapping(
+          R.string.learner_analytics_device_id_clipboard_label_description, appName
+        ),
+        installationId
+      ).toLiveData().observe(fragment) { result ->
+        if (result is AsyncResult.Success) {
+          isInstallationIdCopied.set(true)
+          handler.postDelayed({
+            isInstallationIdCopied.set(false)
+          }, COPY_ICON_RESET_DELAY_MS)
+        } else {
+          oppiaLogger.w(
+            "AppVersionViewModel",
+            "Encountered unexpected non-successful result when copying to clipboard: $result"
+          )
+        }
+      }
+    }
+  }
 
   /** Returns a localized, human-readable app version name. */
   fun computeVersionNameText(): String =

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
@@ -72,7 +72,7 @@ class AppVersionViewModel @Inject constructor(
             isInstallationIdCopied.set(false)
           }
         } else {
-          oppiaLogger.w(
+          oppiaLogger.d(
             "AppVersionViewModel",
             "Encountered unexpected non-successful result when copying to clipboard: $result"
           )

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
@@ -40,6 +40,13 @@ class AppVersionViewModel @Inject constructor(
   /** Indicates whether the installation ID was recently copied. */
   val isInstallationIdCopied = ObservableField(false)
 
+  /** Indicates whether the app version was recently copied. */
+  val isAppVersionCopied = ObservableField(false)
+
+  /** The app version name. */
+  val appVersion: String
+    get() = versionName
+
   /** The device installation ID. */
   val installationId: LiveData<String?> by lazy {
     Transformations.map(
@@ -70,6 +77,29 @@ class AppVersionViewModel @Inject constructor(
             "Encountered unexpected non-successful result when copying to clipboard: $result"
           )
         }
+      }
+    }
+  }
+
+  /** Copies the app version to the user's clipboard. */
+  fun copyAppVersion() {
+    val appName = resourceHandler.getStringInLocale(R.string.app_name)
+    clipboardController.setCurrentClip(
+      resourceHandler.getStringInLocaleWithWrapping(
+        R.string.learner_analytics_device_id_clipboard_label_description, appName
+      ),
+      versionName
+    ).toLiveData().observe(fragment) { result ->
+      if (result is AsyncResult.Success) {
+        isAppVersionCopied.set(true)
+        lifecycleSafeTimerFactory.createTimer(COPY_ICON_RESET_DELAY_MS).observe(fragment) {
+          isAppVersionCopied.set(false)
+        }
+      } else {
+        oppiaLogger.w(
+          "AppVersionViewModel",
+          "Encountered unexpected non-successful result when copying to clipboard: $result"
+        )
       }
     }
   }

--- a/app/src/main/res/layout/app_version_fragment.xml
+++ b/app/src/main/res/layout/app_version_fragment.xml
@@ -139,6 +139,7 @@
 
         <TextView
           android:id="@+id/installation_id_text"
+          style="@style/TextViewStart"
           android:layout_width="0dp"
           android:layout_height="wrap_content"
           android:layout_marginEnd="10dp"
@@ -186,6 +187,7 @@
 
       <TextView
         android:id="@+id/installation_id_explanation"
+        style="@style/TextViewStart"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="12dp"

--- a/app/src/main/res/layout/app_version_fragment.xml
+++ b/app/src/main/res/layout/app_version_fragment.xml
@@ -12,51 +12,155 @@
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/component_color_shared_screen_tertiary_background_color">
+    android:background="@color/component_color_shared_screen_tertiary_background_color"
+    android:fillViewport="true">
 
-    <TextView
-      android:id="@+id/app_version_text_view"
+    <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:background="@drawable/general_item_background_border"
-      android:fontFamily="sans-serif"
-      android:paddingStart="@dimen/app_version_text_view_padding_start"
-      android:paddingTop="20dp"
-      android:paddingEnd="@dimen/app_version_text_view_padding_end"
-      android:paddingBottom="20dp"
-      android:text="@{viewModel.computeVersionNameText()}"
-      android:textColor="@color/component_color_shared_primary_dark_text_color"
-      android:textSize="16sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
+      android:layout_height="wrap_content">
 
-    <ImageView
-      android:id="@+id/app_info_image_view"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="@dimen/app_version_image_view_margin_start"
-      app:layout_constraintEnd_toStartOf="@id/app_last_update_date_text_view"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="@id/app_last_update_date_text_view"
-      app:srcCompat="@drawable/ic_info_icon_gray_24dp"
-      app:tint="@color/component_color_app_version_activity_info_icon_color"
-      android:contentDescription="@string/app_info_icon_content_description" />
+      <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/installation_id_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:background="@drawable/general_item_background_border"
+        android:paddingStart="24dp"
+        android:paddingTop="24dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="24dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-    <TextView
-      android:id="@+id/app_last_update_date_text_view"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="12dp"
-      android:layout_marginTop="28dp"
-      android:layout_marginEnd="@dimen/app_version_text_view_margin_end"
-      android:fontFamily="sans-serif"
-      android:text="@{viewModel.computeLastUpdatedDateText()}"
-      android:textColor="@color/component_color_app_version_activity_description_text_color"
-      android:textSize="12sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintHorizontal_weight="1"
-      app:layout_constraintStart_toEndOf="@id/app_info_image_view"
-      app:layout_constraintTop_toBottomOf="@id/app_version_text_view" />
+        <TextView
+          android:id="@+id/installation_id_label"
+          style="@style/Heading2"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:text="@string/installation_id_label"
+          android:textColor="@color/component_color_shared_primary_dark_text_color"
+          android:textSize="18sp"
+          android:textStyle="bold"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+          android:id="@+id/installation_id_text"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="10dp"
+          android:layout_marginEnd="10dp"
+          android:fontFamily="sans-serif"
+          android:text="@{viewModel.installationId}"
+          android:textColor="@color/component_color_shared_primary_dark_text_color"
+          android:textSize="18sp"
+          app:layout_constraintEnd_toStartOf="@+id/copy_installation_id_button"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/installation_id_label"
+          app:layout_constraintBottom_toBottomOf="parent" />
+
+        <org.oppia.android.app.administratorcontrols.learneranalytics.CopyIdMaterialButtonView
+          style="@style/BorderlessMaterialButton"
+          android:id="@+id/copy_installation_id_button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:minWidth="48dp"
+          android:minHeight="48dp"
+          android:textColor="@color/component_color_profile_and_device_id_activity_primary_text_color"
+          android:enabled="@{viewModel.installationId != null}"
+          android:text="@{viewModel.isInstallationIdCopied ? @string/learner_analytics_copied_to_clipboard_label : @string/learner_analytics_copy_to_clipboard_label}"
+          android:onClick="@{(v) -> viewModel.copyInstallationId(viewModel.installationId)}"
+          app:icon="@{viewModel.isInstallationIdCopied ? @drawable/ic_baseline_check_24 : @drawable/ic_baseline_content_copy_24}"
+          app:iconGravity="top"
+          app:iconSize="28dp"
+          app:iconTint="@color/component_color_profile_and_device_id_activity_enabled_icon_button_color"
+          app:backgroundTint="@color/component_color_shared_white_background_color"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toTopOf="@id/installation_id_text"
+          app:layout_constraintBottom_toBottomOf="@id/installation_id_text"
+          android:contentDescription="@string/copy_installation_id" />
+
+      </androidx.constraintlayout.widget.ConstraintLayout>
+
+      <ImageView
+        android:id="@+id/installation_id_info_image_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/installation_id_container"
+        app:srcCompat="@drawable/ic_info_icon_gray_24dp"
+        app:tint="@color/component_color_app_version_activity_info_icon_color"
+        android:contentDescription="@string/app_info_icon_content_description" />
+
+      <TextView
+        android:id="@+id/installation_id_explanation"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:fontFamily="sans-serif"
+        android:text="@string/installation_id_explanation"
+        android:textColor="@color/component_color_app_version_activity_description_text_color"
+        android:textSize="14sp"
+        android:lineSpacingExtra="4dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/installation_id_info_image_view"
+        app:layout_constraintTop_toBottomOf="@id/installation_id_container" />
+
+      <TextView
+        android:id="@+id/app_version_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:background="@drawable/general_item_background_border"
+        android:fontFamily="sans-serif"
+        android:paddingStart="@dimen/app_version_text_view_padding_start"
+        android:paddingTop="20dp"
+        android:paddingEnd="@dimen/app_version_text_view_padding_end"
+        android:paddingBottom="20dp"
+        android:text="@{viewModel.computeVersionNameText()}"
+        android:textColor="@color/component_color_shared_primary_dark_text_color"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/installation_id_explanation" />
+
+      <ImageView
+        android:id="@+id/app_info_image_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/app_version_image_view_margin_start"
+        android:layout_marginTop="12dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/app_version_text_view"
+        app:srcCompat="@drawable/ic_info_icon_gray_24dp"
+        app:tint="@color/component_color_app_version_activity_info_icon_color"
+        android:contentDescription="@string/app_info_icon_content_description" />
+
+      <TextView
+        android:id="@+id/app_last_update_date_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginEnd="@dimen/app_version_text_view_margin_end"
+        android:fontFamily="sans-serif"
+        android:text="@{viewModel.computeLastUpdatedDateText()}"
+        android:textColor="@color/component_color_app_version_activity_description_text_color"
+        android:textSize="12sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/app_info_image_view"
+        app:layout_constraintTop_toBottomOf="@id/app_version_text_view" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/app_version_fragment.xml
+++ b/app/src/main/res/layout/app_version_fragment.xml
@@ -3,7 +3,6 @@
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <data>
-
     <variable
       name="viewModel"
       type="org.oppia.android.app.administratorcontrols.appversion.AppVersionViewModel" />

--- a/app/src/main/res/layout/app_version_fragment.xml
+++ b/app/src/main/res/layout/app_version_fragment.xml
@@ -11,8 +11,7 @@
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/component_color_shared_screen_tertiary_background_color"
-    android:fillViewport="true">
+    android:background="@color/component_color_shared_screen_tertiary_background_color">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"

--- a/app/src/main/res/layout/app_version_fragment.xml
+++ b/app/src/main/res/layout/app_version_fragment.xml
@@ -18,10 +18,24 @@
       android:layout_height="wrap_content"
       android:padding="16dp">
 
+      <TextView
+        android:id="@+id/app_version_label"
+        style="@style/Heading2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/app_version_label"
+        android:textColor="@color/component_color_shared_primary_dark_text_color"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
       <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/app_version_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
         android:background="@drawable/general_item_background_border"
         android:paddingStart="24dp"
         android:paddingTop="12dp"
@@ -29,7 +43,7 @@
         android:paddingBottom="12dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@id/app_version_label">
 
         <TextView
           android:id="@+id/app_version_text_view"

--- a/app/src/main/res/layout/app_version_fragment.xml
+++ b/app/src/main/res/layout/app_version_fragment.xml
@@ -16,7 +16,10 @@
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:padding="16dp">
+      android:padding="16dp"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent">
 
       <TextView
         android:id="@+id/app_version_label"
@@ -78,7 +81,6 @@
           app:layout_constraintBottom_toBottomOf="@id/app_version_text_view"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintTop_toTopOf="@id/app_version_text_view" />
-
       </androidx.constraintlayout.widget.ConstraintLayout>
 
       <ImageView
@@ -169,7 +171,6 @@
           app:layout_constraintBottom_toBottomOf="@id/installation_id_text"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintTop_toTopOf="@id/installation_id_text" />
-
       </androidx.constraintlayout.widget.ConstraintLayout>
 
       <ImageView
@@ -197,7 +198,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/installation_id_info_image_view"
         app:layout_constraintTop_toBottomOf="@id/installation_id_container" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/app_version_fragment.xml
+++ b/app/src/main/res/layout/app_version_fragment.xml
@@ -15,134 +15,68 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content">
+      android:layout_height="wrap_content"
+      android:padding="16dp">
 
       <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/installation_id_container"
+        android:id="@+id/app_version_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
         android:background="@drawable/general_item_background_border"
         android:paddingStart="24dp"
-        android:paddingTop="24dp"
+        android:paddingTop="12dp"
         android:paddingEnd="24dp"
-        android:paddingBottom="24dp"
+        android:paddingBottom="12dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
         <TextView
-          android:id="@+id/installation_id_label"
-          style="@style/Heading2"
+          android:id="@+id/app_version_text_view"
           android:layout_width="0dp"
           android:layout_height="wrap_content"
-          android:text="@string/installation_id_label"
+          android:layout_marginEnd="10dp"
+          android:fontFamily="sans-serif"
+          android:text="@{viewModel.appVersion}"
           android:textColor="@color/component_color_shared_primary_dark_text_color"
           android:textSize="18sp"
-          android:textStyle="bold"
-          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toStartOf="@+id/copy_app_version_button"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-          android:id="@+id/installation_id_text"
-          android:layout_width="0dp"
-          android:layout_height="wrap_content"
-          android:layout_marginTop="10dp"
-          android:layout_marginEnd="10dp"
-          android:fontFamily="sans-serif"
-          android:text="@{viewModel.installationId}"
-          android:textColor="@color/component_color_shared_primary_dark_text_color"
-          android:textSize="18sp"
-          app:layout_constraintEnd_toStartOf="@+id/copy_installation_id_button"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@id/installation_id_label"
-          app:layout_constraintBottom_toBottomOf="parent" />
-
         <org.oppia.android.app.administratorcontrols.learneranalytics.CopyIdMaterialButtonView
+          android:id="@+id/copy_app_version_button"
           style="@style/BorderlessMaterialButton"
-          android:id="@+id/copy_installation_id_button"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:minWidth="48dp"
           android:minHeight="48dp"
+          android:contentDescription="@string/copy_app_version"
+          android:onClick="@{(v) -> viewModel.copyAppVersion()}"
+          android:text="@{viewModel.isAppVersionCopied ? @string/learner_analytics_copied_to_clipboard_label : @string/learner_analytics_copy_to_clipboard_label}"
           android:textColor="@color/component_color_profile_and_device_id_activity_primary_text_color"
-          android:enabled="@{viewModel.installationId != null}"
-          android:text="@{viewModel.isInstallationIdCopied ? @string/learner_analytics_copied_to_clipboard_label : @string/learner_analytics_copy_to_clipboard_label}"
-          android:onClick="@{(v) -> viewModel.copyInstallationId(viewModel.installationId)}"
-          app:icon="@{viewModel.isInstallationIdCopied ? @drawable/ic_baseline_check_24 : @drawable/ic_baseline_content_copy_24}"
+          app:backgroundTint="@color/component_color_shared_white_background_color"
+          app:icon="@{viewModel.isAppVersionCopied ? @drawable/ic_baseline_check_24 : @drawable/ic_baseline_content_copy_24}"
           app:iconGravity="top"
           app:iconSize="28dp"
           app:iconTint="@color/component_color_profile_and_device_id_activity_enabled_icon_button_color"
-          app:backgroundTint="@color/component_color_shared_white_background_color"
+          app:layout_constraintBottom_toBottomOf="@id/app_version_text_view"
           app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintTop_toTopOf="@id/installation_id_text"
-          app:layout_constraintBottom_toBottomOf="@id/installation_id_text"
-          android:contentDescription="@string/copy_installation_id" />
+          app:layout_constraintTop_toTopOf="@id/app_version_text_view" />
 
       </androidx.constraintlayout.widget.ConstraintLayout>
-
-      <ImageView
-        android:id="@+id/installation_id_info_image_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/installation_id_container"
-        app:srcCompat="@drawable/ic_info_icon_gray_24dp"
-        app:tint="@color/component_color_app_version_activity_info_icon_color"
-        android:contentDescription="@string/app_info_icon_content_description" />
-
-      <TextView
-        android:id="@+id/installation_id_explanation"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:fontFamily="sans-serif"
-        android:text="@string/installation_id_explanation"
-        android:textColor="@color/component_color_app_version_activity_description_text_color"
-        android:textSize="14sp"
-        android:lineSpacingExtra="4dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/installation_id_info_image_view"
-        app:layout_constraintTop_toBottomOf="@id/installation_id_container" />
-
-      <TextView
-        android:id="@+id/app_version_text_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:background="@drawable/general_item_background_border"
-        android:fontFamily="sans-serif"
-        android:paddingStart="@dimen/app_version_text_view_padding_start"
-        android:paddingTop="20dp"
-        android:paddingEnd="@dimen/app_version_text_view_padding_end"
-        android:paddingBottom="20dp"
-        android:text="@{viewModel.computeVersionNameText()}"
-        android:textColor="@color/component_color_shared_primary_dark_text_color"
-        android:textSize="16sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/installation_id_explanation" />
 
       <ImageView
         android:id="@+id/app_info_image_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/app_version_image_view_margin_start"
         android:layout_marginTop="12dp"
+        android:contentDescription="@string/app_info_icon_content_description"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/app_version_text_view"
+        app:layout_constraintTop_toBottomOf="@id/app_version_container"
         app:srcCompat="@drawable/ic_info_icon_gray_24dp"
-        app:tint="@color/component_color_app_version_activity_info_icon_color"
-        android:contentDescription="@string/app_info_icon_content_description" />
+        app:tint="@color/component_color_app_version_activity_info_icon_color" />
 
       <TextView
         android:id="@+id/app_last_update_date_text_view"
@@ -150,14 +84,105 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="12dp"
         android:layout_marginTop="12dp"
-        android:layout_marginEnd="@dimen/app_version_text_view_margin_end"
         android:fontFamily="sans-serif"
+        android:lineSpacingExtra="4dp"
         android:text="@{viewModel.computeLastUpdatedDateText()}"
         android:textColor="@color/component_color_app_version_activity_description_text_color"
-        android:textSize="12sp"
+        android:textSize="14sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/app_info_image_view"
-        app:layout_constraintTop_toBottomOf="@id/app_version_text_view" />
+        app:layout_constraintTop_toBottomOf="@id/app_version_container" />
+
+      <TextView
+        android:id="@+id/installation_id_label"
+        style="@style/Heading2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="28dp"
+        android:text="@string/installation_id_label"
+        android:textColor="@color/component_color_shared_primary_dark_text_color"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/app_last_update_date_text_view" />
+
+      <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/installation_id_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:background="@drawable/general_item_background_border"
+        android:paddingStart="24dp"
+        android:paddingTop="12dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/installation_id_label">
+
+        <TextView
+          android:id="@+id/installation_id_text"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_marginEnd="10dp"
+          android:fontFamily="sans-serif"
+          android:text="@{viewModel.installationId}"
+          android:textColor="@color/component_color_shared_primary_dark_text_color"
+          android:textSize="18sp"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toStartOf="@+id/copy_installation_id_button"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <org.oppia.android.app.administratorcontrols.learneranalytics.CopyIdMaterialButtonView
+          android:id="@+id/copy_installation_id_button"
+          style="@style/BorderlessMaterialButton"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:minWidth="48dp"
+          android:minHeight="48dp"
+          android:contentDescription="@string/copy_installation_id"
+          android:enabled="@{viewModel.installationId != null}"
+          android:onClick="@{(v) -> viewModel.copyInstallationId(viewModel.installationId)}"
+          android:text="@{viewModel.isInstallationIdCopied ? @string/learner_analytics_copied_to_clipboard_label : @string/learner_analytics_copy_to_clipboard_label}"
+          android:textColor="@color/component_color_profile_and_device_id_activity_primary_text_color"
+          app:backgroundTint="@color/component_color_shared_white_background_color"
+          app:icon="@{viewModel.isInstallationIdCopied ? @drawable/ic_baseline_check_24 : @drawable/ic_baseline_content_copy_24}"
+          app:iconGravity="top"
+          app:iconSize="28dp"
+          app:iconTint="@color/component_color_profile_and_device_id_activity_enabled_icon_button_color"
+          app:layout_constraintBottom_toBottomOf="@id/installation_id_text"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toTopOf="@id/installation_id_text" />
+
+      </androidx.constraintlayout.widget.ConstraintLayout>
+
+      <ImageView
+        android:id="@+id/installation_id_info_image_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:contentDescription="@string/app_info_icon_content_description"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/installation_id_container"
+        app:srcCompat="@drawable/ic_info_icon_gray_24dp"
+        app:tint="@color/component_color_app_version_activity_info_icon_color" />
+
+      <TextView
+        android:id="@+id/installation_id_explanation"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="12dp"
+        android:fontFamily="sans-serif"
+        android:lineSpacingExtra="4dp"
+        android:text="@string/installation_id_explanation"
+        android:textColor="@color/component_color_app_version_activity_description_text_color"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/installation_id_info_image_view"
+        app:layout_constraintTop_toBottomOf="@id/installation_id_container" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -421,6 +421,9 @@
   <string name="app_version_name">App Version %s</string>
   <string name="app_last_update_date">The last update was installed on %s. Use the above version number to send feedback about bugs.</string>
   <string name="app_version_activity_title">App Version</string>
+  <string name="installation_id_label">Installation ID</string>
+  <string name="installation_id_explanation">This ID uniquely identifies this app installation. Use this ID when reporting bugs.</string>
+  <string name="copy_installation_id">Copy installation ID</string>
   <!-- OptionsActivity -->
   <string name="app_language_activity_title">App Language</string>
   <string name="audio_language_activity_title">Preferred Audio Language</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -418,12 +418,13 @@
   <string name="log_out_dialog_okay_button" tools:ignore="ButtonCase,Typos">Ok</string>
   <string name="log_out_dialog_message">Are you sure you want to log out of your profile?</string>
   <!-- AppVersionFragment -->
+  <string name="app_version_label">App Version</string>
   <string name="app_version_name">%s</string>
-  <string name="app_last_update_date">The last update was installed on %s. Use the above version number to send feedback about bugs.</string>
+  <string name="app_last_update_date">The last update was installed on %s. Please share the above version when sending feedback about bugs.</string>
   <string name="app_version_activity_title">App Version</string>
   <string name="copy_app_version">Copy app version</string>
   <string name="installation_id_label">Installation ID</string>
-  <string name="installation_id_explanation">This ID uniquely identifies this app installation. Use this ID when reporting bugs.</string>
+  <string name="installation_id_explanation">This ID uniquely identifies this app installation. You may be asked to provide this when filing feedback about the app or using certain features.</string>
   <string name="copy_installation_id">Copy installation ID</string>
   <!-- OptionsActivity -->
   <string name="app_language_activity_title">App Language</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -418,9 +418,10 @@
   <string name="log_out_dialog_okay_button" tools:ignore="ButtonCase,Typos">Ok</string>
   <string name="log_out_dialog_message">Are you sure you want to log out of your profile?</string>
   <!-- AppVersionFragment -->
-  <string name="app_version_name">App Version %s</string>
+  <string name="app_version_name">%s</string>
   <string name="app_last_update_date">The last update was installed on %s. Use the above version number to send feedback about bugs.</string>
   <string name="app_version_activity_title">App Version</string>
+  <string name="copy_app_version">Copy app version</string>
   <string name="installation_id_label">Installation ID</string>
   <string name="installation_id_explanation">This ID uniquely identifies this app installation. Use this ID when reporting bugs.</string>
   <string name="copy_installation_id">Copy installation ID</string>

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
@@ -1,8 +1,6 @@
 package org.oppia.android.app.administratorcontrols.appversion
 
 import android.app.Application
-import android.content.ClipData
-import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
@@ -66,6 +64,7 @@ import org.oppia.android.domain.classify.rules.numericexpressioninput.NumericExp
 import org.oppia.android.domain.classify.rules.numericinput.NumericInputRuleModule
 import org.oppia.android.domain.classify.rules.ratioinput.RatioInputModule
 import org.oppia.android.domain.classify.rules.textinput.TextInputRuleModule
+import org.oppia.android.domain.clipboard.ClipboardController
 import org.oppia.android.domain.exploration.ExplorationProgressModule
 import org.oppia.android.domain.exploration.ExplorationStorageModule
 import org.oppia.android.domain.hintsandsolution.HintsAndSolutionConfigModule
@@ -82,6 +81,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
+import org.oppia.android.testing.data.DataProviderTestMonitor
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule
@@ -123,10 +123,8 @@ class AppVersionActivityTest {
 
   @Inject lateinit var context: Context
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-
-  private val clipboardManager by lazy {
-    context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-  }
+  @Inject lateinit var clipboardController: ClipboardController
+  @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
 
   @Before
   fun setUp() {
@@ -275,15 +273,22 @@ class AppVersionActivityTest {
   fun testAppVersionActivity_clickCopyButton_copiesInstallationIdToClipboard() {
     launchAppVersionActivityIntent().use {
       testCoroutineDispatchers.runCurrent()
+      val currentClipProvider = clipboardController.getCurrentClip()
 
       onView(withId(R.id.copy_installation_id_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
-    }
 
-    val clipData = getCurrentClipData()
-    assertThat(clipData?.description?.label).isEqualTo("Oppia installation ID")
-    assertThat(clipData?.itemCount).isEqualTo(1)
-    assertThat(clipData?.getItemAt(0)?.text?.isNotEmpty()).isTrue()
+      // Verify the button shows "Copied" state, indicating successful copy
+      onView(withId(R.id.copy_installation_id_button))
+        .check(matches(withText(R.string.learner_analytics_copied_to_clipboard_label)))
+
+      // Verify clipboard contains the installation ID using ClipboardController
+      val currentClip = monitorFactory.waitForNextSuccessfulResult(currentClipProvider)
+      assertThat(currentClip).isInstanceOf(ClipboardController.CurrentClip.SetWithAppText::class.java)
+      val clipWithText = currentClip as ClipboardController.CurrentClip.SetWithAppText
+      assertThat(clipWithText.label).isEqualTo("Oppia installation ID")
+      assertThat(clipWithText.text).isNotEmpty()
+    }
   }
 
   @Test
@@ -351,15 +356,21 @@ class AppVersionActivityTest {
   fun testAppVersionActivity_clickAppVersionCopyButton_copiesVersionToClipboard() {
     launchAppVersionActivityIntent().use {
       testCoroutineDispatchers.runCurrent()
+      val currentClipProvider = clipboardController.getCurrentClip()
 
       onView(withId(R.id.copy_app_version_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
-    }
 
-    val clipData = getCurrentClipData()
-    assertThat(clipData?.description?.label).isEqualTo("Oppia installation ID")
-    assertThat(clipData?.itemCount).isEqualTo(1)
-    assertThat(clipData?.getItemAt(0)?.text).isEqualTo(context.getVersionName())
+      // Verify the button shows "Copied" state, indicating successful copy
+      onView(withId(R.id.copy_app_version_button))
+        .check(matches(withText(R.string.learner_analytics_copied_to_clipboard_label)))
+
+      // Verify clipboard contains the app version using ClipboardController
+      val currentClip = monitorFactory.waitForNextSuccessfulResult(currentClipProvider)
+      assertThat(currentClip).isInstanceOf(ClipboardController.CurrentClip.SetWithAppText::class.java)
+      val clipWithText = currentClip as ClipboardController.CurrentClip.SetWithAppText
+      assertThat(clipWithText.text).isEqualTo(context.getVersionName())
+    }
   }
 
   @Test
@@ -398,7 +409,6 @@ class AppVersionActivityTest {
     return createAdministratorControlsActivityIntent(context, profileId)
   }
 
-  private fun getCurrentClipData(): ClipData? = clipboardManager.primaryClip
 
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.
   @Singleton

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
@@ -164,14 +164,8 @@ class AppVersionActivityTest {
   fun testAppVersionActivity_loadFragment_displaysAppVersion() {
     launchAppVersionActivityIntent().use { scenario ->
       val lastUpdateDate = scenario.convertTimeStampToDate(context.getLastUpdateTime())
-      onView(
-        withText(
-          String.format(
-            context.resources.getString(R.string.app_version_name),
-            context.getVersionName()
-          )
-        )
-      ).check(matches(isDisplayed()))
+      onView(withId(R.id.app_version_text_view))
+        .check(matches(withText(context.getVersionName())))
       onView(
         withText(
           String.format(
@@ -190,20 +184,8 @@ class AppVersionActivityTest {
     launchAppVersionActivityIntent().use { scenario ->
       onView(isRoot()).perform(orientationLandscape())
       val lastUpdateDate = scenario.convertTimeStampToDate(context.getLastUpdateTime())
-      onView(
-        withId(
-          R.id.app_version_text_view
-        )
-      ).check(
-        matches(
-          withText(
-            String.format(
-              context.resources.getString(R.string.app_version_name),
-              context.getVersionName()
-            )
-          )
-        )
-      )
+      onView(withId(R.id.app_version_text_view))
+        .check(matches(withText(context.getVersionName())))
       onView(
         withId(
           R.id.app_last_update_date_text_view
@@ -321,6 +303,46 @@ class AppVersionActivityTest {
       onView(withId(R.id.installation_id_explanation)).check(matches(isDisplayed()))
       onView(withId(R.id.installation_id_explanation))
         .check(matches(withText(R.string.installation_id_explanation)))
+    }
+  }
+
+
+  @Test
+  fun testAppVersionActivity_appVersionCopyButton_isDisplayed() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_app_version_button)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_clickAppVersionCopyButton_showsCopiedState() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_app_version_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_app_version_button))
+        .check(matches(withText(R.string.learner_analytics_copied_to_clipboard_label)))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_clickAppVersionCopyButton_afterDelay_resetsState() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_app_version_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+
+      // Advance time past the 2000ms reset delay.
+      testCoroutineDispatchers.advanceTimeBy(2001)
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_app_version_button))
+        .check(matches(withText(R.string.learner_analytics_copy_to_clipboard_label)))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
@@ -1,6 +1,8 @@
 package org.oppia.android.app.administratorcontrols.appversion
 
 import android.app.Application
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
@@ -121,6 +123,10 @@ class AppVersionActivityTest {
 
   @Inject lateinit var context: Context
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
+
+  private val clipboardManager by lazy {
+    context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+  }
 
   @Before
   fun setUp() {
@@ -266,6 +272,22 @@ class AppVersionActivityTest {
   }
 
   @Test
+  fun testAppVersionActivity_clickCopyButton_copiesInstallationIdToClipboard() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_installation_id_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+    }
+
+    val clipData = getCurrentClipData()
+    assertThat(clipData?.description?.label).isEqualTo("Oppia installation ID")
+    assertThat(clipData?.itemCount).isEqualTo(1)
+    // Verify the installation ID is a non-empty string (exact value varies per installation).
+    assertThat(clipData?.getItemAt(0)?.text?.isNotEmpty()).isTrue()
+  }
+
+  @Test
   fun testAppVersionActivity_clickCopyButton_afterDelay_resetsState() {
     launchAppVersionActivityIntent().use {
       testCoroutineDispatchers.runCurrent()
@@ -306,7 +328,6 @@ class AppVersionActivityTest {
     }
   }
 
-
   @Test
   fun testAppVersionActivity_appVersionCopyButton_isDisplayed() {
     launchAppVersionActivityIntent().use {
@@ -327,6 +348,21 @@ class AppVersionActivityTest {
       onView(withId(R.id.copy_app_version_button))
         .check(matches(withText(R.string.learner_analytics_copied_to_clipboard_label)))
     }
+  }
+
+  @Test
+  fun testAppVersionActivity_clickAppVersionCopyButton_copiesVersionToClipboard() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_app_version_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+    }
+
+    val clipData = getCurrentClipData()
+    assertThat(clipData?.description?.label).isEqualTo("Oppia installation ID")
+    assertThat(clipData?.itemCount).isEqualTo(1)
+    assertThat(clipData?.getItemAt(0)?.text).isEqualTo(context.getVersionName())
   }
 
   @Test
@@ -364,6 +400,8 @@ class AppVersionActivityTest {
     val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
     return createAdministratorControlsActivityIntent(context, profileId)
   }
+
+  private fun getCurrentClipData(): ClipData? = clipboardManager.primaryClip
 
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.
   @Singleton

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
@@ -288,21 +288,19 @@ class AppVersionActivityTest {
   }
 
   @Test
-  fun testAppVersionActivity_clickCopyButton_afterDelay_resetsState() {
+  fun testAppVersionActivity_clickAppVersionCopyButton_copiesVersionToClipboard() {
     launchAppVersionActivityIntent().use {
       testCoroutineDispatchers.runCurrent()
 
-      onView(withId(R.id.copy_installation_id_button)).perform(click())
+      onView(withId(R.id.copy_app_version_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
-
-      // Advance time past the 2000ms reset delay.
-      testCoroutineDispatchers.advanceTimeBy(2001)
-      testCoroutineDispatchers.runCurrent()
-
-      onView(withId(R.id.copy_installation_id_button))
-        .check(matches(withText(R.string.learner_analytics_copy_to_clipboard_label)))
     }
+    val clipData = getCurrentClipData()
+    assertThat(clipData?.description?.label).isEqualTo("Oppia installation ID")
+    assertThat(clipData?.itemCount).isEqualTo(1)
+    assertThat(clipData?.getItemAt(0)?.text).isEqualTo(context.getVersionName())
   }
+
 
   @Test
   fun testAppVersionActivity_configurationChange_installationIdIsDisplayed() {

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
@@ -241,6 +241,89 @@ class AppVersionActivityTest {
     }
   }
 
+  @Test
+  fun testAppVersionActivity_installationIdIsDisplayed() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.installation_id_text)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_installationIdLabelIsDisplayed() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.installation_id_label)).check(matches(isDisplayed()))
+      onView(withId(R.id.installation_id_label))
+        .check(matches(withText(R.string.installation_id_label)))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_copyButton_isDisplayed() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_installation_id_button)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_clickCopyButton_showsCopiedState() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_installation_id_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_installation_id_button))
+        .check(matches(withText(R.string.learner_analytics_copied_to_clipboard_label)))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_clickCopyButton_afterDelay_resetsState() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_installation_id_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+
+      // Advance time past the 2000ms reset delay.
+      testCoroutineDispatchers.advanceTimeBy(2001)
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_installation_id_button))
+        .check(matches(withText(R.string.learner_analytics_copy_to_clipboard_label)))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_configurationChange_installationIdIsDisplayed() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(isRoot()).perform(orientationLandscape())
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.installation_id_text)).check(matches(isDisplayed()))
+      onView(withId(R.id.copy_installation_id_button)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_installationIdExplanationIsDisplayed() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.installation_id_explanation)).check(matches(isDisplayed()))
+      onView(withId(R.id.installation_id_explanation))
+        .check(matches(withText(R.string.installation_id_explanation)))
+    }
+  }
+
   private fun ActivityScenario<AppVersionActivity>.convertTimeStampToDate(
     timestampMillis: Long
   ): String {

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
@@ -283,24 +283,23 @@ class AppVersionActivityTest {
     val clipData = getCurrentClipData()
     assertThat(clipData?.description?.label).isEqualTo("Oppia installation ID")
     assertThat(clipData?.itemCount).isEqualTo(1)
-    // Verify the installation ID is a non-empty string (exact value varies per installation).
     assertThat(clipData?.getItemAt(0)?.text?.isNotEmpty()).isTrue()
   }
 
   @Test
-  fun testAppVersionActivity_clickAppVersionCopyButton_copiesVersionToClipboard() {
+  fun testAppVersionActivity_clickCopyButton_afterDelay_resetsState() {
     launchAppVersionActivityIntent().use {
       testCoroutineDispatchers.runCurrent()
 
-      onView(withId(R.id.copy_app_version_button)).perform(click())
+      onView(withId(R.id.copy_installation_id_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
-    }
-    val clipData = getCurrentClipData()
-    assertThat(clipData?.description?.label).isEqualTo("Oppia installation ID")
-    assertThat(clipData?.itemCount).isEqualTo(1)
-    assertThat(clipData?.getItemAt(0)?.text).isEqualTo(context.getVersionName())
-  }
+      testCoroutineDispatchers.advanceTimeBy(2001)
+      testCoroutineDispatchers.runCurrent()
 
+      onView(withId(R.id.copy_installation_id_button))
+        .check(matches(withText(R.string.learner_analytics_copy_to_clipboard_label)))
+    }
+  }
 
   @Test
   fun testAppVersionActivity_configurationChange_installationIdIsDisplayed() {

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
@@ -284,7 +284,8 @@ class AppVersionActivityTest {
 
       // Verify clipboard contains the installation ID using ClipboardController
       val currentClip = monitorFactory.waitForNextSuccessfulResult(currentClipProvider)
-      assertThat(currentClip).isInstanceOf(ClipboardController.CurrentClip.SetWithAppText::class.java)
+      assertThat(currentClip)
+        .isInstanceOf(ClipboardController.CurrentClip.SetWithAppText::class.java)
       val clipWithText = currentClip as ClipboardController.CurrentClip.SetWithAppText
       assertThat(clipWithText.label).isEqualTo("Oppia installation ID")
       assertThat(clipWithText.text).isNotEmpty()
@@ -367,7 +368,8 @@ class AppVersionActivityTest {
 
       // Verify clipboard contains the app version using ClipboardController
       val currentClip = monitorFactory.waitForNextSuccessfulResult(currentClipProvider)
-      assertThat(currentClip).isInstanceOf(ClipboardController.CurrentClip.SetWithAppText::class.java)
+      assertThat(currentClip)
+        .isInstanceOf(ClipboardController.CurrentClip.SetWithAppText::class.java)
       val clipWithText = currentClip as ClipboardController.CurrentClip.SetWithAppText
       assertThat(clipWithText.text).isEqualTo(context.getVersionName())
     }
@@ -408,7 +410,6 @@ class AppVersionActivityTest {
     val profileId = ProfileId.newBuilder().setInternalId(internalProfileId).build()
     return createAdministratorControlsActivityIntent(context, profileId)
   }
-
 
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.
   @Singleton


### PR DESCRIPTION
## Explanation
**Fixes #6006: Adds the Installation ID to the App Version screen and provides a copy button so users can easily share the ID for debugging and support purposes.**

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Screenshots

### Tablet
**Light mode**  
<img width="1336" height="806" alt="image" src="https://github.com/user-attachments/assets/23f1eeb9-7484-4fb2-8bb1-dfb72dc9e4bb" />



**Dark mode**  
<img width="1339" height="811" alt="image" src="https://github.com/user-attachments/assets/0a8d528f-2e1d-4601-8359-4324aee235a8" />




### Phone
**Light mode**  
<img width="385" height="860" alt="image" src="https://github.com/user-attachments/assets/b54c17d1-38dc-4477-9458-dc193c3e45c9" />


**Dark mode**  
<img width="387" height="862" alt="image" src="https://github.com/user-attachments/assets/83a9715d-4d77-4ee7-acb7-8c82b57718e0" />


## Demo Video
[intallationID feature Demo.webm](https://github.com/user-attachments/assets/ab493832-4d3a-4ea1-86e2-585e05835f6b)

**Note: That toast at bottom showing oppia pasted from clipboard.... is not implemented in app, it is android feature as far I have researched, since I have not implemented any toast feature.** 

## Testing
- Manually tested by uninstalling and reinstalling the app to verify Installation ID is generated correctly
- Verified Installation ID remains consistent across app restarts
- Verified copy button copies the correct Installation ID to clipboard
- Verified UI behavior in light and dark mode on phone and tablet
- added test for new features.

##Files changed : 4
- app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
- app/src/main/res/layout/app_version_fragment.xml
- app/src/main/res/values/strings.xml
- app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt


