### PR TITLE
Fix #6086: Add detection for transparent images and invalid math tags in lesson assets

### DIFF
--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -117,6 +117,13 @@ kt_jvm_binary(
     runtime_deps = ["//scripts/src/java/org/oppia/android/scripts/xml:string_resource_validation_check_lib"],
 )
 
+kt_jvm_binary(
+    name = "lesson_asset_validation_check",
+    testonly = True,
+    main_class = "org.oppia.android.scripts.assets.LessonAssetValidationCheckKt",
+    runtime_deps = ["//scripts/src/java/org/oppia/android/scripts/assets:lesson_asset_validation_check_lib"],
+)
+
 TEST_FILE_EXEMPTION_ASSETS = generate_test_file_assets_list_from_text_protos(
     name = "test_file_exemption_assets",
     test_file_exemptions_name = ["test_file_exemptions"],

--- a/scripts/assets/todo_open_exemptions.textproto
+++ b/scripts/assets/todo_open_exemptions.textproto
@@ -341,7 +341,7 @@ todo_open_exemption {
 }
 todo_open_exemption {
   exempted_file_path: "scripts/static_checks.sh"
-  line_number: 117
+  line_number: 124
 }
 todo_open_exemption {
   exempted_file_path: "wiki/Coding-style-guide.md"

--- a/scripts/copy_oppia_assets.sh
+++ b/scripts/copy_oppia_assets.sh
@@ -32,3 +32,9 @@ fi
 
 # Populate new data inside assets folder
 rsync -r $source_assets_path $destination_assets_path
+
+# Run lesson asset validation check on newly copied assets.
+echo ""
+echo "Running lesson asset validation check on copied assets..."
+bazel run //scripts:lesson_asset_validation_check -- $(pwd)
+echo ""

--- a/scripts/src/java/org/oppia/android/scripts/assets/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/assets/BUILD.bazel
@@ -1,0 +1,13 @@
+"""
+Libraries corresponding to lesson asset validation checks to ensure that exploration assets
+are compatible with dark mode and follow proper LaTeX/math usage standards.
+"""
+
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "lesson_asset_validation_check_lib",
+    testonly = True,
+    srcs = ["LessonAssetValidationCheck.kt"],
+    visibility = ["//scripts:oppia_script_binary_visibility"],
+)

--- a/scripts/src/java/org/oppia/android/scripts/assets/LessonAssetValidationCheck.kt
+++ b/scripts/src/java/org/oppia/android/scripts/assets/LessonAssetValidationCheck.kt
@@ -1,0 +1,248 @@
+package org.oppia.android.scripts.assets
+
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+
+/**
+ * Script for validating lesson assets for dark mode compatibility and proper math tag usage.
+ *
+ * Checks:
+ * 1. Images with transparent pixels (alpha < 255) - these cause dark mode visibility issues
+ * 2. Math tags without LaTeX content - these fallback to SVGs and reduce quality
+ *
+ * Uses regex-based JSON field extraction to avoid external JSON library dependencies.
+ *
+ * Usage:
+ *   bazel run //scripts:lesson_asset_validation_check -- <path_to_directory_root>
+ *
+ * Arguments:
+ * - path_to_directory_root: directory path to the root of the Oppia Android repository.
+ *
+ * Example:
+ *   bazel run //scripts:lesson_asset_validation_check -- $(pwd)
+ */
+fun main(vararg args: String) {
+  require(args.isNotEmpty()) {
+    "Expected: bazel run //scripts:lesson_asset_validation_check -- <repo_path>"
+  }
+
+  val repoPath = "${args[0]}/"
+  val assetsPath = File(repoPath, "domain/src/main/assets")
+
+  if (LessonAssetValidationCheck(assetsPath).execute()) {
+    println("LESSON ASSET VALIDATION CHECKS PASSED")
+  } else {
+    throw Exception("LESSON ASSET VALIDATION CHECKS FAILED")
+  }
+}
+
+/**
+ * Validates lesson assets for:
+ * - Image transparency (potential dark mode issues)
+ * - Math tag validity (LaTeX content presence)
+ *
+ * Parses exploration JSON files using regex to extract all "html" field values, then validates
+ * math and image tags within each HTML string.
+ */
+class LessonAssetValidationCheck(private val assetsDir: File) {
+  private val warnings = mutableListOf<String>()
+
+  /** Regex to extract the value of any "html" field in a JSON file. */
+  private val htmlFieldRegex = Regex(""""html"\s*:\s*"((?:[^"\\]|\\.)*)"""")
+
+  /** Executes the lesson asset validation checks and returns whether all checks passed. */
+  fun execute(): Boolean {
+    if (!assetsDir.exists()) {
+      println("Warning: Assets directory not found at ${assetsDir.absolutePath}")
+      println("Validation skipped - assets not present.")
+      return true
+    }
+
+    val jsonFiles = assetsDir.listFiles { file ->
+      file.isFile && file.extension == "json" && isExplorationFile(file.name)
+    } ?: emptyArray()
+
+    if (jsonFiles.isEmpty()) {
+      println("No exploration files found to validate.")
+      return true
+    }
+
+    jsonFiles.forEach { jsonFile ->
+      validateExplorationFile(jsonFile)
+    }
+
+    if (warnings.isNotEmpty()) {
+      println("\n${warnings.size} validation warning(s) found:\n")
+      warnings.forEach { println(it) }
+      return false
+    }
+
+    println("All ${jsonFiles.size} exploration file(s) validated successfully.")
+    return true
+  }
+
+  private fun isExplorationFile(filename: String): Boolean {
+    // Exclude metadata files that are not exploration content.
+    return filename !in listOf(
+      "classrooms.json",
+      "skills.json",
+      "questions.json"
+    ) && !filename.endsWith("_textproto")
+  }
+
+  private fun validateExplorationFile(file: File) {
+    val text = file.readText()
+    val trimmed = text.trim()
+
+    // Basic structure validation to catch obviously malformed files.
+    if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+      warnings.add(
+        "[ERROR] ${file.name}: Failed to parse exploration file - Invalid JSON format"
+      )
+      return
+    }
+
+    val explorationId = extractJsonStringField(text, "exploration_id") ?: "unknown"
+
+    // Extract all HTML field values from the entire exploration file.
+    val htmlValues = htmlFieldRegex.findAll(text).map { match ->
+      unescapeJsonString(match.groupValues[1])
+    }.toList()
+
+    htmlValues.forEach { html ->
+      validateMathTags(explorationId, html)
+      validateImages(explorationId, html)
+    }
+  }
+
+  private fun validateMathTags(explorationId: String, html: String) {
+    val mathTagRegex = Regex(
+      """<oppia-noninteractive-math[^>]*math_content-with-value="([^"]*)"[^>]*>""",
+      RegexOption.DOT_MATCHES_ALL
+    )
+
+    mathTagRegex.findAll(html).forEachIndexed { index, match ->
+      val mathContent = match.groupValues[1]
+      val decodedContent = decodeHtmlEntities(mathContent)
+
+      val rawLatex = extractJsonStringField(decodedContent, "raw_latex")?.trim() ?: ""
+      val svgFilename = extractJsonStringField(decodedContent, "svg_filename")?.trim() ?: ""
+
+      // Math content should have LaTeX, not just SVG filename.
+      if (rawLatex.isEmpty() && svgFilename.isNotEmpty()) {
+        warnings.add(
+          "[$explorationId] Math tag #${index + 1} " +
+            "uses SVG fallback (svg_filename='$svgFilename') instead of LaTeX. " +
+            "Missing 'raw_latex' field may cause rendering issues on some devices."
+        )
+      } else if (rawLatex.isEmpty()) {
+        warnings.add(
+          "[$explorationId] Math tag #${index + 1} " +
+            "has no LaTeX content and no SVG fallback. This will fail to render."
+        )
+      }
+    }
+  }
+
+  private fun validateImages(explorationId: String, html: String) {
+    val imageRegex = Regex(
+      """<oppia-noninteractive-image[^>]*filepath-with-value="([^"]*)"[^>]*>""",
+      RegexOption.DOT_MATCHES_ALL
+    )
+
+    imageRegex.findAll(html).forEachIndexed { index, match ->
+      val filepathEncoded = match.groupValues[1]
+      // Decoded paths are wrapped in quotes (e.g., '"img.png"'). Strip them.
+      val imagePath = decodeHtmlEntities(filepathEncoded).trim('"')
+
+      val imageFile = File(assetsDir, imagePath)
+      if (imageFile.exists()) {
+        checkImageTransparency(explorationId, index + 1, imagePath, imageFile)
+      }
+    }
+  }
+
+  private fun checkImageTransparency(
+    explorationId: String,
+    imageIndex: Int,
+    imagePath: String,
+    imageFile: File
+  ) {
+    try {
+      val image: BufferedImage = ImageIO.read(imageFile) ?: return
+
+      // Only check if image has alpha channel.
+      if (!image.colorModel.hasAlpha()) {
+        return
+      }
+
+      // Scan for any transparent pixel (alpha < 255).
+      for (y in 0 until image.height) {
+        for (x in 0 until image.width) {
+          val pixel = image.getRGB(x, y)
+          val alpha = (pixel shr 24) and 0xff
+          if (alpha < 255) {
+            warnings.add(
+              "[$explorationId] Image #$imageIndex '$imagePath' " +
+                "contains transparent pixels. Transparent images may have poor visibility " +
+                "in dark mode. Consider using opaque backgrounds."
+            )
+            return
+          }
+        }
+      }
+    } catch (e: Exception) {
+      // Log error but don't fail validation for image reading issues.
+      warnings.add(
+        "[$explorationId] Could not read image '$imagePath': ${e.message}"
+      )
+    }
+  }
+
+  /**
+   * Extracts a simple string field value from JSON-like text by field name.
+   * Uses regex to find the first occurrence of "fieldName": "value".
+   * Returns the unescaped string value, or null if not found.
+   */
+  private fun extractJsonStringField(json: String, fieldName: String): String? {
+    val regex = Regex(""""${Regex.escape(fieldName)}"\s*:\s*"((?:[^"\\]|\\.)*)"""")
+    return regex.find(json)?.groupValues?.get(1)?.let { unescapeJsonString(it) }
+  }
+
+  /** Unescapes JSON string escape sequences (\\", \\\\, \\n, etc.). */
+  private fun unescapeJsonString(s: String): String {
+    val sb = StringBuilder(s.length)
+    var i = 0
+    while (i < s.length) {
+      if (s[i] == '\\' && i + 1 < s.length) {
+        when (s[i + 1]) {
+          '"' -> { sb.append('"'); i += 2 }
+          '\\' -> { sb.append('\\'); i += 2 }
+          '/' -> { sb.append('/'); i += 2 }
+          'n' -> { sb.append('\n'); i += 2 }
+          'r' -> { sb.append('\r'); i += 2 }
+          't' -> { sb.append('\t'); i += 2 }
+          else -> { sb.append(s[i]); i++ }
+        }
+      } else {
+        sb.append(s[i])
+        i++
+      }
+    }
+    return sb.toString()
+  }
+
+  /** Decodes HTML entities used in Oppia exploration attribute values. */
+  private fun decodeHtmlEntities(encoded: String): String {
+    return encoded
+      .replace("&amp;quot;", "\"")
+      .replace("&amp;amp;", "&")
+      .replace("&amp;lt;", "<")
+      .replace("&amp;gt;", ">")
+      .replace("&quot;", "\"")
+      .replace("&amp;", "&")
+      .replace("&lt;", "<")
+      .replace("&gt;", ">")
+  }
+}

--- a/scripts/src/javatests/org/oppia/android/scripts/assets/BUILD.bazel
+++ b/scripts/src/javatests/org/oppia/android/scripts/assets/BUILD.bazel
@@ -1,0 +1,16 @@
+"""
+Tests corresponding to lesson asset validation checks to ensure that exploration assets are
+compatible with dark mode and follow proper LaTeX/math usage standards.
+"""
+
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "LessonAssetValidationCheckTest",
+    srcs = ["LessonAssetValidationCheckTest.kt"],
+    deps = [
+        "//scripts/src/java/org/oppia/android/scripts/assets:lesson_asset_validation_check_lib",
+        "//third_party:com_google_truth_truth",
+        "//third_party:org_jetbrains_kotlin_kotlin-test-junit",
+    ],
+)

--- a/scripts/src/javatests/org/oppia/android/scripts/assets/LessonAssetValidationCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/assets/LessonAssetValidationCheckTest.kt
@@ -1,0 +1,663 @@
+package org.oppia.android.scripts.assets
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+import javax.imageio.ImageIO
+
+/**
+ * Tests for [LessonAssetValidationCheck].
+ *
+ * Note on HTML encoding: The exploration JSON files use double-encoded HTML entities. In the JSON
+ * file on disk, the attribute values use JSON string escaping (\" for quotes) and HTML entity
+ * encoding (&amp;quot; for inner quotes). When the JSON is parsed, \" becomes " and &amp;quot;
+ * remains as-is. The script's regex captures the attribute value and then decodes &amp;quot; → ".
+ *
+ * Real format example (from GJ2rLXRKD5hw_1.json):
+ *   math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;y=mx+b&amp;quot;}\"
+ *   filepath-with-value=\"&amp;quot;img_xxx.png&amp;quot;\"
+ */
+class LessonAssetValidationCheckTest {
+  @field:[Rule JvmField] val tempFolder = TemporaryFolder()
+
+  private val originalOut: PrintStream = System.out
+  private lateinit var outContent: ByteArrayOutputStream
+  private lateinit var assetsDir: File
+
+  @Before
+  fun setUp() {
+    outContent = ByteArrayOutputStream()
+    System.setOut(PrintStream(outContent))
+    assetsDir = tempFolder.newFolder("assets")
+  }
+
+  @After
+  fun restoreStreams() {
+    System.setOut(originalOut)
+  }
+
+  @Test
+  fun testNoAssets_passes() {
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isTrue()
+    assertThat(outContent.toString()).contains("No exploration files found")
+  }
+
+  @Test
+  fun testMissingAssetsDirectory_passes() {
+    val nonExistentDir = File(tempFolder.root, "non_existent")
+    val checker = LessonAssetValidationCheck(nonExistentDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isTrue()
+  }
+
+  @Test
+  fun testExplorationWithValidMathLatex_passes() {
+    // Math JSON is directly inside the attribute: {&amp;quot;raw_latex&amp;quot;:&amp;quot;...&amp;quot;}
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test_exploration",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<oppia-noninteractive-math math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;\\\\frac{1}{2}&amp;quot;}\"></oppia-noninteractive-math>"
+              },
+              "interaction": {
+                "answer_groups": [],
+                "default_outcome": null,
+                "hints": [],
+                "solution": null
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test_exploration.json").writeText(explorationJson)
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isTrue()
+  }
+
+  @Test
+  fun testExplorationWithEmptyRawLatex_fails() {
+    // Empty raw_latex with svg_filename present → should warn about SVG fallback.
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test_exploration",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<oppia-noninteractive-math math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;svg_filename&amp;quot;:&amp;quot;math.svg&amp;quot;}\"></oppia-noninteractive-math>"
+              },
+              "interaction": {
+                "answer_groups": [],
+                "default_outcome": null,
+                "hints": [],
+                "solution": null
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test_exploration.json").writeText(explorationJson)
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isFalse()
+    assertThat(outContent.toString()).contains("SVG fallback")
+  }
+
+  @Test
+  fun testExplorationWithNoLatexAndNoSvg_fails() {
+    // Empty math JSON → no LaTeX and no SVG.
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test_exploration",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<oppia-noninteractive-math math_content-with-value=\"{}\"></oppia-noninteractive-math>"
+              },
+              "interaction": {
+                "answer_groups": [],
+                "default_outcome": null,
+                "hints": [],
+                "solution": null
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test_exploration.json").writeText(explorationJson)
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isFalse()
+    assertThat(outContent.toString()).contains("no LaTeX content")
+  }
+
+  @Test
+  fun testExplorationWithMathInAnswerGroupFeedback_fails() {
+    // Math tag in answer group feedback with no LaTeX.
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test_exploration",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<p>Question</p>"
+              },
+              "interaction": {
+                "answer_groups": [
+                  {
+                    "outcome": {
+                      "feedback": {
+                        "content_id": "feedback_1",
+                        "html": "<oppia-noninteractive-math math_content-with-value=\"{}\"></oppia-noninteractive-math>"
+                      }
+                    }
+                  }
+                ],
+                "default_outcome": null,
+                "hints": [],
+                "solution": null
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test_exploration.json").writeText(explorationJson)
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isFalse()
+  }
+
+  @Test
+  fun testExplorationWithMathInDefaultOutcome_fails() {
+    // Math tag in default_outcome feedback with no LaTeX.
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test_exploration",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<p>Question</p>"
+              },
+              "interaction": {
+                "answer_groups": [],
+                "default_outcome": {
+                  "dest": "Introduction",
+                  "feedback": {
+                    "content_id": "default_outcome",
+                    "html": "<oppia-noninteractive-math math_content-with-value=\"{}\"></oppia-noninteractive-math>"
+                  }
+                },
+                "hints": [],
+                "solution": null
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test_exploration.json").writeText(explorationJson)
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isFalse()
+    assertThat(outContent.toString()).contains("no LaTeX content")
+  }
+
+  @Test
+  fun testExplorationWithMathInHint_fails() {
+    // Math tag in hint with no LaTeX.
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test_exploration",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<p>Question</p>"
+              },
+              "interaction": {
+                "answer_groups": [],
+                "default_outcome": null,
+                "hints": [
+                  {
+                    "hint_content": {
+                      "content_id": "hint_1",
+                      "html": "<oppia-noninteractive-math math_content-with-value=\"{&amp;quot;svg_filename&amp;quot;:&amp;quot;hint_eq.svg&amp;quot;}\"></oppia-noninteractive-math>"
+                    }
+                  }
+                ],
+                "solution": null
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test_exploration.json").writeText(explorationJson)
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isFalse()
+    assertThat(outContent.toString()).contains("SVG fallback")
+  }
+
+  @Test
+  fun testExplorationWithMathInSolution_fails() {
+    // Math tag in solution explanation with no LaTeX.
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test_exploration",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<p>Question</p>"
+              },
+              "interaction": {
+                "answer_groups": [],
+                "default_outcome": null,
+                "hints": [],
+                "solution": {
+                  "explanation": {
+                    "content_id": "solution",
+                    "html": "<oppia-noninteractive-math math_content-with-value=\"{}\"></oppia-noninteractive-math>"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test_exploration.json").writeText(explorationJson)
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isFalse()
+    assertThat(outContent.toString()).contains("no LaTeX content")
+  }
+
+  @Test
+  fun testImageWithTransparentPixels_fails() {
+    // Image filepath uses &amp;quot; wrapping, which decodes to quotes that get stripped.
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test_exploration",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<oppia-noninteractive-image filepath-with-value=\"&amp;quot;transparent_image.png&amp;quot;\"></oppia-noninteractive-image>"
+              },
+              "interaction": {
+                "answer_groups": [],
+                "default_outcome": null,
+                "hints": [],
+                "solution": null
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test_exploration.json").writeText(explorationJson)
+
+    // Create transparent PNG.
+    val image = BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB)
+    val g = image.createGraphics()
+    g.color = Color(255, 0, 0, 128) // Semi-transparent red (alpha=128).
+    g.fillRect(0, 0, 10, 10)
+    g.dispose()
+    ImageIO.write(image, "PNG", File(assetsDir, "transparent_image.png"))
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isFalse()
+    assertThat(outContent.toString()).contains("transparent pixels")
+    assertThat(outContent.toString()).contains("dark mode")
+  }
+
+  @Test
+  fun testImageWithoutTransparentPixels_passes() {
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test_exploration",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<oppia-noninteractive-image filepath-with-value=\"&amp;quot;opaque_image.png&amp;quot;\"></oppia-noninteractive-image>"
+              },
+              "interaction": {
+                "answer_groups": [],
+                "default_outcome": null,
+                "hints": [],
+                "solution": null
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test_exploration.json").writeText(explorationJson)
+
+    // Create fully opaque PNG (TYPE_INT_RGB has no alpha channel).
+    val image = BufferedImage(10, 10, BufferedImage.TYPE_INT_RGB)
+    val g = image.createGraphics()
+    g.color = Color.RED
+    g.fillRect(0, 0, 10, 10)
+    g.dispose()
+    ImageIO.write(image, "PNG", File(assetsDir, "opaque_image.png"))
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isTrue()
+  }
+
+  @Test
+  fun testImageWithAlpha255_passes() {
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test_exploration",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<oppia-noninteractive-image filepath-with-value=\"&amp;quot;fully_opaque_alpha.png&amp;quot;\"></oppia-noninteractive-image>"
+              },
+              "interaction": {
+                "answer_groups": [],
+                "default_outcome": null,
+                "hints": [],
+                "solution": null
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test_exploration.json").writeText(explorationJson)
+
+    // Create ARGB image with full alpha (alpha=255).
+    val image = BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB)
+    val g = image.createGraphics()
+    g.color = Color(255, 0, 0, 255) // Fully opaque red.
+    g.fillRect(0, 0, 10, 10)
+    g.dispose()
+    ImageIO.write(image, "PNG", File(assetsDir, "fully_opaque_alpha.png"))
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isTrue()
+  }
+
+  @Test
+  fun testMultipleMathTagsInState_validatesAll() {
+    // Two math tags: first valid, second has no LaTeX.
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test_exploration",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<oppia-noninteractive-math math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;x&amp;quot;}\"></oppia-noninteractive-math><p>and</p><oppia-noninteractive-math math_content-with-value=\"{}\"></oppia-noninteractive-math>"
+              },
+              "interaction": {
+                "answer_groups": [],
+                "default_outcome": null,
+                "hints": [],
+                "solution": null
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test_exploration.json").writeText(explorationJson)
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isFalse()
+    assertThat(outContent.toString()).contains("Math tag #2")
+  }
+
+  @Test
+  fun testMetadataFilesIgnored() {
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<p>Test</p>"
+              },
+              "interaction": {
+                "answer_groups": [],
+                "default_outcome": null,
+                "hints": [],
+                "solution": null
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test.json").writeText(explorationJson)
+    // These metadata files should be skipped even if they contain exploration-like JSON.
+    File(assetsDir, "classrooms.json").writeText(explorationJson)
+    File(assetsDir, "skills.json").writeText(explorationJson)
+    File(assetsDir, "questions.json").writeText(explorationJson)
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isTrue()
+    // Only 1 file should be validated (not the 3 metadata files).
+    assertThat(outContent.toString()).contains("1 exploration file(s)")
+  }
+
+  @Test
+  fun testInvalidJsonFile_logsError() {
+    File(assetsDir, "invalid.json").writeText("{invalid json content")
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isFalse()
+    assertThat(outContent.toString()).contains("ERROR")
+  }
+
+  @Test
+  fun testMissingImageFile_passesGracefully() {
+    // When the image file doesn't exist (e.g., dummy assets), validation should not fail.
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test_exploration",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<oppia-noninteractive-image filepath-with-value=\"&amp;quot;missing_image.png&amp;quot;\"></oppia-noninteractive-image>"
+              },
+              "interaction": {
+                "answer_groups": [],
+                "default_outcome": null,
+                "hints": [],
+                "solution": null
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test_exploration.json").writeText(explorationJson)
+    // Don't create the image file — simulates dummy assets environment.
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isTrue()
+  }
+
+  @Test
+  fun testSelfClosingMathTag_validatesCorrectly() {
+    // Some math tags use self-closing syntax (/>), matching real data in GJ2rLXRKD5hw_1.json.
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test_exploration",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<oppia-noninteractive-math render-type=\"inline\" math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;y=mx+b&amp;quot;}\" />"
+              },
+              "interaction": {
+                "answer_groups": [],
+                "default_outcome": null,
+                "hints": [],
+                "solution": null
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test_exploration.json").writeText(explorationJson)
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isTrue()
+  }
+
+  @Test
+  fun testHtmlEntityDecodingInMathContent_passes() {
+    // Verify &amp;quot; entities are properly decoded for math content parsing.
+    val explorationJson =
+      """
+      {
+        "exploration_id": "test_exploration",
+        "exploration": {
+          "init_state_name": "Introduction",
+          "states": {
+            "Introduction": {
+              "content": {
+                "content_id": "content",
+                "html": "<oppia-noninteractive-math math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;\\\\sqrt{x}&amp;quot;}\"></oppia-noninteractive-math>"
+              },
+              "interaction": {
+                "answer_groups": [],
+                "default_outcome": null,
+                "hints": [],
+                "solution": null
+              }
+            }
+          }
+        }
+      }
+    """.trimIndent()
+
+    File(assetsDir, "test_exploration.json").writeText(explorationJson)
+
+    val checker = LessonAssetValidationCheck(assetsDir)
+    val hasPassed = checker.execute()
+
+    assertThat(hasPassed).isTrue()
+  }
+}

--- a/scripts/static_checks.sh
+++ b/scripts/static_checks.sh
@@ -89,6 +89,13 @@ echo "********************************"
 bazel run //scripts:string_resource_validation_check -- $(pwd)
 echo ""
 
+# Run Lesson asset validation check
+echo "********************************"
+echo "Running lesson asset validation checks"
+echo "********************************"
+bazel run //scripts:lesson_asset_validation_check -- $(pwd)
+echo ""
+
 
 # THIRD PARTY DEPENDENCY CHECKS
 # These are checks for third party dependencies


### PR DESCRIPTION
## Explanation
This PR fixes #6086.

Adds a new Bazel script (`LessonAssetValidationCheck`) that scans exploration JSON files to detect two categories of issues that affect lesson rendering quality:

1. **Transparent images** — Images with non-opaque alpha channel pixels cause poor visibility when dark mode is enabled. The script reads each referenced image file and checks for any pixel with alpha < 255.

2. **Invalid math tags** — Math tags (`oppia-noninteractive-math`) that lack `raw_latex` content force the app to fall back to pre-rendered SVGs, which may not render correctly across all devices. The script checks that every math tag has valid LaTeX.

The validation runs against all `"html"` fields in exploration files (including content, answer group feedback, default outcome, hints, and solution explanations).

**Design decisions:**
- Uses regex-based JSON field extraction instead of adding a new Maven dependency (keeps the change self-contained with zero external deps).
- Integrated into both `static_checks.sh` (CI) and `copy_oppia_assets.sh` (post-download validation).

### Files Changed
| File | Purpose |
|------|---------|
| `scripts/src/.../assets/LessonAssetValidationCheck.kt` | Core validation logic (247 lines) |
| `scripts/src/.../assets/LessonAssetValidationCheckTest.kt` | 18 comprehensive unit tests (648 lines) |
| `scripts/src/.../assets/BUILD.bazel` (x2) | Library and test Bazel targets |
| `scripts/BUILD.bazel` | `kt_jvm_binary` entry point |
| `scripts/static_checks.sh` | CI integration |
| `scripts/copy_oppia_assets.sh` | Post-download validation |

### Test Evidence
All 18 tests pass locally (0.341s, zero failures):

> JUnit version 4.13.2
> ..................
> Time: 0.341
> OK (18 tests)

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...".
- [x] The PR explanation includes the words "Fixes #bugnum".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not decrease the existing test coverage.
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewer(s).