### PR TITLE
Fix #5940: Add window insets handling to prepare for Android 16

### DIFF
--- a/app/src/main/res/layout/add_profile_activity.xml
+++ b/app/src/main/res/layout/add_profile_activity.xml
@@ -16,15 +16,22 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.AppBarLayout
+      android:id="@+id/add_profile_activity_app_bar_layout"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
+      android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+      <androidx.appcompat.widget.Toolbar
       android:id="@+id/add_profile_activity_toolbar"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:background="@color/component_color_shared_activity_toolbar_color"
       android:minHeight="?attr/actionBarSize"
       app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-      app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-      app:titleTextAppearance="@style/ToolbarTextAppearance" />
+        app:titleTextAppearance="@style/ToolbarTextAppearance" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
       android:layout_width="match_parent"

--- a/app/src/main/res/layout/admin_auth_activity.xml
+++ b/app/src/main/res/layout/admin_auth_activity.xml
@@ -19,6 +19,7 @@
       android:id="@+id/admin_auth_app_bar_layout"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/admin_pin_activity.xml
+++ b/app/src/main/res/layout/admin_pin_activity.xml
@@ -13,18 +13,24 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-
-    <androidx.appcompat.widget.Toolbar
-      android:id="@+id/admin_pin_toolbar"
+    <com.google.android.material.appbar.AppBarLayout
+      android:id="@+id/admin_pin_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:minHeight="?attr/actionBarSize"
-      android:elevation="4dp"
+      android:fitsSystemWindows="true"
       android:theme="@style/OppiaActionBarTheme"
-      style="@style/AdminPinToolbarTextAppearance"
-      app:titleTextAppearance="@style/AdminPinToolbarTextAppearance"
-      app:titleTextColor="@color/component_color_shared_activity_toolbar_text_color"
-      app:layout_constraintTop_toTopOf="parent" />
+      app:layout_constraintTop_toTopOf="parent">
+
+      <androidx.appcompat.widget.Toolbar
+        android:id="@+id/admin_pin_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?attr/actionBarSize"
+        android:elevation="4dp"
+        style="@style/AdminPinToolbarTextAppearance"
+        app:titleTextAppearance="@style/AdminPinToolbarTextAppearance"
+        app:titleTextColor="@color/component_color_shared_activity_toolbar_text_color" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.core.widget.NestedScrollView
       android:id="@+id/scrollViewAdminPin"
@@ -37,7 +43,7 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/admin_pin_toolbar"
+      app:layout_constraintTop_toBottomOf="@id/admin_pin_app_bar_layout"
       >
 
       <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/administrator_controls_activity.xml
+++ b/app/src/main/res/layout/administrator_controls_activity.xml
@@ -12,15 +12,22 @@
       android:layout_height="match_parent"
       android:orientation="vertical">
 
-      <androidx.appcompat.widget.Toolbar
+      <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/administrator_controls_activity_app_bar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+        <androidx.appcompat.widget.Toolbar
         android:id="@+id/administrator_controls_activity_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/component_color_shared_activity_toolbar_color"
         android:minHeight="?attr/actionBarSize"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-        app:titleTextAppearance="@style/ToolbarTextAppearance" />
+          app:titleTextAppearance="@style/ToolbarTextAppearance" />
+      </com.google.android.material.appbar.AppBarLayout>
 
       <FrameLayout
         android:id="@+id/administrator_controls_fragment_placeholder"

--- a/app/src/main/res/layout/app_language_activity.xml
+++ b/app/src/main/res/layout/app_language_activity.xml
@@ -10,6 +10,7 @@
       android:id="@+id/reading_list_app_bar_layout"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/app_version_activity.xml
+++ b/app/src/main/res/layout/app_version_activity.xml
@@ -10,6 +10,7 @@
     android:id="@+id/app_version_app_bar_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/audio_language_activity.xml
