### PR TITLE
Add semantic spacing tokens for Jetpack Compose

### DIFF
--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -29,6 +28,7 @@ import androidx.compose.ui.res.integerResource
 import androidx.compose.ui.unit.dp
 import androidx.databinding.ObservableList
 import androidx.fragment.app.Fragment
+import org.oppia.android.app.R
 import org.oppia.android.app.classroom.classroomlist.AllClassroomsHeaderText
 import org.oppia.android.app.classroom.classroomlist.ClassroomList
 import org.oppia.android.app.classroom.promotedlist.ComingSoonTopicList
@@ -54,7 +54,7 @@ import org.oppia.android.app.model.Profile
 import org.oppia.android.app.model.ProfileType
 import org.oppia.android.app.model.TopicSummary
 import org.oppia.android.app.translation.AppLanguageResourceHandler
-import org.oppia.android.app.ui.R
+import org.oppia.android.app.utility.compose.OppiaComposeTheme
 import org.oppia.android.app.utility.datetime.DateTimeUtil
 import org.oppia.android.domain.classroom.ClassroomController
 import org.oppia.android.domain.onboarding.AppStartupStateController
@@ -194,7 +194,7 @@ class ClassroomListFragmentPresenter @Inject constructor(
     binding.composeView.apply {
       setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
       setContent {
-        MaterialTheme {
+        OppiaComposeTheme {
           ClassroomListScreen()
         }
       }

--- a/app/src/main/java/org/oppia/android/app/utility/compose/LocalSpacing.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/compose/LocalSpacing.kt
@@ -1,0 +1,13 @@
+package org.oppia.android.app.utility.compose
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * CompositionLocal providing [Spacing] tokens to Compose UI.
+ *
+ * A default value is intentionally not provided to ensure that spacing
+ * is explicitly supplied by the theme layer.
+ */
+val LocalSpacing = staticCompositionLocalOf<Spacing> {
+  error("LocalSpacing not provided. Did you forget to wrap your content?")
+}

--- a/app/src/main/java/org/oppia/android/app/utility/compose/OppiaComposeTheme.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/compose/OppiaComposeTheme.kt
@@ -1,0 +1,41 @@
+package org.oppia.android.app.utility.compose
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.res.dimensionResource
+import org.oppia.android.app.R
+/**
+ * A minimal Compose theme wrapper that injects Oppia-specific semantic spacing tokens.
+ *
+ * This composable wraps [MaterialTheme] and provides a [Spacing] instance via a
+ * [CompositionLocal], allowing Compose UI components to access consistent spacing
+ * values without directly depending on XML dimension resources.
+ *
+ * The spacing values are derived from existing XML dimensions to preserve visual
+ * parity with the current View-based UI while enabling gradual migration to
+ * Compose-first patterns.
+ *
+ * This theme does not modify colors, typography, or shapes, and is intended to be
+ * adopted incrementally.
+ *
+ * @param content the composable content to be themed
+ */
+@Composable
+fun OppiaComposeTheme(
+  content: @Composable () -> Unit,
+) {
+  val spacing = Spacing(
+    extraSmall = dimensionResource(id = R.dimen.spacing_extra_small),
+    small = dimensionResource(id = R.dimen.spacing_small),
+    medium = dimensionResource(id = R.dimen.spacing_medium),
+    large = dimensionResource(id = R.dimen.spacing_large),
+    extraLarge = dimensionResource(id = R.dimen.spacing_extra_large),
+  )
+
+  CompositionLocalProvider(
+    LocalSpacing provides spacing,
+  ) {
+    MaterialTheme(content = content)
+  }
+}

--- a/app/src/main/java/org/oppia/android/app/utility/compose/Spacing.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/compose/Spacing.kt
@@ -1,0 +1,25 @@
+package org.oppia.android.app.utility.compose
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.unit.Dp
+
+/**
+ * Defines semantic spacing tokens for Jetpack Compose UI.
+ *
+ * This class provides a standardized set of spacing values (from extra-small to extra-large)
+ * that can be used across Compose layouts to ensure visual consistency and scalability.
+ *
+ * The values themselves are intentionally abstracted from concrete measurements and are
+ * expected to be supplied by the caller (for example, via XML dimension resources).
+ *
+ * Using semantic spacing tokens instead of hardcoded values helps maintain design consistency
+ * and enables easier global adjustments to spacing behavior.
+ */
+@Immutable
+data class Spacing(
+  val extraSmall: Dp,
+  val small: Dp,
+  val medium: Dp,
+  val large: Dp,
+  val extraLarge: Dp,
+)

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <dimen name="spacing_extra_small">@dimen/classrooms_card_icon_padding_bottom</dimen>
+  <dimen name="spacing_small">@dimen/classrooms_card_margin_start</dimen>
+  <dimen name="spacing_medium">@dimen/classrooms_card_padding_horizontal</dimen>
+  <dimen name="spacing_large">@dimen/classrooms_text_margin_start</dimen>
+  <dimen name="spacing_extra_large">@dimen/home_fragment_padding_bottom</dimen>
+
   <!-- Default screen margins, per the Android Design guidelines. -->
   <dimen name="activity_horizontal_margin">16dp</dimen>
   <dimen name="activity_vertical_margin">16dp</dimen>


### PR DESCRIPTION
## Explanation

This PR introduces **semantic spacing tokens** for Jetpack Compose to establish a consistent, scalable spacing system across Compose-based UI.

Specifically, this change:

* Adds a `Spacing` data model representing semantic spacing buckets (extraSmall → extraLarge)
* Exposes spacing via a `CompositionLocal` (`LocalSpacing`) for implicit, type-safe access in Compose
* Introduces `OppiaComposeTheme`, a minimal wrapper over `MaterialTheme`, to inject spacing tokens without altering existing theming behavior
* Derives all spacing values from existing `dimens.xml` resources to ensure **visual parity** with the current UI
* Updates a single Compose entry point (`ClassroomListFragmentPresenter`) to demonstrate usage without forcing broad refactors

This PR intentionally limits adoption to infrastructure + one call site. Wider migration can happen incrementally in follow-up PRs.

Related to: Issue #6023 (Jetpack Compose Spacing Tokens)

## Essential Checklist

* [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
* [ ] Any changes to [[scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets)](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
* [x] The PR follows the [[style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide)](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
* [x] The PR does not contain any unnecessary code changes from Android Studio ([[reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
* [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
* [x] The PR is **assigned** to the appropriate reviewers ([[reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

