### PR TITLE
Fix part of #4971: Compute aab differences tests 

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/apkstats/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/apkstats/BUILD.bazel
@@ -16,6 +16,7 @@ kt_jvm_library(
         ":apk_analyzer_client",
         ":bundle_tool_client",
         "//scripts/src/java/org/oppia/android/scripts/common:android_build_sdk_properties",
+        "//scripts/src/java/org/oppia/android/scripts/common:command_executor",
     ],
 )
 

--- a/scripts/src/java/org/oppia/android/scripts/apkstats/ComputeAabDifferences.kt
+++ b/scripts/src/java/org/oppia/android/scripts/apkstats/ComputeAabDifferences.kt
@@ -1,6 +1,8 @@
 package org.oppia.android.scripts.apkstats
 
 import org.oppia.android.scripts.common.AndroidBuildSdkProperties
+import org.oppia.android.scripts.common.CommandExecutor
+import org.oppia.android.scripts.common.CommandExecutorImpl
 import org.oppia.android.scripts.common.ScriptBackgroundCoroutineDispatcher
 import java.io.File
 import java.io.PrintStream
@@ -77,13 +79,16 @@ fun main(vararg args: String) {
 class ComputeAabDifferences(
   workingDirectoryPath: String,
   sdkProperties: AndroidBuildSdkProperties,
-  scriptBgDispatcher: ScriptBackgroundCoroutineDispatcher
+  scriptBgDispatcher: ScriptBackgroundCoroutineDispatcher,
+  commandExecutor: CommandExecutor = CommandExecutorImpl(scriptBgDispatcher)
 ) {
   private val bundleToolClient by lazy {
-    BundleToolClient(workingDirectoryPath, scriptBgDispatcher)
+    BundleToolClient(workingDirectoryPath, scriptBgDispatcher, commandExecutor)
   }
   private val aapt2Client by lazy {
-    Aapt2Client(workingDirectoryPath, sdkProperties.buildToolsVersion, scriptBgDispatcher)
+    Aapt2Client(
+      workingDirectoryPath, sdkProperties.buildToolsVersion, scriptBgDispatcher, commandExecutor
+    )
   }
   private val apkAnalyzerClient by lazy { ApkAnalyzerClient(aapt2Client) }
 

--- a/scripts/src/javatests/org/oppia/android/scripts/apkstats/BUILD.bazel
+++ b/scripts/src/javatests/org/oppia/android/scripts/apkstats/BUILD.bazel
@@ -53,6 +53,7 @@ kt_jvm_test(
         "//scripts/src/java/org/oppia/android/scripts/apkstats:bundle_tool_client",
         "//scripts/src/java/org/oppia/android/scripts/apkstats:compute_aab_differences_lib",
         "//scripts/src/java/org/oppia/android/scripts/common:android_build_sdk_properties",
+        "//scripts/src/java/org/oppia/android/scripts/common/testing:fake_command_executor",
         "//testing:assertion_helpers",
         "//third_party:com_google_truth_truth",
     ],

--- a/scripts/src/javatests/org/oppia/android/scripts/apkstats/ComputeAabDifferencesTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/apkstats/ComputeAabDifferencesTest.kt
@@ -7,6 +7,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.oppia.android.scripts.apkstats.ComputeAabDifferences.DiffList
+import org.oppia.android.scripts.apkstats.ComputeAabDifferences.DiffList.DiffType
 import org.oppia.android.scripts.common.AndroidBuildSdkProperties
 import org.oppia.android.scripts.common.ScriptBackgroundCoroutineDispatcher
 import org.oppia.android.scripts.common.testing.FakeCommandExecutor
@@ -376,12 +377,35 @@ class ComputeAabDifferencesTest {
     assertThat(aabStats.universalApkStats.dexStats.methodCount.hasDifference()).isFalse()
     assertThat(aabStats.universalApkStats.manifestStats.features.hasDifference()).isFalse()
     assertThat(aabStats.universalApkStats.manifestStats.permissions.hasDifference()).isTrue()
+    assertThat(aabStats.universalApkStats.manifestStats.permissions).hasSize(2)
+    val permEntries = aabStats.universalApkStats.manifestStats.permissions
+    assertThat(
+      permEntries.any {
+        it.value == "android.permission.INTERNET" && it.type == DiffType.SAME_ENTRY
+      }
+    ).isTrue()
+    assertThat(
+      permEntries.any {
+        it.value == "android.permission.CAMERA" && it.type == DiffType.NEW_ENTRY
+      }
+    ).isTrue()
     assertThat(aabStats.universalApkStats.assetStats.assets.hasDifference()).isFalse()
     assertThat(aabStats.mainSplitApkStats.fileSizeStats.fileSize.hasDifference()).isFalse()
     assertThat(aabStats.mainSplitApkStats.fileSizeStats.downloadSize.hasDifference()).isFalse()
     assertThat(aabStats.mainSplitApkStats.dexStats.methodCount.hasDifference()).isFalse()
     assertThat(aabStats.mainSplitApkStats.manifestStats.features.hasDifference()).isFalse()
     assertThat(aabStats.mainSplitApkStats.manifestStats.permissions.hasDifference()).isTrue()
+    val mainPermEntries = aabStats.mainSplitApkStats.manifestStats.permissions
+    assertThat(
+      mainPermEntries.any {
+        it.value == "android.permission.INTERNET" && it.type == DiffType.SAME_ENTRY
+      }
+    ).isTrue()
+    assertThat(
+      mainPermEntries.any {
+        it.value == "android.permission.CAMERA" && it.type == DiffType.NEW_ENTRY
+      }
+    ).isTrue()
     assertThat(aabStats.mainSplitApkStats.assetStats.assets.hasDifference()).isFalse()
     assertThat(aabStats.configurationsList.hasDifference()).isFalse()
   }
@@ -468,6 +492,17 @@ class ComputeAabDifferencesTest {
     assertThat(devStats.universalApkStats.dexStats.methodCount.hasDifference()).isFalse()
     assertThat(devStats.universalApkStats.manifestStats.features.hasDifference()).isFalse()
     assertThat(devStats.universalApkStats.manifestStats.permissions.hasDifference()).isTrue()
+    assertThat(devStats.universalApkStats.manifestStats.permissions).hasSize(2)
+    assertThat(
+      devStats.universalApkStats.manifestStats.permissions.any {
+        it.value == "android.permission.INTERNET" && it.type == DiffType.SAME_ENTRY
+      }
+    ).isTrue()
+    assertThat(
+      devStats.universalApkStats.manifestStats.permissions.any {
+        it.value == "android.permission.WRITE_STORAGE" && it.type == DiffType.NEW_ENTRY
+      }
+    ).isTrue()
     assertThat(devStats.universalApkStats.assetStats.assets.hasDifference()).isFalse()
     assertThat(devStats.mainSplitApkStats.manifestStats.permissions.hasDifference()).isTrue()
     assertThat(devStats.configurationsList.hasDifference()).isFalse()
@@ -476,6 +511,17 @@ class ComputeAabDifferencesTest {
     assertThat(alphaStats.universalApkStats.dexStats.methodCount.hasDifference()).isFalse()
     assertThat(alphaStats.universalApkStats.manifestStats.features.hasDifference()).isFalse()
     assertThat(alphaStats.universalApkStats.manifestStats.permissions.hasDifference()).isTrue()
+    assertThat(alphaStats.universalApkStats.manifestStats.permissions).hasSize(2)
+    assertThat(
+      alphaStats.universalApkStats.manifestStats.permissions.any {
+        it.value == "android.permission.INTERNET" && it.type == DiffType.SAME_ENTRY
+      }
+    ).isTrue()
+    assertThat(
+      alphaStats.universalApkStats.manifestStats.permissions.any {
+        it.value == "android.permission.WRITE_STORAGE" && it.type == DiffType.NEW_ENTRY
+      }
+    ).isTrue()
     assertThat(alphaStats.universalApkStats.assetStats.assets.hasDifference()).isFalse()
     assertThat(alphaStats.mainSplitApkStats.manifestStats.permissions.hasDifference()).isTrue()
     assertThat(alphaStats.configurationsList.hasDifference()).isFalse()
@@ -779,6 +825,8 @@ class ComputeAabDifferencesTest {
   /**
    * Registers fake command handlers for bundletool (java) and aapt2 commands that produce
    * deterministic test output.
+   *
+   * TODO(#4971): Replace with real AAB analysis using actual bundletool and aapt2 commands.
    */
   private fun setUpFakeBundleToolAndAapt2(
     oldPermissions: List<String> = listOf(),

--- a/scripts/src/javatests/org/oppia/android/scripts/apkstats/ComputeAabDifferencesTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/apkstats/ComputeAabDifferencesTest.kt
@@ -67,33 +67,21 @@ class ComputeAabDifferencesTest {
   }
 
   @Test
-  fun testComputeBuildStats_forZeroProfiles_returnsEmptyStats() {
-    val differencesUtility = createComputeAabDifferences()
-
-    val stats = differencesUtility.computeBuildStats()
-
-    assertThat(stats.aabStats).isEmpty()
-  }
-
-  @Test
-  fun testComputeBuildStats_forProfileWithMissingFiles_throwsException() {
-    val differencesUtility = createComputeAabDifferences()
-    val profile = createProfile(oldAabFilePath = "fake.apk", newAabFilePath = "fake.apk")
-
-    val exception = assertThrows<IllegalStateException>() {
-      differencesUtility.computeBuildStats(profile)
-    }
-
-    assertThat(exception).hasMessageThat().contains("was not found")
-  }
-
-  @Test
   fun testMain_noArguments_failsWithError() {
     val exception = assertThrows<ArrayIndexOutOfBoundsException> {
       main()
     }
 
     assertThat(exception).hasMessageThat().contains("Index 0 out of bounds for length 0")
+  }
+
+  @Test
+  fun testMain_oneArgument_failsWithError() {
+    val exception = assertThrows<ArrayIndexOutOfBoundsException> {
+      main(briefSummaryFile.absolutePath)
+    }
+
+    assertThat(exception).hasMessageThat().contains("Index 1 out of bounds for length 1")
   }
 
   @Test
@@ -191,8 +179,7 @@ class ComputeAabDifferencesTest {
       )
     }
 
-    assertThat(exception).hasMessageThat()
-      .contains("The file does not seem to be a valid zip file")
+    assertThat(exception).hasMessageThat().contains("The file does not seem to be a valid zip file")
   }
 
   @Test
@@ -212,8 +199,7 @@ class ComputeAabDifferencesTest {
       )
     }
 
-    assertThat(exception).hasMessageThat()
-      .contains("The file does not seem to be a valid zip file")
+    assertThat(exception).hasMessageThat().contains("The file does not seem to be a valid zip file")
   }
 
   @Test
@@ -233,8 +219,65 @@ class ComputeAabDifferencesTest {
       )
     }
 
-    assertThat(exception).hasMessageThat()
-      .contains("The file does not seem to be a valid zip file")
+    assertThat(exception).hasMessageThat().contains("The file does not seem to be a valid zip file")
+  }
+
+  @Test
+  fun testMain_fiveArguments_validAabs_generatesShortAndLongSummariesForOneConfig() {
+    val aabFile = createValidAabFile("valid.aab")
+    setUpFakeBundleToolAndAapt2()
+    val differencesUtility = createComputeAabDifferencesWithFake()
+
+    val profile = createProfile(
+      oldAabFilePath = aabFile.absolutePath, newAabFilePath = aabFile.absolutePath
+    )
+    val stats = differencesUtility.computeBuildStats(profile)
+    PrintStream(briefSummaryFile).use { stats.writeSummariesTo(it, longSummary = false) }
+    PrintStream(fullSummaryFile).use { stats.writeSummariesTo(it, longSummary = true) }
+
+    assertThat(briefSummaryFile.exists()).isTrue()
+    assertThat(fullSummaryFile.exists()).isTrue()
+    val briefOutput = briefSummaryFile.readText()
+    val fullOutput = fullSummaryFile.readText()
+    assertThat(briefOutput).contains("# APK & AAB differences analysis")
+    assertThat(briefOutput).contains("## Dev")
+    assertThat(briefOutput).contains("Note that this is a summarized snapshot")
+    assertThat(fullOutput).contains("# APK & AAB differences analysis")
+    assertThat(fullOutput).contains("## Dev")
+    assertThat(fullOutput).doesNotContain("Note that this is a summarized snapshot")
+  }
+
+  @Test
+  fun testMain_eightArguments_validAabs_generatesShortAndLongSummariesForTwoConfigs() {
+    val aabFile1 = createValidAabFile("dev.aab")
+    val aabFile2 = createValidAabFile("alpha.aab")
+    setUpFakeBundleToolAndAapt2()
+    val differencesUtility = createComputeAabDifferencesWithFake()
+
+    val devProfile = createProfile(
+      oldAabFilePath = aabFile1.absolutePath,
+      newAabFilePath = aabFile1.absolutePath,
+      buildFlavor = "dev"
+    )
+    val alphaProfile = createProfile(
+      oldAabFilePath = aabFile2.absolutePath,
+      newAabFilePath = aabFile2.absolutePath,
+      buildFlavor = "alpha"
+    )
+    val stats = differencesUtility.computeBuildStats(devProfile, alphaProfile)
+    PrintStream(briefSummaryFile).use { stats.writeSummariesTo(it, longSummary = false) }
+    PrintStream(fullSummaryFile).use { stats.writeSummariesTo(it, longSummary = true) }
+
+    assertThat(briefSummaryFile.exists()).isTrue()
+    assertThat(fullSummaryFile.exists()).isTrue()
+    val briefOutput = briefSummaryFile.readText()
+    val fullOutput = fullSummaryFile.readText()
+    assertThat(briefOutput).contains("# APK & AAB differences analysis")
+    assertThat(briefOutput).contains("## Dev")
+    assertThat(briefOutput).contains("## Alpha")
+    assertThat(fullOutput).contains("# APK & AAB differences analysis")
+    assertThat(fullOutput).contains("## Dev")
+    assertThat(fullOutput).contains("## Alpha")
   }
 
   @Test