+++ b/app/src/main/res/layout/audio_language_activity.xml
@@ -10,6 +10,7 @@
       android:id="@+id/reading_list_app_bar_layout"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/classroom_list_activity.xml
+++ b/app/src/main/res/layout/classroom_list_activity.xml
@@ -11,15 +11,22 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.AppBarLayout
+      android:id="@+id/classroom_list_activity_app_bar_layout"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
+      android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+      <androidx.appcompat.widget.Toolbar
       android:id="@+id/classroom_list_activity_toolbar"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:background="@color/component_color_shared_activity_toolbar_color"
       android:minHeight="?attr/actionBarSize"
       app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-      app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-      app:titleTextAppearance="@style/ToolbarTextAppearance" />
+        app:titleTextAppearance="@style/ToolbarTextAppearance" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
       android:id="@+id/classroom_list_fragment_placeholder"

--- a/app/src/main/res/layout/completed_story_list_fragment.xml
+++ b/app/src/main/res/layout/completed_story_list_fragment.xml
@@ -18,6 +18,7 @@
       android:id="@+id/completed_story_list_app_bar_layout"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/concept_card_fragment.xml
+++ b/app/src/main/res/layout/concept_card_fragment.xml
@@ -15,17 +15,24 @@
     android:layout_height="match_parent"
     android:background="@color/component_color_shared_screen_secondary_background_color">
 
-    <androidx.appcompat.widget.Toolbar
-      android:id="@+id/concept_card_toolbar"
+    <com.google.android.material.appbar.AppBarLayout
+      android:id="@+id/concept_card_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:background="@color/component_color_concept_card_fragment_toolbar_color"
+      android:fitsSystemWindows="true"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent"
-      app:title="@string/concept_card_toolbar_title"
-      app:titleTextAppearance="@style/ToolbarTextAppearance"
-      app:titleTextColor="@color/component_color_shared_activity_toolbar_text_color" />
+      app:layout_constraintTop_toTopOf="parent">
+
+      <androidx.appcompat.widget.Toolbar
+        android:id="@+id/concept_card_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/component_color_concept_card_fragment_toolbar_color"
+        app:title="@string/concept_card_toolbar_title"
+        app:titleTextAppearance="@style/ToolbarTextAppearance"
+        app:titleTextColor="@color/component_color_shared_activity_toolbar_text_color" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
       android:layout_width="0dp"
@@ -33,7 +40,7 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/concept_card_toolbar">
+      app:layout_constraintTop_toBottomOf="@+id/concept_card_app_bar_layout">
 
       <ScrollView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/developer_options_activity.xml
+++ b/app/src/main/res/layout/developer_options_activity.xml
@@ -12,15 +12,22 @@
       android:layout_height="match_parent"
       android:orientation="vertical">
 
-      <androidx.appcompat.widget.Toolbar
+      <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/developer_options_activity_app_bar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+        <androidx.appcompat.widget.Toolbar
         android:id="@+id/developer_options_activity_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/component_color_shared_activity_toolbar_color"
         android:minHeight="?attr/actionBarSize"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-        app:titleTextAppearance="@style/ToolbarTextAppearance" />
+          app:titleTextAppearance="@style/ToolbarTextAppearance" />
+      </com.google.android.material.appbar.AppBarLayout>
 
       <FrameLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/exploration_activity.xml
+++ b/app/src/main/res/layout/exploration_activity.xml
@@ -22,6 +22,7 @@
       android:id="@+id/exploration_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
       <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/faq_list_activity.xml
+++ b/app/src/main/res/layout/faq_list_activity.xml
@@ -11,6 +11,7 @@
       android:id="@+id/faq_list_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
       <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/faq_single_activity.xml
+++ b/app/src/main/res/layout/faq_single_activity.xml
@@ -11,6 +11,7 @@
       android:id="@+id/faq_single_app_bar_layout"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/feature_flags_fragment.xml
