### PR TITLE
Add Jetpack Compose spacing tokens and fix typos

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,7 +82,7 @@ kotlin_repositories(
 register_toolchains("//tools/kotlin:kotlin_16_jdk9_toolchain")
 
 # The proto_compiler and proto_java_toolchain bindings load the protos rules needed for generating
-# protos while helping us avoid the unnecessary compilation of protoc. Referecences:
+# protos while helping us avoid the unnecessary compilation of protoc. References:
 # - https://github.com/google/startup-os/blob/5f30a62/WORKSPACE#L179-L187
 # - https://github.com/bazelbuild/bazel/issues/7095
 

--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.integerResource
 import androidx.compose.ui.unit.dp
 import androidx.databinding.ObservableList
@@ -55,6 +54,7 @@ import org.oppia.android.app.model.ProfileType
 import org.oppia.android.app.model.TopicSummary
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.ui.R
+import org.oppia.android.app.ui.theme.OppiaTheme
 import org.oppia.android.app.utility.datetime.DateTimeUtil
 import org.oppia.android.domain.classroom.ClassroomController
 import org.oppia.android.domain.onboarding.AppStartupStateController
@@ -358,7 +358,7 @@ fun <T> LazyListScope.gridItems(
           colorResource(id = R.color.component_color_classroom_topic_list_background_color)
         )
         .padding(
-          horizontal = dimensionResource(id = R.dimen.classrooms_text_margin_start),
+          horizontal = OppiaTheme.spacing.medium,
           vertical = 10.dp
         )
     ) {
@@ -383,7 +383,7 @@ fun <T> LazyListScope.gridItems(
       Spacer(
         modifier = Modifier
           .fillMaxWidth()
-          .height(dimensionResource(id = R.dimen.home_fragment_padding_bottom))
+          .height(OppiaTheme.spacing.extraLarge)
           .background(
             colorResource(id = R.color.component_color_classroom_topic_list_background_color)
           )

--- a/app/src/main/java/org/oppia/android/app/classroom/classroomlist/AllClassroomsHeaderText.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/classroomlist/AllClassroomsHeaderText.kt
@@ -6,12 +6,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import org.oppia.android.app.ui.R
+import org.oppia.android.app.ui.theme.OppiaTheme
 
 /** Test tag for the all classrooms section header. */
 const val ALL_CLASSROOMS_HEADER_TEST_TAG = "TEST_TAG.all_classrooms_header"
@@ -28,9 +28,9 @@ fun AllClassroomsHeaderText() {
     modifier = Modifier
       .testTag(ALL_CLASSROOMS_HEADER_TEST_TAG)
       .padding(
-        start = dimensionResource(id = R.dimen.classrooms_text_margin_start),
-        top = dimensionResource(id = R.dimen.classrooms_text_margin_top),
-        end = dimensionResource(id = R.dimen.classrooms_text_margin_end),
+        start = OppiaTheme.spacing.medium,
+        top = OppiaTheme.spacing.medium,
+        end = OppiaTheme.spacing.medium,
       ),
   )
 }

--- a/app/src/main/java/org/oppia/android/app/classroom/promotedlist/ComingSoonTopicList.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/promotedlist/ComingSoonTopicList.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -31,6 +30,7 @@ import org.oppia.android.app.classroom.ThumbnailImage
 import org.oppia.android.app.home.promotedlist.ComingSoonTopicListViewModel
 import org.oppia.android.app.home.promotedlist.ComingSoonTopicsViewModel
 import org.oppia.android.app.ui.R
+import org.oppia.android.app.ui.theme.OppiaTheme
 import org.oppia.android.util.locale.OppiaLocale
 
 /** Test tag for the header of the promoted story list. */
@@ -53,21 +53,21 @@ fun ComingSoonTopicList(
     fontSize = dimensionResource(id = R.dimen.coming_soon_topic_list_header_text_size).value.sp,
     modifier = Modifier
       .padding(
-        start = dimensionResource(id = R.dimen.coming_soon_topic_list_layout_margin_start),
-        top = dimensionResource(id = R.dimen.coming_soon_topic_list_layout_margin_top),
-        end = dimensionResource(id = R.dimen.coming_soon_topic_list_layout_margin_end),
+        start = OppiaTheme.spacing.medium,
+        top = OppiaTheme.spacing.medium,
+        end = OppiaTheme.spacing.medium,
       )
       .testTag(COMING_SOON_TOPIC_LIST_HEADER_TEST_TAG),
   )
   LazyRow(
     modifier = Modifier
       .padding(
-        top = dimensionResource(id = R.dimen.coming_soon_topic_list_padding)
+        top = OppiaTheme.spacing.small
       )
       .testTag(COMING_SOON_TOPIC_LIST_TEST_TAG),
     contentPadding = PaddingValues(
-      start = dimensionResource(id = R.dimen.coming_soon_topic_list_layout_margin_start),
-      end = dimensionResource(id = R.dimen.home_padding_end),
+      start = OppiaTheme.spacing.medium,
+      end = OppiaTheme.spacing.medium,
     ),
   ) {
     items(comingSoonTopicListViewModel.comingSoonTopicList) {
@@ -87,13 +87,13 @@ fun ComingSoonTopicCard(
 ) {
   Card(
     modifier = Modifier
-      .width(dimensionResource(id = R.dimen.coming_soon_topic_card_width))
+      .width(200.dp)
       .padding(
-        start = dimensionResource(id = R.dimen.coming_soon_topic_card_layout_margin_start),
-        end = dimensionResource(id = R.dimen.coming_soon_topic_card_layout_margin_end),
-        bottom = dimensionResource(id = R.dimen.coming_soon_topic_card_layout_margin_bottom),
+        start = OppiaTheme.spacing.small,
+        end = OppiaTheme.spacing.small,
+        bottom = OppiaTheme.spacing.medium,
       ),
-    elevation = dimensionResource(id = R.dimen.topic_card_elevation),
+    elevation = OppiaTheme.spacing.small,
   ) {
     Box(
       contentAlignment = Alignment.TopEnd
@@ -120,8 +120,8 @@ fun ComingSoonTopicCard(
             shape = RoundedCornerShape(topEnd = 4.dp, bottomStart = 12.dp),
           )
           .padding(
-            horizontal = dimensionResource(id = R.dimen.coming_soon_text_padding_horizontal),
-            vertical = dimensionResource(id = R.dimen.coming_soon_text_padding_vertical),
+            horizontal = OppiaTheme.spacing.small,
+            vertical = OppiaTheme.spacing.extraSmall,
           ),
         fontSize = 12.sp,
         color = colorResource(id = R.color.component_color_shared_secondary_4_text_color),
@@ -150,10 +150,10 @@ fun ComingSoonTopicCardTextSection(comingSoonTopicsViewModel: ComingSoonTopicsVi
       modifier = Modifier
         .fillMaxWidth()
         .padding(
-          start = dimensionResource(id = R.dimen.coming_soon_topic_card_text_padding),
-          top = dimensionResource(id = R.dimen.coming_soon_topic_card_text_padding),
-          end = dimensionResource(id = R.dimen.coming_soon_topic_card_text_padding),
-          bottom = dimensionResource(id = R.dimen.coming_soon_topic_card_text_padding_bottom),
+          start = OppiaTheme.spacing.medium,
+          top = OppiaTheme.spacing.medium,
+          end = OppiaTheme.spacing.medium,
+          bottom = OppiaTheme.spacing.small,
         ),
       color = colorResource(id = R.color.component_color_shared_secondary_4_text_color),
       fontFamily = FontFamily.SansSerif,

--- a/app/src/main/java/org/oppia/android/app/classroom/promotedlist/PromotedStoryList.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/promotedlist/PromotedStoryList.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -35,6 +34,7 @@ import org.oppia.android.app.classroom.ThumbnailImage
 import org.oppia.android.app.home.promotedlist.PromotedStoryListViewModel
 import org.oppia.android.app.home.promotedlist.PromotedStoryViewModel
 import org.oppia.android.app.ui.R
+import org.oppia.android.app.ui.theme.OppiaTheme
 import org.oppia.android.util.locale.OppiaLocale
 
 /** Test tag for the header of the promoted story list. */
@@ -57,9 +57,9 @@ fun PromotedStoryList(
         .testTag(PROMOTED_STORY_LIST_HEADER_TEST_TAG)
         .fillMaxWidth()
         .padding(
-          start = dimensionResource(id = R.dimen.promoted_story_list_layout_margin_start),
-          top = dimensionResource(id = R.dimen.promoted_story_list_layout_margin_top),
-          end = dimensionResource(id = R.dimen.promoted_story_list_layout_margin_end),
+          start = OppiaTheme.spacing.medium,
+          top = OppiaTheme.spacing.medium,
+          end = OppiaTheme.spacing.medium,
         ),
       horizontalArrangement = Arrangement.SpaceBetween,
       verticalAlignment = Alignment.CenterVertically,
@@ -84,7 +84,7 @@ fun PromotedStoryList(
           ).value.sp,
           modifier = Modifier
             .padding(
-              start = dimensionResource(id = R.dimen.promoted_story_list_view_all_padding_start)
+              start = OppiaTheme.spacing.small
             )
             .clickable { promotedStoryListViewModel.clickOnViewAll() },
         )
@@ -94,9 +94,9 @@ fun PromotedStoryList(
   LazyRow(
     modifier = Modifier
       .testTag(PROMOTED_STORY_LIST_TEST_TAG)
-      .padding(top = dimensionResource(id = R.dimen.promoted_story_list_padding)),
+      .padding(top = OppiaTheme.spacing.small),
     contentPadding = PaddingValues(
-      start = dimensionResource(id = R.dimen.promoted_story_list_layout_margin_start),
+      start = OppiaTheme.spacing.medium,
       end = promotedStoryListViewModel.endPadding.dp,
     ),
   ) {
@@ -122,17 +122,17 @@ fun PromotedStoryCard(
 
   Card(
     modifier = Modifier
-      .width(width = dimensionResource(id = R.dimen.promoted_story_card_layout_width))
+      .width(width = 336.dp)
       .padding(
-        start = dimensionResource(id = R.dimen.promoted_story_card_layout_margin_start),
-        end = dimensionResource(id = R.dimen.promoted_story_card_layout_margin_end),
-        bottom = dimensionResource(id = R.dimen.promoted_story_card_layout_margin_bottom),
+        start = OppiaTheme.spacing.small,
+        end = OppiaTheme.spacing.small,
+        bottom = OppiaTheme.spacing.medium,
       )
       .clickable { promotedStoryViewModel.clickOnStoryTile() },
     backgroundColor = colorResource(
       id = R.color.component_color_classroom_promoted_list_card_background_color
     ),
-    elevation = dimensionResource(id = R.dimen.promoted_story_card_elevation),
+    elevation = OppiaTheme.spacing.small,
   ) {
     Column(
       modifier = cardColumnModifier
@@ -146,15 +146,9 @@ fun PromotedStoryCard(
       Text(
         text = promotedStoryViewModel.nextChapterTitle,
         modifier = Modifier.padding(
-          start = dimensionResource(
-            id = R.dimen.promoted_story_card_padding_horizontal
-          ),
-          top = dimensionResource(
-            id = R.dimen.promoted_story_card_padding_vertical
-          ),
-          end = dimensionResource(
-            id = R.dimen.promoted_story_card_padding_horizontal
-          ),
+          start = OppiaTheme.spacing.medium,
+          top = OppiaTheme.spacing.small,
+          end = OppiaTheme.spacing.medium,
         ),
         color = colorResource(id = R.color.component_color_shared_primary_text_color),
         fontFamily = FontFamily.SansSerif,
@@ -169,15 +163,9 @@ fun PromotedStoryCard(
       Text(
         text = machineLocale.run { promotedStoryViewModel.topicTitle.toMachineUpperCase() },
         modifier = Modifier.padding(
-          start = dimensionResource(
-            id = R.dimen.promoted_story_card_padding_horizontal
-          ),
-          top = dimensionResource(
-            id = R.dimen.promoted_story_card_padding_vertical
-          ),
-          end = dimensionResource(
-            id = R.dimen.promoted_story_card_padding_horizontal
-          ),
+          start = OppiaTheme.spacing.medium,
+          top = OppiaTheme.spacing.extraSmall,
+          end = OppiaTheme.spacing.medium,
         ),
         color = colorResource(
           id = R.color.component_color_shared_story_card_topic_name_text_color
@@ -195,8 +183,8 @@ fun PromotedStoryCard(
         text = machineLocale.run { promotedStoryViewModel.classroomTitle.toMachineUpperCase() },
         modifier = Modifier
           .padding(
-            horizontal = dimensionResource(id = R.dimen.promoted_story_card_padding_horizontal),
-            vertical = dimensionResource(id = R.dimen.promoted_story_card_padding_vertical),
+            horizontal = OppiaTheme.spacing.medium,
+            vertical = OppiaTheme.spacing.small,
           )
           .border(
             width = 2.dp,
@@ -206,8 +194,8 @@ fun PromotedStoryCard(
             shape = RoundedCornerShape(50)
           )
           .padding(
-            horizontal = dimensionResource(id = R.dimen.promoted_story_card_padding_horizontal),
-            vertical = dimensionResource(id = R.dimen.promoted_story_card_padding_vertical),
+            horizontal = OppiaTheme.spacing.small,
+            vertical = OppiaTheme.spacing.extraSmall,
           ),
         color = colorResource(
           id = R.color.component_color_classroom_promoted_list_classroom_label_color

--- a/app/src/main/java/org/oppia/android/app/classroom/topiclist/AllTopicsHeaderText.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/topiclist/AllTopicsHeaderText.kt
@@ -8,12 +8,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import org.oppia.android.app.ui.R
+import org.oppia.android.app.ui.theme.OppiaTheme
 
 /** Test tag for the all topics section header. */
 const val ALL_TOPICS_HEADER_TEST_TAG = "TEST_TAG.all_topics_header"
@@ -34,10 +34,10 @@ fun AllTopicsHeaderText() {
         colorResource(id = R.color.component_color_classroom_topic_list_background_color)
       )
       .padding(
-        start = dimensionResource(id = R.dimen.all_topics_text_margin_start),
-        top = dimensionResource(id = R.dimen.all_topics_text_margin_top),
-        end = dimensionResource(id = R.dimen.all_topics_text_margin_end),
-        bottom = dimensionResource(id = R.dimen.all_topics_text_margin_bottom),
+        start = OppiaTheme.spacing.medium,
+        top = OppiaTheme.spacing.medium,
+        end = OppiaTheme.spacing.medium,
+        bottom = OppiaTheme.spacing.medium,
       ),
   )
 }

--- a/app/src/main/java/org/oppia/android/app/classroom/topiclist/TopicCard.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/topiclist/TopicCard.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.sp
 import org.oppia.android.app.classroom.ThumbnailImage
 import org.oppia.android.app.home.topiclist.TopicSummaryViewModel
 import org.oppia.android.app.ui.R
+import org.oppia.android.app.ui.theme.OppiaTheme
 
 /** Displays a card with the topic summary information. */
 @Composable
@@ -29,11 +30,11 @@ fun TopicCard(topicSummaryViewModel: TopicSummaryViewModel) {
   Card(
     modifier = Modifier
       .padding(
-        start = dimensionResource(R.dimen.topic_card_margin_start),
-        end = dimensionResource(R.dimen.topic_card_margin_end),
+        start = OppiaTheme.spacing.medium,
+        end = OppiaTheme.spacing.medium,
       )
       .clickable { topicSummaryViewModel.clickOnSummaryTile() },
-    elevation = dimensionResource(id = R.dimen.topic_card_elevation),
+    elevation = OppiaTheme.spacing.small,
   ) {
     Column(
       verticalArrangement = Arrangement.Center,
@@ -66,9 +67,9 @@ fun TopicCardTextSection(topicSummaryViewModel: TopicSummaryViewModel) {
       text = topicSummaryViewModel.title,
       modifier = Modifier
         .padding(
-          start = dimensionResource(id = R.dimen.topic_list_item_text_padding),
-          top = dimensionResource(id = R.dimen.topic_list_item_text_padding),
-          end = dimensionResource(id = R.dimen.topic_list_item_text_padding)
+          start = OppiaTheme.spacing.medium,
+          top = OppiaTheme.spacing.medium,
+          end = OppiaTheme.spacing.medium
         ),
       color = colorResource(id = R.color.component_color_shared_secondary_4_text_color),
       fontFamily = FontFamily.SansSerif,
@@ -80,7 +81,7 @@ fun TopicCardTextSection(topicSummaryViewModel: TopicSummaryViewModel) {
     Text(
       text = topicSummaryViewModel.computeLessonCountText(),
       modifier = Modifier
-        .padding(all = dimensionResource(id = R.dimen.topic_list_item_text_padding)),
+        .padding(all = OppiaTheme.spacing.medium),
       color = colorResource(id = R.color.component_color_shared_secondary_4_text_color),
       fontFamily = FontFamily.SansSerif,
       fontWeight = FontWeight.Light,

--- a/app/src/main/java/org/oppia/android/app/classroom/welcome/WelcomeText.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/welcome/WelcomeText.kt
@@ -8,12 +8,12 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.oppia.android.app.home.WelcomeViewModel
 import org.oppia.android.app.ui.R
+import org.oppia.android.app.ui.theme.OppiaTheme
 
 /** Test tag for the welcome section. */
 const val WELCOME_TEST_TAG = "TEST_TAG.welcome"
@@ -21,8 +21,6 @@ const val WELCOME_TEST_TAG = "TEST_TAG.welcome"
 /** Displays a welcome text with an underline. */
 @Composable
 fun WelcomeText(welcomeViewModel: WelcomeViewModel) {
-  val outerPadding = dimensionResource(id = R.dimen.home_welcome_outer_padding)
-  val textMarginEnd = dimensionResource(id = R.dimen.home_welcome_text_view_margin_end)
   val greetingLineColor = colorResource(
     id = R.color.component_color_home_activity_layout_greeting_text_line_color
   )
@@ -32,9 +30,9 @@ fun WelcomeText(welcomeViewModel: WelcomeViewModel) {
     modifier = Modifier
       .testTag(WELCOME_TEST_TAG)
       .padding(
-        start = outerPadding,
-        top = outerPadding,
-        end = outerPadding + textMarginEnd,
+        start = OppiaTheme.spacing.medium,
+        top = OppiaTheme.spacing.medium,
+        end = OppiaTheme.spacing.large,
       )
       .drawBehind {
         val strokeWidthPx = 6.dp.toPx()

--- a/app/src/main/java/org/oppia/android/app/ui/theme/OppiaTheme.kt
+++ b/app/src/main/java/org/oppia/android/app/ui/theme/OppiaTheme.kt
@@ -1,0 +1,87 @@
+package org.oppia.android.app.ui.theme
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+
+/**
+ * CompositionLocal for providing spacing values throughout the Compose tree.
+ *
+ * This allows spacing to be accessed anywhere in the composition hierarchy
+ * without explicitly passing it down through every composable function.
+ */
+val LocalSpacing = compositionLocalOf { PhoneSpacing }
+
+/**
+ * Main theme object for accessing Oppia Android design tokens.
+ *
+ * Usage example:
+ * ```
+ * @Composable
+ * fun MyComposable() {
+ *   Column(
+ *     modifier = Modifier.padding(OppiaTheme.spacing.medium)
+ *   ) {
+ *     // content
+ *   }
+ * }
+ * ```
+ */
+object OppiaTheme {
+  /**
+   * The current spacing values based on screen size and configuration.
+   */
+  val spacing: Spacing
+    @Composable
+    get() = LocalSpacing.current
+}
+
+/**
+ * Oppia Android theme wrapper that provides design tokens including spacing.
+ *
+ * This composable should wrap your UI content to provide access to theme values
+ * like spacing that adapt to different screen sizes.
+ *
+ * @param content The composable content to be themed
+ */
+@Composable
+fun OppiaTheme(
+  content: @Composable () -> Unit
+) {
+  val spacing = rememberSpacing()
+  
+  CompositionLocalProvider(LocalSpacing provides spacing) {
+    MaterialTheme {
+      content()
+    }
+  }
+}
+
+/**
+ * Determines the appropriate spacing values based on screen configuration.
+ *
+ * This function calculates whether the device is a tablet or phone based on
+ * the smallest screen width and returns the appropriate spacing values.
+ *
+ * @return Spacing values appropriate for the current device configuration
+ */
+@Composable
+fun rememberSpacing(): Spacing {
+  val configuration = LocalConfiguration.current
+  
+  return remember(configuration.screenWidthDp, configuration.screenHeightDp) {
+    // Use smallest width to determine if device is a tablet
+    // Tablets typically have sw >= 600dp
+    val smallestWidth = minOf(configuration.screenWidthDp, configuration.screenHeightDp)
+    
+    if (smallestWidth >= 600) {
+      TabletSpacing
+    } else {
+      PhoneSpacing
+    }
+  }
+}

--- a/app/src/main/java/org/oppia/android/app/ui/theme/Spacing.kt
+++ b/app/src/main/java/org/oppia/android/app/ui/theme/Spacing.kt
@@ -1,0 +1,47 @@
+package org.oppia.android.app.ui.theme
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Defines spacing values for the Oppia Android app.
+ *
+ * This data class provides semantic spacing tokens that can be used throughout
+ * Compose UI code to maintain consistent spacing across different screen sizes
+ * and orientations.
+ *
+ * @property extraSmall The smallest spacing value (e.g., for tight spacing between elements)
+ * @property small Small spacing value (e.g., for spacing within a component)
+ * @property medium Medium spacing value (e.g., for standard padding and margins)
+ * @property large Large spacing value (e.g., for section spacing)
+ * @property extraLarge The largest spacing value (e.g., for major layout divisions)
+ */
+data class Spacing(
+  val extraSmall: Dp = 4.dp,
+  val small: Dp = 8.dp,
+  val medium: Dp = 16.dp,
+  val large: Dp = 24.dp,
+  val extraLarge: Dp = 32.dp
+)
+
+/**
+ * Default spacing values for phone devices in portrait mode.
+ */
+val PhoneSpacing = Spacing(
+  extraSmall = 4.dp,
+  small = 8.dp,
+  medium = 16.dp,
+  large = 24.dp,
+  extraLarge = 32.dp
+)
+
+/**
+ * Spacing values for tablet devices with larger screens.
+ */
+val TabletSpacing = Spacing(
+  extraSmall = 6.dp,
+  small = 12.dp,
+  medium = 24.dp,
+  large = 32.dp,
+  extraLarge = 48.dp
+)

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AppLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AppLanguageFragmentTest.kt
@@ -318,11 +318,11 @@ class AppLanguageFragmentTest {
 
           val appLanguageFragment = activity.supportFragmentManager
             .findFragmentById(R.id.app_language_fragment_container) as AppLanguageFragment
-          val recievedLanguage = appLanguageFragment.arguments?.retrieveLanguageFromArguments()
+          val receivedLanguage = appLanguageFragment.arguments?.retrieveLanguageFromArguments()
           val receivedProfileId =
             appLanguageFragment.arguments?.extractCurrentUserProfileId()?.internalId
 
-          assertThat(recievedLanguage).isEqualTo(OppiaLanguage.ENGLISH)
+          assertThat(receivedLanguage).isEqualTo(OppiaLanguage.ENGLISH)
           assertThat(receivedProfileId).isEqualTo(internalProfileId)
         }
       }

--- a/app/src/test/java/org/oppia/android/app/ui/theme/SpacingTest.kt
+++ b/app/src/test/java/org/oppia/android/app/ui/theme/SpacingTest.kt
@@ -1,0 +1,66 @@
+package org.oppia.android.app.ui.theme
+
+import androidx.compose.ui.unit.dp
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Tests for [Spacing] data class and predefined spacing values.
+ */
+class SpacingTest {
+
+  @Test
+  fun testPhoneSpacing_hasCorrectValues() {
+    assertThat(PhoneSpacing.extraSmall).isEqualTo(4.dp)
+    assertThat(PhoneSpacing.small).isEqualTo(8.dp)
+    assertThat(PhoneSpacing.medium).isEqualTo(16.dp)
+    assertThat(PhoneSpacing.large).isEqualTo(24.dp)
+    assertThat(PhoneSpacing.extraLarge).isEqualTo(32.dp)
+  }
+
+  @Test
+  fun testTabletSpacing_hasCorrectValues() {
+    assertThat(TabletSpacing.extraSmall).isEqualTo(6.dp)
+    assertThat(TabletSpacing.small).isEqualTo(12.dp)
+    assertThat(TabletSpacing.medium).isEqualTo(24.dp)
+    assertThat(TabletSpacing.large).isEqualTo(32.dp)
+    assertThat(TabletSpacing.extraLarge).isEqualTo(48.dp)
+  }
+
+  @Test
+  fun testTabletSpacing_isLargerThanPhoneSpacing() {
+    assertThat(TabletSpacing.extraSmall).isGreaterThan(PhoneSpacing.extraSmall)
+    assertThat(TabletSpacing.small).isGreaterThan(PhoneSpacing.small)
+    assertThat(TabletSpacing.medium).isGreaterThan(PhoneSpacing.medium)
+    assertThat(TabletSpacing.large).isGreaterThan(PhoneSpacing.large)
+    assertThat(TabletSpacing.extraLarge).isGreaterThan(PhoneSpacing.extraLarge)
+  }
+
+  @Test
+  fun testSpacing_customValues_createsCorrectInstance() {
+    val customSpacing = Spacing(
+      extraSmall = 2.dp,
+      small = 4.dp,
+      medium = 8.dp,
+      large = 16.dp,
+      extraLarge = 24.dp
+    )
+
+    assertThat(customSpacing.extraSmall).isEqualTo(2.dp)
+    assertThat(customSpacing.small).isEqualTo(4.dp)
+    assertThat(customSpacing.medium).isEqualTo(8.dp)
+    assertThat(customSpacing.large).isEqualTo(16.dp)
+    assertThat(customSpacing.extraLarge).isEqualTo(24.dp)
+  }
+
+  @Test
+  fun testSpacing_defaultValues_matchPhoneSpacing() {
+    val defaultSpacing = Spacing()
+
+    assertThat(defaultSpacing.extraSmall).isEqualTo(PhoneSpacing.extraSmall)
+    assertThat(defaultSpacing.small).isEqualTo(PhoneSpacing.small)
+    assertThat(defaultSpacing.medium).isEqualTo(PhoneSpacing.medium)
+    assertThat(defaultSpacing.large).isEqualTo(PhoneSpacing.large)
+    assertThat(defaultSpacing.extraLarge).isEqualTo(PhoneSpacing.extraLarge)
+  }
+}

--- a/wiki/Writing-tests-with-good-behavioral-coverage.md
+++ b/wiki/Writing-tests-with-good-behavioral-coverage.md
@@ -335,7 +335,7 @@ fun checkSign(number: Int): String {
 }
 ```
 
-### Testing different scenerios
+### Testing different scenarios
 
 Positive Number: Verifies that the function correctly identifies positive numbers.
 
@@ -627,7 +627,7 @@ In this scenario, the `confirmPayment()` function throws an `IllegalStateExcepti
 
 ### Importance of Specific Error Messages
 
-Imagine if both checks in the `reserveSeat()` and `confirmPayment()` functions used generic messages like "Error occured" as:
+Imagine if both checks in the `reserveSeat()` and `confirmPayment()` functions used generic messages like "Error occurred" as:
 
 ```kotlin
 check(seatsAvailable > 0) { "Error occurred" }


### PR DESCRIPTION
- Create Spacing data class with semantic tokens (extraSmall, small, medium, large, extraLarge)
- Implement OppiaTheme with CompositionLocal and automatic phone/tablet detection
- Migrate 7 Compose files to use spacing tokens:
  * TopicCard.kt
  * AllTopicsHeaderText.kt
  * AllClassroomsHeaderText.kt
  * WelcomeText.kt
  * ComingSoonTopicList.kt
  * PromotedStoryList.kt
  * ClassroomListFragmentPresenter.kt
- Add unit tests for spacing values
- Fix spelling typos in WORKSPACE, wiki, and test files

Fixes #6023

<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