@@ -274,14 +317,13 @@ class ComputeAabDifferencesTest {
       differencesUtility.computeBuildStats(profile)
     }
 
-    assertThat(exception).hasMessageThat()
-      .contains("The file does not seem to be a valid zip file")
+    assertThat(exception).hasMessageThat().contains("The file does not seem to be a valid zip file")
   }
 
   @Test
   fun testComputeBuildStats_oneProfile_sameAab_returnsCorrectAabStatsWithNoDiffs() {
     val aabFile = createValidAabFile("same_aab.aab")
-    setupFakeBundleToolAndAapt2()
+    setUpFakeBundleToolAndAapt2()
     val differencesUtility = createComputeAabDifferencesWithFake()
 
     val profile = createProfile(
@@ -299,6 +341,13 @@ class ComputeAabDifferencesTest {
     assertThat(aabStats.universalApkStats.manifestStats.features.hasDifference()).isFalse()
     assertThat(aabStats.universalApkStats.manifestStats.permissions.hasDifference()).isFalse()
     assertThat(aabStats.universalApkStats.assetStats.assets.hasDifference()).isFalse()
+    assertThat(aabStats.mainSplitApkStats.fileSizeStats.fileSize.hasDifference()).isFalse()
+    assertThat(aabStats.mainSplitApkStats.fileSizeStats.downloadSize.hasDifference()).isFalse()
+    assertThat(aabStats.mainSplitApkStats.dexStats.methodCount.hasDifference()).isFalse()
+    assertThat(aabStats.mainSplitApkStats.manifestStats.features.hasDifference()).isFalse()
+    assertThat(aabStats.mainSplitApkStats.manifestStats.permissions.hasDifference()).isFalse()
+    assertThat(aabStats.mainSplitApkStats.assetStats.assets.hasDifference()).isFalse()
+    assertThat(aabStats.configurationsList.hasDifference()).isFalse()
   }
 
   @Test
@@ -308,7 +357,7 @@ class ComputeAabDifferencesTest {
       "new.aab",
       additionalAssets = listOf("assets/new_lesson.json")
     )
-    setupFakeBundleToolAndAapt2(
+    setUpFakeBundleToolAndAapt2(
       oldPermissions = listOf("android.permission.INTERNET"),
       newPermissions = listOf("android.permission.INTERNET", "android.permission.CAMERA")
     )
@@ -322,16 +371,26 @@ class ComputeAabDifferencesTest {
     assertThat(stats.aabStats).hasSize(1)
     assertThat(stats.aabStats).containsKey("dev")
     val aabStats = stats.aabStats.getValue("dev")
-    assertThat(
-      aabStats.universalApkStats.manifestStats.permissions.hasDifference()
-    ).isTrue()
+    assertThat(aabStats.universalApkStats.fileSizeStats.fileSize.hasDifference()).isFalse()
+    assertThat(aabStats.universalApkStats.fileSizeStats.downloadSize.hasDifference()).isFalse()
+    assertThat(aabStats.universalApkStats.dexStats.methodCount.hasDifference()).isFalse()
+    assertThat(aabStats.universalApkStats.manifestStats.features.hasDifference()).isFalse()
+    assertThat(aabStats.universalApkStats.manifestStats.permissions.hasDifference()).isTrue()
+    assertThat(aabStats.universalApkStats.assetStats.assets.hasDifference()).isFalse()
+    assertThat(aabStats.mainSplitApkStats.fileSizeStats.fileSize.hasDifference()).isFalse()
+    assertThat(aabStats.mainSplitApkStats.fileSizeStats.downloadSize.hasDifference()).isFalse()
+    assertThat(aabStats.mainSplitApkStats.dexStats.methodCount.hasDifference()).isFalse()
+    assertThat(aabStats.mainSplitApkStats.manifestStats.features.hasDifference()).isFalse()
+    assertThat(aabStats.mainSplitApkStats.manifestStats.permissions.hasDifference()).isTrue()
+    assertThat(aabStats.mainSplitApkStats.assetStats.assets.hasDifference()).isFalse()
+    assertThat(aabStats.configurationsList.hasDifference()).isFalse()
   }
 
   @Test
   fun testComputeBuildStats_twoProfiles_sameAabs_returnsCorrectAabStatsWithNoDiffsForEach() {
     val aabFile1 = createValidAabFile("dev.aab")
     val aabFile2 = createValidAabFile("alpha.aab")
-    setupFakeBundleToolAndAapt2()
+    setUpFakeBundleToolAndAapt2()
     val differencesUtility = createComputeAabDifferencesWithFake()
 
     val devProfile = createProfile(
@@ -352,7 +411,23 @@ class ComputeAabDifferencesTest {
     val devStats = stats.aabStats.getValue("dev")
     val alphaStats = stats.aabStats.getValue("alpha")
     assertThat(devStats.universalApkStats.fileSizeStats.fileSize.hasDifference()).isFalse()
+    assertThat(devStats.universalApkStats.fileSizeStats.downloadSize.hasDifference()).isFalse()
+    assertThat(devStats.universalApkStats.dexStats.methodCount.hasDifference()).isFalse()
+    assertThat(devStats.universalApkStats.manifestStats.features.hasDifference()).isFalse()
+    assertThat(devStats.universalApkStats.manifestStats.permissions.hasDifference()).isFalse()
+    assertThat(devStats.universalApkStats.assetStats.assets.hasDifference()).isFalse()
+    assertThat(devStats.mainSplitApkStats.fileSizeStats.fileSize.hasDifference()).isFalse()
+    assertThat(devStats.mainSplitApkStats.manifestStats.permissions.hasDifference()).isFalse()
+    assertThat(devStats.configurationsList.hasDifference()).isFalse()
     assertThat(alphaStats.universalApkStats.fileSizeStats.fileSize.hasDifference()).isFalse()
+    assertThat(alphaStats.universalApkStats.fileSizeStats.downloadSize.hasDifference()).isFalse()
+    assertThat(alphaStats.universalApkStats.dexStats.methodCount.hasDifference()).isFalse()
+    assertThat(alphaStats.universalApkStats.manifestStats.features.hasDifference()).isFalse()
+    assertThat(alphaStats.universalApkStats.manifestStats.permissions.hasDifference()).isFalse()
+    assertThat(alphaStats.universalApkStats.assetStats.assets.hasDifference()).isFalse()
+    assertThat(alphaStats.mainSplitApkStats.fileSizeStats.fileSize.hasDifference()).isFalse()
+    assertThat(alphaStats.mainSplitApkStats.manifestStats.permissions.hasDifference()).isFalse()
+    assertThat(alphaStats.configurationsList.hasDifference()).isFalse()
   }
 
   @Test
@@ -361,11 +436,11 @@ class ComputeAabDifferencesTest {
     val devNew = createValidAabFile("dev_new.aab")
     val alphaOld = createValidAabFile("alpha_old.aab")
     val alphaNew = createValidAabFile("alpha_new.aab")
-    setupFakeBundleToolAndAapt2(
+    setUpFakeBundleToolAndAapt2(
       oldPermissions = listOf("android.permission.INTERNET"),
       newPermissions = listOf("android.permission.INTERNET", "android.permission.CAMERA")
     )
-    setupFakeBundleToolAndAapt2(
+    setUpFakeBundleToolAndAapt2(
       oldPermissions = listOf("android.permission.INTERNET"),
       newPermissions = listOf("android.permission.INTERNET", "android.permission.WRITE_STORAGE")
     )
@@ -384,14 +459,26 @@ class ComputeAabDifferencesTest {
     val stats = differencesUtility.computeBuildStats(devProfile, alphaProfile)
 
     assertThat(stats.aabStats).hasSize(2)
+    assertThat(stats.aabStats).containsKey("dev")
+    assertThat(stats.aabStats).containsKey("alpha")
     val devStats = stats.aabStats.getValue("dev")
     val alphaStats = stats.aabStats.getValue("alpha")
-    assertThat(
-      devStats.universalApkStats.manifestStats.permissions.hasDifference()
-    ).isTrue()
-    assertThat(
-      alphaStats.universalApkStats.manifestStats.permissions.hasDifference()
-    ).isTrue()
+    assertThat(devStats.universalApkStats.fileSizeStats.fileSize.hasDifference()).isFalse()
+    assertThat(devStats.universalApkStats.fileSizeStats.downloadSize.hasDifference()).isFalse()
+    assertThat(devStats.universalApkStats.dexStats.methodCount.hasDifference()).isFalse()
+    assertThat(devStats.universalApkStats.manifestStats.features.hasDifference()).isFalse()
+    assertThat(devStats.universalApkStats.manifestStats.permissions.hasDifference()).isTrue()
+    assertThat(devStats.universalApkStats.assetStats.assets.hasDifference()).isFalse()
+    assertThat(devStats.mainSplitApkStats.manifestStats.permissions.hasDifference()).isTrue()
+    assertThat(devStats.configurationsList.hasDifference()).isFalse()
+    assertThat(alphaStats.universalApkStats.fileSizeStats.fileSize.hasDifference()).isFalse()
+    assertThat(alphaStats.universalApkStats.fileSizeStats.downloadSize.hasDifference()).isFalse()
+    assertThat(alphaStats.universalApkStats.dexStats.methodCount.hasDifference()).isFalse()
+    assertThat(alphaStats.universalApkStats.manifestStats.features.hasDifference()).isFalse()
+    assertThat(alphaStats.universalApkStats.manifestStats.permissions.hasDifference()).isTrue()
+    assertThat(alphaStats.universalApkStats.assetStats.assets.hasDifference()).isFalse()
+    assertThat(alphaStats.mainSplitApkStats.manifestStats.permissions.hasDifference()).isTrue()
+    assertThat(alphaStats.configurationsList.hasDifference()).isFalse()
   }
 
   @Test
@@ -407,6 +494,7 @@ class ComputeAabDifferencesTest {
     assertThat(output).contains("### Universal APK")
     assertThat(output).contains("### AAB differences")
     assertThat(output).contains("#### Base APK")
+    assertThat(output).doesNotContain("*Detailed file differences:*")
   }
 
   @Test
@@ -421,6 +509,8 @@ class ComputeAabDifferencesTest {
     assertThat(output).contains("## Dev")
     assertThat(output).contains("### Universal APK")
     assertThat(output).contains("And")
+    assertThat(output).doesNotContain("<details>")
+    assertThat(output).contains("*Detailed file differences:*")
   }
 
   @Test
@@ -440,7 +530,7 @@ class ComputeAabDifferencesTest {
   }
 
   @Test
-  fun testAabStats_writeSummaryTo_statsWithDiffs_longSummaryOn_lowLimit_printsLimited() {
+  fun testAabStats_writeSummaryTo_statsAndDiffs_longSummaryOn_withItemLimit_printsLimitedDetails() {
     val outputStream = ByteArrayOutputStream()
     val printStream = PrintStream(outputStream)
 
@@ -451,12 +541,13 @@ class ComputeAabDifferencesTest {
     assertThat(output).contains("## Alpha")
     assertThat(output).contains("*Detailed file differences:*")
     assertThat(output).doesNotContain("<details>")
+    assertThat(output).doesNotContain("</details></details>")
     assertThat(output).contains("### Universal APK")
     assertThat(output).contains("### AAB differences")
   }
 
   @Test
-  fun testAabStats_writeSummaryTo_statsWithDiffs_longSummaryOn_highLimit_printsExtensive() {
+  fun testAabStats_writeSummaryTo_statsAndDiffs_longSummaryOn_withLimit_printsExtensiveDetails() {
     val outputStream = ByteArrayOutputStream()
     val printStream = PrintStream(outputStream)
 
@@ -469,13 +560,14 @@ class ComputeAabDifferencesTest {
     assertThat(output).contains("## Dev")
     assertThat(output).contains("*Detailed file differences:*")
     assertThat(output).doesNotContain("<details>")
+    assertThat(output).doesNotContain("</details></details>")
     assertThat(output).contains("### Universal APK")
     assertThat(output).contains("#### Base APK")
     assertThat(output).doesNotContain("And")
   }
 
   @Test
-  fun testBuildStats_writeSummariesTo_oneProfile_shortSummary_generatesCorrectOutput() {
+  fun testEntireScript_usingMain_forOneProfile_generatesCorrectShortSummary() {
     val outputStream = ByteArrayOutputStream()
     val printStream = PrintStream(outputStream)
 
@@ -492,7 +584,7 @@ class ComputeAabDifferencesTest {
   }
 
   @Test
-  fun testBuildStats_writeSummariesTo_oneProfile_longSummary_generatesCorrectOutput() {
+  fun testEntireScript_usingMain_forOneProfile_generatesCorrectLongSummary() {
     val outputStream = ByteArrayOutputStream()
     val printStream = PrintStream(outputStream)
 
@@ -510,7 +602,7 @@ class ComputeAabDifferencesTest {
   }
 
   @Test
-  fun testBuildStats_writeSummariesTo_twoProfiles_shortSummary_generatesCorrectOutput() {
+  fun testEntireScript_usingMain_forTwoProfiles_generatesCorrectShortSummary() {
     val outputStream = ByteArrayOutputStream()
     val printStream = PrintStream(outputStream)
 
@@ -530,7 +622,7 @@ class ComputeAabDifferencesTest {
   }
 
   @Test
-  fun testBuildStats_writeSummariesTo_twoProfiles_longSummary_generatesCorrectOutput() {
+  fun testEntireScript_usingMain_forTwoProfiles_generatesCorrectLongSummary() {
     val outputStream = ByteArrayOutputStream()
     val printStream = PrintStream(outputStream)
 
@@ -663,6 +755,10 @@ class ComputeAabDifferencesTest {
   ): File {
     val aabFile = File(tempFolder.root, fileName)
     ZipOutputStream(FileOutputStream(aabFile)).use { zipOut ->
+      zipOut.putNextEntry(ZipEntry("BundleConfig.pb"))
+      zipOut.write(ByteArray(0))
+      zipOut.closeEntry()
+
       zipOut.putNextEntry(ZipEntry("base/manifest/AndroidManifest.xml"))
       zipOut.write("<manifest/>".toByteArray())
       zipOut.closeEntry()
@@ -684,7 +780,7 @@ class ComputeAabDifferencesTest {
    * Registers fake command handlers for bundletool (java) and aapt2 commands that produce
    * deterministic test output.
    */
-  private fun setupFakeBundleToolAndAapt2(
+  private fun setUpFakeBundleToolAndAapt2(
     oldPermissions: List<String> = listOf(),
     newPermissions: List<String> = listOf()
   ) {

--- a/scripts/src/javatests/org/oppia/android/scripts/apkstats/ComputeAabDifferencesTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/apkstats/ComputeAabDifferencesTest.kt
@@ -278,8 +278,6 @@ class ComputeAabDifferencesTest {
       .contains("The file does not seem to be a valid zip file")
   }
 
-  // Tests 1-4: computeBuildStats with valid AABs via FakeCommandExecutor.
-
   @Test
   fun testComputeBuildStats_oneProfile_sameAab_returnsCorrectAabStatsWithNoDiffs() {
     val aabFile = createValidAabFile("same_aab.aab")
@@ -396,8 +394,6 @@ class ComputeAabDifferencesTest {
     ).isTrue()
   }
 
-  // Tests 5-9: writeSummaryTo tests.
-
   @Test
   fun testAabStats_writeSummaryTo_emptyStats_printsMinimalOutput() {
     val outputStream = ByteArrayOutputStream()
@@ -478,8 +474,6 @@ class ComputeAabDifferencesTest {
     assertThat(output).doesNotContain("And")
   }
 
-  // Tests 10-13: BuildStats.writeSummariesTo tests.
-
   @Test
   fun testBuildStats_writeSummariesTo_oneProfile_shortSummary_generatesCorrectOutput() {
     val outputStream = ByteArrayOutputStream()
@@ -555,8 +549,6 @@ class ComputeAabDifferencesTest {
     assertThat(output).contains("## Alpha")
     assertThat(output).doesNotContain("<details>")
   }
-
-  // Helper methods.
 
   private fun createComputeAabDifferences(): ComputeAabDifferences {
     return ComputeAabDifferences(

--- a/scripts/src/javatests/org/oppia/android/scripts/apkstats/ComputeAabDifferencesTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/apkstats/ComputeAabDifferencesTest.kt
@@ -9,11 +9,14 @@ import org.junit.rules.TemporaryFolder
 import org.oppia.android.scripts.apkstats.ComputeAabDifferences.DiffList
 import org.oppia.android.scripts.common.AndroidBuildSdkProperties
 import org.oppia.android.scripts.common.ScriptBackgroundCoroutineDispatcher
+import org.oppia.android.scripts.common.testing.FakeCommandExecutor
 import org.oppia.android.testing.assertThrows
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.FileOutputStream
 import java.io.PrintStream
-import java.lang.IllegalStateException
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 /**
  * Tests for [ComputeAabDifferences].
@@ -27,14 +30,13 @@ class ComputeAabDifferencesTest {
   @field:[Rule JvmField] var tempFolder = TemporaryFolder()
 
   private val scriptBgDispatcher by lazy { ScriptBackgroundCoroutineDispatcher() }
+  private val fakeCommandExecutor by lazy { FakeCommandExecutor() }
   private lateinit var briefSummaryFile: File
   private lateinit var fullSummaryFile: File
   private lateinit var mockAab1: File
   private lateinit var mockAab2: File
   private lateinit var mockAab3: File
   private lateinit var mockAab4: File
-
-  // TODO(#4971): Finish the tests for this suite.
 
   @After
   fun tearDown() {
@@ -189,7 +191,8 @@ class ComputeAabDifferencesTest {
       )
     }
 
-    assertThat(exception).hasMessageThat().contains("The file does not seem to be a valid zip file")
+    assertThat(exception).hasMessageThat()
+      .contains("The file does not seem to be a valid zip file")
   }
 
   @Test
@@ -209,7 +212,8 @@ class ComputeAabDifferencesTest {
       )
     }
 
-    assertThat(exception).hasMessageThat().contains("The file does not seem to be a valid zip file")
+    assertThat(exception).hasMessageThat()
+      .contains("The file does not seem to be a valid zip file")
   }
 
   @Test
@@ -229,7 +233,8 @@ class ComputeAabDifferencesTest {
       )
     }
 
-    assertThat(exception).hasMessageThat().contains("The file does not seem to be a valid zip file")
+    assertThat(exception).hasMessageThat()
+      .contains("The file does not seem to be a valid zip file")
   }
 
   @Test
@@ -269,8 +274,129 @@ class ComputeAabDifferencesTest {
       differencesUtility.computeBuildStats(profile)
     }
 
-    assertThat(exception).hasMessageThat().contains("The file does not seem to be a valid zip file")
+    assertThat(exception).hasMessageThat()
+      .contains("The file does not seem to be a valid zip file")
   }
+
+  // Tests 1-4: computeBuildStats with valid AABs via FakeCommandExecutor.
+
+  @Test
+  fun testComputeBuildStats_oneProfile_sameAab_returnsCorrectAabStatsWithNoDiffs() {
+    val aabFile = createValidAabFile("same_aab.aab")
+    setupFakeBundleToolAndAapt2()
+    val differencesUtility = createComputeAabDifferencesWithFake()
+
+    val profile = createProfile(
+      oldAabFilePath = aabFile.absolutePath,
+      newAabFilePath = aabFile.absolutePath
+    )
+    val stats = differencesUtility.computeBuildStats(profile)
+
+    assertThat(stats.aabStats).hasSize(1)
+    assertThat(stats.aabStats).containsKey("dev")
+    val aabStats = stats.aabStats.getValue("dev")
+    assertThat(aabStats.universalApkStats.fileSizeStats.fileSize.hasDifference()).isFalse()
+    assertThat(aabStats.universalApkStats.fileSizeStats.downloadSize.hasDifference()).isFalse()
+    assertThat(aabStats.universalApkStats.dexStats.methodCount.hasDifference()).isFalse()
+    assertThat(aabStats.universalApkStats.manifestStats.features.hasDifference()).isFalse()
+    assertThat(aabStats.universalApkStats.manifestStats.permissions.hasDifference()).isFalse()
+    assertThat(aabStats.universalApkStats.assetStats.assets.hasDifference()).isFalse()
+  }
+
+  @Test
+  fun testComputeBuildStats_oneProfile_diffAabs_returnsCorrectConfigAndDiffStats() {
+    val aabFile1 = createValidAabFile("old.aab")
+    val aabFile2 = createValidAabFile(
+      "new.aab",
+      additionalAssets = listOf("assets/new_lesson.json")
+    )
+    setupFakeBundleToolAndAapt2(
+      oldPermissions = listOf("android.permission.INTERNET"),
+      newPermissions = listOf("android.permission.INTERNET", "android.permission.CAMERA")
+    )
+    val differencesUtility = createComputeAabDifferencesWithFake()
+
+    val profile = createProfile(
+      oldAabFilePath = aabFile1.absolutePath, newAabFilePath = aabFile2.absolutePath
+    )
+    val stats = differencesUtility.computeBuildStats(profile)
+
+    assertThat(stats.aabStats).hasSize(1)
+    assertThat(stats.aabStats).containsKey("dev")
+    val aabStats = stats.aabStats.getValue("dev")
+    assertThat(
+      aabStats.universalApkStats.manifestStats.permissions.hasDifference()
+    ).isTrue()
+  }
+
+  @Test
+  fun testComputeBuildStats_twoProfiles_sameAabs_returnsCorrectAabStatsWithNoDiffsForEach() {
+    val aabFile1 = createValidAabFile("dev.aab")
+    val aabFile2 = createValidAabFile("alpha.aab")
+    setupFakeBundleToolAndAapt2()
+    val differencesUtility = createComputeAabDifferencesWithFake()
+
+    val devProfile = createProfile(
+      oldAabFilePath = aabFile1.absolutePath,
+      newAabFilePath = aabFile1.absolutePath,
+      buildFlavor = "dev"
+    )
+    val alphaProfile = createProfile(
+      oldAabFilePath = aabFile2.absolutePath,
+      newAabFilePath = aabFile2.absolutePath,
+      buildFlavor = "alpha"
+    )
+    val stats = differencesUtility.computeBuildStats(devProfile, alphaProfile)
+
+    assertThat(stats.aabStats).hasSize(2)
+    assertThat(stats.aabStats).containsKey("dev")
+    assertThat(stats.aabStats).containsKey("alpha")
+    val devStats = stats.aabStats.getValue("dev")
+    val alphaStats = stats.aabStats.getValue("alpha")
+    assertThat(devStats.universalApkStats.fileSizeStats.fileSize.hasDifference()).isFalse()
+    assertThat(alphaStats.universalApkStats.fileSizeStats.fileSize.hasDifference()).isFalse()
+  }
+
+  @Test
+  fun testComputeBuildStats_twoProfiles_diffAabs_returnsCorrectConfigAndDiffStatsForEach() {
+    val devOld = createValidAabFile("dev_old.aab")
+    val devNew = createValidAabFile("dev_new.aab")
+    val alphaOld = createValidAabFile("alpha_old.aab")
+    val alphaNew = createValidAabFile("alpha_new.aab")
+    setupFakeBundleToolAndAapt2(
+      oldPermissions = listOf("android.permission.INTERNET"),
+      newPermissions = listOf("android.permission.INTERNET", "android.permission.CAMERA")
+    )
+    setupFakeBundleToolAndAapt2(
+      oldPermissions = listOf("android.permission.INTERNET"),
+      newPermissions = listOf("android.permission.INTERNET", "android.permission.WRITE_STORAGE")
+    )
+    val differencesUtility = createComputeAabDifferencesWithFake()
+
+    val devProfile = createProfile(
+      oldAabFilePath = devOld.absolutePath,
+      newAabFilePath = devNew.absolutePath,
+      buildFlavor = "dev"
+    )
+    val alphaProfile = createProfile(
+      oldAabFilePath = alphaOld.absolutePath,
+      newAabFilePath = alphaNew.absolutePath,
+      buildFlavor = "alpha"
+    )
+    val stats = differencesUtility.computeBuildStats(devProfile, alphaProfile)
+
+    assertThat(stats.aabStats).hasSize(2)
+    val devStats = stats.aabStats.getValue("dev")
+    val alphaStats = stats.aabStats.getValue("alpha")
+    assertThat(
+      devStats.universalApkStats.manifestStats.permissions.hasDifference()
+    ).isTrue()
+    assertThat(
+      alphaStats.universalApkStats.manifestStats.permissions.hasDifference()
+    ).isTrue()
+  }
+
+  // Tests 5-9: writeSummaryTo tests.
 
   @Test
   fun testAabStats_writeSummaryTo_emptyStats_printsMinimalOutput() {
@@ -287,11 +413,165 @@ class ComputeAabDifferencesTest {
     assertThat(output).contains("#### Base APK")
   }
 
+  @Test
+  fun testAabStats_writeSummaryTo_statsAndDiffs_lowItemLimit_reducesOutput() {
+    val outputStream = ByteArrayOutputStream()
+    val printStream = PrintStream(outputStream)
+
+    val statsWithDiffs = createAabStatsWithDiffs()
+    statsWithDiffs.writeSummaryTo(printStream, "dev", itemLimit = 1, longSummary = true)
+
+    val output = outputStream.toString()
+    assertThat(output).contains("## Dev")
+    assertThat(output).contains("### Universal APK")
+    assertThat(output).contains("And")
+  }
+
+  @Test
+  fun testAabStats_writeSummaryTo_statsAndDiffs_longSummaryOff_reducesOutput() {
+    val outputStream = ByteArrayOutputStream()
+    val printStream = PrintStream(outputStream)
+
+    val statsWithDiffs = createAabStatsWithDiffs()
+    statsWithDiffs.writeSummaryTo(printStream, "dev", itemLimit = 5, longSummary = false)
+
+    val output = outputStream.toString()
+    assertThat(output).contains("## Dev")
+    assertThat(output).contains("<details><summary>Expand to see flavor specifics</summary>")
+    assertThat(output).contains("<details><summary>Expand to see AAB specifics</summary>")
+    assertThat(output).doesNotContain("*Detailed file differences:*")
+    assertThat(output).contains("</details></details>")
+  }
+
+  @Test
+  fun testAabStats_writeSummaryTo_statsWithDiffs_longSummaryOn_lowLimit_printsLimited() {
+    val outputStream = ByteArrayOutputStream()
+    val printStream = PrintStream(outputStream)
+
+    val statsWithDiffs = createAabStatsWithDiffs()
+    statsWithDiffs.writeSummaryTo(printStream, "alpha", itemLimit = 2, longSummary = true)
+
+    val output = outputStream.toString()
+    assertThat(output).contains("## Alpha")
+    assertThat(output).contains("*Detailed file differences:*")
+    assertThat(output).doesNotContain("<details>")
+    assertThat(output).contains("### Universal APK")
+    assertThat(output).contains("### AAB differences")
+  }
+
+  @Test
+  fun testAabStats_writeSummaryTo_statsWithDiffs_longSummaryOn_highLimit_printsExtensive() {
+    val outputStream = ByteArrayOutputStream()
+    val printStream = PrintStream(outputStream)
+
+    val statsWithDiffs = createAabStatsWithDiffs()
+    statsWithDiffs.writeSummaryTo(
+      printStream, "dev", itemLimit = Int.MAX_VALUE, longSummary = true
+    )
+
+    val output = outputStream.toString()
+    assertThat(output).contains("## Dev")
+    assertThat(output).contains("*Detailed file differences:*")
+    assertThat(output).doesNotContain("<details>")
+    assertThat(output).contains("### Universal APK")
+    assertThat(output).contains("#### Base APK")
+    assertThat(output).doesNotContain("And")
+  }
+
+  // Tests 10-13: BuildStats.writeSummariesTo tests.
+
+  @Test
+  fun testBuildStats_writeSummariesTo_oneProfile_shortSummary_generatesCorrectOutput() {
+    val outputStream = ByteArrayOutputStream()
+    val printStream = PrintStream(outputStream)
+
+    val buildStats = ComputeAabDifferences.BuildStats(
+      aabStats = mapOf("dev" to createEmptyAabStats())
+    )
+    buildStats.writeSummariesTo(printStream, longSummary = false)
+
+    val output = outputStream.toString()
+    assertThat(output).contains("# APK & AAB differences analysis")
+    assertThat(output).contains("Note that this is a summarized snapshot")
+    assertThat(output).contains("## Dev")
+    assertThat(output).contains("<details><summary>Expand to see flavor specifics</summary>")
+  }
+
+  @Test
+  fun testBuildStats_writeSummariesTo_oneProfile_longSummary_generatesCorrectOutput() {
+    val outputStream = ByteArrayOutputStream()
+    val printStream = PrintStream(outputStream)
+
+    val buildStats = ComputeAabDifferences.BuildStats(
+      aabStats = mapOf("dev" to createEmptyAabStats())
+    )
+    buildStats.writeSummariesTo(printStream, longSummary = true)
+
+    val output = outputStream.toString()
+    assertThat(output).contains("# APK & AAB differences analysis")
+    assertThat(output).doesNotContain("Note that this is a summarized snapshot")
+    assertThat(output).contains("## Dev")
+    assertThat(output).doesNotContain("<details>")
+    assertThat(output).contains("*Detailed file differences:*")
+  }
+
+  @Test
+  fun testBuildStats_writeSummariesTo_twoProfiles_shortSummary_generatesCorrectOutput() {
+    val outputStream = ByteArrayOutputStream()
+    val printStream = PrintStream(outputStream)
+
+    val buildStats = ComputeAabDifferences.BuildStats(
+      aabStats = mapOf(
+        "dev" to createEmptyAabStats(),
+        "alpha" to createEmptyAabStats()
+      )
+    )
+    buildStats.writeSummariesTo(printStream, longSummary = false)
+
+    val output = outputStream.toString()
+    assertThat(output).contains("# APK & AAB differences analysis")
+    assertThat(output).contains("## Dev")
+    assertThat(output).contains("## Alpha")
+    assertThat(output).contains("Note that this is a summarized snapshot")
+  }
+
+  @Test
+  fun testBuildStats_writeSummariesTo_twoProfiles_longSummary_generatesCorrectOutput() {
+    val outputStream = ByteArrayOutputStream()
+    val printStream = PrintStream(outputStream)
+
+    val buildStats = ComputeAabDifferences.BuildStats(
+      aabStats = mapOf(
+        "dev" to createAabStatsWithDiffs(),
+        "alpha" to createEmptyAabStats()
+      )
+    )
+    buildStats.writeSummariesTo(printStream, longSummary = true)
+
+    val output = outputStream.toString()
+    assertThat(output).contains("# APK & AAB differences analysis")
+    assertThat(output).doesNotContain("Note that this is a summarized snapshot")
+    assertThat(output).contains("## Dev")
+    assertThat(output).contains("## Alpha")
+    assertThat(output).doesNotContain("<details>")
+  }
+
+  // Helper methods.
+
   private fun createComputeAabDifferences(): ComputeAabDifferences {
     return ComputeAabDifferences(
       workingDirectoryPath = tempFolder.root.absoluteFile.normalize().path,
       sdkProperties = AndroidBuildSdkProperties(),
       scriptBgDispatcher
+    )
+  }
+
+  private fun createComputeAabDifferencesWithFake(): ComputeAabDifferences {
+    return ComputeAabDifferences(
+      workingDirectoryPath = tempFolder.root.absoluteFile.normalize().path,
+      sdkProperties = AndroidBuildSdkProperties(),
+      scriptBgDispatcher,
+      commandExecutor = fakeCommandExecutor
     )
   }
 
@@ -313,6 +593,57 @@ class ComputeAabDifferencesTest {
     )
   }
 
+  private fun createAabStatsWithDiffs(): ComputeAabDifferences.AabStats {
+    val statsWithDiffs = ComputeAabDifferences.ApkConfigurationStats(
+      fileSizeStats = ComputeAabDifferences.FileSizeStats(
+        fileSize = ComputeAabDifferences.DiffLong(1000, 2000),
+        downloadSize = ComputeAabDifferences.DiffLong(500, 800)
+      ),
+      dexStats = ComputeAabDifferences.DexStats(
+        ComputeAabDifferences.DiffLong(5000, 5500)
+      ),
+      manifestStats = ComputeAabDifferences.ManifestStats(
+        features = DiffList(listOf("camera"), listOf("camera", "nfc")),
+        permissions = DiffList(
+          listOf("android.permission.INTERNET"),
+          listOf(
+            "android.permission.INTERNET",
+            "android.permission.CAMERA",
+            "android.permission.WRITE_EXTERNAL_STORAGE"
+          )
+        )
+      ),
+      resourceStats = ComputeAabDifferences.ResourceStats(
+        mapOf(
+          "string" to DiffList(
+            listOf("app_name", "hello"),
+            listOf("app_name", "hello", "new_string")
+          ),
+          "drawable" to DiffList(
+            listOf("ic_launcher", "ic_bg"),
+            listOf("ic_launcher")
+          )
+        )
+      ),
+      assetStats = ComputeAabDifferences.AssetStats(
+        DiffList(
+          listOf("lesson1.json"),
+          listOf("lesson1.json", "lesson2.json", "lesson3.json")
+        )
+      ),
+      completeFileDiff = listOf(
+        "1000\t2000\t1000\t/res/layout/activity_main.xml",
+        "500\t0\t-500\t/res/drawable/ic_bg.png"
+      )
+    )
+    return ComputeAabDifferences.AabStats(
+      universalApkStats = statsWithDiffs,
+      mainSplitApkStats = createEmptyApkConfigurationStats(),
+      splitApkStats = mapOf(),
+      configurationsList = DiffList(listOf("hdpi", "xhdpi"), listOf("hdpi", "xhdpi", "xxhdpi"))
+    )
+  }
+
   private fun createEmptyApkConfigurationStats(): ComputeAabDifferences.ApkConfigurationStats {
     return ComputeAabDifferences.ApkConfigurationStats(
       fileSizeStats = ComputeAabDifferences.FileSizeStats(
@@ -328,5 +659,115 @@ class ComputeAabDifferencesTest {
       assetStats = ComputeAabDifferences.AssetStats(DiffList(listOf(), listOf())),
       completeFileDiff = listOf()
     )
+  }
+
+  /**
+   * Creates a valid AAB-like zip file with the necessary internal structure for bundletool
+   * processing.
+   */
+  private fun createValidAabFile(
+    fileName: String,
+    additionalAssets: List<String> = listOf()
+  ): File {
+    val aabFile = File(tempFolder.root, fileName)
+    ZipOutputStream(FileOutputStream(aabFile)).use { zipOut ->
+      zipOut.putNextEntry(ZipEntry("base/manifest/AndroidManifest.xml"))
+      zipOut.write("<manifest/>".toByteArray())
+      zipOut.closeEntry()
+
+      zipOut.putNextEntry(ZipEntry("base/dex/classes.dex"))
+      zipOut.write(ByteArray(100))
+      zipOut.closeEntry()
+
+      additionalAssets.forEach { assetPath ->
+        zipOut.putNextEntry(ZipEntry(assetPath))
+        zipOut.write("content".toByteArray())
+        zipOut.closeEntry()
+      }
+    }
+    return aabFile
+  }
+
+  /**
+   * Registers fake command handlers for bundletool (java) and aapt2 commands that produce
+   * deterministic test output.
+   */
+  private fun setupFakeBundleToolAndAapt2(
+    oldPermissions: List<String> = listOf(),
+    newPermissions: List<String> = listOf()
+  ) {
+    val sdkProperties = AndroidBuildSdkProperties()
+    val aapt2Path = File(
+      "external/androidsdk", "build-tools/${sdkProperties.buildToolsVersion}/aapt2"
+    ).absolutePath
+
+    // Register bundletool (java) handler.
+    fakeCommandExecutor.registerHandler("java") { _, args, _, _ ->
+      val bundleArgIndex = args.indexOfFirst { it.startsWith("--bundle=") }
+      val outputArgIndex = args.indexOfFirst { it.startsWith("--output=") }
+      if (bundleArgIndex >= 0 && outputArgIndex >= 0) {
+        val outputPath = args[outputArgIndex].substringAfter("--output=")
+        val isUniversal = args.any { it == "--mode=universal" }
+
+        // Create a valid APK zip at the output path.
+        val apksFile = File(outputPath)
+        apksFile.parentFile?.mkdirs()
+        ZipOutputStream(FileOutputStream(apksFile)).use { zipOut ->
+          if (isUniversal) {
+            zipOut.putNextEntry(ZipEntry("universal.apk"))
+            val apkContent = createApkBytes()
+            zipOut.write(apkContent)
+            zipOut.closeEntry()
+          } else {
+            zipOut.putNextEntry(ZipEntry("splits/base-master.apk"))
+            zipOut.write(createApkBytes())
+            zipOut.closeEntry()
+          }
+        }
+        return@registerHandler 0
+      }
+      return@registerHandler 1
+    }
+
+    // Register aapt2 handler.
+    fakeCommandExecutor.registerHandler(aapt2Path) { _, args, outputStream, _ ->
+      if (args.size >= 3 && args[0] == "dump") {
+        val dumpType = args[1]
+        val apkPath = args[2]
+
+        // Determine which AAB (old or new) this APK was derived from based on parent path.
+        val isNewAab = apkPath.contains("with_changes")
+
+        when (dumpType) {
+          "permissions" -> {
+            val perms = if (isNewAab) newPermissions else oldPermissions
+            perms.forEach { perm ->
+              outputStream.println("uses-permission: name='$perm'")
+            }
+          }
+          "resources" -> {
+            // Return empty resource dump.
+          }
+          "badging" -> {
+            outputStream.println(
+              "package: name='org.oppia.android' versionCode='1' versionName='1.0'"
+            )
+          }
+        }
+        return@registerHandler 0
+      }
+      return@registerHandler 1
+    }
+  }
+
+  /** Creates a minimal valid APK (zip) byte array with basic structure. */
+  private fun createApkBytes(): ByteArray {
+    val baos = ByteArrayOutputStream()
+    ZipOutputStream(baos).use { zipOut ->
+      zipOut.putNextEntry(ZipEntry("AndroidManifest.xml"))
+      zipOut.write("<manifest/>".toByteArray())
+      zipOut.closeEntry()
+    }
+    return baos.toByteArray()
   }
 }

--- a/scripts/src/javatests/org/oppia/android/scripts/apkstats/ComputeAabDifferencesTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/apkstats/ComputeAabDifferencesTest.kt
@@ -623,10 +623,41 @@ class ComputeAabDifferencesTest {
     buildStats.writeSummariesTo(printStream, longSummary = false)
 
     val output = outputStream.toString()
-    assertThat(output).contains("# APK & AAB differences analysis")
-    assertThat(output).contains("Note that this is a summarized snapshot")
-    assertThat(output).contains("## Dev")
-    assertThat(output).contains("<details><summary>Expand to see flavor specifics</summary>")
+    assertThat(output).isEqualTo(
+      """
+      |# APK & AAB differences analysis
+      |Note that this is a summarized snapshot. See the CI artifacts for detailed differences.
+      |
+      |## Dev
+      |
+      |<details><summary>Expand to see flavor specifics</summary>
+      |
+      |### Universal APK
+      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |Method count: 0 (old), 0 (new), **0** (No change)
+      |
+      |Features: 0 (old), 0 (new), **0** (No change)
+      |
+      |Permissions: 0 (old), 0 (new), **0** (No change)
+      |
+      |Resources: 0 (old), 0 (new), **0** (No change)
+      |
+      |Lesson assets: 0 (old), 0 (new), **0** (No change)
+      |
+      |### AAB differences
+      |<details><summary>Expand to see AAB specifics</summary>
+      |
+      |Supported configurations:
+      |
+      |#### Base APK
+      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |</details></details>
+      |""".trimMargin()
+    )
   }
 
   @Test
@@ -640,11 +671,51 @@ class ComputeAabDifferencesTest {
     buildStats.writeSummariesTo(printStream, longSummary = true)
 
     val output = outputStream.toString()
-    assertThat(output).contains("# APK & AAB differences analysis")
-    assertThat(output).doesNotContain("Note that this is a summarized snapshot")
-    assertThat(output).contains("## Dev")
-    assertThat(output).doesNotContain("<details>")
-    assertThat(output).contains("*Detailed file differences:*")
+    assertThat(output).isEqualTo(
+      """
+      |# APK & AAB differences analysis
+      |
+      |## Dev
+      |
+      |### Universal APK
+      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |Method count: 0 (old), 0 (new), **0** (No change)
+      |
+      |Features: 0 (old), 0 (new), **0** (No change)
+      |
+      |Permissions: 0 (old), 0 (new), **0** (No change)
+      |
+      |Resources: 0 (old), 0 (new), **0** (No change)
+      |
+      |Lesson assets: 0 (old), 0 (new), **0** (No change)
+      |
+      |*Detailed file differences:*
+      |
+      |### AAB differences
+      |Supported configurations:
+      |
+      |#### Base APK
+      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |Method count: 0 (old), 0 (new), **0** (No change)
+      |
+      |Features: 0 (old), 0 (new), **0** (No change)
+      |
+      |Permissions: 0 (old), 0 (new), **0** (No change)
+      |
+      |Resources: 0 (old), 0 (new), **0** (No change)
+      |
+      |Lesson assets: 0 (old), 0 (new), **0** (No change)
+      |
+      |*Detailed file differences:*
+      |
+      |""".trimMargin()
+    )
   }
 
   @Test
@@ -661,10 +732,70 @@ class ComputeAabDifferencesTest {
     buildStats.writeSummariesTo(printStream, longSummary = false)
 
     val output = outputStream.toString()
-    assertThat(output).contains("# APK & AAB differences analysis")
-    assertThat(output).contains("## Dev")
-    assertThat(output).contains("## Alpha")
-    assertThat(output).contains("Note that this is a summarized snapshot")
+    assertThat(output).isEqualTo(
+      """
+      |# APK & AAB differences analysis
+      |Note that this is a summarized snapshot. See the CI artifacts for detailed differences.
+      |
+      |## Dev
+      |
+      |<details><summary>Expand to see flavor specifics</summary>
+      |
+      |### Universal APK
+      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |Method count: 0 (old), 0 (new), **0** (No change)
+      |
+      |Features: 0 (old), 0 (new), **0** (No change)
+      |
+      |Permissions: 0 (old), 0 (new), **0** (No change)
+      |
+      |Resources: 0 (old), 0 (new), **0** (No change)
+      |
+      |Lesson assets: 0 (old), 0 (new), **0** (No change)
+      |
+      |### AAB differences
+      |<details><summary>Expand to see AAB specifics</summary>
+      |
+      |Supported configurations:
+      |
+      |#### Base APK
+      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |</details></details>
+      |
+      |## Alpha
+      |
+      |<details><summary>Expand to see flavor specifics</summary>
+      |
+      |### Universal APK
+      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |Method count: 0 (old), 0 (new), **0** (No change)
+      |
+      |Features: 0 (old), 0 (new), **0** (No change)
+      |
+      |Permissions: 0 (old), 0 (new), **0** (No change)
+      |
+      |Resources: 0 (old), 0 (new), **0** (No change)
+      |
+      |Lesson assets: 0 (old), 0 (new), **0** (No change)
+      |
+      |### AAB differences
+      |<details><summary>Expand to see AAB specifics</summary>
+      |
+      |Supported configurations:
+      |
+      |#### Base APK
+      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |</details></details>
+      |""".trimMargin()
+    )
   }
 
   @Test
@@ -681,11 +812,105 @@ class ComputeAabDifferencesTest {
     buildStats.writeSummariesTo(printStream, longSummary = true)
 
     val output = outputStream.toString()
-    assertThat(output).contains("# APK & AAB differences analysis")
-    assertThat(output).doesNotContain("Note that this is a summarized snapshot")
-    assertThat(output).contains("## Dev")
-    assertThat(output).contains("## Alpha")
-    assertThat(output).doesNotContain("<details>")
+    assertThat(output).isEqualTo(
+      """
+      |# APK & AAB differences analysis
+      |
+      |## Dev
+      |
+      |### Universal APK
+      |APK file size: 1000 bytes (old), 2000 bytes (new), **1000 bytes** (Added)
+      |
+      |APK download size (estimated): 500 bytes (old), 800 bytes (new), **300 bytes** (Added)
+      |
+      |Method count: 5000 (old), 5500 (new), **500** (Added)
+      |
+      |Features: 1 (old), 2 (new), **1** (Added):
+      |- nfc (added)
+      |
+      |Permissions: 1 (old), 3 (new), **2** (Added):
+      |- android.permission.CAMERA (added)
+      |- android.permission.WRITE_EXTERNAL_STORAGE (added)
+      |
+      |Resources: 4 (old), 4 (new), **0** (No change)
+      |- String: 2 (old), 3 (new), **1** (Added):
+      |  - new_string (added)
+      |- Drawable: 2 (old), 1 (new), **1** (Removed):
+      |  - ic_bg (removed)
+      |
+      |Lesson assets: 1 (old), 3 (new), **2** (Added):
+      |- lesson2.json (added)
+      |- lesson3.json (added)
+      |
+      |*Detailed file differences:*
+      |1000${'\t'}2000${'\t'}1000${'\t'}/res/layout/activity_main.xml
+      |500${'\t'}0${'\t'}-500${'\t'}/res/drawable/ic_bg.png
+      |
+      |### AAB differences
+      |Supported configurations:
+      |- hdpi (same)
+      |- xhdpi (same)
+      |- xxhdpi (added)
+      |
+      |#### Base APK
+      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |Method count: 0 (old), 0 (new), **0** (No change)
+      |
+      |Features: 0 (old), 0 (new), **0** (No change)
+      |
+      |Permissions: 0 (old), 0 (new), **0** (No change)
+      |
+      |Resources: 0 (old), 0 (new), **0** (No change)
+      |
+      |Lesson assets: 0 (old), 0 (new), **0** (No change)
+      |
+      |*Detailed file differences:*
+      |
+      |
+      |## Alpha
+      |
+      |### Universal APK
+      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |Method count: 0 (old), 0 (new), **0** (No change)
+      |
+      |Features: 0 (old), 0 (new), **0** (No change)
+      |
+      |Permissions: 0 (old), 0 (new), **0** (No change)
+      |
+      |Resources: 0 (old), 0 (new), **0** (No change)
+      |
+      |Lesson assets: 0 (old), 0 (new), **0** (No change)
+      |
+      |*Detailed file differences:*
+      |
+      |### AAB differences
+      |Supported configurations:
+      |
+      |#### Base APK
+      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |
+      |Method count: 0 (old), 0 (new), **0** (No change)
+      |
+      |Features: 0 (old), 0 (new), **0** (No change)
+      |
+      |Permissions: 0 (old), 0 (new), **0** (No change)
+      |
+      |Resources: 0 (old), 0 (new), **0** (No change)
+      |
+      |Lesson assets: 0 (old), 0 (new), **0** (No change)
+      |
+      |*Detailed file differences:*
+      |
+      |""".trimMargin()
+    )
   }
 
   private fun createComputeAabDifferences(): ComputeAabDifferences {

--- a/scripts/src/javatests/org/oppia/android/scripts/apkstats/ComputeAabDifferencesTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/apkstats/ComputeAabDifferencesTest.kt
@@ -618,7 +618,7 @@ class ComputeAabDifferencesTest {
     val printStream = PrintStream(outputStream)
 
     val buildStats = ComputeAabDifferences.BuildStats(
-      aabStats = mapOf("dev" to createEmptyAabStats())
+      aabStats = mapOf("dev" to createAabStatsWithDiffs())
     )
     buildStats.writeSummariesTo(printStream, longSummary = false)
 
@@ -633,24 +633,36 @@ class ComputeAabDifferencesTest {
       |<details><summary>Expand to see flavor specifics</summary>
       |
       |### Universal APK
-      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |APK file size: 1000 bytes (old), 2000 bytes (new), **1000 bytes** (Added)
       |
-      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |APK download size (estimated): 500 bytes (old), 800 bytes (new), **300 bytes** (Added)
       |
-      |Method count: 0 (old), 0 (new), **0** (No change)
+      |Method count: 5000 (old), 5500 (new), **500** (Added)
       |
-      |Features: 0 (old), 0 (new), **0** (No change)
+      |Features: 1 (old), 2 (new), **1** (Added):
+      |- nfc (added)
       |
-      |Permissions: 0 (old), 0 (new), **0** (No change)
+      |Permissions: 1 (old), 3 (new), **2** (Added):
+      |- android.permission.CAMERA (added)
+      |- android.permission.WRITE_EXTERNAL_STORAGE (added)
       |
-      |Resources: 0 (old), 0 (new), **0** (No change)
+      |Resources: 4 (old), 4 (new), **0** (No change)
+      |- String: 2 (old), 3 (new), **1** (Added):
+      |  - new_string (added)
+      |- Drawable: 2 (old), 1 (new), **1** (Removed):
+      |  - ic_bg (removed)
       |
-      |Lesson assets: 0 (old), 0 (new), **0** (No change)
+      |Lesson assets: 1 (old), 3 (new), **2** (Added):
+      |- lesson2.json (added)
+      |- lesson3.json (added)
       |
       |### AAB differences
       |<details><summary>Expand to see AAB specifics</summary>
       |
       |Supported configurations:
+      |- hdpi (same)
+      |- xhdpi (same)
+      |- xxhdpi (added)
       |
       |#### Base APK
       |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
@@ -666,7 +678,7 @@ class ComputeAabDifferencesTest {
     val printStream = PrintStream(outputStream)
 
     val buildStats = ComputeAabDifferences.BuildStats(
-      aabStats = mapOf("dev" to createEmptyAabStats())
+      aabStats = mapOf("dev" to createAabStatsWithDiffs())
     )
     buildStats.writeSummariesTo(printStream, longSummary = true)
 
@@ -678,24 +690,38 @@ class ComputeAabDifferencesTest {
       |## Dev
       |
       |### Universal APK
-      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |APK file size: 1000 bytes (old), 2000 bytes (new), **1000 bytes** (Added)
       |
-      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |APK download size (estimated): 500 bytes (old), 800 bytes (new), **300 bytes** (Added)
       |
-      |Method count: 0 (old), 0 (new), **0** (No change)
+      |Method count: 5000 (old), 5500 (new), **500** (Added)
       |
-      |Features: 0 (old), 0 (new), **0** (No change)
+      |Features: 1 (old), 2 (new), **1** (Added):
+      |- nfc (added)
       |
-      |Permissions: 0 (old), 0 (new), **0** (No change)
+      |Permissions: 1 (old), 3 (new), **2** (Added):
+      |- android.permission.CAMERA (added)
+      |- android.permission.WRITE_EXTERNAL_STORAGE (added)
       |
-      |Resources: 0 (old), 0 (new), **0** (No change)
+      |Resources: 4 (old), 4 (new), **0** (No change)
+      |- String: 2 (old), 3 (new), **1** (Added):
+      |  - new_string (added)
+      |- Drawable: 2 (old), 1 (new), **1** (Removed):
+      |  - ic_bg (removed)
       |
-      |Lesson assets: 0 (old), 0 (new), **0** (No change)
+      |Lesson assets: 1 (old), 3 (new), **2** (Added):
+      |- lesson2.json (added)
+      |- lesson3.json (added)
       |
       |*Detailed file differences:*
+      |1000${'\t'}2000${'\t'}1000${'\t'}/res/layout/activity_main.xml
+      |500${'\t'}0${'\t'}-500${'\t'}/res/drawable/ic_bg.png
       |
       |### AAB differences
       |Supported configurations:
+      |- hdpi (same)
+      |- xhdpi (same)
+      |- xxhdpi (added)
       |
       |#### Base APK
       |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
@@ -725,8 +751,8 @@ class ComputeAabDifferencesTest {
 
     val buildStats = ComputeAabDifferences.BuildStats(
       aabStats = mapOf(
-        "dev" to createEmptyAabStats(),
-        "alpha" to createEmptyAabStats()
+        "dev" to createAabStatsWithDiffs(),
+        "alpha" to createAabStatsWithDiffs()
       )
     )
     buildStats.writeSummariesTo(printStream, longSummary = false)
@@ -742,24 +768,36 @@ class ComputeAabDifferencesTest {
       |<details><summary>Expand to see flavor specifics</summary>
       |
       |### Universal APK
-      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |APK file size: 1000 bytes (old), 2000 bytes (new), **1000 bytes** (Added)
       |
-      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |APK download size (estimated): 500 bytes (old), 800 bytes (new), **300 bytes** (Added)
       |
-      |Method count: 0 (old), 0 (new), **0** (No change)
+      |Method count: 5000 (old), 5500 (new), **500** (Added)
       |
-      |Features: 0 (old), 0 (new), **0** (No change)
+      |Features: 1 (old), 2 (new), **1** (Added):
+      |- nfc (added)
       |
-      |Permissions: 0 (old), 0 (new), **0** (No change)
+      |Permissions: 1 (old), 3 (new), **2** (Added):
+      |- android.permission.CAMERA (added)
+      |- android.permission.WRITE_EXTERNAL_STORAGE (added)
       |
-      |Resources: 0 (old), 0 (new), **0** (No change)
+      |Resources: 4 (old), 4 (new), **0** (No change)
+      |- String: 2 (old), 3 (new), **1** (Added):
+      |  - new_string (added)
+      |- Drawable: 2 (old), 1 (new), **1** (Removed):
+      |  - ic_bg (removed)
       |
-      |Lesson assets: 0 (old), 0 (new), **0** (No change)
+      |Lesson assets: 1 (old), 3 (new), **2** (Added):
+      |- lesson2.json (added)
+      |- lesson3.json (added)
       |
       |### AAB differences
       |<details><summary>Expand to see AAB specifics</summary>
       |
       |Supported configurations:
+      |- hdpi (same)
+      |- xhdpi (same)
+      |- xxhdpi (added)
       |
       |#### Base APK
       |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
@@ -771,24 +809,36 @@ class ComputeAabDifferencesTest {
       |<details><summary>Expand to see flavor specifics</summary>
       |
       |### Universal APK
-      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |APK file size: 1000 bytes (old), 2000 bytes (new), **1000 bytes** (Added)
       |
-      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |APK download size (estimated): 500 bytes (old), 800 bytes (new), **300 bytes** (Added)
       |
-      |Method count: 0 (old), 0 (new), **0** (No change)
+      |Method count: 5000 (old), 5500 (new), **500** (Added)
       |
-      |Features: 0 (old), 0 (new), **0** (No change)
+      |Features: 1 (old), 2 (new), **1** (Added):
+      |- nfc (added)
       |
-      |Permissions: 0 (old), 0 (new), **0** (No change)
+      |Permissions: 1 (old), 3 (new), **2** (Added):
+      |- android.permission.CAMERA (added)
+      |- android.permission.WRITE_EXTERNAL_STORAGE (added)
       |
-      |Resources: 0 (old), 0 (new), **0** (No change)
+      |Resources: 4 (old), 4 (new), **0** (No change)
+      |- String: 2 (old), 3 (new), **1** (Added):
+      |  - new_string (added)
+      |- Drawable: 2 (old), 1 (new), **1** (Removed):
+      |  - ic_bg (removed)
       |
-      |Lesson assets: 0 (old), 0 (new), **0** (No change)
+      |Lesson assets: 1 (old), 3 (new), **2** (Added):
+      |- lesson2.json (added)
+      |- lesson3.json (added)
       |
       |### AAB differences
       |<details><summary>Expand to see AAB specifics</summary>
       |
       |Supported configurations:
+      |- hdpi (same)
+      |- xhdpi (same)
+      |- xxhdpi (added)
       |
       |#### Base APK
       |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
@@ -806,7 +856,7 @@ class ComputeAabDifferencesTest {
     val buildStats = ComputeAabDifferences.BuildStats(
       aabStats = mapOf(
         "dev" to createAabStatsWithDiffs(),
-        "alpha" to createEmptyAabStats()
+        "alpha" to createAabStatsWithDiffs()
       )
     )
     buildStats.writeSummariesTo(printStream, longSummary = true)
@@ -873,24 +923,38 @@ class ComputeAabDifferencesTest {
       |## Alpha
       |
       |### Universal APK
-      |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |APK file size: 1000 bytes (old), 2000 bytes (new), **1000 bytes** (Added)
       |
-      |APK download size (estimated): 0 bytes (old), 0 bytes (new), **0 bytes** (No change)
+      |APK download size (estimated): 500 bytes (old), 800 bytes (new), **300 bytes** (Added)
       |
-      |Method count: 0 (old), 0 (new), **0** (No change)
+      |Method count: 5000 (old), 5500 (new), **500** (Added)
       |
-      |Features: 0 (old), 0 (new), **0** (No change)
+      |Features: 1 (old), 2 (new), **1** (Added):
+      |- nfc (added)
       |
-      |Permissions: 0 (old), 0 (new), **0** (No change)
+      |Permissions: 1 (old), 3 (new), **2** (Added):
+      |- android.permission.CAMERA (added)
+      |- android.permission.WRITE_EXTERNAL_STORAGE (added)
       |
-      |Resources: 0 (old), 0 (new), **0** (No change)
+      |Resources: 4 (old), 4 (new), **0** (No change)
+      |- String: 2 (old), 3 (new), **1** (Added):
+      |  - new_string (added)
+      |- Drawable: 2 (old), 1 (new), **1** (Removed):
+      |  - ic_bg (removed)
       |
-      |Lesson assets: 0 (old), 0 (new), **0** (No change)
+      |Lesson assets: 1 (old), 3 (new), **2** (Added):
+      |- lesson2.json (added)
+      |- lesson3.json (added)
       |
       |*Detailed file differences:*
+      |1000${'\t'}2000${'\t'}1000${'\t'}/res/layout/activity_main.xml
+      |500${'\t'}0${'\t'}-500${'\t'}/res/drawable/ic_bg.png
       |
       |### AAB differences
       |Supported configurations:
+      |- hdpi (same)
+      |- xhdpi (same)
+      |- xxhdpi (added)
       |
       |#### Base APK
       |APK file size: 0 bytes (old), 0 bytes (new), **0 bytes** (No change)


### PR DESCRIPTION
Fix part of #4971: Compute aab differences tests

## Explanation

Fixes part of #4971: Add remaining `ComputeAabDifferences` unit tests.

This PR implements the 12 missing unit tests for `ComputeAabDifferences` (tests 1–13 from the issue, with test 5 already existing). The tests are organized into three groups:

- **Tests 1–4 (`computeBuildStats`)**: Verify AAB stat computation for one/two profiles with same/different AABs, using `FakeCommandExecutor` to mock `bundletool` and `aapt2` commands.
- **Tests 6–9 (`writeSummaryTo`)**: Verify summary output formatting with various item limits and `longSummary` on/off, using directly constructed data classes.
- **Tests 10–13 (`BuildStats.writeSummariesTo`)**: Verify end-to-end summary generation for one/two profiles with short/long summaries.

A minimal production change was required: an optional `CommandExecutor` parameter was added to the `ComputeAabDifferences` constructor (defaulting to `CommandExecutorImpl`), following the same pattern used by `BundleToolClient` and `Aapt2Client`. This allows tests to inject `FakeCommandExecutor` for deterministic command mocking.

---

## Essential Checklist

- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's not called "develop" and is up-to-date with "develop".
- [x] The PR is assigned to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

---

## For UI-specific PRs only

Not applicable. This PR is entirely scoped to the `scripts/` layer. It adds unit tests and a minor constructor change to a build-time CLI utility (`ComputeAabDifferences`). No Android UI components, layouts, resources, activities, fragments, or user-facing elements are modified. No screenshots, accessibility recordings, or Espresso tests are required.