+++ b/app/src/main/res/layout/feature_flags_fragment.xml
@@ -19,6 +19,7 @@
       android:id="@+id/feature_flags_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/force_network_type_fragment.xml
+++ b/app/src/main/res/layout/force_network_type_fragment.xml
@@ -19,6 +19,7 @@
       android:id="@+id/force_network_type_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/help_activity.xml
+++ b/app/src/main/res/layout/help_activity.xml
@@ -10,15 +10,22 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.AppBarLayout
+      android:id="@+id/help_activity_app_bar_layout"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
+      android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+      <androidx.appcompat.widget.Toolbar
       android:id="@+id/help_activity_toolbar"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:background="@color/component_color_shared_activity_toolbar_color"
       android:minHeight="?attr/actionBarSize"
       app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-      app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-      app:titleTextAppearance="@style/ToolbarTextAppearance" />
+        app:titleTextAppearance="@style/ToolbarTextAppearance" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
       android:layout_width="match_parent"

--- a/app/src/main/res/layout/help_without_drawer_activity.xml
+++ b/app/src/main/res/layout/help_without_drawer_activity.xml
@@ -9,15 +9,22 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.AppBarLayout
+      android:id="@+id/help_activity_app_bar_layout"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
+      android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+      <androidx.appcompat.widget.Toolbar
       android:id="@+id/help_activity_toolbar"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:background="@color/component_color_shared_activity_toolbar_color"
       android:minHeight="?attr/actionBarSize"
       app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-      app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-      app:titleTextAppearance="@style/ToolbarTextAppearance" />
+        app:titleTextAppearance="@style/ToolbarTextAppearance" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
       android:layout_width="match_parent"

--- a/app/src/main/res/layout/hints_and_solution_fragment.xml
+++ b/app/src/main/res/layout/hints_and_solution_fragment.xml
@@ -18,6 +18,7 @@
       android:id="@+id/hints_and_solution_app_bar_layout"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/home_activity.xml
+++ b/app/src/main/res/layout/home_activity.xml
@@ -16,15 +16,22 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.appcompat.widget.Toolbar
-      android:id="@+id/home_activity_toolbar"
+    <com.google.android.material.appbar.AppBarLayout
+      android:id="@+id/home_activity_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:background="@color/component_color_shared_activity_toolbar_color"
-      android:minHeight="?attr/actionBarSize"
-      app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-      app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-      app:titleTextAppearance="@style/ToolbarTextAppearance" />
+      android:fitsSystemWindows="true"
+      android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+      <androidx.appcompat.widget.Toolbar
+        android:id="@+id/home_activity_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/component_color_shared_activity_toolbar_color"
+        android:minHeight="?attr/actionBarSize"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+        app:titleTextAppearance="@style/ToolbarTextAppearance" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
       android:id="@+id/home_fragment_placeholder"

--- a/app/src/main/res/layout/license_list_activity.xml
+++ b/app/src/main/res/layout/license_list_activity.xml
@@ -11,6 +11,7 @@
       android:id="@+id/license_list_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
       <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/license_text_viewer_activity.xml
+++ b/app/src/main/res/layout/license_text_viewer_activity.xml
@@ -11,6 +11,7 @@
       android:id="@+id/license_text_viewer_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
       <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/mark_chapters_completed_fragment.xml
+++ b/app/src/main/res/layout/mark_chapters_completed_fragment.xml
@@ -23,6 +23,7 @@
       android:id="@+id/mark_chapters_completed_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/mark_stories_completed_fragment.xml
+++ b/app/src/main/res/layout/mark_stories_completed_fragment.xml
@@ -23,6 +23,7 @@
       android:id="@+id/mark_stories_completed_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/mark_topics_completed_fragment.xml
+++ b/app/src/main/res/layout/mark_topics_completed_fragment.xml
@@ -23,6 +23,7 @@
       android:id="@+id/mark_topics_completed_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/math_expression_parser_fragment.xml
