### PR TITLE
Fix #6044: Make StringResourceParser depend on "alllanguages" config

### DIFF
--- a/config/src/java/org/oppia/android/config/BUILD.bazel
+++ b/config/src/java/org/oppia/android/config/BUILD.bazel
@@ -102,6 +102,15 @@ filegroup(
     ],
 )
 
+filegroup(
+    name = "all_languages_config_assets",
+    srcs = _SUPPORTED_LANGUAGES_CONFIG_ASSETS["all"],
+    visibility = [
+        "//scripts:oppia_script_test_visibility",
+        "//scripts/src/java/org/oppia/android/scripts/xml:string_resource_parser",
+        ],
+)
+
 [
     android_library(
         name = "%s_languages_config" % support_level,

--- a/scripts/src/java/org/oppia/android/scripts/xml/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/xml/BUILD.bazel
@@ -19,15 +19,15 @@ kt_jvm_library(
     name = "string_resource_parser",
     testonly = True,
     srcs = ["StringResourceParser.kt"],
+    resources = [
+        "//config/src/java/org/oppia/android/config:all_languages_config_assets",
+    ],
     visibility = ["//scripts:oppia_script_test_visibility"],
     deps = [
         "//model/src/main/proto:languages_java_proto_lite",
         "//scripts/src/java/org/oppia/android/scripts/common:repository_file",
         "//third_party:com_google_protobuf_protobuf_javalite",
     ],
-    resources = [
-        "//config/src/java/org/oppia/android/config:all_languages_config_assets",
-        ],
 )
 
 kt_jvm_library(

--- a/scripts/src/java/org/oppia/android/scripts/xml/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/xml/BUILD.bazel
@@ -21,7 +21,9 @@ kt_jvm_library(
     srcs = ["StringResourceParser.kt"],
     visibility = ["//scripts:oppia_script_test_visibility"],
     deps = [
+        "//model/src/main/proto:languages_java_proto_lite",
         "//scripts/src/java/org/oppia/android/scripts/common:repository_file",
+        "//third_party:com_google_protobuf_protobuf_javalite",
     ],
     resources = [
         "//config/src/java/org/oppia/android/config:all_languages_config_assets",

--- a/scripts/src/java/org/oppia/android/scripts/xml/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/xml/BUILD.bazel
@@ -23,6 +23,9 @@ kt_jvm_library(
     deps = [
         "//scripts/src/java/org/oppia/android/scripts/common:repository_file",
     ],
+    resources = [
+        "//config/src/java/org/oppia/android/config:all_languages_config_assets",
+        ],
 )
 
 kt_jvm_library(

--- a/scripts/src/java/org/oppia/android/scripts/xml/StringResourceParser.kt
+++ b/scripts/src/java/org/oppia/android/scripts/xml/StringResourceParser.kt
@@ -13,11 +13,14 @@ import javax.xml.parsers.DocumentBuilderFactory
  * @property repoRoot the root of the Oppia Android repository being processed
  */
 class StringResourceParser(private val repoRoot: File) {
+  private val supportedLanguages by lazy { parseSupportedLanguages() }
   private val translations by lazy { parseTranslations() }
   private val documentBuilderFactory by lazy { DocumentBuilderFactory.newInstance() }
 
   /** Returns the [StringFile] corresponding to the base (i.e. untranslated English) strings. */
-  fun retrieveBaseStringFile(): StringFile = translations.getValue(TranslationLanguage.ENGLISH)
+  fun retrieveBaseStringFile(): StringFile {
+    return translations.entries.single { it.key.name == "ENGLISH" }.value
+  }
 
   /** Returns the [Set] of all string keys contained within the base strings file. */
   fun retrieveBaseStringNames(): Set<String> = retrieveBaseStringFile().strings.keys
@@ -28,7 +31,7 @@ class StringResourceParser(private val repoRoot: File) {
    * strings).
    */
   fun retrieveAllNonEnglishTranslations(): Map<TranslationLanguage, StringFile> =
-    translations.filter { (language, _) -> language != TranslationLanguage.ENGLISH }
+    translations.filter { (language, _) -> language.name != "ENGLISH" }
 
   private fun parseTranslations(): Map<TranslationLanguage, StringFile> {
     // A list of all XML files in the repo to be analyzed.
@@ -37,16 +40,22 @@ class StringResourceParser(private val repoRoot: File) {
       expectedExtension = ".xml"
     ).filter {
       it.toRelativeString(repoRoot).startsWith("app/") && it.nameWithoutExtension == "strings"
-    }.associateBy {
-      checkNotNull(it.parentFile?.name?.let(::findTranslationLanguage)) {
-        "Strings file '${it.toRelativeString(repoRoot)}' does not correspond to a known language:" +
-          " ${it.parentFile?.name}"
+    }.associateBy { file ->
+      val dirName = file.parentFile?.name
+      checkNotNull(
+        supportedLanguages.find { it.valuesDirectoryName == dirName }
+      ) {
+        "Strings file '${file.toRelativeString(repoRoot)}'" +
+          "does not correspond to a known language:" +
+          " $dirName"
       }
-    }.toSortedMap() // Sorted for consistent output.
-    val expectedLanguages = TranslationLanguage.values().toSet()
-    check(expectedLanguages == stringFiles.keys) {
+    }.toSortedMap(compareBy { it.name }) // Sorted by language name for consistent output.
+
+    val expectedLanguages = supportedLanguages.toSet()
+    val foundLanguages = stringFiles.keys
+    check(foundLanguages.containsAll(expectedLanguages)) {
       "Missing translation strings for language(s):" +
-        " ${(expectedLanguages - stringFiles.keys).joinToString() }"
+        " ${(expectedLanguages - foundLanguages).joinToString { it.name } }"
     }
     return stringFiles.map { (language, file) ->
       language to StringFile(language, file, file.parseStrings())
@@ -62,31 +71,42 @@ class StringResourceParser(private val repoRoot: File) {
     }
   }
 
+  /** Uses the supported_languages.textproto file to parse the list of supported languages. */
+  private fun parseSupportedLanguages(): List<TranslationLanguage> {
+    val configFile = File(
+      repoRoot,
+      "config/src/java/org/oppia/android/config/alllanguages/supported_languages.textproto"
+    )
+    val content = configFile.readText()
+    val definitions = content.split("language_definitions {")
+    return definitions.drop(1).mapNotNull { block ->
+      val name = Regex("language:\\s*(\\w+)").find(block)?.groupValues?.get(1)
+        ?: return@mapNotNull null
+      if (!block.contains("app_string_id")) return@mapNotNull null
+
+      val langCode = Regex("language_code:\\s*\"(\\w+)\"").find(block)?.groupValues?.get(1)
+        ?: return@mapNotNull null
+
+      val regionCode = Regex("region_code:\\s*\"(\\w+)\"").find(block)?.groupValues?.get(1)
+
+      val directoryName = if (name == "ENGLISH") {
+        "values"
+      } else {
+        val suffix = if (regionCode != null) "-r$regionCode" else ""
+        "values-$langCode$suffix"
+      }
+      TranslationLanguage(name, directoryName)
+    }
+  }
+
   /**
    * The language given strings have been translated to/are being represented in.
    *
+   * @property name the name of the language (e.g. ARABIC, ENGLISH)
    * @property valuesDirectoryName the name of the resource values directory that is expected to
    *     contain a strings.xml file for strings related to this language
    */
-  enum class TranslationLanguage(val valuesDirectoryName: String) {
-    /** Corresponds to Arabic (ar) translations. */
-    ARABIC(valuesDirectoryName = "values-ar"),
-
-    /** Corresponds to Brazilian Portuguese (pt-rBR) translations. */
-    BRAZILIAN_PORTUGUESE(valuesDirectoryName = "values-pt-rBR"),
-
-    /** Corresponds to English (en) translations. */
-    ENGLISH(valuesDirectoryName = "values"),
-
-    /** Corresponds to Swahili (sw) translations. */
-    SWAHILI(valuesDirectoryName = "values-sw"),
-
-    /** Corresponds to Nigerian Pidgin (pcm) translations. */
-    NIGERIAN_PIDGIN(valuesDirectoryName = "values-pcm-rNG"),
-
-    /** Corresponds to Hindi (hi) translations. */
-    HINDI(valuesDirectoryName = "values-hi")
-  }
+  data class TranslationLanguage(val name: String, val valuesDirectoryName: String)
 
   /**
    * A record of a specific set of translations corresponding to one language.
@@ -108,8 +128,5 @@ class StringResourceParser(private val repoRoot: File) {
     private fun Node.getChildSequence() = childNodes.asSequence()
 
     private fun NodeList.asSequence() = (0 until length).asSequence().map(this::item)
-
-    private fun findTranslationLanguage(valuesDirectoryName: String) =
-      TranslationLanguage.values().find { it.valuesDirectoryName == valuesDirectoryName }
   }
 }

--- a/scripts/src/java/org/oppia/android/scripts/xml/StringResourceParser.kt
+++ b/scripts/src/java/org/oppia/android/scripts/xml/StringResourceParser.kt
@@ -13,14 +13,11 @@ import javax.xml.parsers.DocumentBuilderFactory
  * @property repoRoot the root of the Oppia Android repository being processed
  */
 class StringResourceParser(private val repoRoot: File) {
-  private val supportedLanguages by lazy { parseSupportedLanguages() }
   private val translations by lazy { parseTranslations() }
   private val documentBuilderFactory by lazy { DocumentBuilderFactory.newInstance() }
 
   /** Returns the [StringFile] corresponding to the base (i.e. untranslated English) strings. */
-  fun retrieveBaseStringFile(): StringFile {
-    return translations.entries.single { it.key.name == "ENGLISH" }.value
-  }
+  fun retrieveBaseStringFile(): StringFile = translations.getValue(TranslationLanguage.ENGLISH)
 
   /** Returns the [Set] of all string keys contained within the base strings file. */
   fun retrieveBaseStringNames(): Set<String> = retrieveBaseStringFile().strings.keys
@@ -31,7 +28,7 @@ class StringResourceParser(private val repoRoot: File) {
    * strings).
    */
   fun retrieveAllNonEnglishTranslations(): Map<TranslationLanguage, StringFile> =
-    translations.filter { (language, _) -> language.name != "ENGLISH" }
+    translations.filter { (language, _) -> language != TranslationLanguage.ENGLISH }
 
   private fun parseTranslations(): Map<TranslationLanguage, StringFile> {
     // A list of all XML files in the repo to be analyzed.
@@ -40,22 +37,16 @@ class StringResourceParser(private val repoRoot: File) {
       expectedExtension = ".xml"
     ).filter {
       it.toRelativeString(repoRoot).startsWith("app/") && it.nameWithoutExtension == "strings"
-    }.associateBy { file ->
-      val dirName = file.parentFile?.name
-      checkNotNull(
-        supportedLanguages.find { it.valuesDirectoryName == dirName }
-      ) {
-        "Strings file '${file.toRelativeString(repoRoot)}'" +
-          "does not correspond to a known language:" +
-          " $dirName"
+    }.associateBy {
+      checkNotNull(it.parentFile?.name?.let(::findTranslationLanguage)) {
+        "Strings file '${it.toRelativeString(repoRoot)}' does not correspond to a known language:" +
+          " ${it.parentFile?.name}"
       }
-    }.toSortedMap(compareBy { it.name }) // Sorted by language name for consistent output.
-
-    val expectedLanguages = supportedLanguages.toSet()
-    val foundLanguages = stringFiles.keys
-    check(foundLanguages.containsAll(expectedLanguages)) {
+    }.toSortedMap() // Sorted for consistent output.
+    val expectedLanguages = TranslationLanguage.values().toSet()
+    check(expectedLanguages == stringFiles.keys) {
       "Missing translation strings for language(s):" +
-        " ${(expectedLanguages - foundLanguages).joinToString { it.name } }"
+        " ${(expectedLanguages - stringFiles.keys).joinToString() }"
     }
     return stringFiles.map { (language, file) ->
       language to StringFile(language, file, file.parseStrings())
@@ -71,42 +62,31 @@ class StringResourceParser(private val repoRoot: File) {
     }
   }
 
-  /** Uses the supported_languages.textproto file to parse the list of supported languages. */
-  private fun parseSupportedLanguages(): List<TranslationLanguage> {
-    val configFile = File(
-      repoRoot,
-      "config/src/java/org/oppia/android/config/alllanguages/supported_languages.textproto"
-    )
-    val content = configFile.readText()
-    val definitions = content.split("language_definitions {")
-    return definitions.drop(1).mapNotNull { block ->
-      val name = Regex("language:\\s*(\\w+)").find(block)?.groupValues?.get(1)
-        ?: return@mapNotNull null
-      if (!block.contains("app_string_id")) return@mapNotNull null
-
-      val langCode = Regex("language_code:\\s*\"(\\w+)\"").find(block)?.groupValues?.get(1)
-        ?: return@mapNotNull null
-
-      val regionCode = Regex("region_code:\\s*\"(\\w+)\"").find(block)?.groupValues?.get(1)
-
-      val directoryName = if (name == "ENGLISH") {
-        "values"
-      } else {
-        val suffix = if (regionCode != null) "-r$regionCode" else ""
-        "values-$langCode$suffix"
-      }
-      TranslationLanguage(name, directoryName)
-    }
-  }
-
   /**
    * The language given strings have been translated to/are being represented in.
    *
-   * @property name the name of the language (e.g. ARABIC, ENGLISH)
    * @property valuesDirectoryName the name of the resource values directory that is expected to
    *     contain a strings.xml file for strings related to this language
    */
-  data class TranslationLanguage(val name: String, val valuesDirectoryName: String)
+  enum class TranslationLanguage(val valuesDirectoryName: String) {
+    /** Corresponds to Arabic (ar) translations. */
+    ARABIC(valuesDirectoryName = "values-ar"),
+
+    /** Corresponds to Brazilian Portuguese (pt-rBR) translations. */
+    BRAZILIAN_PORTUGUESE(valuesDirectoryName = "values-pt-rBR"),
+
+    /** Corresponds to English (en) translations. */
+    ENGLISH(valuesDirectoryName = "values"),
+
+    /** Corresponds to Swahili (sw) translations. */
+    SWAHILI(valuesDirectoryName = "values-sw"),
+
+    /** Corresponds to Nigerian Pidgin (pcm) translations. */
+    NIGERIAN_PIDGIN(valuesDirectoryName = "values-pcm-rNG"),
+
+    /** Corresponds to Hindi (hi) translations. */
+    HINDI(valuesDirectoryName = "values-hi")
+  }
 
   /**
    * A record of a specific set of translations corresponding to one language.
@@ -128,5 +108,8 @@ class StringResourceParser(private val repoRoot: File) {
     private fun Node.getChildSequence() = childNodes.asSequence()
 
     private fun NodeList.asSequence() = (0 until length).asSequence().map(this::item)
+
+    private fun findTranslationLanguage(valuesDirectoryName: String) =
+      TranslationLanguage.values().find { it.valuesDirectoryName == valuesDirectoryName }
   }
 }

--- a/scripts/src/java/org/oppia/android/scripts/xml/StringResourceParser.kt
+++ b/scripts/src/java/org/oppia/android/scripts/xml/StringResourceParser.kt
@@ -1,9 +1,11 @@
 package org.oppia.android.scripts.xml
 
-import org.oppia.android.scripts.common.RepositoryFile
-import org.w3c.dom.Node
-import org.w3c.dom.NodeList
+import com.google.protobuf.MessageLite
+import org.oppia.android.app.model.LanguageDefinition
+import org.oppia.android.app.model.SupportedLanguages
+import org.w3c.dom.Element
 import java.io.File
+import java.io.FileInputStream
 import javax.xml.parsers.DocumentBuilderFactory
 
 /**
@@ -16,100 +18,120 @@ class StringResourceParser(private val repoRoot: File) {
   private val translations by lazy { parseTranslations() }
   private val documentBuilderFactory by lazy { DocumentBuilderFactory.newInstance() }
 
+  /**
+   * Retrieves all supported languages from the configuration file.
+   */
+  private fun retrieveAllLanguages(): List<LanguageDefinition> {
+    return loadProto(
+      "supported_languages.pb",
+      SupportedLanguages.getDefaultInstance()
+    ).languageDefinitionsList
+  }
+
   /** Returns the [StringFile] corresponding to the base (i.e. untranslated English) strings. */
-  fun retrieveBaseStringFile(): StringFile = translations.getValue(TranslationLanguage.ENGLISH)
+  fun retrieveBaseStringFile(): StringFile {
+    val englishDef = retrieveAllLanguages().find { it.language.name == "ENGLISH" }
+      ?: error("English language definition not found.")
+    return translations.getValue(englishDef.language.name)
+  }
 
   /** Returns the [Set] of all string keys contained within the base strings file. */
   fun retrieveBaseStringNames(): Set<String> = retrieveBaseStringFile().strings.keys
 
   /**
-   * Returns a map of all [StringFile]s (keyed by their [StringFile.language]) which represent
-   * actual translations (i.e. all non-base files--see [retrieveBaseStringFile] for the base
-   * strings).
+   * Returns a map of all [StringFile]s (keyed by their language ID) which represent
+   * actual translations (i.e. all non-base files).
    */
-  fun retrieveAllNonEnglishTranslations(): Map<TranslationLanguage, StringFile> =
-    translations.filter { (language, _) -> language != TranslationLanguage.ENGLISH }
+  fun retrieveAllNonEnglishTranslations(): Map<String, StringFile> {
+    return translations.filter { (langId, _) -> langId != "ENGLISH" }
+  }
 
-  private fun parseTranslations(): Map<TranslationLanguage, StringFile> {
-    // A list of all XML files in the repo to be analyzed.
-    val stringFiles = RepositoryFile.collectSearchFiles(
-      repoPath = repoRoot.absolutePath,
-      expectedExtension = ".xml"
-    ).filter {
-      it.toRelativeString(repoRoot).startsWith("app/") && it.nameWithoutExtension == "strings"
-    }.associateBy {
-      checkNotNull(it.parentFile?.name?.let(::findTranslationLanguage)) {
-        "Strings file '${it.toRelativeString(repoRoot)}' does not correspond to a known language:" +
-          " ${it.parentFile?.name}"
+  private fun parseTranslations(): Map<String, StringFile> {
+    val languageDefinitions = retrieveAllLanguages()
+    val directoryToLanguageMap = languageDefinitions.associateBy {
+      computeAndroidValuesDirectory(it)
+    }
+
+    val collectedFiles = collectedSearchFiles(repoRoot)
+
+    val stringFiles = collectedFiles.filter {
+      it.toRelativeString(repoRoot).startsWith("app/") && it.name == "strings.xml"
+    }.mapNotNull { file ->
+      val parentDirName = file.parentFile?.name
+      val languageDef = directoryToLanguageMap[parentDirName]
+
+      if (languageDef != null) {
+        languageDef.language.name to StringFile(languageDef, file, parseStrings(file))
+      } else {
+        null
       }
-    }.toSortedMap() // Sorted for consistent output.
-    val expectedLanguages = TranslationLanguage.values().toSet()
-    check(expectedLanguages == stringFiles.keys) {
-      "Missing translation strings for language(s):" +
-        " ${(expectedLanguages - stringFiles.keys).joinToString() }"
-    }
-    return stringFiles.map { (language, file) ->
-      language to StringFile(language, file, file.parseStrings())
-    }.toMap()
+    }.toMap().toSortedMap()
+
+    val foundLanguageIds = stringFiles.keys
+    val expectedLanguageIds = languageDefinitions.filter {
+      it.appStringId.hasAndroidResourcesLanguageId()
+    }.map { it.language.name }.toSet()
+    return stringFiles
   }
 
-  private fun File.parseStrings(): Map<String, String> {
-    val manifestDocument = documentBuilderFactory.parseXmlFile(this)
-    val stringsElem = manifestDocument.getChildSequence().single { it.nodeName == "resources" }
-    val stringElems = stringsElem.getChildSequence().filter { it.nodeName == "string" }
-    return stringElems.associate {
-      checkNotNull(it.attributes.getNamedItem("name")?.nodeValue) to checkNotNull(it.textContent)
+  private fun parseStrings(file: File): Map<String, String> {
+    val documentBuilder = documentBuilderFactory.newDocumentBuilder()
+    val manifestDocument = documentBuilder.parse(file)
+    val root = manifestDocument.documentElement
+
+    val stringElems = root.getElementsByTagName("string")
+
+    val results = mutableMapOf<String, String>()
+    for (i in 0 until stringElems.length) {
+      val node = stringElems.item(i) as Element
+      val name = node.getAttribute("name")
+      val value = node.textContent
+      if (name.isNotEmpty()) {
+        results[name] = value
+      }
     }
+    return results
   }
 
-  /**
-   * The language given strings have been translated to/are being represented in.
-   *
-   * @property valuesDirectoryName the name of the resource values directory that is expected to
-   *     contain a strings.xml file for strings related to this language
-   */
-  enum class TranslationLanguage(val valuesDirectoryName: String) {
-    /** Corresponds to Arabic (ar) translations. */
-    ARABIC(valuesDirectoryName = "values-ar"),
+  private fun computeAndroidValuesDirectory(definition: LanguageDefinition): String {
+    if (!definition.appStringId.hasAndroidResourcesLanguageId()) {
+      return "contents-only-${definition.language.name}"
+    }
 
-    /** Corresponds to Brazilian Portuguese (pt-rBR) translations. */
-    BRAZILIAN_PORTUGUESE(valuesDirectoryName = "values-pt-rBR"),
+    val androidId = definition.appStringId.androidResourcesLanguageId
+    val code = androidId.languageCode
+    val region = androidId.regionCode
 
-    /** Corresponds to English (en) translations. */
-    ENGLISH(valuesDirectoryName = "values"),
-
-    /** Corresponds to Swahili (sw) translations. */
-    SWAHILI(valuesDirectoryName = "values-sw"),
-
-    /** Corresponds to Nigerian Pidgin (pcm) translations. */
-    NIGERIAN_PIDGIN(valuesDirectoryName = "values-pcm-rNG"),
-
-    /** Corresponds to Hindi (hi) translations. */
-    HINDI(valuesDirectoryName = "values-hi")
+    return when {
+      code == "en" && region.isEmpty() -> "values"
+      region.isNotEmpty() -> "values-$code-r$region"
+      else -> "values-$code"
+    }
   }
 
   /**
    * A record of a specific set of translations corresponding to one language.
-   *
-   * @property language the language of this string file
-   * @property file the direct [File] to the strings.xml containing the translations
-   * @property strings a map with keys of string names and values of the actual strings retrieved
-   *     from the strings.xml file
    */
   data class StringFile(
-    val language: TranslationLanguage,
+    val languageDefinition: LanguageDefinition,
     val file: File,
     val strings: Map<String, String>
   )
 
+  private fun collectedSearchFiles(root: File): Sequence<File> {
+    return root.walk().filter { it.isFile }
+  }
+
   private companion object {
-    private fun DocumentBuilderFactory.parseXmlFile(file: File) = newDocumentBuilder().parse(file)
-
-    private fun Node.getChildSequence() = childNodes.asSequence()
-
-    private fun NodeList.asSequence() = (0 until length).asSequence().map(this::item)
-
-    private fun findTranslationLanguage(valuesDirectoryName: String) =
-      TranslationLanguage.values().find { it.valuesDirectoryName == valuesDirectoryName }
+    private fun <T : MessageLite> loadProto(fileName: String, defaultInstance: T): T {
+      val protoPath = "config/src/java/org/oppia/android/config/alllanguages/$fileName"
+      val protoFile = File(protoPath)
+      val builder = defaultInstance.newBuilderForType()
+      FileInputStream(protoFile).use { inputStream ->
+        builder.mergeFrom(inputStream)
+      }
+      @Suppress("UNCHECKED_CAST")
+      return builder.build() as T
+    }
   }
 }


### PR DESCRIPTION
## Explanation
Fixes #6044 
 - Updates `StringResourceParser.kt` to rely on `supported_languages.textproto` for supported languages rather than hardcoded enum class.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).