### PR TITLE
Fix part of #5815: Add Missing Tests

### DIFF
--- a/app/src/main/java/org/oppia/android/app/testing/AdministratorControlsFragmentTestActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/AdministratorControlsFragmentTestActivity.kt
@@ -5,9 +5,11 @@ import android.content.Intent
 import android.os.Bundle
 import org.oppia.android.app.activity.ActivityComponentImpl
 import org.oppia.android.app.administratorcontrols.LoadAppVersionListener
+import org.oppia.android.app.administratorcontrols.LoadLearnerAnalyticsListener
 import org.oppia.android.app.administratorcontrols.LoadProfileEditListener
 import org.oppia.android.app.administratorcontrols.LoadProfileListListener
 import org.oppia.android.app.administratorcontrols.RouteToAppVersionListener
+import org.oppia.android.app.administratorcontrols.RouteToLearnerAnalyticsListener
 import org.oppia.android.app.administratorcontrols.RouteToProfileListListener
 import org.oppia.android.app.administratorcontrols.ShowLogoutDialogListener
 import org.oppia.android.app.administratorcontrols.appversion.AppVersionActivity
@@ -23,8 +25,10 @@ class AdministratorControlsFragmentTestActivity :
   TestActivity(),
   RouteToProfileListListener,
   RouteToAppVersionListener,
+  RouteToLearnerAnalyticsListener,
   LoadProfileListListener,
   LoadAppVersionListener,