+++ b/app/src/main/res/layout/math_expression_parser_fragment.xml
@@ -23,6 +23,7 @@
       android:id="@+id/math_expression_parser_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/my_downloads_fragment.xml
+++ b/app/src/main/res/layout/my_downloads_fragment.xml
@@ -10,6 +10,7 @@
       android:id="@+id/my_downloads_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
       app:layout_constraintBottom_toTopOf="@+id/my_downloads_tabs_viewpager_container"
       app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/ongoing_topic_list_fragment.xml
+++ b/app/src/main/res/layout/ongoing_topic_list_fragment.xml
@@ -18,6 +18,7 @@
       android:id="@+id/ongoing_topic_list_app_bar_layout"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/option_activity.xml
+++ b/app/src/main/res/layout/option_activity.xml
@@ -10,15 +10,22 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.AppBarLayout
+      android:id="@+id/options_activity_app_bar_layout"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
+      android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+      <androidx.appcompat.widget.Toolbar
       android:id="@+id/options_activity_toolbar"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:background="@color/component_color_shared_activity_toolbar_color"
       android:minHeight="?attr/actionBarSize"
       app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-      app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-      app:titleTextAppearance="@style/ToolbarTextAppearance" />
+        app:titleTextAppearance="@style/ToolbarTextAppearance" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
       android:layout_width="match_parent"

--- a/app/src/main/res/layout/options_without_drawer_activity.xml
+++ b/app/src/main/res/layout/options_without_drawer_activity.xml
@@ -9,15 +9,22 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.AppBarLayout
+      android:id="@+id/options_activity_app_bar_layout"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
+      android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+      <androidx.appcompat.widget.Toolbar
       android:id="@+id/options_activity_toolbar"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:background="@color/component_color_shared_activity_toolbar_color"
       android:minHeight="?attr/actionBarSize"
       app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-      app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-      app:titleTextAppearance="@style/ToolbarTextAppearance" />
+        app:titleTextAppearance="@style/ToolbarTextAppearance" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
       android:layout_width="match_parent"

--- a/app/src/main/res/layout/pin_password_activity.xml
+++ b/app/src/main/res/layout/pin_password_activity.xml
@@ -23,6 +23,7 @@
       android:id="@+id/pin_password_app_bar_layout"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/platform_parameters_fragment.xml
+++ b/app/src/main/res/layout/platform_parameters_fragment.xml
@@ -19,6 +19,7 @@
       android:id="@+id/platform_parameters_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/policies_activity.xml
+++ b/app/src/main/res/layout/policies_activity.xml
@@ -11,6 +11,7 @@
       android:id="@+id/policies_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
       <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/profile_and_device_id_activity.xml
+++ b/app/src/main/res/layout/profile_and_device_id_activity.xml
@@ -10,6 +10,7 @@
     android:id="@+id/profile_and_device_id_app_bar_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/profile_edit_activity.xml
+++ b/app/src/main/res/layout/profile_edit_activity.xml
@@ -10,6 +10,7 @@
     android:id="@+id/profile_edit_app_bar_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/profile_list_fragment.xml
+++ b/app/src/main/res/layout/profile_list_fragment.xml
@@ -17,6 +17,7 @@
       android:id="@+id/profile_list_app_bar_layout"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/profile_picture_activity.xml
+++ b/app/src/main/res/layout/profile_picture_activity.xml
@@ -18,6 +18,7 @@
       android:id="@+id/profile_picture_activity_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/profile_progress_activity.xml
+++ b/app/src/main/res/layout/profile_progress_activity.xml
@@ -7,15 +7,22 @@
   android:orientation="vertical"
   tools:context=".app.profileprogress.ProfileProgressActivity">
 
