### PR TITLE
Fixes #5934: Fixes flaky CI failures in `zlib` fetch

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,8 +35,8 @@ http_archive(
     sha256 = HTTP_DEPENDENCY_VERSIONS["zlib"]["sha"],
     strip_prefix = "zlib-" + HTTP_DEPENDENCY_VERSIONS["zlib"]["version"],
     urls = [
-        "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz",
-        "http://zlib.net/fossils/zlib-1.3.1.tar.gz",
+        "https://github.com/madler/zlib/releases/download/v{0}/zlib-{0}.tar.gz".format(HTTP_DEPENDENCY_VERSIONS["zlib"]["version"]),
+        "http://zlib.net/fossils/zlib-%s.tar.gz" % HTTP_DEPENDENCY_VERSIONS["zlib"]["version"],
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,7 +34,10 @@ http_archive(
     build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
     sha256 = HTTP_DEPENDENCY_VERSIONS["zlib"]["sha"],
     strip_prefix = "zlib-" + HTTP_DEPENDENCY_VERSIONS["zlib"]["version"],
-    url = "http://zlib.net/fossils/zlib-%s.tar.gz" % HTTP_DEPENDENCY_VERSIONS["zlib"]["version"],
+    urls = [
+        "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz",
+        "http://zlib.net/fossils/zlib-1.3.1.tar.gz",
+    ],
 )
 
 # Oppia's backend proto API definitions.


### PR DESCRIPTION
Fix #5934: Fixes flaky CI failures in zlib fetch by adding a reliable GitHub mirror to WORKSPACE.

## Explanation

Fixes #5934: Flaky CI failures in `zlib` fetch by adding a reliable GitHub mirror to `WORKSPACE`.

The `zlib.net` server is often unstable or rate-limited, causing intermittent build failures. This PR updates the `http_archive` for `zlib` to primarily fetch from a stable GitHub release (v1.3.1) while keeping the original URL as a fallback. This ensures deterministic and resilient builds.

**Verified by:**

1. **Local Build:** `bazel build @zlib//:zlib` executes successfully with the new configuration.
2. **Fault Injection:** Verified that the build succeeds even when the `zlib.net` URL is removed, proving the GitHub mirror works independently.
3. **Lint:** Ran `buildifier` on `WORKSPACE` file.

---

## Essential Checklist

- [x] The PR title and explanation each start with "Fix #bugnum:" (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...")
- [x] Any changes to `scripts/assets` files have their rationale included in the PR explanation.  
  *(No changes)*
- [x] The PR follows the style guide.
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference]).
- [x] The PR is made from a branch that's not called "develop" and is up-to-date with "develop".
- [x] The PR is assigned to the appropriate reviewers ([reference]).

## For UI-specific PRs only

This PR does not include any UI-related changes. It is an infrastructural dependency update that does not affect the app’s UI or user-facing behavior.