### PR TITLE
Fix #5895: Support feature flag toggling in StateFragmentTest

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5830,6 +5830,34 @@ class StateFragmentTest {
   }
 
   @Test
+  fun testFlashback_featureFlagOff_thenFeatureFlagOn() {
+    // Start with feature flag disabled
+    executeInPreviousAppInstance {
+      TestPlatformParameterModule.forceEnableFlashbackSupport(false)
+    }
+    
+    // Enable feature flag and continue exploration
+    setUpTestWithFlashbackFeatureOn()
+    launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
+      startPlayingExploration()
+      
+      // Submit wrong answer.
+      playThroughPrototypeState1()
+      playThroughPrototypeState2()
+      playThroughPrototypeState3()
+      playThroughPrototypeState4()
+      playThroughPrototypeState5()
+      playThroughPrototypeState6()
+      typeRatioExpression("4:8")
+      clickSubmitAnswerButton()
+      
+      // Verify flashback button is visible.
+      scrollToViewType(FLASHBACK_BUTTON)
+      onView(withId(R.id.flashback_button)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
   fun testStateFragment_submitMultipleChoiceAnswer_verifyMultipleChoiceSubmittedAnswer() {
     setUpTestWithFlashbackFeatureOn()
     launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
@@ -7074,6 +7102,27 @@ class StateFragmentTest {
     fun isOnRobolectric(): Boolean
   }
 
+  /**
+   * Creates a separate test application component and executes the specified block. This should be
+   * called before setUpTestApplicationComponent to avoid undefined behavior in production code.
+   * This can be used to simulate arranging state in a "prior" run of the app.
+   *
+   * Note that only dependencies fetched from the specified [TestApplicationComponent] should be
+   * used, not any class-level injected dependencies.
+   */
+  private fun executeInPreviousAppInstance(block: (TestApplicationComponent) -> Unit) {
+    val testApplication = TestApplication()
+    // The true application is hooked as a base context. This is to make sure the new application
+    // can behave like a real Android application class (per Robolectric) without having a shared
+    // Dagger dependency graph with the application under test.
+    testApplication.attachBaseContext(ApplicationProvider.getApplicationContext())
+    block(
+      DaggerStateFragmentTest_TestApplicationComponent.builder()
+        .setApplication(testApplication)
+        .build()
+    )
+  }
+
   class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {
     private val component: TestApplicationComponent by lazy {
       DaggerStateFragmentTest_TestApplicationComponent.builder()
@@ -7087,6 +7136,10 @@ class StateFragmentTest {
 
     override fun createActivityComponent(activity: AppCompatActivity): ActivityComponent {
       return component.getActivityComponentBuilderProvider().get().setActivity(activity).build()
+    }
+
+    public override fun attachBaseContext(base: Context?) {
+      super.attachBaseContext(base)
     }
 
     override fun getApplicationInjector(): ApplicationInjector = component

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5833,7 +5833,7 @@ class StateFragmentTest {
   @Test
   fun testFlashback_featureFlagOff_thenFeatureFlagOn() {
     // Simulate previous app instance with feature flag disabled.
-    executeInPreviousAppInstance {
+    executeInPreviousAppInstance { _ ->
       TestPlatformParameterModule.forceEnableFlashbackSupport(false)
     }
 
@@ -5856,7 +5856,7 @@ class StateFragmentTest {
   @Test
   fun testFlashback_featureFlagOff_thenFeatureFlagOn_flashbackButtonShown() {
     // Simulate previous app instance with feature flag disabled.
-    executeInPreviousAppInstance {
+    executeInPreviousAppInstance { _ ->
       TestPlatformParameterModule.forceEnableFlashbackSupport(false)
     }
 
@@ -5880,7 +5880,7 @@ class StateFragmentTest {
   @Test
   fun testFlashback_featureFlagOn_persistsAcrossAppInstances() {
     // Simulate previous app instance with feature flag enabled.
-    executeInPreviousAppInstance {
+    executeInPreviousAppInstance { _ ->
       TestPlatformParameterModule.forceEnableFlashbackSupport(true)
     }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5832,19 +5832,22 @@ class StateFragmentTest {
 
   @Test
   fun testFlashback_featureFlagOff_thenFeatureFlagOn() {
+    setUpTest()
     executeInPreviousAppInstance { _ ->
       TestPlatformParameterModule.forceEnableFlashbackSupport(false)
 
-      startPlayingExploration()
+      launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
+        startPlayingExploration()
 
-      navigateToPrototypeRatioInputState()
+        navigateToPrototypeRatioInputState()
 
-      // Submit wrong answer.
-      typeRatioExpression("4:8")
-      clickSubmitAnswerButton()
+        // Submit wrong answer.
+        typeRatioExpression("4:8")
+        clickSubmitAnswerButton()
 
-      // Verify flashback button is NOT shown.
-      onView(withId(R.id.flashback_button)).check(doesNotExist())
+        // Verify flashback button is NOT shown.
+        onView(withId(R.id.flashback_button)).check(doesNotExist())
+      }
     }
 
     // In the current app instance, keep feature flag on and verify button is shown.
@@ -5866,23 +5869,25 @@ class StateFragmentTest {
     }
   }
 
-
   @Test
   fun testFlashback_featureFlagOn_persistsAcrossAppInstances() {
+    setUpTest()
     executeInPreviousAppInstance { _ ->
       TestPlatformParameterModule.forceEnableFlashbackSupport(true)
 
-      startPlayingExploration()
+      launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
+        startPlayingExploration()
 
-      navigateToPrototypeRatioInputState()
+        navigateToPrototypeRatioInputState()
 
-      // Submit wrong answer.
-      typeRatioExpression("4:8")
-      clickSubmitAnswerButton()
+        // Submit wrong answer.
+        typeRatioExpression("4:8")
+        clickSubmitAnswerButton()
 
-      // Verify flashback button IS shown.
-      scrollToViewType(FLASHBACK_BUTTON)
-      onView(withId(R.id.flashback_button)).check(matches(isDisplayed()))
+        // Verify flashback button IS shown.
+        scrollToViewType(FLASHBACK_BUTTON)
+        onView(withId(R.id.flashback_button)).check(matches(isDisplayed()))
+      }
     }
 
     // In the current app instance, feature flag should still be on.
@@ -5909,7 +5914,6 @@ class StateFragmentTest {
       startPlayingExploration()
       playThroughPrototypeState1()
       playThroughPrototypeState2()
-
       // Submit Multiple choice answer.
       selectMultipleChoiceOption(optionPosition = 2, expectedOptionText = "Eagle")
       clickSubmitAnswerButton()

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5832,25 +5832,11 @@ class StateFragmentTest {
 
   @Test
   fun testFlashback_featureFlagOff_thenFeatureFlagOn() {
-    setUpTest()
-    executeInPreviousAppInstance { _ ->
-      TestPlatformParameterModule.forceEnableFlashbackSupport(false)
+    // Set up the previous app instance with the flashback feature flag OFF.
+    TestPlatformParameterModule.forceEnableFlashbackSupport(false)
+    executeInPreviousAppInstance { _ -> }
 
-      launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
-        startPlayingExploration()
-
-        navigateToPrototypeRatioInputState()
-
-        // Submit wrong answer.
-        typeRatioExpression("4:8")
-        clickSubmitAnswerButton()
-
-        // Verify flashback button is NOT shown.
-        onView(withId(R.id.flashback_button)).check(doesNotExist())
-      }
-    }
-
-    // In the current app instance, keep feature flag on and verify button is shown.
+    // In the current app instance, enable the feature flag and verify flashback button is shown.
     setUpTestWithFlashbackFeatureOn()
     launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
       startPlayingExploration()
@@ -5871,26 +5857,11 @@ class StateFragmentTest {
 
   @Test
   fun testFlashback_featureFlagOn_persistsAcrossAppInstances() {
-    setUpTest()
-    executeInPreviousAppInstance { _ ->
-      TestPlatformParameterModule.forceEnableFlashbackSupport(true)
+    // Set up the previous app instance with the flashback feature flag ON.
+    TestPlatformParameterModule.forceEnableFlashbackSupport(true)
+    executeInPreviousAppInstance { _ -> }
 
-      launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
-        startPlayingExploration()
-
-        navigateToPrototypeRatioInputState()
-
-        // Submit wrong answer.
-        typeRatioExpression("4:8")
-        clickSubmitAnswerButton()
-
-        // Verify flashback button IS shown.
-        scrollToViewType(FLASHBACK_BUTTON)
-        onView(withId(R.id.flashback_button)).check(matches(isDisplayed()))
-      }
-    }
-
-    // In the current app instance, feature flag should still be on.
+    // In the current app instance, flag should still be on.
     setUpTestWithFlashbackFeatureOn()
     launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
       startPlayingExploration()

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5833,8 +5833,9 @@ class StateFragmentTest {
   @Test
   fun testFlashback_featureFlagOff_thenFeatureFlagOn() {
     // Simulate previous app instance with feature flag disabled.
+    TestPlatformParameterModule.forceEnableFlashbackSupport(false)
     executeInPreviousAppInstance { _ ->
-      TestPlatformParameterModule.forceEnableFlashbackSupport(false)
+      // No additional state needs to be arranged since the flag is already disabled.
     }
 
     // In the current app instance, keep feature flag off and verify button is not shown.
@@ -5856,8 +5857,9 @@ class StateFragmentTest {
   @Test
   fun testFlashback_featureFlagOff_thenFeatureFlagOn_flashbackButtonShown() {
     // Simulate previous app instance with feature flag disabled.
+    TestPlatformParameterModule.forceEnableFlashbackSupport(false)
     executeInPreviousAppInstance { _ ->
-      TestPlatformParameterModule.forceEnableFlashbackSupport(false)
+      // No additional state needs to be arranged since the flag is already disabled.
     }
 
     // In the current app instance, enable feature flag and verify button is shown.
@@ -5880,8 +5882,9 @@ class StateFragmentTest {
   @Test
   fun testFlashback_featureFlagOn_persistsAcrossAppInstances() {
     // Simulate previous app instance with feature flag enabled.
+    TestPlatformParameterModule.forceEnableFlashbackSupport(true)
     executeInPreviousAppInstance { _ ->
-      TestPlatformParameterModule.forceEnableFlashbackSupport(true)
+      // No additional state needs to be arranged since the flag is already enabled.
     }
 
     // In the current app instance, feature flag should still be on.
@@ -7165,6 +7168,10 @@ class StateFragmentTest {
         .setApplication(testApplication)
         .build()
     )
+
+    // Resetting after the previous instance is important so that the next (main) app instance
+    // can set its own flags.
+    TestPlatformParameterModule.reset()
   }
 
   class TestApplication : Application(), ActivityComponentFactory, ApplicationInjectorProvider {

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5832,15 +5832,9 @@ class StateFragmentTest {
 
   @Test
   fun testFlashback_featureFlagOff_thenFeatureFlagOn() {
-    // Simulate previous app instance with feature flag disabled.
-    TestPlatformParameterModule.forceEnableFlashbackSupport(false)
     executeInPreviousAppInstance { _ ->
-      // No additional state needs to be arranged since the flag is already disabled.
-    }
+      TestPlatformParameterModule.forceEnableFlashbackSupport(false)
 
-    // In the current app instance, keep feature flag off and verify button is not shown.
-    setUpTestWithFlashbackFeatureOff()
-    launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
       startPlayingExploration()
 
       navigateToPrototypeRatioInputState()
@@ -5849,20 +5843,11 @@ class StateFragmentTest {
       typeRatioExpression("4:8")
       clickSubmitAnswerButton()
 
-      // Verify flashback button is NOT shown (flag is off).
+      // Verify flashback button is NOT shown.
       onView(withId(R.id.flashback_button)).check(doesNotExist())
     }
-  }
 
-  @Test
-  fun testFlashback_featureFlagOff_thenFeatureFlagOn_flashbackButtonShown() {
-    // Simulate previous app instance with feature flag disabled.
-    TestPlatformParameterModule.forceEnableFlashbackSupport(false)
-    executeInPreviousAppInstance { _ ->
-      // No additional state needs to be arranged since the flag is already disabled.
-    }
-
-    // In the current app instance, enable feature flag and verify button is shown.
+    // In the current app instance, keep feature flag on and verify button is shown.
     setUpTestWithFlashbackFeatureOn()
     launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
       startPlayingExploration()
@@ -5873,18 +5858,31 @@ class StateFragmentTest {
       typeRatioExpression("4:8")
       clickSubmitAnswerButton()
 
-      // Verify flashback button IS shown (flag was toggled on).
+      // Verify flashback button is visible.
       scrollToViewType(FLASHBACK_BUTTON)
-      onView(withId(R.id.flashback_button)).check(matches(isDisplayed()))
+      onView(withId(R.id.flashback_button)).check(
+        matches(withText(R.string.state_flashback_button))
+      )
     }
   }
 
+
   @Test
   fun testFlashback_featureFlagOn_persistsAcrossAppInstances() {
-    // Simulate previous app instance with feature flag enabled.
-    TestPlatformParameterModule.forceEnableFlashbackSupport(true)
     executeInPreviousAppInstance { _ ->
-      // No additional state needs to be arranged since the flag is already enabled.
+      TestPlatformParameterModule.forceEnableFlashbackSupport(true)
+
+      startPlayingExploration()
+
+      navigateToPrototypeRatioInputState()
+
+      // Submit wrong answer.
+      typeRatioExpression("4:8")
+      clickSubmitAnswerButton()
+
+      // Verify flashback button IS shown.
+      scrollToViewType(FLASHBACK_BUTTON)
+      onView(withId(R.id.flashback_button)).check(matches(isDisplayed()))
     }
 
     // In the current app instance, feature flag should still be on.

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5831,27 +5831,70 @@ class StateFragmentTest {
 
   @Test
   fun testFlashback_featureFlagOff_thenFeatureFlagOn() {
-    // Start with feature flag disabled
+    // Simulate previous app instance with feature flag disabled.
     executeInPreviousAppInstance {
       TestPlatformParameterModule.forceEnableFlashbackSupport(false)
     }
-    
-    // Enable feature flag and continue exploration
+
+    // In the current app instance, keep feature flag off and verify button is not shown.
+    setUpTestWithFlashbackFeatureOff()
+    launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
+      startPlayingExploration()
+
+      navigateToPrototypeRatioInputState()
+
+      // Submit wrong answer.
+      typeRatioExpression("4:8")
+      clickSubmitAnswerButton()
+
+      // Verify flashback button is NOT shown (flag is off).
+      onView(withId(R.id.flashback_button)).check(doesNotExist())
+    }
+  }
+
+  @Test
+  fun testFlashback_featureFlagOff_thenFeatureFlagOn_flashbackButtonShown() {
+    // Simulate previous app instance with feature flag disabled.
+    executeInPreviousAppInstance {
+      TestPlatformParameterModule.forceEnableFlashbackSupport(false)
+    }
+
+    // In the current app instance, enable feature flag and verify button is shown.
     setUpTestWithFlashbackFeatureOn()
     launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
       startPlayingExploration()
-      
+
+      navigateToPrototypeRatioInputState()
+
       // Submit wrong answer.
-      playThroughPrototypeState1()
-      playThroughPrototypeState2()
-      playThroughPrototypeState3()
-      playThroughPrototypeState4()
-      playThroughPrototypeState5()
-      playThroughPrototypeState6()
       typeRatioExpression("4:8")
       clickSubmitAnswerButton()
-      
-      // Verify flashback button is visible.
+
+      // Verify flashback button IS shown (flag was toggled on).
+      scrollToViewType(FLASHBACK_BUTTON)
+      onView(withId(R.id.flashback_button)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testFlashback_featureFlagOn_persistsAcrossAppInstances() {
+    // Simulate previous app instance with feature flag enabled.
+    executeInPreviousAppInstance {
+      TestPlatformParameterModule.forceEnableFlashbackSupport(true)
+    }
+
+    // In the current app instance, feature flag should still be on.
+    setUpTestWithFlashbackFeatureOn()
+    launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
+      startPlayingExploration()
+
+      navigateToPrototypeRatioInputState()
+
+      // Submit wrong answer.
+      typeRatioExpression("4:8")
+      clickSubmitAnswerButton()
+
+      // Verify flashback button IS shown (flag persisted across app instances).
       scrollToViewType(FLASHBACK_BUTTON)
       onView(withId(R.id.flashback_button)).check(matches(isDisplayed()))
     }

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5832,21 +5832,12 @@ class StateFragmentTest {
 
   @Test
   fun testFlashback_featureFlagOff_thenFeatureFlagOn() {
+    // In the previous app instance, the flashback feature flag is OFF.
     executeInPreviousAppInstance(
       preSetup = { TestPlatformParameterModule.forceEnableFlashbackSupport(false) }
-    ) { _ ->
-      launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
-        startPlayingExploration()
-        navigateToPrototypeRatioInputState()
-        // Submit wrong answer.
-        typeRatioExpression("4:8")
-        clickSubmitAnswerButton()
-        // Verify flashback button is NOT shown.
-        onView(withId(R.id.flashback_button)).check(doesNotExist())
-      }
-    }
+    ) { _ -> }
 
-    // In the current app instance, keep feature flag on and verify button is shown.
+    // In the current app instance, enable the feature flag and verify flashback button is shown.
     setUpTestWithFlashbackFeatureOn()
     launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
       startPlayingExploration()
@@ -5864,20 +5855,10 @@ class StateFragmentTest {
 
   @Test
   fun testFlashback_featureFlagOn_persistsAcrossAppInstances() {
+    // In the previous app instance, the flashback feature flag is ON.
     executeInPreviousAppInstance(
       preSetup = { TestPlatformParameterModule.forceEnableFlashbackSupport(true) }
-    ) { _ ->
-      launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
-        startPlayingExploration()
-        navigateToPrototypeRatioInputState()
-        // Submit wrong answer.
-        typeRatioExpression("4:8")
-        clickSubmitAnswerButton()
-        // Verify flashback button IS shown (flag set in previous instance).
-        scrollToViewType(FLASHBACK_BUTTON)
-        onView(withId(R.id.flashback_button)).check(matches(isDisplayed()))
-      }
-    }
+    ) { _ -> }
 
     // In the current app instance, flag should still be on.
     setUpTestWithFlashbackFeatureOn()
@@ -7146,9 +7127,8 @@ class StateFragmentTest {
    * feature flags via [TestPlatformParameterModule]) to be configured so that the previous app
    * instance's component is initialized with the correct values.
    *
-   * The [block] receives the built [TestApplicationComponent] and may use class-level injected
-   * dependencies (since this method injects them from the previous component) to perform UI
-   * operations such as launching activities and verifying state.
+   * Note that only dependencies fetched from the specified [TestApplicationComponent] should be
+   * used, not any class-level injected dependencies.
    */
   private fun executeInPreviousAppInstance(
     preSetup: () -> Unit = {},
@@ -7160,14 +7140,11 @@ class StateFragmentTest {
     // Dagger dependency graph with the application under test.
     testApplication.attachBaseContext(ApplicationProvider.getApplicationContext())
     preSetup()
-    val component = DaggerStateFragmentTest_TestApplicationComponent.builder()
-      .setApplication(testApplication)
-      .build()
-    component.inject(this)
-    testCoroutineDispatchers.registerIdlingResource()
-    profileTestHelper.initializeProfiles()
-    block(component)
-    testCoroutineDispatchers.unregisterIdlingResource()
+    block(
+      DaggerStateFragmentTest_TestApplicationComponent.builder()
+        .setApplication(testApplication)
+        .build()
+    )
 
     // Resetting after the previous instance is important so that the next (main) app instance
     // can set its own flags.

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5832,22 +5832,28 @@ class StateFragmentTest {
 
   @Test
   fun testFlashback_featureFlagOff_thenFeatureFlagOn() {
-    // In the previous app instance, the flashback feature flag is OFF.
-    executeInPreviousAppInstance { _ ->
-      TestPlatformParameterModule.forceEnableFlashbackSupport(false)
+    executeInPreviousAppInstance(
+      preSetup = { TestPlatformParameterModule.forceEnableFlashbackSupport(false) }
+    ) { _ ->
+      launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
+        startPlayingExploration()
+        navigateToPrototypeRatioInputState()
+        // Submit wrong answer.
+        typeRatioExpression("4:8")
+        clickSubmitAnswerButton()
+        // Verify flashback button is NOT shown.
+        onView(withId(R.id.flashback_button)).check(doesNotExist())
+      }
     }
 
-    // In the current app instance, enable the feature flag and verify flashback button is shown.
+    // In the current app instance, keep feature flag on and verify button is shown.
     setUpTestWithFlashbackFeatureOn()
     launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
       startPlayingExploration()
-
       navigateToPrototypeRatioInputState()
-
       // Submit wrong answer.
       typeRatioExpression("4:8")
       clickSubmitAnswerButton()
-
       // Verify flashback button is visible.
       scrollToViewType(FLASHBACK_BUTTON)
       onView(withId(R.id.flashback_button)).check(
@@ -5858,22 +5864,29 @@ class StateFragmentTest {
 
   @Test
   fun testFlashback_featureFlagOn_persistsAcrossAppInstances() {
-    // In the previous app instance, the flashback feature flag is ON.
-    executeInPreviousAppInstance { _ ->
-      TestPlatformParameterModule.forceEnableFlashbackSupport(true)
+    executeInPreviousAppInstance(
+      preSetup = { TestPlatformParameterModule.forceEnableFlashbackSupport(true) }
+    ) { _ ->
+      launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
+        startPlayingExploration()
+        navigateToPrototypeRatioInputState()
+        // Submit wrong answer.
+        typeRatioExpression("4:8")
+        clickSubmitAnswerButton()
+        // Verify flashback button IS shown (flag set in previous instance).
+        scrollToViewType(FLASHBACK_BUTTON)
+        onView(withId(R.id.flashback_button)).check(matches(isDisplayed()))
+      }
     }
 
     // In the current app instance, flag should still be on.
     setUpTestWithFlashbackFeatureOn()
     launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
       startPlayingExploration()
-
       navigateToPrototypeRatioInputState()
-
       // Submit wrong answer.
       typeRatioExpression("4:8")
       clickSubmitAnswerButton()
-
       // Verify flashback button IS shown (flag persisted across app instances).
       scrollToViewType(FLASHBACK_BUTTON)
       onView(withId(R.id.flashback_button)).check(matches(isDisplayed()))
@@ -7129,20 +7142,32 @@ class StateFragmentTest {
    * called before setUpTestApplicationComponent to avoid undefined behavior in production code.
    * This can be used to simulate arranging state in a "prior" run of the app.
    *
-   * Note that only dependencies fetched from the specified [TestApplicationComponent] should be
-   * used, not any class-level injected dependencies.
+   * The optional [preSetup] lambda runs before the component is built, allowing flags (e.g.
+   * feature flags via [TestPlatformParameterModule]) to be configured so that the previous app
+   * instance's component is initialized with the correct values.
+   *
+   * The [block] receives the built [TestApplicationComponent] and may use class-level injected
+   * dependencies (since this method injects them from the previous component) to perform UI
+   * operations such as launching activities and verifying state.
    */
-  private fun executeInPreviousAppInstance(block: (TestApplicationComponent) -> Unit) {
+  private fun executeInPreviousAppInstance(
+    preSetup: () -> Unit = {},
+    block: (TestApplicationComponent) -> Unit
+  ) {
     val testApplication = TestApplication()
     // The true application is hooked as a base context. This is to make sure the new application
     // can behave like a real Android application class (per Robolectric) without having a shared
     // Dagger dependency graph with the application under test.
     testApplication.attachBaseContext(ApplicationProvider.getApplicationContext())
-    block(
-      DaggerStateFragmentTest_TestApplicationComponent.builder()
-        .setApplication(testApplication)
-        .build()
-    )
+    preSetup()
+    val component = DaggerStateFragmentTest_TestApplicationComponent.builder()
+      .setApplication(testApplication)
+      .build()
+    component.inject(this)
+    testCoroutineDispatchers.registerIdlingResource()
+    profileTestHelper.initializeProfiles()
+    block(component)
+    testCoroutineDispatchers.unregisterIdlingResource()
 
     // Resetting after the previous instance is important so that the next (main) app instance
     // can set its own flags.

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5832,9 +5832,10 @@ class StateFragmentTest {
 
   @Test
   fun testFlashback_featureFlagOff_thenFeatureFlagOn() {
-    // Set up the previous app instance with the flashback feature flag OFF.
-    TestPlatformParameterModule.forceEnableFlashbackSupport(false)
-    executeInPreviousAppInstance { _ -> }
+    // In the previous app instance, the flashback feature flag is OFF.
+    executeInPreviousAppInstance { _ ->
+      TestPlatformParameterModule.forceEnableFlashbackSupport(false)
+    }
 
     // In the current app instance, enable the feature flag and verify flashback button is shown.
     setUpTestWithFlashbackFeatureOn()
@@ -5857,9 +5858,10 @@ class StateFragmentTest {
 
   @Test
   fun testFlashback_featureFlagOn_persistsAcrossAppInstances() {
-    // Set up the previous app instance with the flashback feature flag ON.
-    TestPlatformParameterModule.forceEnableFlashbackSupport(true)
-    executeInPreviousAppInstance { _ -> }
+    // In the previous app instance, the flashback feature flag is ON.
+    executeInPreviousAppInstance { _ ->
+      TestPlatformParameterModule.forceEnableFlashbackSupport(true)
+    }
 
     // In the current app instance, flag should still be on.
     setUpTestWithFlashbackFeatureOn()


### PR DESCRIPTION
## Explanation

Fixes #5895 
 Support feature flag toggling in StateFragmentTest

This PR implements support for feature flag toggling mid-session within `StateFragmentTest`. The changes follow the approach approved in the issue:

* Moved `executeInPreviousAppInstance` into `StateFragmentTest`.
* Updated the internal `TestApplication` to override `attachBaseContext`.
* Added a new test (`testFlashback_featureFlagOff_thenFeatureFlagOn`) to verify the feature flag change mid-session. This test confirms that the flashback button successfully becomes visible after enabling the flag.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only

Not applicable. This PR is entirely scoped to test infrastructure and unit/instrumentation tests (`StateFragmentTest`). It adds support for feature flag toggling during tests. No production Android UI components, layouts, or user-facing elements are modified. No screenshots, accessibility recordings, or UI-specific manual checks are required.