-  <androidx.appcompat.widget.Toolbar
+  <com.google.android.material.appbar.AppBarLayout
+    android:id="@+id/profile_progress_activity_app_bar_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:fitsSystemWindows="true"
+    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+    <androidx.appcompat.widget.Toolbar
     android:id="@+id/profile_progress_activity_toolbar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/component_color_shared_activity_toolbar_color"
     android:minHeight="?attr/actionBarSize"
     app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-    app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-    app:titleTextAppearance="@style/ToolbarTextAppearance" />
+      app:titleTextAppearance="@style/ToolbarTextAppearance" />
+  </com.google.android.material.appbar.AppBarLayout>
 
   <FrameLayout
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/profile_rename_activity.xml
+++ b/app/src/main/res/layout/profile_rename_activity.xml
@@ -10,6 +10,7 @@
       android:id="@+id/profile_rename_app_bar_layout"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/profile_reset_pin_activity.xml
+++ b/app/src/main/res/layout/profile_reset_pin_activity.xml
@@ -11,6 +11,7 @@
       android:id="@+id/profile_reset_pin_app_bar_layout"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/question_player_activity.xml
+++ b/app/src/main/res/layout/question_player_activity.xml
@@ -13,6 +13,7 @@
       android:id="@+id/question_player_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
       <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/reading_text_size_activity.xml
+++ b/app/src/main/res/layout/reading_text_size_activity.xml
@@ -8,6 +8,7 @@
     android:id="@+id/reading_list_app_bar_layout"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/recently_played_activity.xml
+++ b/app/src/main/res/layout/recently_played_activity.xml
@@ -10,6 +10,7 @@
       android:id="@+id/recently_played_app_bar_layout"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/resume_lesson_activity.xml
+++ b/app/src/main/res/layout/resume_lesson_activity.xml
@@ -11,6 +11,7 @@
       android:id="@+id/resume_lesson_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
       <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/revision_card_activity.xml
+++ b/app/src/main/res/layout/revision_card_activity.xml
@@ -13,6 +13,7 @@
       android:id="@+id/revision_card_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/story_fragment.xml
+++ b/app/src/main/res/layout/story_fragment.xml
@@ -19,6 +19,7 @@
       android:id="@+id/topic_app_bar_layout"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/survey_fragment.xml
+++ b/app/src/main/res/layout/survey_fragment.xml
@@ -19,6 +19,7 @@
       android:id="@+id/survey_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/third_party_dependency_list_activity.xml
+++ b/app/src/main/res/layout/third_party_dependency_list_activity.xml
@@ -11,6 +11,7 @@
       android:id="@+id/third_party_dependency_list_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
       <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/topic_fragment.xml
+++ b/app/src/main/res/layout/topic_fragment.xml
@@ -17,6 +17,7 @@
       android:id="@+id/topic_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:background="@color/component_color_shared_activity_toolbar_color"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintBottom_toTopOf="@+id/topic_tabs_viewpager_container"

--- a/app/src/main/res/layout/view_event_logs_fragment.xml
+++ b/app/src/main/res/layout/view_event_logs_fragment.xml
@@ -19,6 +19,7 @@
       android:id="@+id/view_event_logs_app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:fitsSystemWindows="true"
       android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values-v35/themes.xml
+++ b/app/src/main/res/values-v35/themes.xml
@@ -7,8 +7,7 @@
     <item name="colorAccent">@color/color_palette_primary_color</item>
     <item name="actionBarTheme">@style/OppiaActionBarTheme</item>
     <item name="android:statusBarColor">@color/component_color_shared_activity_status_bar_color</item>
-    <!-- Commented out to demonstrate edge-to-edge enforcement with fitsSystemWindows fix -->
-    <!-- <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item> -->
+    <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
   </style>
 
   <style name="OppiaThemeWithoutActionBar" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
@@ -20,14 +19,12 @@
     <item name="android:editTextStyle">@style/InputInteractionEditText</item>
     <item name="android:windowAnimationStyle">@style/Animation.Activity</item>
     <item name="android:statusBarColor">@color/component_color_shared_activity_status_bar_color</item>
