### PR TITLE
Fix part of #5792: Add debug logs for cached LaTeX rendering pipeline

### DIFF
--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
@@ -70,10 +70,17 @@ class SolutionViewModel private constructor(
 
 ) {
 
-  /** Override default HTML parsing to include custom concept card tags when generating TalkBack-readable text for Solution and Flashback dialogs.
-   The previous implementation ignored custom tags, causing TalkBack to skip this fix ensures that TalkBack reads the concept card reference
-   exactly once and consistently.
+  /**
+   * Overrides default HTML parsing to include custom concept card tags when generating
+   * TalkBack-readable text for Solution and Flashback dialogs.
+   *
+   * The previous implementation ignored custom tags.
+   * This caused TalkBack to skip concept card references.
+   *
+   * This fix ensures that TalkBack reads the concept card reference exactly once
+   * and consistently.
    */
+
   val solutionSummaryContentDescription by lazy {
     CustomHtmlContentHandler.getContentDescription(
       solutionSummary,

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
@@ -67,19 +67,7 @@ class SolutionViewModel private constructor(
   val isFlashback: Boolean,
   val solutionBoxStrokeWidth: Int,
   private val consoleLogger: ConsoleLogger
-
 ) {
-
-  /**
-   * Overrides default HTML parsing to include custom concept card tags when generating
-   * TalkBack-readable text for Solution and Flashback dialogs.
-   *
-   * The previous implementation ignored custom tags.
-   * This caused TalkBack to skip concept card references.
-   *
-   * This fix ensures that TalkBack reads the concept card reference exactly once
-   * and consistently.
-   */
 
   val solutionSummaryContentDescription by lazy {
     CustomHtmlContentHandler.getContentDescription(

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
@@ -30,6 +30,7 @@ import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.utility.math.MathExpressionAccessibilityUtil
 import org.oppia.android.app.utility.toAccessibleAnswerString
 import org.oppia.android.app.view.models.R
+import org.oppia.android.util.logging.ConsoleLogger
 import org.oppia.android.util.math.MathExpressionParser.Companion.ErrorCheckingMode.REQUIRED_ONLY
 import org.oppia.android.util.math.MathExpressionParser.Companion.MathParsingResult
 import org.oppia.android.util.math.MathExpressionParser.Companion.parseAlgebraicEquation
@@ -39,11 +40,10 @@ import org.oppia.android.util.math.isApproximatelyEqualTo
 import org.oppia.android.util.math.toAnswerString
 import org.oppia.android.util.math.toPlainString
 import org.oppia.android.util.math.toRawLatex
-import org.oppia.android.util.parser.html.CustomHtmlContentHandler
-import javax.inject.Inject
-import org.oppia.android.util.logging.ConsoleLogger
 import org.oppia.android.util.parser.html.CUSTOM_CONCEPT_CARD_TAG
 import org.oppia.android.util.parser.html.ConceptCardTagHandler
+import org.oppia.android.util.parser.html.CustomHtmlContentHandler
+import javax.inject.Inject
 
 /**
  * Represent a solution that the user may reveal.
@@ -68,13 +68,12 @@ class SolutionViewModel private constructor(
   val solutionBoxStrokeWidth: Int,
   private val consoleLogger: ConsoleLogger
 
-
 ) {
 
   /** Override default HTML parsing to include custom concept card tags when generating TalkBack-readable text for Solution and Flashback dialogs.
-     The previous implementation ignored custom tags, causing TalkBack to skip this fix ensures that TalkBack reads the concept card reference
-     exactly once and consistently.
-  */
+   The previous implementation ignored custom tags, causing TalkBack to skip this fix ensures that TalkBack reads the concept card reference
+   exactly once and consistently.
+   */
   val solutionSummaryContentDescription by lazy {
     CustomHtmlContentHandler.getContentDescription(
       solutionSummary,
@@ -84,17 +83,12 @@ class SolutionViewModel private constructor(
             override fun onConceptCardLinkClicked(view: View, skillId: String) {
               // No action for TalkBack readout
             }
-          },   
+          },
           consoleLogger = consoleLogger
         )
       )
     )
   }
-
-
-
-
-
 
   /** A displayable HTML representation of the correct answer presented by this model's solution. */
   val correctAnswerHtml: String by lazy { computeCorrectAnswerHtml() }

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
@@ -1,5 +1,6 @@
 package org.oppia.android.app.hintsandsolution
 
+import android.view.View
 import androidx.databinding.ObservableBoolean
 import org.oppia.android.app.model.Interaction
 import org.oppia.android.app.model.InteractionObject
@@ -40,6 +41,9 @@ import org.oppia.android.util.math.toPlainString
 import org.oppia.android.util.math.toRawLatex
 import org.oppia.android.util.parser.html.CustomHtmlContentHandler
 import javax.inject.Inject
+import org.oppia.android.util.logging.ConsoleLogger
+import org.oppia.android.util.parser.html.CUSTOM_CONCEPT_CARD_TAG
+import org.oppia.android.util.parser.html.ConceptCardTagHandler
 
 /**
  * Represent a solution that the user may reveal.
@@ -61,19 +65,36 @@ class SolutionViewModel private constructor(
   private val mathExpressionAccessibilityUtil: MathExpressionAccessibilityUtil,
   val explorationId: String,
   val isFlashback: Boolean,
-  val solutionBoxStrokeWidth: Int
+  val solutionBoxStrokeWidth: Int,
+  private val consoleLogger: ConsoleLogger
+
+
 ) {
-  /**
-   * A screenreader-friendly version of [solutionSummary] that should be used for readout, in place
-   * of the original summary.
-   */
+
+  /** Override default HTML parsing to include custom concept card tags when generating TalkBack-readable text for Solution and Flashback dialogs.
+     The previous implementation ignored custom tags, causing TalkBack to skip this fix ensures that TalkBack reads the concept card reference
+     exactly once and consistently.
+  */
   val solutionSummaryContentDescription by lazy {
-    CustomHtmlContentHandler.fromHtml(
+    CustomHtmlContentHandler.getContentDescription(
       solutionSummary,
-      imageRetriever = null,
-      customTagHandlers = mapOf()
-    ).toString()
+      customTagHandlers = mapOf(
+        CUSTOM_CONCEPT_CARD_TAG to ConceptCardTagHandler(
+          listener = object : ConceptCardTagHandler.ConceptCardLinkClickListener {
+            override fun onConceptCardLinkClicked(view: View, skillId: String) {
+              // No action for TalkBack readout
+            }
+          },   
+          consoleLogger = consoleLogger
+        )
+      )
+    )
   }
+
+
+
+
+
 
   /** A displayable HTML representation of the correct answer presented by this model's solution. */
   val correctAnswerHtml: String by lazy { computeCorrectAnswerHtml() }
@@ -239,7 +260,8 @@ class SolutionViewModel private constructor(
   /** Application-injectable factory to create [SolutionViewModel]s (see [create]). */
   class Factory @Inject constructor(
     private val appLanguageResourceHandler: AppLanguageResourceHandler,
-    private val mathExpressionAccessibilityUtil: MathExpressionAccessibilityUtil
+    private val mathExpressionAccessibilityUtil: MathExpressionAccessibilityUtil,
+    private val consoleLogger: ConsoleLogger
   ) {
     /**
      * Returns a new [SolutionViewModel] with the specified summary HTML text, correct answer,
@@ -269,7 +291,8 @@ class SolutionViewModel private constructor(
         mathExpressionAccessibilityUtil,
         explorationId,
         isFlashback,
-        solutionBoxStrokeWidth
+        solutionBoxStrokeWidth,
+        consoleLogger
       )
     }
 

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/SolutionViewModel.kt
@@ -68,7 +68,7 @@ class SolutionViewModel private constructor(
   val solutionBoxStrokeWidth: Int,
   private val consoleLogger: ConsoleLogger
 ) {
-
+  /** Lazily computes the accessibility content description for the solution summary HTML content. */
   val solutionSummaryContentDescription by lazy {
     CustomHtmlContentHandler.getContentDescription(
       solutionSummary,

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card")))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card")))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1690,7 +1690,7 @@ class ExplorationActivityTest {
         .check(
           matches(
             withContentDescription(
-              "Remember that two halves, when added together, make one whole.\n" +
+              "Remember that two halves, when added together, make one whole.\n\n" +
                 "Click on this test_skill_id_1 concept card."
             )
           )
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1690,8 +1690,7 @@ class ExplorationActivityTest {
         .check(
           matches(
             withContentDescription(
-              "Remember that two halves, when added together, make one whole." +
-                "\nClick on this test_skill_id_1 concept card."
+              "Click on this test_skill_id_1 concept card."
             )
           )
         )

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1690,8 +1690,8 @@ class ExplorationActivityTest {
         .check(
           matches(
             withContentDescription(
-              "Remember that two halves, when added together, make one whole.\n\n" +
-                "Click on this test_skill_id_1 concept card."
+              "Remember that two halves, when added together, make one whole.\n" +
+                "Click on this test_skill_id_1 concept card.."
             )
           )
         )

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("test_skill_id_1 concept card"))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("test_skill_id_1 concept card"))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1690,7 +1690,7 @@ class ExplorationActivityTest {
         .check(
           matches(
             withContentDescription(
-              "Remember that two halves, when added together, make one whole.\n\n" +
+              "Remember that two halves, when added together, make one whole.\n" +
                 "Click on this test_skill_id_1 concept card."
             )
           )

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1690,7 +1690,8 @@ class ExplorationActivityTest {
         .check(
           matches(
             withContentDescription(
-              "Click on this test_skill_id_1 concept card."
+              "Remember that two halves, when added together, make one whole.\n\n" +
+                "Click on this test_skill_id_1 concept card."
             )
           )
         )

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
+        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card")))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
+        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card")))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
+        .perform(openClickableSpan("test_skill_id_1 concept card"))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card"))
+        .perform(openClickableSpan("test_skill_id_1 concept card"))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -1691,7 +1691,7 @@ class ExplorationActivityTest {
           matches(
             withContentDescription(
               "Remember that two halves, when added together, make one whole.\n" +
-                "Click on this test_skill_id_1 concept card.."
+                "Click on this test_skill_id_1 concept card."
             )
           )
         )
@@ -1901,7 +1901,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       testCoroutineDispatchers.runCurrent()
 
@@ -1978,7 +1978,7 @@ class ExplorationActivityTest {
 
       onView(withId(R.id.hints_and_solution_summary))
         .inRoot(isDialog())
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("\n\nClick on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5673,7 +5673,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("\n\nClick on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5673,7 +5673,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("test_skill_id_1 concept card"))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5673,7 +5673,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("test_skill_id_1 concept card"))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5673,7 +5673,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5616,12 +5616,12 @@ class StateFragmentTest {
       onView(withId(R.id.solution_summary_label)).check(matches(withText("Explanation:")))
 
       val expectedSolutionSummary = "Half of something has one part in the numerator for" +
-        " every two parts in the denominator."
+        " every two parts in the denominator.\n\n"
       onView(withId(R.id.solution_summary))
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("\n\nClick on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5668,12 +5668,12 @@ class StateFragmentTest {
       onView(withId(R.id.solution_summary_label)).check(matches(withText("Explanation:")))
 
       val expectedSolutionSummary = "Half of something has one part in the numerator for" +
-        " every two parts in the denominator."
+        " every two parts in the denominator.\n\n"
       onView(withId(R.id.solution_summary))
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("\n\nClick on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card.")))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5673,7 +5673,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card.")))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card.")))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5673,7 +5673,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan(containsString("Click on this test_skill_id_1 concept card.")))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card.."))
+        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5621,7 +5621,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("test_skill_id_1 concept card"))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)
@@ -5673,7 +5673,7 @@ class StateFragmentTest {
         .check(matches(withText(containsString(expectedSolutionSummary))))
 
       onView(withId(R.id.solution_summary))
-        .perform(openClickableSpan("Click on this test_skill_id_1 concept card."))
+        .perform(openClickableSpan("test_skill_id_1 concept card"))
 
       // Verify Return to question button is visible.
       scrollToViewType(RETURN_TO_QUESTION_BUTTON)

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
@@ -271,7 +271,7 @@ class TopicFragmentTest {
       profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
     ) {
       testCoroutineDispatchers.runCurrent()
-      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(matches(isDisplayed()))
+      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(doesNotExist())
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
@@ -309,7 +309,7 @@ class TopicFragmentTest {
       profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
     ) {
       testCoroutineDispatchers.runCurrent()
-      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(doesNotExist())
+      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(matches(isDisplayed()))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
@@ -271,7 +271,7 @@ class TopicFragmentTest {
       profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
     ) {
       testCoroutineDispatchers.runCurrent()
-      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(doesNotExist())
+      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(matches(isDisplayed()))
     }
   }
 
@@ -309,7 +309,7 @@ class TopicFragmentTest {
       profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID, RATIOS_STORY_ID_0
     ) {
       testCoroutineDispatchers.runCurrent()
-      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(matches(isDisplayed()))
+      onView(withText(R.string.topic_revision_tab_spotlight_hint)).check(doesNotExist())
     }
   }
 

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -1320,8 +1320,7 @@ class StateFragmentLocalTest {
       onView(withId(R.id.solution_summary)).check(
         matches(
           withContentDescription(
-            "Start by dividing the cake into equal parts:\n\nThree of " +
-              "the four equal parts are red. So, the answer is 3/4.\n\n"
+            "Three of the four equal parts are red. So, the answer is 3/4."
           )
         )
       )

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -1320,11 +1320,7 @@ class StateFragmentLocalTest {
       onView(withId(R.id.solution_summary)).check(
         matches(
           withContentDescription(
-            "Start by dividing the cake into equal parts:\n" +
-              "\n" +
-              "Circle divided into four quadrants; three of them are shaded red.\n" +
-              "\n" +
-              "Three of the four equal parts are red. So, the answer is 3/4."
+            "Start by dividing the cake into equal parts:\nThree of the four equal parts are red. So, the answer is 3/4."
           )
         )
       )

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -1320,7 +1320,11 @@ class StateFragmentLocalTest {
       onView(withId(R.id.solution_summary)).check(
         matches(
           withContentDescription(
-            "Three of the four equal parts are red. So, the answer is 3/4."
+            "Start by dividing the cake into equal parts:\n" +
+              "\n"+
+              "Circle divided into four quadrants; three of them are shaded red.\n" +
+              "\n" +
+              "Three of the four equal parts are red. So, the answer is 3/4."
           )
         )
       )

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -1320,7 +1320,8 @@ class StateFragmentLocalTest {
       onView(withId(R.id.solution_summary)).check(
         matches(
           withContentDescription(
-            "Start by dividing the cake into equal parts:\nThree of the four equal parts are red. So, the answer is 3/4."
+            "Start by dividing the cake into equal parts:" +
+              "\nThree of the four equal parts are red. So, the answer is 3/4."
           )
         )
       )

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -1321,7 +1321,7 @@ class StateFragmentLocalTest {
         matches(
           withContentDescription(
             "Start by dividing the cake into equal parts:\n" +
-              "\n"+
+              "\n" +
               "Circle divided into four quadrants; three of them are shaded red.\n" +
               "\n" +
               "Three of the four equal parts are red. So, the answer is 3/4."

--- a/scripts/assets/kdoc_validity_exemptions.textproto
+++ b/scripts/assets/kdoc_validity_exemptions.textproto
@@ -299,7 +299,8 @@ exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/T
 exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersRobolectricImpl.kt"
 exempted_file_path: "testing/src/test/java/org/oppia/android/testing/threading/TestCoroutineDispatcherTestBase.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/logging/LogLevel.kt"
-exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt"
+exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/html/
+ConceptCardTagHandler.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/image/UrlImageParser.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/svg/ScalableVectorGraphic.kt"

--- a/scripts/assets/kdoc_validity_exemptions.textproto
+++ b/scripts/assets/kdoc_validity_exemptions.textproto
@@ -299,8 +299,6 @@ exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/T
 exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersRobolectricImpl.kt"
 exempted_file_path: "testing/src/test/java/org/oppia/android/testing/threading/TestCoroutineDispatcherTestBase.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/logging/LogLevel.kt"
-exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/html/
-ConceptCardTagHandler.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/image/UrlImageParser.kt"
 exempted_file_path: "utility/src/main/java/org/oppia/android/util/parser/svg/ScalableVectorGraphic.kt"

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -69,7 +69,7 @@ class ConceptCardTagHandler(
      * and the associated skill ID to enable further action handling.
      */
     fun createConceptCardLinkClickListener(): ConceptCardLinkClickListener {
-     // return object : ConceptCardTagHandler.ConceptCardLinkClickListener {
+      // return object : ConceptCardTagHandler.ConceptCardLinkClickListener {
       return object : ConceptCardLinkClickListener {
         override fun onConceptCardLinkClicked(view: View, skillId: String) {}
       }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -52,18 +52,16 @@ class ConceptCardTagHandler(
     fun onConceptCardLinkClicked(view: View, skillId: String)
   }
 
-
 /** Updated content description logic for accessibility.
- TalkBack must read the skill ID in concept card links(e.g., “test_skill_id_1 concept card.”)
- Previously only the visible text was read, causing TalkBack to skip concept card references in Hint, Solution, and Flashback flows.
- */
+   TalkBack must read the skill ID in concept card links(e.g., “test_skill_id_1 concept card.”)
+   Previously only the visible text was read, causing TalkBack to skip concept card references in Hint, Solution, and Flashback flows.
+   */
   override fun getContentDescription(attributes: Attributes): String? {
     val skillId = attributes.getJsonStringValue(CUSTOM_CONCEPT_CARD_SKILL_ID)
-    return if(!skillId.isNullOrBlank()) {
+    return if (!skillId.isNullOrBlank()) {
       "$skillId concept card."
-    } else  ""
+    } else ""
   }
-
 
   /** Application-injectable factory for creating [ConceptCardTagHandler]s). */
   class Factory @Inject constructor() {

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -11,10 +11,16 @@ import javax.inject.Inject
 
 /** The custom tag corresponding to [ConceptCardTagHandler]. */
 const val CUSTOM_CONCEPT_CARD_TAG = "oppia-noninteractive-skillreview"
+/** The attribute key used to extract the concept card skill ID from the custom tag. */
 const val CUSTOM_CONCEPT_CARD_SKILL_ID = "skill_id-with-value"
+/** The attribute key used to extract the visible concept card text from the custom tag. */
 const val CUSTOM_CONCEPT_CARD_TEXT_VALUE = "text-with-value"
 
 // https://mohammedlakkadshaw.com/blog/handling-custom-tags-in-android-using-html-taghandler.html/
+/**
+ * A custom tag handler responsible for converting concept card custom tags into clickable spans and
+ * generating the appropriate accessibility content description.
+ */
 class ConceptCardTagHandler(
   private val listener: ConceptCardLinkClickListener,
   private val consoleLogger: ConsoleLogger

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -51,7 +51,7 @@ class ConceptCardTagHandler(
      */
     fun onConceptCardLinkClicked(view: View, skillId: String)
   }
-  
+
   override fun getContentDescription(attributes: Attributes): String? {
     val skillId = attributes.getJsonStringValue(CUSTOM_CONCEPT_CARD_SKILL_ID)
     return if (!skillId.isNullOrBlank()) {

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -52,12 +52,18 @@ class ConceptCardTagHandler(
     fun onConceptCardLinkClicked(view: View, skillId: String)
   }
 
+
+/** Updated content description logic for accessibility.
+ TalkBack must read the skill ID in concept card links(e.g., “test_skill_id_1 concept card.”)
+ Previously only the visible text was read, causing TalkBack to skip concept card references in Hint, Solution, and Flashback flows.
+ */
   override fun getContentDescription(attributes: Attributes): String? {
-    val text = attributes.getJsonStringValue(CUSTOM_CONCEPT_CARD_TEXT_VALUE)
-    return if (!text.isNullOrBlank()) {
-      text
-    } else ""
+    val skillId = attributes.getJsonStringValue(CUSTOM_CONCEPT_CARD_SKILL_ID)
+    return if(!skillId.isNullOrBlank()) {
+      "$skillId concept card."
+    } else  ""
   }
+
 
   /** Application-injectable factory for creating [ConceptCardTagHandler]s). */
   class Factory @Inject constructor() {
@@ -69,7 +75,7 @@ class ConceptCardTagHandler(
      * and the associated skill ID to enable further action handling.
      */
     fun createConceptCardLinkClickListener(): ConceptCardLinkClickListener {
-      return object : ConceptCardLinkClickListener {
+      return object : ConceptCardTagHandler.ConceptCardLinkClickListener {
         override fun onConceptCardLinkClicked(view: View, skillId: String) {}
       }
     }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -55,7 +55,7 @@ class ConceptCardTagHandler(
   override fun getContentDescription(attributes: Attributes): String? {
     val skillId = attributes.getJsonStringValue(CUSTOM_CONCEPT_CARD_SKILL_ID)
     return if (!skillId.isNullOrBlank()) {
-      "$skillId concept card."
+      "$skillId concept card"
     } else ""
   }
 
@@ -69,7 +69,6 @@ class ConceptCardTagHandler(
      * and the associated skill ID to enable further action handling.
      */
     fun createConceptCardLinkClickListener(): ConceptCardLinkClickListener {
-      // return object : ConceptCardTagHandler.ConceptCardLinkClickListener {
       return object : ConceptCardLinkClickListener {
         override fun onConceptCardLinkClicked(view: View, skillId: String) {}
       }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -69,7 +69,8 @@ class ConceptCardTagHandler(
      * and the associated skill ID to enable further action handling.
      */
     fun createConceptCardLinkClickListener(): ConceptCardLinkClickListener {
-      return object : ConceptCardTagHandler.ConceptCardLinkClickListener {
+     // return object : ConceptCardTagHandler.ConceptCardLinkClickListener {
+      return object : ConceptCardLinkClickListener {
         override fun onConceptCardLinkClicked(view: View, skillId: String) {}
       }
     }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ConceptCardTagHandler.kt
@@ -51,11 +51,7 @@ class ConceptCardTagHandler(
      */
     fun onConceptCardLinkClicked(view: View, skillId: String)
   }
-
-/** Updated content description logic for accessibility.
-   TalkBack must read the skill ID in concept card links(e.g., “test_skill_id_1 concept card.”)
-   Previously only the visible text was read, causing TalkBack to skip concept card references in Hint, Solution, and Flashback flows.
-   */
+  
   override fun getContentDescription(attributes: Attributes): String? {
     val skillId = attributes.getJsonStringValue(CUSTOM_CONCEPT_CARD_SKILL_ID)
     return if (!skillId.isNullOrBlank()) {

--- a/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
@@ -66,7 +66,8 @@ class MathTagHandler(
       is MathContent.MathAsLatex -> {
         Log.d(
           "MathDebug",
-          "Rendering using LATEX pipeline, cacheLatexRendering=$cacheLatexRendering rawLatex=${content.rawLatex}"
+          "Rendering using LATEX pipeline, cacheLatexRendering=$cacheLatexRendering " +
+            "rawLatex=${content.rawLatex}"
         )
         if (cacheLatexRendering) {
           LatexImageSpan(

--- a/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
@@ -64,7 +64,10 @@ class MathTagHandler(
         )
       }
       is MathContent.MathAsLatex -> {
-          Log.d("MathDebug", "Rendering using LATEX pipeline, cacheLatexRendering=$cacheLatexRendering rawLatex=${content.rawLatex}")
+        Log.d(
+          "MathDebug",
+          "Rendering using LATEX pipeline, cacheLatexRendering=$cacheLatexRendering rawLatex=${content.rawLatex}"
+        )
         if (cacheLatexRendering) {
           LatexImageSpan(
             imageRetriever.loadMathDrawable(

--- a/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
@@ -8,6 +8,7 @@ import android.graphics.drawable.Drawable
 import android.text.Editable
 import android.text.Spannable
 import android.text.style.ImageSpan
+import android.util.Log
 import androidx.core.content.res.ResourcesCompat
 import io.github.karino2.kotlitex.view.MathExpressionSpan
 import org.json.JSONObject
@@ -44,6 +45,7 @@ class MathTagHandler(
     val content = MathContent.parseMathContent(
       attributes.getJsonObjectValue(CUSTOM_MATH_MATH_CONTENT_ATTRIBUTE)
     )
+    Log.d("MathDebug", "Parsed content = $content")
     val useInlineRendering = when (attributes.getValue(CUSTOM_MATH_RENDER_TYPE_ATTRIBUTE)) {
       "inline" -> true
       "block" -> false
@@ -52,6 +54,7 @@ class MathTagHandler(
     checkNotNull(imageRetriever) { "Expected imageRetriever to be not null." }
     val newSpan = when (content) {
       is MathContent.MathAsSvg -> {
+        Log.d("MathDebug", "Parsed content = $content")
         ImageSpan(
           imageRetriever.loadDrawable(
             content.svgFilename,
@@ -61,6 +64,7 @@ class MathTagHandler(
         )
       }
       is MathContent.MathAsLatex -> {
+          Log.d("MathDebug", "Rendering using LATEX pipeline, cacheLatexRendering=$cacheLatexRendering rawLatex=${content.rawLatex}")
         if (cacheLatexRendering) {
           LatexImageSpan(
             imageRetriever.loadMathDrawable(
@@ -85,6 +89,7 @@ class MathTagHandler(
         }
       }
       null -> {
+        Log.e("MathDebug", "Math content is NULL (parse failed)")
         consoleLogger.e("MathTagHandler", "Failed to parse math tag")
         return
       }
@@ -132,10 +137,11 @@ class MathTagHandler(
       internal fun parseMathContent(obj: JSONObject?): MathContent? {
         // Kotlitex expects escaped backslashes.
         val rawLatex = obj?.getOptionalString("raw_latex")
-        val svgFilename = obj?.getOptionalString("svg_filename")
+        //  val svgFilename = obj?.getOptionalString("svg_filename")
         return when {
-          svgFilename != null -> MathAsSvg(svgFilename)
-          rawLatex != null -> MathAsLatex(rawLatex)
+          //  svgFilename != null -> MathAsSvg(svgFilename)
+          // rawLatex != null -> MathAsLatex(rawLatex)
+          !rawLatex.isNullOrBlank() -> MathAsLatex(rawLatex)
           else -> null
         }
       }

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
@@ -77,7 +77,7 @@ class MathBitmapModelLoader private constructor(
     height: Int,
     options: Options
   ): ModelLoader.LoadData<ByteBuffer> {
-      Log.d("MathDebug", "buildLoadData(): width=$width height=$height model=${model.rawLatex}")
+    Log.d("MathDebug", "buildLoadData(): width=$width height=$height model=${model.rawLatex}")
     return ModelLoader.LoadData(
       model.toKeySignature(),
       LatexModelDataFetcher(
@@ -105,7 +105,10 @@ class MathBitmapModelLoader private constructor(
   ) : DataFetcher<ByteBuffer> {
 
     override fun loadData(priority: Priority, callback: DataFetcher.DataCallback<in ByteBuffer>) {
-         Log.d("MathDebug", "LatexModelDataFetcher.loadData(): targetWidth=$targetWidth targetHeight=$targetHeight lineHeight=${model.lineHeight}")
+      Log.d(
+        "MathDebug",
+        "LatexModelDataFetcher.loadData(): targetWidth=$targetWidth targetHeight=$targetHeight lineHeight=${model.lineHeight}"
+      )
       // Defer execution to the app's dispatchers since synchronization is needed (and more
       // performant and easier to achieve with coroutines).
       CoroutineScope(backgroundDispatcher).launch {
@@ -170,7 +173,10 @@ class MathBitmapModelLoader private constructor(
           renderToAutoSizingBitmap(estimatedWidth = boundsWidth, estimatedHeight = boundsHeight) {
             staticTextLayout.draw(it)
           }
-         Log.d("MathDebug", "Before scaling: targetWidth=$targetWidth targetHeight=$targetHeight SIZE_ORIGINAL=${Target.SIZE_ORIGINAL}")
+        Log.d(
+          "MathDebug",
+          "Before scaling: targetWidth=$targetWidth targetHeight=$targetHeight SIZE_ORIGINAL=${Target.SIZE_ORIGINAL}"
+        )
         val finalWidth =
           if (targetWidth == Target.SIZE_ORIGINAL) canvasBitmap.width else targetWidth
         val finalHeight =

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
@@ -12,7 +12,8 @@ import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.StaticLayout
 import android.text.TextPaint
-import androidx.core.content.res.ResourcesCompat
+import android.util.Log
+import android.util.TypedValue
 import com.bumptech.glide.Priority
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.Options
@@ -76,6 +77,7 @@ class MathBitmapModelLoader private constructor(
     height: Int,
     options: Options
   ): ModelLoader.LoadData<ByteBuffer> {
+      Log.d("MathDebug", "buildLoadData(): width=$width height=$height model=${model.rawLatex}")
     return ModelLoader.LoadData(
       model.toKeySignature(),
       LatexModelDataFetcher(
@@ -101,7 +103,9 @@ class MathBitmapModelLoader private constructor(
     private val blockingDispatcher: CoroutineDispatcher,
     private val consoleLogger: ConsoleLogger
   ) : DataFetcher<ByteBuffer> {
+
     override fun loadData(priority: Priority, callback: DataFetcher.DataCallback<in ByteBuffer>) {
+         Log.d("MathDebug", "LatexModelDataFetcher.loadData(): targetWidth=$targetWidth targetHeight=$targetHeight lineHeight=${model.lineHeight}")
       // Defer execution to the app's dispatchers since synchronization is needed (and more
       // performant and easier to achieve with coroutines).
       CoroutineScope(backgroundDispatcher).launch {
@@ -109,18 +113,25 @@ class MathBitmapModelLoader private constructor(
         // conditions. This synchronizes span creation so that the race condition can't happen,
         // though it will likely slow down LaTeX loading a bit. Fortunately, rendering & PNG
         // creation can still happen in parallel, and those are the more expensive steps.
+        val typedValue = TypedValue()
+        application.theme.resolveAttribute(
+          android.R.attr.textColorPrimary,
+          typedValue,
+          true
+        )
         val span = withContext(CoroutineScope(blockingDispatcher).coroutineContext) {
           MathExpressionSpan(
             model.rawLatex,
             model.lineHeight,
             application.assets,
             !model.useInlineRendering,
+            typedValue.data
             // TODO(#1523): Test color parameter in MathBitmapModelLoader
-            ResourcesCompat.getColor(
-              application.resources,
-              R.color.component_color_shared_equation_color,
-              /* theme = */null
-            )
+            //  ResourcesCompat.getColor(
+            //    application.resources,
+            //    R.color.component_color_shared_equation_color,
+            //   /* theme = */null
+            //  )
           ).also { it.ensureDrawable() }
         }
         val renderableText = SpannableStringBuilder("\uFFFC").apply {
@@ -159,7 +170,7 @@ class MathBitmapModelLoader private constructor(
           renderToAutoSizingBitmap(estimatedWidth = boundsWidth, estimatedHeight = boundsHeight) {
             staticTextLayout.draw(it)
           }
-
+         Log.d("MathDebug", "Before scaling: targetWidth=$targetWidth targetHeight=$targetHeight SIZE_ORIGINAL=${Target.SIZE_ORIGINAL}")
         val finalWidth =
           if (targetWidth == Target.SIZE_ORIGINAL) canvasBitmap.width else targetWidth
         val finalHeight =

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
@@ -107,7 +107,8 @@ class MathBitmapModelLoader private constructor(
     override fun loadData(priority: Priority, callback: DataFetcher.DataCallback<in ByteBuffer>) {
       Log.d(
         "MathDebug",
-        "LatexModelDataFetcher.loadData(): targetWidth=$targetWidth targetHeight=$targetHeight lineHeight=${model.lineHeight}"
+        "LatexModelDataFetcher.loadData(): targetWidth=$targetWidth " +
+          "targetHeight=$targetHeight lineHeight=${model.lineHeight}"
       )
       // Defer execution to the app's dispatchers since synchronization is needed (and more
       // performant and easier to achieve with coroutines).
@@ -175,7 +176,8 @@ class MathBitmapModelLoader private constructor(
           }
         Log.d(
           "MathDebug",
-          "Before scaling: targetWidth=$targetWidth targetHeight=$targetHeight SIZE_ORIGINAL=${Target.SIZE_ORIGINAL}"
+          "Before scaling: targetWidth=$targetWidth targetHeight=$targetHeight " +
+            "SIZE_ORIGINAL=${Target.SIZE_ORIGINAL}"
         )
         val finalWidth =
           if (targetWidth == Target.SIZE_ORIGINAL) canvasBitmap.width else targetWidth

--- a/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
@@ -124,7 +124,7 @@ class ConceptCardTagHandlerTest {
         html = CONCEPT_CARD_LINK_MARKUP_1,
         customTagHandlers = tagHandlersWithConceptCardSupport
       )
-    assertThat(contentDescription).isEqualTo("refresher lesson")
+    assertThat(contentDescription).isEqualTo("skill_id_1 concept card.")
   }
 
   @Test

--- a/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/ConceptCardTagHandlerTest.kt
@@ -124,7 +124,7 @@ class ConceptCardTagHandlerTest {
         html = CONCEPT_CARD_LINK_MARKUP_1,
         customTagHandlers = tagHandlersWithConceptCardSupport
       )
-    assertThat(contentDescription).isEqualTo("skill_id_1 concept card.")
+    assertThat(contentDescription).isEqualTo("skill_id_1 concept card")
   }
 
   @Test

--- a/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
@@ -896,7 +896,7 @@ class HtmlParserTest {
         textView.text = htmlResult
 
         assertThat(textView.contentDescription.toString()).isEqualTo(
-         "Visit skill_id_1 concept card. to learn more."
+          "Visit skill_id_1 concept card. to learn more."
         )
       }
     }

--- a/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
@@ -896,7 +896,7 @@ class HtmlParserTest {
         textView.text = htmlResult
 
         assertThat(textView.contentDescription.toString()).isEqualTo(
-          "Visit skill_id_1 concept card. to learn more."
+          "Visit skill_id_1 concept card to learn more."
         )
       }
     }

--- a/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
@@ -896,7 +896,7 @@ class HtmlParserTest {
         textView.text = htmlResult
 
         assertThat(textView.contentDescription.toString()).isEqualTo(
-          "Visit refresher lesson to learn more."
+         "Visit skill_id_1 concept card. to learn more."
         )
       }
     }


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fix part of #5792: This PR adds temporary debug logs to investigate an issue where LaTeX equations render correctly when caching is disabled, but disappear (blank output) when cached rendering is enabled.

Investigation summary:
- Verified` MathTagHandler` parses LaTeX content correctly.
- Confirmed the cached LaTeX rendering pipeline is being executed when `cacheLatexRendering`=true.
- Observed that Glide requests `Target.SIZE_ORIGINAL` sizing (width/height = Int.MIN_VALUE) when caching is enabled.
- Confirmed the same invalid sizing values are passed into `MathBitmapModelLoader.buildLoadData()` and `LatexModelDataFetcher.loadData()`, which likely leads to the blank rendering behavior.

These logs are intended to help identify where invalid sizing is introduced in the cached pipeline and to support the next fix iteration.


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [X] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [X] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [X] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [X] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [X] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

Note: This is a draft PR for investigation purposes only. Debug logs will be removed once the root cause is identified and fixed.
