### PR TITLE
Fix part of #5035: Add missing deleteAllProfiles tests for ProfileManagementController

### DIFF
--- a/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
@@ -1060,7 +1060,8 @@ class ProfileManagementController @Inject constructor(
         directoryManagementUtil.deleteDir(internalProfileId.toString())
         learnerAnalyticsLogger.logDeleteProfile(installationId, profileId = null, profile.learnerId)
       }
-      Pair(ProfileDatabase.getDefaultInstance(), ProfileActionStatus.SUCCESS)
+      val clearedDatabase = it.toBuilder().clearProfiles().build()
+      Pair(clearedDatabase, ProfileActionStatus.SUCCESS)
     }
     return dataProviders.createInMemoryDataProviderAsync(DELETE_PROFILE_PROVIDER_ID) {
       getDeferredResult(profileId = null, name = null, deferred)

--- a/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
@@ -1301,6 +1301,62 @@ class ProfileManagementControllerTest {
   }
 
   @Test
+  fun testProfileManagementController_deleteAllProfiles_profilesListIsEmpty() {
+    setUpTestApplicationComponent()
+    addTestProfiles()
+
+    profileManagementController.deleteAllProfiles().ensureExecutes()
+    // Restart the application to reload from disk, verifying on-disk state is correct.
+    setUpTestApplicationComponent()
+
+    val profiles = monitorFactory.waitForNextSuccessfulResult(
+      profileManagementController.getProfiles()
+    )
+    assertThat(profiles).isEmpty()
+  }
+
+  @Test
+  fun testProfileManagementController_deleteAllProfiles_inMemoryCacheUpdated() {
+    setUpTestApplicationComponent()
+    addTestProfiles()
+
+    profileManagementController.deleteAllProfiles().ensureExecutes()
+
+    // Verify that the in-memory data provider reflects the deletion without restarting.
+    val profiles = monitorFactory.waitForNextSuccessfulResult(
+      profileManagementController.getProfiles()
+    )
+    assertThat(profiles).isEmpty()
+  }
+
+  @Test
+  fun testProfileManagementController_deleteAllProfiles_preservesNonProfileData() {
+    setUpTestApplicationComponent()
+    addAdminProfileAndWait(name = "James")
+    // Update device settings to non-default values before deletion.
+    monitorFactory.ensureDataProviderExecutes(
+      profileManagementController.updateWifiPermissionDeviceSettings(
+        ADMIN_PROFILE_ID_0, downloadAndUpdateOnWifiOnly = true
+      )
+    )
+    monitorFactory.ensureDataProviderExecutes(
+      profileManagementController.updateTopicAutomaticallyPermissionDeviceSettings(
+        ADMIN_PROFILE_ID_0, automaticallyUpdateTopics = true
+      )
+    )
+
+    profileManagementController.deleteAllProfiles().ensureExecutes()
+    // Restart to verify on-disk state preserves non-profile data.
+    setUpTestApplicationComponent()
+
+    val deviceSettings = monitorFactory.waitForNextSuccessfulResult(
+      profileManagementController.getDeviceSettings()
+    )
+    assertThat(deviceSettings.allowDownloadAndUpdateOnlyOnWifi).isTrue()
+    assertThat(deviceSettings.automaticallyUpdateTopics).isTrue()
+  }
+
+  @Test
   fun testAddAdminProfile_addAnotherAdminProfile_checkSecondAdminProfileWasNotAdded() {
     setUpTestApplicationComponent()
     addAdminProfileAndWait(name = "Rohit")


### PR DESCRIPTION
## Explanation
Fix part of #5035: Add the three missing tests for
`ProfileManagementController.deleteAllProfiles()` as listed in the issue:

- `testProfileManagementController_deleteAllProfiles_profilesListIsEmpty`: verifies
  that after deleting all profiles and restarting the app, the on-disk profiles list
  is empty.
- `testProfileManagementController_deleteAllProfiles_inMemoryCacheUpdated`: verifies
  that after deleting all profiles (without restarting), the in-memory data provider
  immediately reflects the deletion.
- `testProfileManagementController_deleteAllProfiles_preservesNonProfileData`: verifies
  that deleting all profiles preserves non-profile data in the `ProfileDatabase`, such
  as `device_settings`, `was_profile_ever_added`, and `next_profile_id`.

The third test uncovered a bug in `deleteAllProfiles()`: it was replacing the entire
`ProfileDatabase` with `ProfileDatabase.getDefaultInstance()`, which also clears
`device_settings` and other non-profile fields. This is fixed by using
`it.toBuilder().clearProfiles().build()` instead, so only the profiles map is removed.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).