-    <!-- Commented out to demonstrate edge-to-edge enforcement with fitsSystemWindows fix -->
-    <!-- <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item> -->
+    <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
   </style>
 
   <style name="RevisionCardActivityTheme" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
     <item name="colorPrimaryDark">@color/component_color_revision_card_activity_status_bar_color</item>
-    <!-- Commented out to demonstrate edge-to-edge enforcement with fitsSystemWindows fix -->
-    <!-- <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item> -->
+    <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
   </style>
 
   <style name="OppiaThemeWithoutActionBarColorAccentColorPrimary" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
@@ -38,8 +35,7 @@
     <item name="windowNoTitle">true</item>
     <item name="android:windowAnimationStyle">@style/Animation.Activity</item>
     <item name="android:statusBarColor">@color/component_color_shared_activity_status_bar_color</item>
-    <!-- Commented out to demonstrate edge-to-edge enforcement with fitsSystemWindows fix -->
-    <!-- <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item> -->
+    <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
   </style>
 
   <style name="OppiaDialogFragmentTheme" parent="OppiaTheme">

--- a/app/src/main/res/values-v35/themes.xml
+++ b/app/src/main/res/values-v35/themes.xml
@@ -7,7 +7,8 @@
     <item name="colorAccent">@color/color_palette_primary_color</item>
     <item name="actionBarTheme">@style/OppiaActionBarTheme</item>
     <item name="android:statusBarColor">@color/component_color_shared_activity_status_bar_color</item>
-    <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    <!-- Commented out to demonstrate edge-to-edge enforcement with fitsSystemWindows fix -->
+    <!-- <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item> -->
   </style>
 
   <style name="OppiaThemeWithoutActionBar" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
@@ -19,12 +20,14 @@
     <item name="android:editTextStyle">@style/InputInteractionEditText</item>
     <item name="android:windowAnimationStyle">@style/Animation.Activity</item>
     <item name="android:statusBarColor">@color/component_color_shared_activity_status_bar_color</item>
-    <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    <!-- Commented out to demonstrate edge-to-edge enforcement with fitsSystemWindows fix -->
+    <!-- <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item> -->
   </style>
 
   <style name="RevisionCardActivityTheme" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
     <item name="colorPrimaryDark">@color/component_color_revision_card_activity_status_bar_color</item>
-    <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    <!-- Commented out to demonstrate edge-to-edge enforcement with fitsSystemWindows fix -->
+    <!-- <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item> -->
   </style>
 
   <style name="OppiaThemeWithoutActionBarColorAccentColorPrimary" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
@@ -35,7 +38,8 @@
     <item name="windowNoTitle">true</item>
     <item name="android:windowAnimationStyle">@style/Animation.Activity</item>
     <item name="android:statusBarColor">@color/component_color_shared_activity_status_bar_color</item>
-    <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    <!-- Commented out to demonstrate edge-to-edge enforcement with fitsSystemWindows fix -->
+    <!-- <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item> -->
   </style>
 
   <style name="OppiaDialogFragmentTheme" parent="OppiaTheme">


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fix #5940
This PR adds `android:fitsSystemWindows="true"` to all AppBarLayout elements, where the `windowOptOutEdgeToEdgeEnforcement` attribute will be deprecated and edge-to-edge enforcement will be mandatory.

This PR adds to all the toolbar layouts so when we remove that temporary trick later, the toolbars won't overlap with the status bar.                                                                                                                                                   

No visual changes for now since we're keeping the old setup. Tested on Android 15 (API 35) Pixel 4a emulator

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
**Before**
<img width="368" height="809" alt="before" src="https://github.com/user-attachments/assets/068129c8-b0a8-4f92-859c-124308a23f68" />


**After**
<img width="368" height="809" alt="after" src="https://github.com/user-attachments/assets/653b8d5c-d685-400e-ac26-80a299fb2311" />

