### PR TITLE
Fix #5935: Prevent submitted answer and feedback text from flashing previous card's content

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,7 +34,10 @@ http_archive(
     build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
     sha256 = HTTP_DEPENDENCY_VERSIONS["zlib"]["sha"],
     strip_prefix = "zlib-" + HTTP_DEPENDENCY_VERSIONS["zlib"]["version"],
-    url = "http://zlib.net/fossils/zlib-%s.tar.gz" % HTTP_DEPENDENCY_VERSIONS["zlib"]["version"],
+    urls = [
+        "https://github.com/madler/zlib/releases/download/v{0}/zlib-{0}.tar.gz".format(HTTP_DEPENDENCY_VERSIONS["zlib"]["version"]),
+        "http://zlib.net/fossils/zlib-%s.tar.gz" % HTTP_DEPENDENCY_VERSIONS["zlib"]["version"],
+    ],
 )
 
 # Oppia's backend proto API definitions.

--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -544,6 +544,7 @@ kt_android_library(
         ":resources",
         "//app/src/main/java/org/oppia/android/app/shim:intent_factory_shim",
         "//app/src/main/java/org/oppia/android/app/utility/datetime:date_time_util",
+        "//app/src/main/java/org/oppia/android/app/utility/lifecycle:lifecycle_safe_timer_factory",
         "//app/src/main/java/org/oppia/android/app/utility/math:math_expression_accessibility_util",
         "//app/src/main/java/org/oppia/android/app/viewmodel:observable_array_list",
         "//app/src/main/java/org/oppia/android/app/viewmodel:observable_view_model",

--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionViewModel.kt
@@ -1,24 +1,108 @@
 package org.oppia.android.app.administratorcontrols.appversion
 
 import android.content.Context
+import androidx.databinding.ObservableField
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import org.oppia.android.app.fragment.FragmentScope
 import org.oppia.android.app.translation.AppLanguageResourceHandler
+import org.oppia.android.app.utility.lifecycle.LifecycleSafeTimerFactory
 import org.oppia.android.app.view.models.R
 import org.oppia.android.app.viewmodel.ObservableViewModel
+import org.oppia.android.domain.clipboard.ClipboardController
+import org.oppia.android.domain.oppialogger.LoggingIdentifierController
+import org.oppia.android.domain.oppialogger.OppiaLogger
+import org.oppia.android.util.data.AsyncResult
+import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.getLastUpdateTime
 import org.oppia.android.util.extensions.getVersionName
 import javax.inject.Inject
+
+private const val COPY_ICON_RESET_DELAY_MS = 2000L
 
 /** [ViewModel] for [AppVersionFragment]. */
 @FragmentScope
 class AppVersionViewModel @Inject constructor(
   private val resourceHandler: AppLanguageResourceHandler,
+  private val loggingIdentifierController: LoggingIdentifierController,
+  private val clipboardController: ClipboardController,
+  private val oppiaLogger: OppiaLogger,
+  private val fragment: Fragment,
+  private val lifecycleSafeTimerFactory: LifecycleSafeTimerFactory,
   context: Context
 ) : ObservableViewModel() {
 
   private val versionName: String = context.getVersionName()
   private val lastUpdateDateTime = context.getLastUpdateTime()
+
+  /** Indicates whether the installation ID was recently copied. */
+  val isInstallationIdCopied = ObservableField(false)
+
+  /** Indicates whether the app version was recently copied. */
+  val isAppVersionCopied = ObservableField(false)
+
+  /** The app version name. */
+  val appVersion: String
+    get() = versionName
+
+  /** The device installation ID. */
+  val installationId: LiveData<String?> by lazy {
+    Transformations.map(
+      loggingIdentifierController.getInstallationId().toLiveData()
+    ) { result ->
+      (result as? AsyncResult.Success)?.value
+    }
+  }
+
+  /** Copies the specified installation ID (if non-null) to the user's clipboard. */
+  fun copyInstallationId(installationId: String?) {
+    installationId?.let {
+      val appName = resourceHandler.getStringInLocale(R.string.app_name)
+      clipboardController.setCurrentClip(
+        resourceHandler.getStringInLocaleWithWrapping(
+          R.string.learner_analytics_device_id_clipboard_label_description, appName
+        ),
+        installationId
+      ).toLiveData().observe(fragment) { result ->
+        if (result is AsyncResult.Success) {
+          isInstallationIdCopied.set(true)
+          lifecycleSafeTimerFactory.createTimer(COPY_ICON_RESET_DELAY_MS).observe(fragment) {
+            isInstallationIdCopied.set(false)
+          }
+        } else {
+          oppiaLogger.d(
+            "AppVersionViewModel",
+            "Encountered unexpected non-successful result when copying to clipboard: $result"
+          )
+        }
+      }
+    }
+  }
+
+  /** Copies the app version to the user's clipboard. */
+  fun copyAppVersion() {
+    val appName = resourceHandler.getStringInLocale(R.string.app_name)
+    clipboardController.setCurrentClip(
+      resourceHandler.getStringInLocaleWithWrapping(
+        R.string.learner_analytics_device_id_clipboard_label_description, appName
+      ),
+      versionName
+    ).toLiveData().observe(fragment) { result ->
+      if (result is AsyncResult.Success) {
+        isAppVersionCopied.set(true)
+        lifecycleSafeTimerFactory.createTimer(COPY_ICON_RESET_DELAY_MS).observe(fragment) {
+          isAppVersionCopied.set(false)
+        }
+      } else {
+        oppiaLogger.w(
+          "AppVersionViewModel",
+          "Encountered unexpected non-successful result when copying to clipboard: $result"
+        )
+      }
+    }
+  }
 
   /** Returns a localized, human-readable app version name. */
   fun computeVersionNameText(): String =

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
@@ -1,5 +1,6 @@
 package org.oppia.android.app.hintsandsolution
 
+import android.view.View
 import androidx.databinding.ObservableBoolean
 import org.oppia.android.app.model.Interaction
 import org.oppia.android.app.model.InteractionObject
@@ -29,6 +30,7 @@ import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.utility.math.MathExpressionAccessibilityUtil
 import org.oppia.android.app.utility.toAccessibleAnswerString
 import org.oppia.android.app.view.models.R
+import org.oppia.android.util.logging.ConsoleLogger
 import org.oppia.android.util.math.MathExpressionParser.Companion.ErrorCheckingMode.REQUIRED_ONLY
 import org.oppia.android.util.math.MathExpressionParser.Companion.MathParsingResult
 import org.oppia.android.util.math.MathExpressionParser.Companion.parseAlgebraicEquation
@@ -38,6 +40,8 @@ import org.oppia.android.util.math.isApproximatelyEqualTo
 import org.oppia.android.util.math.toAnswerString
 import org.oppia.android.util.math.toPlainString
 import org.oppia.android.util.math.toRawLatex
+import org.oppia.android.util.parser.html.CUSTOM_CONCEPT_CARD_TAG
+import org.oppia.android.util.parser.html.ConceptCardTagHandler
 import org.oppia.android.util.parser.html.CustomHtmlContentHandler
 import javax.inject.Inject
 
@@ -61,18 +65,24 @@ class SolutionViewModel private constructor(
   private val mathExpressionAccessibilityUtil: MathExpressionAccessibilityUtil,
   val explorationId: String,
   val isFlashback: Boolean,
-  val solutionBoxStrokeWidth: Int
+  val solutionBoxStrokeWidth: Int,
+  private val consoleLogger: ConsoleLogger
 ) {
-  /**
-   * A screenreader-friendly version of [solutionSummary] that should be used for readout, in place
-   * of the original summary.
-   */
+  /** Lazily computes the accessibility content description for the solution summary HTML content. */
   val solutionSummaryContentDescription by lazy {
-    CustomHtmlContentHandler.fromHtml(
+    CustomHtmlContentHandler.getContentDescription(
       solutionSummary,
-      imageRetriever = null,
-      customTagHandlers = mapOf()
-    ).toString()
+      customTagHandlers = mapOf(
+        CUSTOM_CONCEPT_CARD_TAG to ConceptCardTagHandler(
+          listener = object : ConceptCardTagHandler.ConceptCardLinkClickListener {
+            override fun onConceptCardLinkClicked(view: View, skillId: String) {
+              // No action for TalkBack readout
+            }
+          },
+          consoleLogger = consoleLogger
+        )
+      )
+    )
   }
 
   /** A displayable HTML representation of the correct answer presented by this model's solution. */
@@ -239,7 +249,8 @@ class SolutionViewModel private constructor(
   /** Application-injectable factory to create [SolutionViewModel]s (see [create]). */
   class Factory @Inject constructor(
     private val appLanguageResourceHandler: AppLanguageResourceHandler,
-    private val mathExpressionAccessibilityUtil: MathExpressionAccessibilityUtil
+    private val mathExpressionAccessibilityUtil: MathExpressionAccessibilityUtil,
+    private val consoleLogger: ConsoleLogger
   ) {
     /**
      * Returns a new [SolutionViewModel] with the specified summary HTML text, correct answer,
@@ -269,7 +280,8 @@ class SolutionViewModel private constructor(
         mathExpressionAccessibilityUtil,
         explorationId,
         isFlashback,
-        solutionBoxStrokeWidth
+        solutionBoxStrokeWidth,
+        consoleLogger
       )
     }
 

--- a/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
@@ -1350,8 +1350,6 @@ class StatePlayerRecyclerViewAssembler private constructor(
           val binding = DataBindingUtil.findBinding<FeedbackItemBinding>(view)!!
           val feedbackViewModel = viewModel as FeedbackViewModel
           binding.viewModel = feedbackViewModel
-          binding.htmlContent = ""
-          binding.executePendingBindings()
           binding.htmlContent =
             htmlParserFactory.create(
               resourceBucketName,
@@ -1455,7 +1453,6 @@ class StatePlayerRecyclerViewAssembler private constructor(
           val binding = DataBindingUtil.findBinding<SubmittedAnswerItemBinding>(view)!!
           val submittedAnswerViewModel = viewModel as SubmittedAnswerViewModel
           binding.viewModel = submittedAnswerViewModel
-          binding.executePendingBindings()
           val userAnswer = submittedAnswerViewModel.submittedUserAnswer
           when (userAnswer.textualAnswerCase) {
             UserAnswer.TextualAnswerCase.ITEM_SELECTION_ANSWER -> {

--- a/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
@@ -1350,6 +1350,8 @@ class StatePlayerRecyclerViewAssembler private constructor(
           val binding = DataBindingUtil.findBinding<FeedbackItemBinding>(view)!!
           val feedbackViewModel = viewModel as FeedbackViewModel
           binding.viewModel = feedbackViewModel
+          binding.htmlContent = ""
+          binding.executePendingBindings()
           binding.htmlContent =
             htmlParserFactory.create(
               resourceBucketName,
@@ -1453,6 +1455,7 @@ class StatePlayerRecyclerViewAssembler private constructor(
           val binding = DataBindingUtil.findBinding<SubmittedAnswerItemBinding>(view)!!
           val submittedAnswerViewModel = viewModel as SubmittedAnswerViewModel
           binding.viewModel = submittedAnswerViewModel
+          binding.executePendingBindings()
           val userAnswer = submittedAnswerViewModel.submittedUserAnswer
           when (userAnswer.textualAnswerCase) {
             UserAnswer.TextualAnswerCase.ITEM_SELECTION_ANSWER -> {

--- a/app/src/main/java/org/oppia/android/app/recyclerview/BindableAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/recyclerview/BindableAdapter.kt
@@ -3,6 +3,7 @@ package org.oppia.android.app.recyclerview
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
@@ -161,6 +162,12 @@ class BindableAdapter<T : Any> internal constructor(
         object : BindableViewHolder<T>(inflatedView) {
           override fun bind(data: T) {
             bindView(inflatedView, data)
+            // Force immediate binding execution after bindView completes. Some views registered
+            // via registerViewBinder use data binding internally (e.g. via DataBindingUtil) and
+            // set properties like htmlContent that are deferred by the binding framework. Without
+            // this call, RecyclerView may briefly display stale content from a recycled view
+            // before the binding framework flushes updates on the next frame. See: #5935.
+            DataBindingUtil.findBinding<ViewDataBinding>(inflatedView)?.executePendingBindings()
           }
         }
       }
@@ -280,6 +287,12 @@ class BindableAdapter<T : Any> internal constructor(
         object : BindableViewHolder<T>(inflatedView) {
           override fun bind(data: T) {
             bindView(inflatedView, data)
+            // Force immediate binding execution after bindView completes. Some views registered
+            // via registerViewBinder use data binding internally (e.g. via DataBindingUtil) and
+            // set properties like htmlContent that are deferred by the binding framework. Without
+            // this call, RecyclerView may briefly display stale content from a recycled view
+            // before the binding framework flushes updates on the next frame. See: #5935.
+            DataBindingUtil.findBinding<ViewDataBinding>(inflatedView)?.executePendingBindings()
           }
         }
       }

--- a/app/src/main/res/layout/app_version_fragment.xml
+++ b/app/src/main/res/layout/app_version_fragment.xml
@@ -3,7 +3,6 @@
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <data>
-
     <variable
       name="viewModel"
       type="org.oppia.android.app.administratorcontrols.appversion.AppVersionViewModel" />
@@ -14,49 +13,193 @@
     android:layout_height="match_parent"
     android:background="@color/component_color_shared_screen_tertiary_background_color">
 
-    <TextView
-      android:id="@+id/app_version_text_view"
+    <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:background="@drawable/general_item_background_border"
-      android:fontFamily="sans-serif"
-      android:paddingStart="@dimen/app_version_text_view_padding_start"
-      android:paddingTop="20dp"
-      android:paddingEnd="@dimen/app_version_text_view_padding_end"
-      android:paddingBottom="20dp"
-      android:text="@{viewModel.computeVersionNameText()}"
-      android:textColor="@color/component_color_shared_primary_dark_text_color"
-      android:textSize="16sp"
+      android:padding="16dp"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
+      app:layout_constraintTop_toTopOf="parent">
 
-    <ImageView
-      android:id="@+id/app_info_image_view"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="@dimen/app_version_image_view_margin_start"
-      app:layout_constraintEnd_toStartOf="@id/app_last_update_date_text_view"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="@id/app_last_update_date_text_view"
-      app:srcCompat="@drawable/ic_info_icon_gray_24dp"
-      app:tint="@color/component_color_app_version_activity_info_icon_color"
-      android:contentDescription="@string/app_info_icon_content_description" />
+      <TextView
+        android:id="@+id/app_version_label"
+        style="@style/Heading2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/app_version_label"
+        android:textColor="@color/component_color_shared_primary_dark_text_color"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-      android:id="@+id/app_last_update_date_text_view"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="12dp"
-      android:layout_marginTop="28dp"
-      android:layout_marginEnd="@dimen/app_version_text_view_margin_end"
-      android:fontFamily="sans-serif"
-      android:text="@{viewModel.computeLastUpdatedDateText()}"
-      android:textColor="@color/component_color_app_version_activity_description_text_color"
-      android:textSize="12sp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintHorizontal_weight="1"
-      app:layout_constraintStart_toEndOf="@id/app_info_image_view"
-      app:layout_constraintTop_toBottomOf="@id/app_version_text_view" />
+      <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/app_version_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:background="@drawable/general_item_background_border"
+        android:paddingStart="24dp"
+        android:paddingTop="12dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/app_version_label">
+
+        <TextView
+          android:id="@+id/app_version_text_view"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_marginEnd="10dp"
+          android:fontFamily="sans-serif"
+          android:text="@{viewModel.appVersion}"
+          android:textColor="@color/component_color_shared_primary_dark_text_color"
+          android:textSize="18sp"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toStartOf="@+id/copy_app_version_button"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <org.oppia.android.app.administratorcontrols.learneranalytics.CopyIdMaterialButtonView
+          android:id="@+id/copy_app_version_button"
+          style="@style/BorderlessMaterialButton"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:minWidth="48dp"
+          android:minHeight="48dp"
+          android:contentDescription="@string/copy_app_version"
+          android:onClick="@{(v) -> viewModel.copyAppVersion()}"
+          android:text="@{viewModel.isAppVersionCopied ? @string/learner_analytics_copied_to_clipboard_label : @string/learner_analytics_copy_to_clipboard_label}"
+          android:textColor="@color/component_color_profile_and_device_id_activity_primary_text_color"
+          app:backgroundTint="@color/component_color_shared_white_background_color"
+          app:icon="@{viewModel.isAppVersionCopied ? @drawable/ic_baseline_check_24 : @drawable/ic_baseline_content_copy_24}"
+          app:iconGravity="top"
+          app:iconSize="28dp"
+          app:iconTint="@color/component_color_profile_and_device_id_activity_enabled_icon_button_color"
+          app:layout_constraintBottom_toBottomOf="@id/app_version_text_view"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toTopOf="@id/app_version_text_view" />
+      </androidx.constraintlayout.widget.ConstraintLayout>
+
+      <ImageView
+        android:id="@+id/app_info_image_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:contentDescription="@string/app_info_icon_content_description"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/app_version_container"
+        app:srcCompat="@drawable/ic_info_icon_gray_24dp"
+        app:tint="@color/component_color_app_version_activity_info_icon_color" />
+
+      <TextView
+        android:id="@+id/app_last_update_date_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="12dp"
+        android:fontFamily="sans-serif"
+        android:lineSpacingExtra="4dp"
+        android:text="@{viewModel.computeLastUpdatedDateText()}"
+        android:textColor="@color/component_color_app_version_activity_description_text_color"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/app_info_image_view"
+        app:layout_constraintTop_toBottomOf="@id/app_version_container" />
+
+      <TextView
+        android:id="@+id/installation_id_label"
+        style="@style/Heading2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="28dp"
+        android:text="@string/installation_id_label"
+        android:textColor="@color/component_color_shared_primary_dark_text_color"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/app_last_update_date_text_view" />
+
+      <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/installation_id_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:background="@drawable/general_item_background_border"
+        android:paddingStart="24dp"
+        android:paddingTop="12dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/installation_id_label">
+
+        <TextView
+          android:id="@+id/installation_id_text"
+          style="@style/TextViewStart"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_marginEnd="10dp"
+          android:fontFamily="sans-serif"
+          android:text="@{viewModel.installationId}"
+          android:textColor="@color/component_color_shared_primary_dark_text_color"
+          android:textSize="18sp"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toStartOf="@+id/copy_installation_id_button"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <org.oppia.android.app.administratorcontrols.learneranalytics.CopyIdMaterialButtonView
+          android:id="@+id/copy_installation_id_button"
+          style="@style/BorderlessMaterialButton"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:minWidth="48dp"
+          android:minHeight="48dp"
+          android:contentDescription="@string/copy_installation_id"
+          android:enabled="@{viewModel.installationId != null}"
+          android:onClick="@{(v) -> viewModel.copyInstallationId(viewModel.installationId)}"
+          android:text="@{viewModel.isInstallationIdCopied ? @string/learner_analytics_copied_to_clipboard_label : @string/learner_analytics_copy_to_clipboard_label}"
+          android:textColor="@color/component_color_profile_and_device_id_activity_primary_text_color"
+          app:backgroundTint="@color/component_color_shared_white_background_color"
+          app:icon="@{viewModel.isInstallationIdCopied ? @drawable/ic_baseline_check_24 : @drawable/ic_baseline_content_copy_24}"
+          app:iconGravity="top"
+          app:iconSize="28dp"
+          app:iconTint="@color/component_color_profile_and_device_id_activity_enabled_icon_button_color"
+          app:layout_constraintBottom_toBottomOf="@id/installation_id_text"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toTopOf="@id/installation_id_text" />
+      </androidx.constraintlayout.widget.ConstraintLayout>
+
+      <ImageView
+        android:id="@+id/installation_id_info_image_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:contentDescription="@string/app_info_icon_content_description"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/installation_id_container"
+        app:srcCompat="@drawable/ic_info_icon_gray_24dp"
+        app:tint="@color/component_color_app_version_activity_info_icon_color" />
+
+      <TextView
+        android:id="@+id/installation_id_explanation"
+        style="@style/TextViewStart"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="12dp"
+        android:fontFamily="sans-serif"
+        android:lineSpacingExtra="4dp"
+        android:text="@string/installation_id_explanation"
+        android:textColor="@color/component_color_app_version_activity_description_text_color"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/installation_id_info_image_view"
+        app:layout_constraintTop_toBottomOf="@id/installation_id_container" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -418,9 +418,14 @@
   <string name="log_out_dialog_okay_button" tools:ignore="ButtonCase,Typos">Ok</string>
   <string name="log_out_dialog_message">Are you sure you want to log out of your profile?</string>
   <!-- AppVersionFragment -->
-  <string name="app_version_name">App Version %s</string>
-  <string name="app_last_update_date">The last update was installed on %s. Use the above version number to send feedback about bugs.</string>
+  <string name="app_version_label">App Version</string>
+  <string name="app_version_name">%s</string>
+  <string name="app_last_update_date">The last update was installed on %s. Please share the above version when sending feedback about bugs.</string>
   <string name="app_version_activity_title">App Version</string>
+  <string name="copy_app_version">Copy app version</string>
+  <string name="installation_id_label">Installation ID</string>
+  <string name="installation_id_explanation">This ID uniquely identifies this app installation. You may be asked to provide this when filing feedback about the app or using certain features.</string>
+  <string name="copy_installation_id">Copy installation ID</string>
   <!-- OptionsActivity -->
   <string name="app_language_activity_title">App Language</string>
   <string name="audio_language_activity_title">Preferred Audio Language</string>

--- a/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/administratorcontrols/appversion/AppVersionActivityTest.kt
@@ -64,6 +64,7 @@ import org.oppia.android.domain.classify.rules.numericexpressioninput.NumericExp
 import org.oppia.android.domain.classify.rules.numericinput.NumericInputRuleModule
 import org.oppia.android.domain.classify.rules.ratioinput.RatioInputModule
 import org.oppia.android.domain.classify.rules.textinput.TextInputRuleModule
+import org.oppia.android.domain.clipboard.ClipboardController
 import org.oppia.android.domain.exploration.ExplorationProgressModule
 import org.oppia.android.domain.exploration.ExplorationStorageModule
 import org.oppia.android.domain.hintsandsolution.HintsAndSolutionConfigModule
@@ -80,6 +81,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
+import org.oppia.android.testing.data.DataProviderTestMonitor
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule
@@ -121,6 +123,8 @@ class AppVersionActivityTest {
 
   @Inject lateinit var context: Context
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
+  @Inject lateinit var clipboardController: ClipboardController
+  @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
 
   @Before
   fun setUp() {
@@ -164,14 +168,8 @@ class AppVersionActivityTest {
   fun testAppVersionActivity_loadFragment_displaysAppVersion() {
     launchAppVersionActivityIntent().use { scenario ->
       val lastUpdateDate = scenario.convertTimeStampToDate(context.getLastUpdateTime())
-      onView(
-        withText(
-          String.format(
-            context.resources.getString(R.string.app_version_name),
-            context.getVersionName()
-          )
-        )
-      ).check(matches(isDisplayed()))
+      onView(withId(R.id.app_version_text_view))
+        .check(matches(withText(context.getVersionName())))
       onView(
         withText(
           String.format(
@@ -190,20 +188,8 @@ class AppVersionActivityTest {
     launchAppVersionActivityIntent().use { scenario ->
       onView(isRoot()).perform(orientationLandscape())
       val lastUpdateDate = scenario.convertTimeStampToDate(context.getLastUpdateTime())
-      onView(
-        withId(
-          R.id.app_version_text_view
-        )
-      ).check(
-        matches(
-          withText(
-            String.format(
-              context.resources.getString(R.string.app_version_name),
-              context.getVersionName()
-            )
-          )
-        )
-      )
+      onView(withId(R.id.app_version_text_view))
+        .check(matches(withText(context.getVersionName())))
       onView(
         withId(
           R.id.app_last_update_date_text_view
@@ -238,6 +224,171 @@ class AppVersionActivityTest {
       intended(hasComponent(AppVersionActivity::class.java.name))
       onView(isRoot()).perform(pressBack())
       onView(withId(R.id.administrator_controls_list)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_installationIdIsDisplayed() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.installation_id_text)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_installationIdLabelIsDisplayed() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.installation_id_label)).check(matches(isDisplayed()))
+      onView(withId(R.id.installation_id_label))
+        .check(matches(withText(R.string.installation_id_label)))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_copyButton_isDisplayed() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_installation_id_button)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_clickCopyButton_showsCopiedState() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_installation_id_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_installation_id_button))
+        .check(matches(withText(R.string.learner_analytics_copied_to_clipboard_label)))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_clickCopyButton_copiesInstallationIdToClipboard() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+      val currentClipProvider = clipboardController.getCurrentClip()
+
+      onView(withId(R.id.copy_installation_id_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+
+      // Verify the button shows "Copied" state, indicating successful copy
+      onView(withId(R.id.copy_installation_id_button))
+        .check(matches(withText(R.string.learner_analytics_copied_to_clipboard_label)))
+
+      // Verify clipboard contains the installation ID using ClipboardController
+      val currentClip = monitorFactory.waitForNextSuccessfulResult(currentClipProvider)
+      assertThat(currentClip)
+        .isInstanceOf(ClipboardController.CurrentClip.SetWithAppText::class.java)
+      val clipWithText = currentClip as ClipboardController.CurrentClip.SetWithAppText
+      assertThat(clipWithText.label).isEqualTo("Oppia installation ID")
+      assertThat(clipWithText.text).isNotEmpty()
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_clickCopyButton_afterDelay_resetsState() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_installation_id_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+      testCoroutineDispatchers.advanceTimeBy(2001)
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_installation_id_button))
+        .check(matches(withText(R.string.learner_analytics_copy_to_clipboard_label)))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_configurationChange_installationIdIsDisplayed() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(isRoot()).perform(orientationLandscape())
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.installation_id_text)).check(matches(isDisplayed()))
+      onView(withId(R.id.copy_installation_id_button)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_installationIdExplanationIsDisplayed() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.installation_id_explanation)).check(matches(isDisplayed()))
+      onView(withId(R.id.installation_id_explanation))
+        .check(matches(withText(R.string.installation_id_explanation)))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_appVersionCopyButton_isDisplayed() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_app_version_button)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_clickAppVersionCopyButton_showsCopiedState() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_app_version_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_app_version_button))
+        .check(matches(withText(R.string.learner_analytics_copied_to_clipboard_label)))
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_clickAppVersionCopyButton_copiesVersionToClipboard() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+      val currentClipProvider = clipboardController.getCurrentClip()
+
+      onView(withId(R.id.copy_app_version_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+
+      // Verify the button shows "Copied" state, indicating successful copy
+      onView(withId(R.id.copy_app_version_button))
+        .check(matches(withText(R.string.learner_analytics_copied_to_clipboard_label)))
+
+      // Verify clipboard contains the app version using ClipboardController
+      val currentClip = monitorFactory.waitForNextSuccessfulResult(currentClipProvider)
+      assertThat(currentClip)
+        .isInstanceOf(ClipboardController.CurrentClip.SetWithAppText::class.java)
+      val clipWithText = currentClip as ClipboardController.CurrentClip.SetWithAppText
+      assertThat(clipWithText.text).isEqualTo(context.getVersionName())
+    }
+  }
+
+  @Test
+  fun testAppVersionActivity_clickAppVersionCopyButton_afterDelay_resetsState() {
+    launchAppVersionActivityIntent().use {
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_app_version_button)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+
+      // Advance time past the 2000ms reset delay.
+      testCoroutineDispatchers.advanceTimeBy(2001)
+      testCoroutineDispatchers.runCurrent()
+
+      onView(withId(R.id.copy_app_version_button))
+        .check(matches(withText(R.string.learner_analytics_copy_to_clipboard_label)))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1682,8 +1682,8 @@ class ExplorationActivityTest {
         .check(
           matches(
             withContentDescription(
-              "Remember that two halves, when added together, make one whole." +
-                "\nClick on this test_skill_id_1 concept card."
+              "Remember that two halves, when added together, make one whole.\n" +
+                "Click on this test_skill_id_1 concept card."
             )
           )
         )

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5600,7 +5600,7 @@ class StateFragmentTest {
       onView(withId(R.id.solution_summary_label)).check(matches(withText("Explanation:")))
 
       val expectedSolutionSummary = "Half of something has one part in the numerator for" +
-        " every two parts in the denominator."
+        " every two parts in the denominator.\n\n"
       onView(withId(R.id.solution_summary))
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
@@ -5652,7 +5652,7 @@ class StateFragmentTest {
       onView(withId(R.id.solution_summary_label)).check(matches(withText("Explanation:")))
 
       val expectedSolutionSummary = "Half of something has one part in the numerator for" +
-        " every two parts in the denominator."
+        " every two parts in the denominator.\n\n"
       onView(withId(R.id.solution_summary))
         .check(matches(withText(containsString(expectedSolutionSummary))))
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5942,6 +5942,60 @@ class StateFragmentTest {
     }
   }
 
+  @Test
+  fun testStateFragment_moveFromState2ToState3_submittedAnswerShowsState3Answer() {
+    setUpTestWithLanguageSwitchingFeatureOff()
+    launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
+      startPlayingExploration()
+      playThroughPrototypeState1()
+
+      // State 2: submit "1/2" (fraction answer).
+      typeFractionText("1/2")
+      clickSubmitAnswerButton()
+      scrollToViewType(SUBMITTED_ANSWER)
+      onView(withId(R.id.submitted_answer_text_view)).check(matches(withText("1/2")))
+      clickContinueNavigationButton()
+
+      // State 3: RecyclerView recycles State 2's submitted answer view.
+      selectMultipleChoiceOption(optionPosition = 2, expectedOptionText = "Eagle")
+      clickSubmitAnswerButton()
+
+      // Regression test for #5935: submitted answer must show State 3's answer, not "1/2" from
+      // State 2's recycled view.
+      scrollToViewType(SUBMITTED_ANSWER)
+      verifyMultipleChoiceSubmittedAnswer(
+        optionPosition = 2,
+        expectedOptionText = "Eagle",
+        labelTextId = R.string.submitted_answer_label_text
+      )
+    }
+  }
+
+  @Test
+  fun testStateFragment_submitFractionAnswerInState2_moveToState3_feedbackShowsState3Feedback() {
+    setUpTestWithLanguageSwitchingFeatureOff()
+    launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
+      startPlayingExploration()
+      playThroughPrototypeState1()
+
+      // State 2: submit "1/2" and verify feedback is shown.
+      typeFractionText("1/2")
+      clickSubmitAnswerButton()
+      scrollToViewType(FEEDBACK)
+      onView(withId(R.id.feedback_text_view)).check(matches(isDisplayed()))
+      clickContinueNavigationButton()
+
+      // State 3: RecyclerView recycles State 2's feedback view.
+      selectMultipleChoiceOption(optionPosition = 2, expectedOptionText = "Eagle")
+      clickSubmitAnswerButton()
+
+      // Regression test for #5935: feedback must be visible and correspond to State 3, not carry
+      // over stale content from State 2's recycled feedback view.
+      scrollToViewType(FEEDBACK)
+      onView(withId(R.id.feedback_text_view)).check(matches(isDisplayed()))
+    }
+  }
+
   private fun moveToFlashbackState() {
     playThroughPrototypeState1()
     playThroughPrototypeState2()

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -1317,8 +1317,8 @@ class StateFragmentLocalTest {
       onView(withId(R.id.solution_summary)).check(
         matches(
           withContentDescription(
-            "Start by dividing the cake into equal parts:\n\nThree of " +
-              "the four equal parts are red. So, the answer is 3/4.\n\n"
+            "Start by dividing the cake into equal parts:" +
+              "\nThree of the four equal parts are red. So, the answer is 3/4."
           )
         )
       )

--- a/scripts/assets/kdoc_validity_exemptions.textproto
+++ b/scripts/assets/kdoc_validity_exemptions.textproto
@@ -299,7 +299,6 @@ exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/T
 exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersRobolectricImpl.kt"
 exempted_file_path: "testing/src/test/java/org/oppia/android/testing/threading/TestCoroutineDispatcherTestBase.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/logging/LogLevel.kt"
-exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/image/UrlImageParser.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/svg/ScalableVectorGraphic.kt"

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -11,10 +11,16 @@ import javax.inject.Inject
 
 /** The custom tag corresponding to [ConceptCardTagHandler]. */
 const val CUSTOM_CONCEPT_CARD_TAG = "oppia-noninteractive-skillreview"
+/** The attribute key used to extract the concept card skill ID from the custom tag. */
 const val CUSTOM_CONCEPT_CARD_SKILL_ID = "skill_id-with-value"
+/** The attribute key used to extract the visible concept card text from the custom tag. */
 const val CUSTOM_CONCEPT_CARD_TEXT_VALUE = "text-with-value"
 
 // https://mohammedlakkadshaw.com/blog/handling-custom-tags-in-android-using-html-taghandler.html/
+/**
+ * A custom tag handler responsible for converting concept card custom tags into clickable spans and
+ * generating the appropriate accessibility content description.
+ */
 class ConceptCardTagHandler(
   private val listener: ConceptCardLinkClickListener,
   private val consoleLogger: ConsoleLogger
@@ -53,9 +59,9 @@ class ConceptCardTagHandler(
   }
 
   override fun getContentDescription(attributes: Attributes): String? {
-    val text = attributes.getJsonStringValue(CUSTOM_CONCEPT_CARD_TEXT_VALUE)
-    return if (!text.isNullOrBlank()) {
-      text
+    val skillId = attributes.getJsonStringValue(CUSTOM_CONCEPT_CARD_SKILL_ID)
+    return if (!skillId.isNullOrBlank()) {
+      "$skillId concept card"
     } else ""
   }
 

--- a/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
@@ -124,7 +124,7 @@ class ConceptCardTagHandlerTest {
         html = CONCEPT_CARD_LINK_MARKUP_1,
         customTagHandlers = tagHandlersWithConceptCardSupport
       )
-    assertThat(contentDescription).isEqualTo("refresher lesson")
+    assertThat(contentDescription).isEqualTo("skill_id_1 concept card")
   }
 
   @Test

--- a/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
@@ -895,7 +895,7 @@ class HtmlParserTest {
         textView.text = htmlResult
 
         assertThat(textView.contentDescription.toString()).isEqualTo(
-          "Visit refresher lesson to learn more."
+          "Visit skill_id_1 concept card to learn more."
         )
       }
     }


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fixes #5935 
When submitting an answer, the submitted answer and feedback text briefly flashed the previous card's content before updating to the correct one. This happened because RecyclerView reuses old views and data binding updates aren't instant.

Fixed by calling `executePendingBindings()` to force immediate binding updates before HTML parsing starts. This clears the old recycled view content right away instead of showing it during the parsing delay.                          

Tested on device - no more flash. 

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
  The video has been slowed down to 0.2x speed to make the issue and solution more visible.                                                                                                   
                                                                                                                                                                                              
  **Before**                                                                                                                                                                                  

https://github.com/user-attachments/assets/3a241518-7e70-4c39-b3ce-3cbb9d99ef8e

                                                                                                                                                                                           
  **After**                                                                                                                                                                                   

https://github.com/user-attachments/assets/e6c7d788-29ca-46af-9ed4-64ef43279303