+  LoadLearnerAnalyticsListener,
   LoadProfileEditListener,
   ShowLogoutDialogListener {
   @Inject
@@ -56,6 +60,8 @@ class AdministratorControlsFragmentTestActivity :
 
   override fun showLogoutDialog() {}
 
+  override fun loadLearnerAnalyticsData() {}
+  override fun routeToLearnerAnalytics() {}
   companion object {
     /** Returns an [Intent] to start this activity. */
     fun createAdministratorControlsFragmentTestActivityIntent(

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -874,6 +874,7 @@ class AdministratorControlsActivityTest {
       )
     }
   }
+
   @Test
   fun testAdministratorControls_learnerAnalyticsDisabled_profileNotDisplayed() {
     TestPlatformParameterModule.forceEnableEditAccountsOptionsUi(true)

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -825,8 +825,7 @@ class AdministratorControlsActivityTest {
   }
 
   @Test
-  fun testAdministratorControls_AnalyticsEnabled_profileAndDeviceIdIsDisplayed() {
-    TestPlatformParameterModule.forceEnableEditAccountsOptionsUi(true)
+  fun testAdministratorControls_analyticsEnabled_profileAndDeviceIdIsDisplayed() {
     TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(true)
     setUpTestApplicationComponent()
     launch<AdministratorControlsActivity>(
@@ -837,12 +836,12 @@ class AdministratorControlsActivityTest {
       testCoroutineDispatchers.runCurrent()
       verifyItemDisplayedOnListItem(
         recyclerViewId = administratorControlsListRecyclerViewId,
-        itemPosition = 2,
+        itemPosition = 1,
         targetView = R.id.learner_analytics_text_view
       )
       verifyTextOnListItemAtPosition(
         recyclerViewId = administratorControlsListRecyclerViewId,
-        itemPosition = 2,
+        itemPosition = 1,
         targetViewId = R.id.profile_and_device_id_text_view,
         stringIdToMatch = R.string.profile_and_device_id_activity_title
       )
@@ -850,8 +849,7 @@ class AdministratorControlsActivityTest {
   }
 
   @Test
-  fun testAdministratorControls_Landscape_AnalyticsEnabled_profileAndDeviceIdIsDisplayed() {
-    TestPlatformParameterModule.forceEnableEditAccountsOptionsUi(true)
+  fun testAdministratorControls_landscape_analyticsEnabled_profileAndDeviceIdIsDisplayed() {
     TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(true)
     setUpTestApplicationComponent()
     launch<AdministratorControlsActivity>(
@@ -863,12 +861,12 @@ class AdministratorControlsActivityTest {
       onView(isRoot()).perform(orientationLandscape())
       verifyItemDisplayedOnListItem(
         recyclerViewId = administratorControlsListRecyclerViewId,
-        itemPosition = 2,
+        itemPosition = 1,
         targetView = R.id.learner_analytics_text_view
       )
       verifyTextOnListItemAtPosition(
         recyclerViewId = administratorControlsListRecyclerViewId,
-        itemPosition = 2,
+        itemPosition = 1,
         targetViewId = R.id.profile_and_device_id_text_view,
         stringIdToMatch = R.string.profile_and_device_id_activity_title
       )
@@ -876,8 +874,7 @@ class AdministratorControlsActivityTest {
   }
 
   @Test
-  fun testAdministratorControls_learnerAnalyticsDisabled_profileNotDisplayed() {
-    TestPlatformParameterModule.forceEnableEditAccountsOptionsUi(true)
+  fun testAdministratorControls_analyticsDisabled_profileNotDisplayed() {
     TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(false)
     setUpTestApplicationComponent()
     launch<AdministratorControlsActivity>(
@@ -888,7 +885,51 @@ class AdministratorControlsActivityTest {
       testCoroutineDispatchers.runCurrent()
       verifyItemDisplayedOnListItemDoesNotExist(
         recyclerViewId = administratorControlsListRecyclerViewId,
-        itemPosition = 2,
+        itemPosition = 1,
+        targetView = R.id.learner_analytics_text_view
+      )
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "sw600dp")
+  fun testAdministratorControls_tablet_analyticsEnabled_profileAndDeviceIdIsDisplayed() {
+    TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(true)
+    setUpTestApplicationComponent()
+    launch<AdministratorControlsActivity>(
+      createAdministratorControlsActivityIntent(
+        profileId = profileId
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      verifyItemDisplayedOnListItem(
+        recyclerViewId = administratorControlsListRecyclerViewId,
+        itemPosition = 1,
+        targetView = R.id.learner_analytics_text_view
+      )
+      verifyTextOnListItemAtPosition(
+        recyclerViewId = administratorControlsListRecyclerViewId,
+        itemPosition = 1,
+        targetViewId = R.id.profile_and_device_id_text_view,
+        stringIdToMatch = R.string.profile_and_device_id_activity_title
+      )
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "sw600dp")
+  fun testAdministratorControls_tablet_analyticsDisabled_profileNotDisplayed() {
+    TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(false)
+    setUpTestApplicationComponent()
+    launch<AdministratorControlsActivity>(
+      createAdministratorControlsActivityIntent(
+        profileId = profileId
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      verifyItemDisplayedOnListItemDoesNotExist(
+        recyclerViewId = administratorControlsListRecyclerViewId,
+        itemPosition = 1,
         targetView = R.id.learner_analytics_text_view
       )
     }

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsActivityTest.kt
@@ -825,6 +825,75 @@ class AdministratorControlsActivityTest {
   }
 
   @Test
+  fun testAdministratorControls_AnalyticsEnabled_profileAndDeviceIdIsDisplayed() {
+    TestPlatformParameterModule.forceEnableEditAccountsOptionsUi(true)
+    TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(true)
+    setUpTestApplicationComponent()
+    launch<AdministratorControlsActivity>(
+      createAdministratorControlsActivityIntent(
+        profileId = profileId
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      verifyItemDisplayedOnListItem(
+        recyclerViewId = administratorControlsListRecyclerViewId,
+        itemPosition = 2,
+        targetView = R.id.learner_analytics_text_view
+      )
+      verifyTextOnListItemAtPosition(
+        recyclerViewId = administratorControlsListRecyclerViewId,
+        itemPosition = 2,
+        targetViewId = R.id.profile_and_device_id_text_view,
+        stringIdToMatch = R.string.profile_and_device_id_activity_title
+      )
+    }
+  }
+
+  @Test
+  fun testAdministratorControls_Landscape_AnalyticsEnabled_profileAndDeviceIdIsDisplayed() {
+    TestPlatformParameterModule.forceEnableEditAccountsOptionsUi(true)
+    TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(true)
+    setUpTestApplicationComponent()
+    launch<AdministratorControlsActivity>(
+      createAdministratorControlsActivityIntent(
+        profileId = profileId
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(isRoot()).perform(orientationLandscape())
+      verifyItemDisplayedOnListItem(
+        recyclerViewId = administratorControlsListRecyclerViewId,
+        itemPosition = 2,
+        targetView = R.id.learner_analytics_text_view
+      )
+      verifyTextOnListItemAtPosition(
+        recyclerViewId = administratorControlsListRecyclerViewId,
+        itemPosition = 2,
+        targetViewId = R.id.profile_and_device_id_text_view,
+        stringIdToMatch = R.string.profile_and_device_id_activity_title
+      )
+    }
+  }
+  @Test
+  fun testAdministratorControls_learnerAnalyticsDisabled_profileNotDisplayed() {
+    TestPlatformParameterModule.forceEnableEditAccountsOptionsUi(true)
+    TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(false)
+    setUpTestApplicationComponent()
+    launch<AdministratorControlsActivity>(
+      createAdministratorControlsActivityIntent(
+        profileId = profileId
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      verifyItemDisplayedOnListItemDoesNotExist(
+        recyclerViewId = administratorControlsListRecyclerViewId,
+        itemPosition = 2,
+        targetView = R.id.learner_analytics_text_view
+      )
+    }
+  }
+
+  @Test
   fun testActivity_createIntent_verifyScreenNameInIntent() {
     TestPlatformParameterModule.forceEnableEditAccountsOptionsUi(true)
     setUpTestApplicationComponent()

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -467,6 +467,93 @@ class AdministratorControlsFragmentTest {
   }
 
   @Test
+  fun testAdministratorControlsFragment_Portrait_AnalyticsEnabled_profileAndDeviceIdDisplayed() {
+    TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(true)
+    setUpTestApplicationComponent()
+    launch<AdministratorControlsFragmentTestActivity>(
+      createAdministratorControlsFragmentTestActivityIntent(
+        profileId = internalProfileId
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      verifyItemDisplayedOnListItem(
+        recyclerViewId = R.id.administrator_controls_list,
+        itemPosition = 2,
+        targetView = R.id.learner_analytics_text_view
+      )
+      verifyTextOnListItemAtPosition(
+        recyclerViewId = R.id.administrator_controls_list,
+        itemPosition = 2,
+        targetViewId = R.id.profile_and_device_id_text_view,
+        stringIdToMatch = R.string.profile_and_device_id_activity_title
+      )
+    }
+  }
+
+  @Test
+  fun testAdministratorControlsFragment_Landscape_AnalyticsEnabled_profileAndDeviceIdDisplayed() {
+    TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(true)
+    setUpTestApplicationComponent()
+    launch<AdministratorControlsFragmentTestActivity>(
+      createAdministratorControlsFragmentTestActivityIntent(
+        profileId = internalProfileId
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(isRoot()).perform(orientationLandscape())
+      testCoroutineDispatchers.runCurrent()
+      verifyItemDisplayedOnListItem(
+        recyclerViewId = R.id.administrator_controls_list,
+        itemPosition = 2,
+        targetView = R.id.learner_analytics_text_view
+      )
+      verifyTextOnListItemAtPosition(
+        recyclerViewId = R.id.administrator_controls_list,
+        itemPosition = 2,
+        targetViewId = R.id.profile_and_device_id_text_view,
+        stringIdToMatch = R.string.profile_and_device_id_activity_title
+      )
+    }
+  }
+
+  @Test
+  fun testAdministratorControlsFragment_Portrait_AnalyticsDisabled_profileAndDeviceIdNotDisplayed() {
+    TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(false)
+    setUpTestApplicationComponent()
+    launch<AdministratorControlsFragmentTestActivity>(
+      createAdministratorControlsFragmentTestActivityIntent(
+        profileId = internalProfileId
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      verifyItemDisplayedOnListItemDoesNotExist(
+        recyclerViewId = R.id.administrator_controls_list,
+        itemPosition = 2,
+        targetView = R.id.learner_analytics_text_view
+      )
+    }
+  }
+
+  @Test
+  fun testAdministratorControlsFragment_Landscape_AnalyticsDisabled_profileAndDeviceIdNotDisplayed() {
+    TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(false)
+    setUpTestApplicationComponent()
+    launch<AdministratorControlsFragmentTestActivity>(
+      createAdministratorControlsFragmentTestActivityIntent(
+        profileId = internalProfileId
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      onView(isRoot()).perform(orientationLandscape())
+      verifyItemDisplayedOnListItemDoesNotExist(
+        recyclerViewId = R.id.administrator_controls_list,
+        itemPosition = 2,
+        targetView = R.id.learner_analytics_text_view
+      )
+    }
+  }
+
+  @Test
   fun testFragment_argumentsAreCorrect() {
     TestPlatformParameterModule.forceEnableDownloadsSupport(true)
     setUpTestApplicationComponent()

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -467,7 +467,7 @@ class AdministratorControlsFragmentTest {
   }
 
   @Test
-  fun testAdministratorControlsFragment_Portrait_AnalyticsEnabled_profileIdDisplayed() {
+  fun testAdministratorControlsFragment_portrait_analyticsEnabled_profileIdDisplayed() {
     TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(true)
     setUpTestApplicationComponent()
     launch<AdministratorControlsFragmentTestActivity>(
@@ -491,7 +491,7 @@ class AdministratorControlsFragmentTest {
   }
 
   @Test
-  fun testAdministratorControlsFragment_Landscape_AnalyticsEnabled_profileIdDisplayed() {
+  fun testAdministratorControlsFragment_landscape_analyticsEnabled_profileIdDisplayed() {
     TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(true)
     setUpTestApplicationComponent()
     launch<AdministratorControlsFragmentTestActivity>(
@@ -517,7 +517,7 @@ class AdministratorControlsFragmentTest {
   }
 
   @Test
-  fun testAdministratorControlsFragment_Portrait_AnalyticsDisabled_profileIdNotDisplayed() {
+  fun testAdministratorControlsFragment_portrait_analyticsDisabled_profileIdNotDisplayed() {
     TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(false)
     setUpTestApplicationComponent()
     launch<AdministratorControlsFragmentTestActivity>(
@@ -535,7 +535,7 @@ class AdministratorControlsFragmentTest {
   }
 
   @Test
-  fun testAdministratorControlsFragment_Landscape_AnalyticsDisabled_profileIdNotDisplayed() {
+  fun testAdministratorControlsFragment_landscape_analyticsDisabled_profileIdNotDisplayed() {
     TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(false)
     setUpTestApplicationComponent()
     launch<AdministratorControlsFragmentTestActivity>(
@@ -545,6 +545,50 @@ class AdministratorControlsFragmentTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
+      verifyItemDisplayedOnListItemDoesNotExist(
+        recyclerViewId = R.id.administrator_controls_list,
+        itemPosition = 2,
+        targetView = R.id.learner_analytics_text_view
+      )
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "sw600dp")
+  fun testAdministratorControlsFragment_tablet_analyticsEnabled_profileIdDisplayed() {
+    TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(true)
+    setUpTestApplicationComponent()
+    launch<AdministratorControlsFragmentTestActivity>(
+      createAdministratorControlsFragmentTestActivityIntent(
+        profileId = internalProfileId
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
+      verifyItemDisplayedOnListItem(
+        recyclerViewId = R.id.administrator_controls_list,
+        itemPosition = 2,
+        targetView = R.id.learner_analytics_text_view
+      )
+      verifyTextOnListItemAtPosition(
+        recyclerViewId = R.id.administrator_controls_list,
+        itemPosition = 2,
+        targetViewId = R.id.profile_and_device_id_text_view,
+        stringIdToMatch = R.string.profile_and_device_id_activity_title
+      )
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "sw600dp")
+  fun testAdministratorControlsFragment_tablet_analyticsDisabled_profileIdNotDisplayed() {
+    TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(false)
+    setUpTestApplicationComponent()
+    launch<AdministratorControlsFragmentTestActivity>(
+      createAdministratorControlsFragmentTestActivityIntent(
+        profileId = internalProfileId
+      )
+    ).use {
+      testCoroutineDispatchers.runCurrent()
       verifyItemDisplayedOnListItemDoesNotExist(
         recyclerViewId = R.id.administrator_controls_list,
         itemPosition = 2,

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/AdministratorControlsFragmentTest.kt
@@ -467,7 +467,7 @@ class AdministratorControlsFragmentTest {
   }
 
   @Test
-  fun testAdministratorControlsFragment_Portrait_AnalyticsEnabled_profileAndDeviceIdDisplayed() {
+  fun testAdministratorControlsFragment_Portrait_AnalyticsEnabled_profileIdDisplayed() {
     TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(true)
     setUpTestApplicationComponent()
     launch<AdministratorControlsFragmentTestActivity>(
@@ -491,7 +491,7 @@ class AdministratorControlsFragmentTest {
   }
 
   @Test
-  fun testAdministratorControlsFragment_Landscape_AnalyticsEnabled_profileAndDeviceIdDisplayed() {
+  fun testAdministratorControlsFragment_Landscape_AnalyticsEnabled_profileIdDisplayed() {
     TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(true)
     setUpTestApplicationComponent()
     launch<AdministratorControlsFragmentTestActivity>(
@@ -517,7 +517,7 @@ class AdministratorControlsFragmentTest {
   }
 
   @Test
-  fun testAdministratorControlsFragment_Portrait_AnalyticsDisabled_profileAndDeviceIdNotDisplayed() {
+  fun testAdministratorControlsFragment_Portrait_AnalyticsDisabled_profileIdNotDisplayed() {
     TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(false)
     setUpTestApplicationComponent()
     launch<AdministratorControlsFragmentTestActivity>(
@@ -535,7 +535,7 @@ class AdministratorControlsFragmentTest {
   }
 
   @Test
-  fun testAdministratorControlsFragment_Landscape_AnalyticsDisabled_profileAndDeviceIdNotDisplayed() {
+  fun testAdministratorControlsFragment_Landscape_AnalyticsDisabled_profileIdNotDisplayed() {
     TestPlatformParameterModule.forceEnableLearnerStudyAnalytics(false)
     setUpTestApplicationComponent()
     launch<AdministratorControlsFragmentTestActivity>(

--- a/utility/src/test/java/org/oppia/android/util/math/MathExpressionExtensionsTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/math/MathExpressionExtensionsTest.kt
@@ -271,9 +271,101 @@ class MathExpressionExtensionsTest {
     assertThat(result2).isFalse()
   }
 
+  @Test
+  fun testStripRedundantGroups_singleConstant_returnsSameExpression() {
+    val expression = parseNumericExpression("2")
+
+    val stripped = expression.stripRedundantGroups()
+
+    assertThat(stripped.isApproximatelyEqualTo(expression)).isTrue()
+  }
+
+  @Test
+  fun testStripRedundantGroups_singleVariable_returnsSameExpression() {
+    val expression = parseAlgebraicExpression("x")
+
+    val stripped = expression.stripRedundantGroups()
+
+    assertThat(stripped.isApproximatelyEqualTo(expression)).isTrue()
+  }
+
+  @Test
+  fun testStripRedundantGroups_redundantGroupAroundConstant_stripsGroup() {
+    val original = parseNumericExpression("(2)", errorCheckingMode = REQUIRED_ONLY)
+    val expected = parseNumericExpression("2")
+
+    val stripped = original.stripRedundantGroups()
+
+    assertThat(stripped.isApproximatelyEqualTo(expected)).isTrue()
+  }
+
+  @Test
+  fun testStripRedundantGroups_redundantGroupAroundVariable_stripsGroup() {
+    val original = parseAlgebraicExpression("(x)", errorCheckingMode = REQUIRED_ONLY)
+    val expected = parseAlgebraicExpression("x")
+
+    val stripped = original.stripRedundantGroups()
+
+    assertThat(stripped.isApproximatelyEqualTo(expected)).isTrue()
+  }
+
+  @Test
+  fun testStripRedundantGroups_nestedRedundantGroups_stripsAll() {
+    val original = parseNumericExpression("((2))", errorCheckingMode = REQUIRED_ONLY)
+    val expected = parseNumericExpression("2")
+
+    val stripped = original.stripRedundantGroups()
+
+    assertThat(stripped.isApproximatelyEqualTo(expected)).isTrue()
+  }
+
+  @Test
+  fun testStripRedundantGroups_groupAroundBinaryOperation_keepsGroup() {
+    val expression = parseNumericExpression("(2+3)", errorCheckingMode = REQUIRED_ONLY)
+
+    val stripped = expression.stripRedundantGroups()
+
+    assertThat(stripped.isApproximatelyEqualTo(expression)).isTrue()
+  }
+
+  @Test
+  fun testStripRedundantGroups_redundantGroupInBinaryOperation_stripsInnerGroup() {
+    val original = parseNumericExpression("2+(3)", errorCheckingMode = REQUIRED_ONLY)
+    val expected = parseNumericExpression("2+3")
+
+    val stripped = original.stripRedundantGroups()
+
+    assertThat(stripped.isApproximatelyEqualTo(expected)).isTrue()
+  }
+
+  @Test
+  fun testStripRedundantGroups_redundantGroupInFunctionArgument_stripsGroup() {
+    val original = parseNumericExpression("sqrt((2))", errorCheckingMode = REQUIRED_ONLY)
+    val expected = parseNumericExpression("sqrt(2)")
+
+    val stripped = original.stripRedundantGroups()
+
+    assertThat(stripped.isApproximatelyEqualTo(expected)).isTrue()
+  }
+
+  @Test
+  fun testStripRedundantGroups_redundantGroupInUnaryOperation_stripsGroup() {
+    val original = parseNumericExpression("-( (2) )", errorCheckingMode = REQUIRED_ONLY)
+    val expected = parseNumericExpression("-2")
+
+    val stripped = original.stripRedundantGroups()
+
+    assertThat(stripped.isApproximatelyEqualTo(expected)).isTrue()
+  }
+
   private companion object {
-    private fun parseNumericExpression(expression: String): MathExpression {
-      return parseNumericExpression(expression, ALL_ERRORS).retrieveExpectedSuccessfulResult()
+    private fun parseNumericExpression(
+      expression: String,
+      errorCheckingMode: ErrorCheckingMode = ALL_ERRORS
+    ): MathExpression {
+      return MathExpressionParser.parseNumericExpression(
+        expression, errorCheckingMode
+      ).retrieveExpectedSuccessfulResult()
     }
 
     private fun parseAlgebraicExpression(


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fix part of #5815
  - It includes tests for:
     - AdminstatorControlsFragmentTest
     - [x] Portrait, Landascape & Mutipane (Analytics Disabled and Enabled)
     - AdminstartorControlsActivityTest
     -   [x] Portrait, Landscape & Multipane (Analytics Disabled and Enabled)
     -  MathExpressionExtensionTest

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
