### PR TITLE
 Fix #6086: Add transparent image detection and math tag validation

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/assets/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/assets/BUILD.bazel
@@ -51,5 +51,9 @@ kt_jvm_library(
     name = "image_repairer",
     testonly = True,
     srcs = ["ImageRepairer.kt"],
+    visibility = [
+        "//scripts/src/java/org/oppia/android/scripts/assets:__pkg__",
+        "//scripts/src/javatests/org/oppia/android/scripts/assets:__pkg__",
+    ],
     deps = ["//third_party:com_github_weisj_jsvg"],
 )

--- a/scripts/src/java/org/oppia/android/scripts/assets/DownloadLessons.kt
+++ b/scripts/src/java/org/oppia/android/scripts/assets/DownloadLessons.kt
@@ -699,8 +699,6 @@ class LessonDownloader(
     )
     println("- ${translationIssues.size}/${issues.size} correspond to missing translations")
     println()
-    println("Note: Transparent image detection and math tag validation are performed separately.")
-    println()
     println("Images with invalid extensions:")
     imageInvalidExtIssues.groupBy { it.container }.forEach { (container, issues) ->
       println("- Within ${container.referenceString}:")
@@ -775,8 +773,11 @@ class LessonDownloader(
     val transparentImages = memoizedLoadedImageData.filter { (file, data) ->
       imageRepairer.hasTransparentPixels(data, file.extension)
     }.keys.toList()
+    println()
+    println(
+      "Transparent image check: ${transparentImages.size} image(s) found with transparency."
+    )
     if (transparentImages.isNotEmpty()) {
-      println()
       println("Images with transparent pixels (may cause dark mode visibility issues):")
       transparentImages.forEach { file ->
         println("- ${file.name}")

--- a/scripts/src/java/org/oppia/android/scripts/assets/DownloadLessons.kt
+++ b/scripts/src/java/org/oppia/android/scripts/assets/DownloadLessons.kt
@@ -699,6 +699,8 @@ class LessonDownloader(
     )
     println("- ${translationIssues.size}/${issues.size} correspond to missing translations")
     println()
+    println("Note: Transparent image detection and math tag validation are performed separately.")
+    println()
     println("Images with invalid extensions:")
     imageInvalidExtIssues.groupBy { it.container }.forEach { (container, issues) ->
       println("- Within ${container.referenceString}:")
@@ -770,6 +772,17 @@ class LessonDownloader(
       }
     }
 
+    val transparentImages = memoizedLoadedImageData.filter { (file, data) ->
+      imageRepairer.hasTransparentPixels(data, file.extension)
+    }.keys.toList()
+    if (transparentImages.isNotEmpty()) {
+      println()
+      println("Images with transparent pixels (may cause dark mode visibility issues):")
+      transparentImages.forEach { file ->
+        println("- ${file.name}")
+      }
+    }
+
     if (renamedImages.isNotEmpty() || convertedImages.isNotEmpty()) {
       println("WARNING: Images needed to be auto-fixed. Please verify that they are correct")
       println("(look at above output for specific images that require verification).")
@@ -777,7 +790,8 @@ class LessonDownloader(
 
     val hasAnyFailure = (
       issues.isNotEmpty() || imageDownloadFailures.isNotEmpty() ||
-        renamedImages.isNotEmpty() || convertedImages.isNotEmpty()
+        renamedImages.isNotEmpty() || convertedImages.isNotEmpty() ||
+        transparentImages.isNotEmpty()
       )
     if (hasAnyFailure && failOnError) {
       throw Exception(

--- a/scripts/src/java/org/oppia/android/scripts/assets/ImageRepairer.kt
+++ b/scripts/src/java/org/oppia/android/scripts/assets/ImageRepairer.kt
@@ -50,16 +50,6 @@ class ImageRepairer {
     return areImagesEqual(image1, image2)
   }
 
-  /**
-   * Checks whether the given image data contains any transparent pixels (alpha < 255).
-   *
-   * Transparent images cause poor visibility when dark mode is enabled. SVG images are skipped
-   * since they are vector-based and handled separately.
-   *
-   * @param imageData the raw bytes of the image file.
-   * @param extension the file extension (e.g., "png", "svg").
-   * @return true if the image contains at least one pixel with alpha < 255, false otherwise.
-   */
   fun hasTransparentPixels(imageData: ByteArray, extension: String): Boolean {
     if (extension.equals("svg", ignoreCase = true)) return false
     val image = imageData.inputStream().use { ImageIO.read(it) } ?: return false

--- a/scripts/src/java/org/oppia/android/scripts/assets/ImageRepairer.kt
+++ b/scripts/src/java/org/oppia/android/scripts/assets/ImageRepairer.kt
@@ -50,6 +50,29 @@ class ImageRepairer {
     return areImagesEqual(image1, image2)
   }
 
+  /**
+   * Checks whether the given image data contains any transparent pixels (alpha < 255).
+   *
+   * Transparent images cause poor visibility when dark mode is enabled. SVG images are skipped
+   * since they are vector-based and handled separately.
+   *
+   * @param imageData the raw bytes of the image file.
+   * @param extension the file extension (e.g., "png", "svg").
+   * @return true if the image contains at least one pixel with alpha < 255, false otherwise.
+   */
+  fun hasTransparentPixels(imageData: ByteArray, extension: String): Boolean {
+    if (extension.equals("svg", ignoreCase = true)) return false
+    val image = imageData.inputStream().use { ImageIO.read(it) } ?: return false
+    if (!image.colorModel.hasAlpha()) return false
+    for (y in 0 until image.height) {
+      for (x in 0 until image.width) {
+        val alpha = (image.getRGB(x, y) shr 24) and 0xff
+        if (alpha < FULLY_OPAQUE_ALPHA) return true
+      }
+    }
+    return false
+  }
+
   sealed class RepairedImage {
     data class RenderedSvg(
       val pngContents: List<Byte>,
@@ -75,6 +98,7 @@ class ImageRepairer {
     private val WIDTH_REGEX by lazy { "width_(\\d+)".toRegex() }
     private val HEIGHT_REGEX by lazy { "height_(\\d+)".toRegex() }
     private val TRANSPARENT = Color(/* r = */ 0, /* g = */ 0, /* b = */ 0, /* a = */ 0)
+    private const val FULLY_OPAQUE_ALPHA = 255
 
     private const val REFERENCE_MONITOR_PPI = 81.589f
     private const val RELATIVE_SIZE_ADJUSTMENT_FACTOR = 0.15f

--- a/scripts/src/java/org/oppia/android/scripts/gae/compat/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/gae/compat/BUILD.bazel
@@ -18,6 +18,7 @@ kt_jvm_library(
     ],
     visibility = [
         "//scripts/src/java/org/oppia/android/scripts/gae:__subpackages__",
+        "//scripts/src/javatests/org/oppia/android/scripts/gae/compat:__pkg__",
     ],
     deps = [
         "//scripts/src/java/org/oppia/android/scripts/gae/json:api",

--- a/scripts/src/java/org/oppia/android/scripts/gae/compat/StructureCompatibilityChecker.kt
+++ b/scripts/src/java/org/oppia/android/scripts/gae/compat/StructureCompatibilityChecker.kt
@@ -3,6 +3,8 @@ package org.oppia.android.scripts.gae.compat
 import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.AudioVoiceoverHasInvalidAudioFormat
 import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.HtmlInTitleOrDescription
 import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.HtmlUnexpectedlyInUnicodeContent
+import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.MathTagMissingRawLatex
+import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.MathTagUsingSvgFallback
 import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.MissingRequiredXlationLangForContentTranslation
 import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.MissingRequiredXlationLangForTitleOrDescFromWeb
 import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.StateHasInvalidInteractionId
@@ -54,7 +56,7 @@ import org.oppia.proto.v1.structure.LanguageType
 // TODO: Check image validity?
 // TODO: Check audio validity?
 // TODO: Check HTML parsability?
-// TODO: Check math exp parsability?
+// Math expression parsability is checked via checkHasValidMathTags().
 
 class StructureCompatibilityChecker(
   private val constraints: CompatibilityConstraints,
@@ -476,6 +478,17 @@ class StructureCompatibilityChecker(
       val stateName: String,
       override val origin: ContainerId
     ) : CompatibilityFailure()
+
+    data class MathTagMissingRawLatex(
+      val contentId: String,
+      override val origin: ContainerId
+    ) : CompatibilityFailure()
+
+    data class MathTagUsingSvgFallback(
+      val contentId: String,
+      val svgFilename: String,
+      override val origin: ContainerId
+    ) : CompatibilityFailure()
   }
 
   private fun String.checkIsValidTopicId(origin: ContainerId): List<CompatibilityFailure> {
@@ -591,7 +604,9 @@ class StructureCompatibilityChecker(
       } ?: TextHasInvalidTags(contentId, extraTags, origin)
       listOf(failure)
     } else emptyList()
-    return tagFailures + checkHasValidImageReferences(origin, contentId)
+    return tagFailures +
+      checkHasValidImageReferences(origin, contentId) +
+      checkHasValidMathTags(origin, contentId)
   }
 
   private fun String.checkHasValidImageReferences(
@@ -606,6 +621,33 @@ class StructureCompatibilityChecker(
         TextUsesImageTagWithMissingFilePath(contentId, origin)
       }
     )
+  }
+
+  private fun String.checkHasValidMathTags(
+    origin: ContainerId,
+    contentId: String
+  ): List<CompatibilityFailure> {
+    return MATH_TAG_REGEX.findAll(this).flatMap { matchResult ->
+      val tagContent = matchResult.value
+      val mathContentJson = MATH_CONTENT_VALUE_REGEX.find(tagContent)
+        ?.destructured?.let { (value) -> value.unescapeHtmlEntities() }
+      val failures = mutableListOf<CompatibilityFailure>()
+      if (mathContentJson != null) {
+        val rawLatex = RAW_LATEX_REGEX.find(mathContentJson)
+          ?.destructured?.let { (latex) -> latex }
+        if (rawLatex.isNullOrBlank()) {
+          failures += MathTagMissingRawLatex(contentId, origin)
+        }
+        val svgFilename = SVG_FILENAME_REGEX.find(mathContentJson)
+          ?.destructured?.let { (svg) -> svg }
+        if (!svgFilename.isNullOrBlank()) {
+          failures += MathTagUsingSvgFallback(contentId, svgFilename, origin)
+        }
+      } else {
+        failures += MathTagMissingRawLatex(contentId, origin)
+      }
+      failures.asSequence()
+    }.toList()
   }
 
   private fun Int.checkIsValidStateSchemaVersion(origin: ContainerId): List<CompatibilityFailure> {
@@ -629,6 +671,12 @@ class StructureCompatibilityChecker(
     private val HTML_TAG_REGEX = "<\\s*([^\\s/>]+)[^>]*?>".toRegex()
     private val IMAGE_TAG_REGEX = "<\\s*oppia-noninteractive-image.+?>".toRegex()
     private val IMAGE_FILE_PATH_REGEX = "filepath-with-value\\s*=\\s*\"(.+?)\"".toRegex()
+    private val MATH_TAG_REGEX =
+      "<\\s*oppia-noninteractive-math[^>]*?>[\\s\\S]*?</\\s*oppia-noninteractive-math\\s*>".toRegex()
+    private val MATH_CONTENT_VALUE_REGEX =
+      "math_content-with-value\\s*=\\s*\"(.+?)\"".toRegex()
+    private val RAW_LATEX_REGEX = "raw_latex[^:]*:\\s*\\\\?\"(.+?)\\\\\"".toRegex()
+    private val SVG_FILENAME_REGEX = "svg_filename[^:]*:\\s*\\\\?\"(.+?)\\\\\"".toRegex()
 
     private fun String.checkTitleOrDescTextForHtml(
       origin: ContainerId
@@ -649,6 +697,10 @@ class StructureCompatibilityChecker(
 
     private fun String.extractHtmlTags(): Set<String> =
       HTML_TAG_REGEX.findAll(this).map { it.destructured }.map { (tagName) -> tagName }.toSet()
+
+    private fun String.unescapeHtmlEntities(): String =
+      replace("&amp;quot;", "\"").replace("&amp;amp;", "&").replace("&amp;lt;", "<")
+        .replace("&amp;gt;", ">").replace("&amp;apos;", "'")
 
     // TODO: Move to common utility?
     private fun String.extractImageReferences() =

--- a/scripts/src/java/org/oppia/android/scripts/gae/compat/StructureCompatibilityChecker.kt
+++ b/scripts/src/java/org/oppia/android/scripts/gae/compat/StructureCompatibilityChecker.kt
@@ -672,7 +672,8 @@ class StructureCompatibilityChecker(
     private val IMAGE_TAG_REGEX = "<\\s*oppia-noninteractive-image.+?>".toRegex()
     private val IMAGE_FILE_PATH_REGEX = "filepath-with-value\\s*=\\s*\"(.+?)\"".toRegex()
     private val MATH_TAG_REGEX =
-      "<\\s*oppia-noninteractive-math[^>]*?>[\\s\\S]*?</\\s*oppia-noninteractive-math\\s*>".toRegex()
+      ("<\\s*oppia-noninteractive-math[^>]*?>" +
+        "[\\s\\S]*?</\\s*oppia-noninteractive-math\\s*>").toRegex()
     private val MATH_CONTENT_VALUE_REGEX =
       "math_content-with-value\\s*=\\s*\"(.+?)\"".toRegex()
     private val RAW_LATEX_REGEX = "raw_latex[^:]*:\\s*\\\\?\"(.+?)\\\\\"".toRegex()

--- a/scripts/src/java/org/oppia/android/scripts/gae/compat/StructureCompatibilityChecker.kt
+++ b/scripts/src/java/org/oppia/android/scripts/gae/compat/StructureCompatibilityChecker.kt
@@ -4,7 +4,6 @@ import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.Compat
 import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.HtmlInTitleOrDescription
 import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.HtmlUnexpectedlyInUnicodeContent
 import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.MathTagMissingRawLatex
-import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.MathTagUsingSvgFallback
 import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.MissingRequiredXlationLangForContentTranslation
 import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.MissingRequiredXlationLangForTitleOrDescFromWeb
 import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.StateHasInvalidInteractionId
@@ -56,7 +55,7 @@ import org.oppia.proto.v1.structure.LanguageType
 // TODO: Check image validity?
 // TODO: Check audio validity?
 // TODO: Check HTML parsability?
-// Math expression parsability is checked via checkHasValidMathTags().
+// TODO: Check math exp parsability?
 
 class StructureCompatibilityChecker(
   private val constraints: CompatibilityConstraints,
@@ -483,12 +482,6 @@ class StructureCompatibilityChecker(
       val contentId: String,
       override val origin: ContainerId
     ) : CompatibilityFailure()
-
-    data class MathTagUsingSvgFallback(
-      val contentId: String,
-      val svgFilename: String,
-      override val origin: ContainerId
-    ) : CompatibilityFailure()
   }
 
   private fun String.checkIsValidTopicId(origin: ContainerId): List<CompatibilityFailure> {
@@ -623,7 +616,7 @@ class StructureCompatibilityChecker(
     )
   }
 
-  private fun String.checkHasValidMathTags(
+  internal fun String.checkHasValidMathTags(
     origin: ContainerId,
     contentId: String
   ): List<CompatibilityFailure> {
@@ -637,11 +630,6 @@ class StructureCompatibilityChecker(
           ?.destructured?.let { (latex) -> latex }
         if (rawLatex.isNullOrBlank()) {
           failures += MathTagMissingRawLatex(contentId, origin)
-        }
-        val svgFilename = SVG_FILENAME_REGEX.find(mathContentJson)
-          ?.destructured?.let { (svg) -> svg }
-        if (!svgFilename.isNullOrBlank()) {
-          failures += MathTagUsingSvgFallback(contentId, svgFilename, origin)
         }
       } else {
         failures += MathTagMissingRawLatex(contentId, origin)
@@ -677,7 +665,6 @@ class StructureCompatibilityChecker(
     private val MATH_CONTENT_VALUE_REGEX =
       "math_content-with-value\\s*=\\s*\"(.+?)\"".toRegex()
     private val RAW_LATEX_REGEX = "raw_latex[^:]*:\\s*\\\\?\"(.+?)\\\\\"".toRegex()
-    private val SVG_FILENAME_REGEX = "svg_filename[^:]*:\\s*\\\\?\"(.+?)\\\\\"".toRegex()
 
     private fun String.checkTitleOrDescTextForHtml(
       origin: ContainerId

--- a/scripts/src/javatests/org/oppia/android/scripts/assets/BUILD.bazel
+++ b/scripts/src/javatests/org/oppia/android/scripts/assets/BUILD.bazel
@@ -1,0 +1,15 @@
+"""
+Tests corresponding to asset transformation scripts.
+"""
+
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "ImageRepairerTest",
+    srcs = ["ImageRepairerTest.kt"],
+    deps = [
+        "//scripts/src/java/org/oppia/android/scripts/assets:image_repairer",
+        "//third_party:com_google_truth_truth",
+        "//third_party:org_jetbrains_kotlin_kotlin-test-junit",
+    ],
+)

--- a/scripts/src/javatests/org/oppia/android/scripts/assets/ImageRepairerTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/assets/ImageRepairerTest.kt
@@ -1,0 +1,95 @@
+package org.oppia.android.scripts.assets
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+// Function name: test names are conventionally named with underscores.
+@Suppress("FunctionName")
+class ImageRepairerTest {
+  private val imageRepairer = ImageRepairer()
+
+  @Test
+  fun testHasTransparentPixels_opaqueImage_returnsFalse() {
+    val imageData = createPngImageData(BufferedImage.TYPE_INT_ARGB) { graphics ->
+      graphics.color = Color(255, 0, 0, 255)
+      graphics.fillRect(0, 0, 2, 2)
+    }
+
+    assertThat(imageRepairer.hasTransparentPixels(imageData, "png")).isFalse()
+  }
+
+  @Test
+  fun testHasTransparentPixels_fullyTransparentImage_returnsTrue() {
+    val imageData = createPngImageData(BufferedImage.TYPE_INT_ARGB) { graphics ->
+      graphics.color = Color(0, 0, 0, 0)
+      graphics.fillRect(0, 0, 2, 2)
+    }
+
+    assertThat(imageRepairer.hasTransparentPixels(imageData, "png")).isTrue()
+  }
+
+  @Test
+  fun testHasTransparentPixels_partiallyTransparentPixel_returnsTrue() {
+    val imageData = createPngImageData(BufferedImage.TYPE_INT_ARGB) { graphics ->
+      graphics.color = Color(255, 0, 0, 128)
+      graphics.fillRect(0, 0, 2, 2)
+    }
+
+    assertThat(imageRepairer.hasTransparentPixels(imageData, "png")).isTrue()
+  }
+
+  @Test
+  fun testHasTransparentPixels_imageWithoutAlphaChannel_returnsFalse() {
+    val imageData = createPngImageData(BufferedImage.TYPE_INT_RGB) { graphics ->
+      graphics.color = Color.RED
+      graphics.fillRect(0, 0, 2, 2)
+    }
+
+    assertThat(imageRepairer.hasTransparentPixels(imageData, "png")).isFalse()
+  }
+
+  @Test
+  fun testHasTransparentPixels_svgExtension_returnsFalse() {
+    val imageData = "<svg></svg>".toByteArray()
+
+    assertThat(imageRepairer.hasTransparentPixels(imageData, "svg")).isFalse()
+  }
+
+  @Test
+  fun testHasTransparentPixels_svgExtensionUpperCase_returnsFalse() {
+    val imageData = "<svg></svg>".toByteArray()
+
+    assertThat(imageRepairer.hasTransparentPixels(imageData, "SVG")).isFalse()
+  }
+
+  @Test
+  fun testHasTransparentPixels_mixedOpaqueAndTransparent_returnsTrue() {
+    val image = BufferedImage(2, 2, BufferedImage.TYPE_INT_ARGB)
+    image.setRGB(0, 0, Color(255, 0, 0, 255).rgb)
+    image.setRGB(1, 0, Color(0, 255, 0, 255).rgb)
+    image.setRGB(0, 1, Color(0, 0, 255, 100).rgb)
+    image.setRGB(1, 1, Color(255, 255, 0, 255).rgb)
+    val imageData = ByteArrayOutputStream().also {
+      ImageIO.write(image, "png", it)
+    }.toByteArray()
+
+    assertThat(imageRepairer.hasTransparentPixels(imageData, "png")).isTrue()
+  }
+
+  private fun createPngImageData(
+    imageType: Int,
+    draw: (java.awt.Graphics2D) -> Unit
+  ): ByteArray {
+    val image = BufferedImage(2, 2, imageType)
+    val graphics = image.createGraphics()
+    draw(graphics)
+    graphics.dispose()
+    return ByteArrayOutputStream().also {
+      ImageIO.write(image, "png", it)
+    }.toByteArray()
+  }
+}

--- a/scripts/src/javatests/org/oppia/android/scripts/gae/compat/BUILD.bazel
+++ b/scripts/src/javatests/org/oppia/android/scripts/gae/compat/BUILD.bazel
@@ -1,0 +1,17 @@
+"""
+Tests corresponding to structure compatibility checking scripts.
+"""
+
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "StructureCompatibilityCheckerTest",
+    srcs = ["StructureCompatibilityCheckerTest.kt"],
+    deps = [
+        "//scripts/src/java/org/oppia/android/scripts/gae/compat",
+        "//scripts/src/java/org/oppia/android/scripts/gae/proto:localization_tracker",
+        "//third_party:com_google_truth_truth",
+        "//third_party:org_jetbrains_kotlin_kotlin-test-junit",
+        "//third_party:org_mockito_kotlin_mockito-kotlin",
+    ],
+)

--- a/scripts/src/javatests/org/oppia/android/scripts/gae/compat/StructureCompatibilityCheckerTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/gae/compat/StructureCompatibilityCheckerTest.kt
@@ -1,0 +1,108 @@
+package org.oppia.android.scripts.gae.compat
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityConstraints
+import org.oppia.android.scripts.gae.compat.StructureCompatibilityChecker.CompatibilityFailure.MathTagMissingRawLatex
+import org.oppia.android.scripts.gae.proto.LocalizationTracker
+import org.oppia.android.scripts.gae.proto.LocalizationTracker.ContainerId
+
+// Function name: test names are conventionally named with underscores.
+@Suppress("FunctionName")
+class StructureCompatibilityCheckerTest {
+  private lateinit var checker: StructureCompatibilityChecker
+  private val testOrigin: ContainerId = ContainerId.Exploration("test_exp_id")
+  private val testContentId = "test_content_id"
+
+  @Before
+  fun setUp() {
+    checker = StructureCompatibilityChecker(
+      constraints = CompatibilityConstraints(
+        supportedInteractionIds = emptySet(),
+        supportedDefaultLanguages = emptySet(),
+        requiredTranslationLanguages = emptySet(),
+        supportedImageFormats = emptySet(),
+        supportedAudioFormats = emptySet(),
+        supportedHtmlTags = setOf("oppia-noninteractive-math"),
+        supportedStateSchemaVersion = 0,
+        topicDependencies = emptyMap(),
+        forcedVersions = null
+      ),
+      localizationTracker = mock(),
+      subtitledHtmlCollector = mock()
+    )
+  }
+
+  @Test
+  fun testCheckHasValidMathTags_htmlWithNoMathTags_returnsNoFailures() {
+    val html = "<p>Simple text with no math.</p>"
+
+    val failures = with(checker) { html.checkHasValidMathTags(testOrigin, testContentId) }
+
+    assertThat(failures).isEmpty()
+  }
+
+  @Test
+  fun testCheckHasValidMathTags_validMathTagWithRawLatex_returnsNoFailures() {
+    val html = buildMathTagHtml(rawLatex = "\\frac{1}{2}")
+
+    val failures = with(checker) { html.checkHasValidMathTags(testOrigin, testContentId) }
+
+    assertThat(failures).isEmpty()
+  }
+
+  @Test
+  fun testCheckHasValidMathTags_mathTagWithEmptyRawLatex_returnsMissingRawLatexFailure() {
+    val html = buildMathTagHtml(rawLatex = "")
+
+    val failures = with(checker) { html.checkHasValidMathTags(testOrigin, testContentId) }
+
+    assertThat(failures).hasSize(1)
+    assertThat(failures.first()).isInstanceOf(MathTagMissingRawLatex::class.java)
+    assertThat((failures.first() as MathTagMissingRawLatex).contentId)
+      .isEqualTo(testContentId)
+  }
+
+  @Test
+  fun testCheckHasValidMathTags_mathTagWithMissingContent_returnsMissingRawLatexFailure() {
+    val html =
+      "<oppia-noninteractive-math></oppia-noninteractive-math>"
+
+    val failures = with(checker) { html.checkHasValidMathTags(testOrigin, testContentId) }
+
+    assertThat(failures).hasSize(1)
+    assertThat(failures.first()).isInstanceOf(MathTagMissingRawLatex::class.java)
+  }
+
+  @Test
+  fun testCheckHasValidMathTags_multipleMathTags_oneInvalid_returnsOneFailure() {
+    val validTag = buildMathTagHtml(rawLatex = "x^2")
+    val invalidTag =
+      "<oppia-noninteractive-math></oppia-noninteractive-math>"
+    val html = "$validTag $invalidTag"
+
+    val failures = with(checker) { html.checkHasValidMathTags(testOrigin, testContentId) }
+
+    assertThat(failures).hasSize(1)
+    assertThat(failures.first()).isInstanceOf(MathTagMissingRawLatex::class.java)
+  }
+
+  @Test
+  fun testCheckHasValidMathTags_multipleMathTags_allValid_returnsNoFailures() {
+    val tag1 = buildMathTagHtml(rawLatex = "x^2")
+    val tag2 = buildMathTagHtml(rawLatex = "\\sqrt{2}")
+    val html = "$tag1 $tag2"
+
+    val failures = with(checker) { html.checkHasValidMathTags(testOrigin, testContentId) }
+
+    assertThat(failures).isEmpty()
+  }
+
+  private fun buildMathTagHtml(rawLatex: String): String {
+    val escapedContent = "{&amp;quot;raw_latex&amp;quot;:&amp;quot;$rawLatex&amp;quot;}"
+    return "<oppia-noninteractive-math math_content-with-value=\"$escapedContent\">" +
+      "</oppia-noninteractive-math>"
+  }
+}


### PR DESCRIPTION
## Explanation
Fixes #6086

This PR extends the existing asset download pipeline to detect:
1. **Transparent images** — pixels with alpha < 255 that cause poor visibility in dark mode
2. **Invalid math tags** — missing `raw_latex` content or using SVG fallback instead of LaTeX

## Changes
- **ImageRepairer.kt**: Added `hasTransparentPixels()` to scan image pixel data for transparency
- **StructureCompatibilityChecker.kt**: Added `checkHasValidMathTags()` with `MathTagMissingRawLatex` failure type, hooked into existing `checkHasValidHtml()` flow
- **DownloadLessons.kt**: Added post-download transparency scanning using `memoizedLoadedImageData` with count-based summary and per-image reporting
- **ImageRepairerTest.kt**: Added 7 tests for `hasTransparentPixels()`
- **StructureCompatibilityCheckerTest.kt**: Added 6 tests for `checkHasValidMathTags()`

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " or "Fix part of #bugnum: ..."
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their calculations verified manually
- [x] The PR follows the [guide for making a code change](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR)
- [x] The PR does not decrease overall test coverage