### PR TITLE
Fix part of #5792: Make LaTeX rendering theme-aware and separate Glide caching across Light/Dark modes

### DIFF
--- a/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
@@ -270,7 +270,7 @@ class CustomHtmlContentHandler private constructor(
      * Returns a new [Drawable] representing a cached render of the specified [rawLatex] for the
      * given [lineHeight] and for the rendering [type].
      */
-    fun loadMathDrawable(rawLatex: String, lineHeight: Float, type: Type): Drawable
+    fun loadMathDrawable(rawLatex: String, lineHeight: Float, equationColor: Int,  type: Type): Drawable
 
     /** Corresponds to the types of images that can be retrieved. */
     enum class Type {

--- a/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/CustomHtmlContentHandler.kt
@@ -270,7 +270,12 @@ class CustomHtmlContentHandler private constructor(
      * Returns a new [Drawable] representing a cached render of the specified [rawLatex] for the
      * given [lineHeight] and for the rendering [type].
      */
-    fun loadMathDrawable(rawLatex: String, lineHeight: Float, equationColor: Int,  type: Type): Drawable
+    fun loadMathDrawable(
+      rawLatex: String,
+      lineHeight: Float,
+      equationColor: Int,
+      type: Type
+    ): Drawable
 
     /** Corresponds to the types of images that can be retrieved. */
     enum class Type {

--- a/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
@@ -133,7 +133,7 @@ class MathTagHandler(
         // Kotlitex expects escaped backslashes.
         val rawLatex = obj?.getOptionalString("raw_latex")
         return when {
-          rawLatex != null -> MathAsLatex(rawLatex)
+          !rawLatex.isNullOrBlank() -> MathAsLatex(rawLatex)
           else -> null
         }
       }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
@@ -50,6 +50,11 @@ class MathTagHandler(
       else -> true
     }
     checkNotNull(imageRetriever) { "Expected imageRetriever to be not null." }
+    val equationColor = ResourcesCompat.getColor(
+      application.resources,
+      R.color.component_color_shared_equation_color,
+      null
+    )
     val newSpan = when (content) {
       is MathContent.MathAsSvg -> {
         ImageSpan(
@@ -66,6 +71,7 @@ class MathTagHandler(
             imageRetriever.loadMathDrawable(
               content.rawLatex,
               lineHeight,
+              equationColor,
               type = if (useInlineRendering) INLINE_TEXT_IMAGE else BLOCK_IMAGE
             ),
             useInlineRendering
@@ -76,11 +82,7 @@ class MathTagHandler(
             lineHeight,
             assetManager,
             isMathMode = !useInlineRendering,
-            ResourcesCompat.getColor(
-              application.resources,
-              R.color.component_color_shared_equation_color,
-              /* theme = */ null
-            )
+            equationColor
           )
         }
       }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
@@ -132,9 +132,7 @@ class MathTagHandler(
       internal fun parseMathContent(obj: JSONObject?): MathContent? {
         // Kotlitex expects escaped backslashes.
         val rawLatex = obj?.getOptionalString("raw_latex")
-        val svgFilename = obj?.getOptionalString("svg_filename")
         return when {
-          svgFilename != null -> MathAsSvg(svgFilename)
           rawLatex != null -> MathAsLatex(rawLatex)
           else -> null
         }

--- a/utility/src/main/java/org/oppia/android/util/parser/image/GlideImageLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/image/GlideImageLoader.kt
@@ -26,7 +26,7 @@ import javax.inject.Singleton
 /** An [ImageLoader] that uses Glide. */
 @Singleton
 class GlideImageLoader @Inject constructor(
-  private val context: Context,
+  context: Context,
   @LoadImagesFromAssets private val loadImagesFromAssets: Boolean,
   private val assetRepository: AssetRepository
 ) : ImageLoader {

--- a/utility/src/main/java/org/oppia/android/util/parser/image/GlideImageLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/image/GlideImageLoader.kt
@@ -1,7 +1,6 @@
 package org.oppia.android.util.parser.image
 
 import android.content.Context
-import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.net.Uri

--- a/utility/src/main/java/org/oppia/android/util/parser/image/GlideImageLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/image/GlideImageLoader.kt
@@ -75,14 +75,12 @@ class GlideImageLoader @Inject constructor(
     rawLatex: String,
     lineHeight: Float,
     useInlineRendering: Boolean,
+    equationColor: Int,
     target: ImageTarget<Bitmap>
   ) {
-    val isNightMode =
-      (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
-        Configuration.UI_MODE_NIGHT_YES
     glide
       .asBitmap()
-      .load(MathModel(rawLatex, lineHeight, useInlineRendering, isNightMode))
+      .load(MathModel(rawLatex, lineHeight, useInlineRendering, equationColor))
       .intoTarget(target)
   }
 

--- a/utility/src/main/java/org/oppia/android/util/parser/image/GlideImageLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/image/GlideImageLoader.kt
@@ -1,6 +1,7 @@
 package org.oppia.android.util.parser.image
 
 import android.content.Context
+import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.net.Uri
@@ -26,7 +27,7 @@ import javax.inject.Singleton
 /** An [ImageLoader] that uses Glide. */
 @Singleton
 class GlideImageLoader @Inject constructor(
-  context: Context,
+  private val context: Context,
   @LoadImagesFromAssets private val loadImagesFromAssets: Boolean,
   private val assetRepository: AssetRepository
 ) : ImageLoader {
@@ -76,9 +77,12 @@ class GlideImageLoader @Inject constructor(
     useInlineRendering: Boolean,
     target: ImageTarget<Bitmap>
   ) {
+    val isNightMode =
+      (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+        Configuration.UI_MODE_NIGHT_YES
     glide
       .asBitmap()
-      .load(MathModel(rawLatex, lineHeight, useInlineRendering))
+      .load(MathModel(rawLatex, lineHeight, useInlineRendering, isNightMode))
       .intoTarget(target)
   }
 

--- a/utility/src/main/java/org/oppia/android/util/parser/image/ImageLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/image/ImageLoader.kt
@@ -59,6 +59,7 @@ interface ImageLoader {
     rawLatex: String,
     lineHeight: Float,
     useInlineRendering: Boolean,
+    equationColor: Int,
     target: ImageTarget<Bitmap>
   )
 }

--- a/utility/src/main/java/org/oppia/android/util/parser/image/TestGlideImageLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/image/TestGlideImageLoader.kt
@@ -80,7 +80,10 @@ class TestGlideImageLoader @Inject constructor(
     target: ImageTarget<Bitmap>
   ) {
     loadedMathDrawables += MathModel(rawLatex, lineHeight, useInlineRendering, equationColor)
-    glideImageLoader.loadMathDrawable(rawLatex, lineHeight, useInlineRendering, equationColor, target)
+    glideImageLoader.loadMathDrawable(
+      rawLatex, lineHeight,
+      useInlineRendering, equationColor, target
+    )
   }
 
   /**

--- a/utility/src/main/java/org/oppia/android/util/parser/image/TestGlideImageLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/image/TestGlideImageLoader.kt
@@ -78,7 +78,7 @@ class TestGlideImageLoader @Inject constructor(
     useInlineRendering: Boolean,
     target: ImageTarget<Bitmap>
   ) {
-    loadedMathDrawables += MathModel(rawLatex, lineHeight, useInlineRendering)
+    loadedMathDrawables += MathModel(rawLatex, lineHeight, useInlineRendering, isNightMode = false)
     glideImageLoader.loadMathDrawable(rawLatex, lineHeight, useInlineRendering, target)
   }
 

--- a/utility/src/main/java/org/oppia/android/util/parser/image/TestGlideImageLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/image/TestGlideImageLoader.kt
@@ -76,9 +76,10 @@ class TestGlideImageLoader @Inject constructor(
     rawLatex: String,
     lineHeight: Float,
     useInlineRendering: Boolean,
+    equationColor: Int,
     target: ImageTarget<Bitmap>
   ) {
-    loadedMathDrawables += MathModel(rawLatex, lineHeight, useInlineRendering, isNightMode = false)
+    loadedMathDrawables += MathModel(rawLatex, lineHeight, useInlineRendering, equationColor)
     glideImageLoader.loadMathDrawable(rawLatex, lineHeight, useInlineRendering, target)
   }
 

--- a/utility/src/main/java/org/oppia/android/util/parser/image/TestGlideImageLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/image/TestGlideImageLoader.kt
@@ -80,7 +80,7 @@ class TestGlideImageLoader @Inject constructor(
     target: ImageTarget<Bitmap>
   ) {
     loadedMathDrawables += MathModel(rawLatex, lineHeight, useInlineRendering, equationColor)
-    glideImageLoader.loadMathDrawable(rawLatex, lineHeight, useInlineRendering, target)
+    glideImageLoader.loadMathDrawable(rawLatex, lineHeight, useInlineRendering, equationColor, target)
   }
 
   /**

--- a/utility/src/main/java/org/oppia/android/util/parser/image/UrlImageParser.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/image/UrlImageParser.kt
@@ -128,6 +128,7 @@ class UrlImageParser private constructor(
   override fun loadMathDrawable(
     rawLatex: String,
     lineHeight: Float,
+    equationColor: Int,
     type: ImageRetriever.Type
   ): Drawable {
     return ProxyDrawable().also { drawable ->
@@ -135,6 +136,7 @@ class UrlImageParser private constructor(
         rawLatex,
         lineHeight,
         useInlineRendering = type == INLINE_TEXT_IMAGE,
+        equationColor,
         createCustomTarget(drawable) {
           when (type) {
             INLINE_TEXT_IMAGE -> AutoAdjustingImageTarget.InlineTextImage.createForMath(context, it)

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
@@ -36,7 +36,6 @@ import java.nio.ByteBuffer
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
-import androidx.core.content.res.ResourcesCompat
 /**
  * [ModelLoader] for rendering and caching bitmap representations of LaTeX represented by
  * [MathModel]s.

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
@@ -398,7 +398,7 @@ class MathBitmapModelLoader private constructor(
     override fun build(factory: MultiModelLoaderFactory): ModelLoader<MathModel, ByteBuffer> {
       return MathBitmapModelLoader(application)
     }
-    
+
     override fun teardown() {}
   }
 }

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
@@ -12,7 +12,7 @@ import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.StaticLayout
 import android.text.TextPaint
-import androidx.core.content.res.ResourcesCompat
+import android.util.Log
 import com.bumptech.glide.Priority
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.Options
@@ -27,7 +27,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.oppia.android.util.R
 import org.oppia.android.util.logging.ConsoleLogger
 import org.oppia.android.util.logging.ConsoleLoggerInjectorProvider
 import org.oppia.android.util.threading.DispatcherInjectorProvider
@@ -75,6 +74,7 @@ class MathBitmapModelLoader private constructor(
     height: Int,
     options: Options
   ): ModelLoader.LoadData<ByteBuffer> {
+    Log.d("MathDebug", "buildLoadData called for latex=${model.rawLatex.take(10)}")
     return ModelLoader.LoadData(
       model.toKeySignature(),
       LatexModelDataFetcher(
@@ -114,12 +114,7 @@ class MathBitmapModelLoader private constructor(
             model.lineHeight,
             application.assets,
             !model.useInlineRendering,
-            // TODO(#1523): Test color parameter in MathBitmapModelLoader
-            ResourcesCompat.getColor(
-              application.resources,
-              R.color.component_color_shared_equation_color,
-              /* theme = */null
-            )
+            model.equationColor
           ).also { it.ensureDrawable() }
         }
         val renderableText = SpannableStringBuilder("\uFFFC").apply {
@@ -190,7 +185,7 @@ class MathBitmapModelLoader private constructor(
     override fun getDataClass(): Class<ByteBuffer> = ByteBuffer::class.java
 
     // 'Retrieval' is expensive in this case since a rendering operation is needed.
-  //  override fun getDataSource(): DataSource = DataSource.REMOTE
+    //  override fun getDataSource(): DataSource = DataSource.REMOTE
     override fun getDataSource(): DataSource = DataSource.LOCAL
 
     /**

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
@@ -36,7 +36,7 @@ import java.nio.ByteBuffer
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
-
+import androidx.core.content.res.ResourcesCompat
 /**
  * [ModelLoader] for rendering and caching bitmap representations of LaTeX represented by
  * [MathModel]s.
@@ -159,7 +159,6 @@ class MathBitmapModelLoader private constructor(
           renderToAutoSizingBitmap(estimatedWidth = boundsWidth, estimatedHeight = boundsHeight) {
             staticTextLayout.draw(it)
           }
-
         val finalWidth =
           if (targetWidth == Target.SIZE_ORIGINAL) canvasBitmap.width else targetWidth
         val finalHeight =
@@ -192,7 +191,8 @@ class MathBitmapModelLoader private constructor(
     override fun getDataClass(): Class<ByteBuffer> = ByteBuffer::class.java
 
     // 'Retrieval' is expensive in this case since a rendering operation is needed.
-    override fun getDataSource(): DataSource = DataSource.REMOTE
+  //  override fun getDataSource(): DataSource = DataSource.REMOTE
+    override fun getDataSource(): DataSource = DataSource.LOCAL
 
     /**
      * A [DrawableSurface] which tracks the bounds necessary to draw each constituent part of LaTeX
@@ -405,7 +405,6 @@ class MathBitmapModelLoader private constructor(
     override fun build(factory: MultiModelLoaderFactory): ModelLoader<MathModel, ByteBuffer> {
       return MathBitmapModelLoader(application)
     }
-
     override fun teardown() {}
   }
 }

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
@@ -12,7 +12,6 @@ import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.StaticLayout
 import android.text.TextPaint
-import android.util.Log
 import com.bumptech.glide.Priority
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.Options
@@ -35,6 +34,7 @@ import java.nio.ByteBuffer
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
+
 /**
  * [ModelLoader] for rendering and caching bitmap representations of LaTeX represented by
  * [MathModel]s.
@@ -74,7 +74,6 @@ class MathBitmapModelLoader private constructor(
     height: Int,
     options: Options
   ): ModelLoader.LoadData<ByteBuffer> {
-    Log.d("MathDebug", "buildLoadData called for latex=${model.rawLatex.take(10)}")
     return ModelLoader.LoadData(
       model.toKeySignature(),
       LatexModelDataFetcher(
@@ -153,6 +152,7 @@ class MathBitmapModelLoader private constructor(
           renderToAutoSizingBitmap(estimatedWidth = boundsWidth, estimatedHeight = boundsHeight) {
             staticTextLayout.draw(it)
           }
+
         val finalWidth =
           if (targetWidth == Target.SIZE_ORIGINAL) canvasBitmap.width else targetWidth
         val finalHeight =
@@ -185,7 +185,6 @@ class MathBitmapModelLoader private constructor(
     override fun getDataClass(): Class<ByteBuffer> = ByteBuffer::class.java
 
     // 'Retrieval' is expensive in this case since a rendering operation is needed.
-    //  override fun getDataSource(): DataSource = DataSource.REMOTE
     override fun getDataSource(): DataSource = DataSource.LOCAL
 
     /**
@@ -399,6 +398,7 @@ class MathBitmapModelLoader private constructor(
     override fun build(factory: MultiModelLoaderFactory): ModelLoader<MathModel, ByteBuffer> {
       return MathBitmapModelLoader(application)
     }
+    
     override fun teardown() {}
   }
 }

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathModel.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathModel.kt
@@ -14,11 +14,12 @@ import java.security.MessageDigest
 data class MathModel(
   val rawLatex: String,
   val lineHeight: Float,
-  val useInlineRendering: Boolean
+  val useInlineRendering: Boolean,
+  val isNightMode : Boolean
 ) {
   /** Returns a Glide [Key] signature (see [MathModelSignature] for specifics). */
   fun toKeySignature(): MathModelSignature =
-    MathModelSignature.createSignature(rawLatex, lineHeight, useInlineRendering)
+    MathModelSignature.createSignature(rawLatex, lineHeight, useInlineRendering,isNightMode)
 
   /**
    * Glide [Key] that provides caching support by allowing individual renderable math scenarios to
@@ -33,17 +34,19 @@ data class MathModel(
   data class MathModelSignature(
     val rawLatex: String,
     val lineHeightHundredX: Int,
-    val useInlineRendering: Boolean
+    val useInlineRendering: Boolean,
+    val isNightMode: Boolean
   ) : Key {
     // Impl reference: http://bumptech.github.io/glide/doc/caching.html#custom-cache-invalidation.
 
     override fun updateDiskCacheKey(messageDigest: MessageDigest) {
       val rawLatexBytes = rawLatex.encodeToByteArray()
       messageDigest.update(
-        ByteBuffer.allocate(rawLatexBytes.size + Int.SIZE_BYTES + 1).apply {
+        ByteBuffer.allocate(rawLatexBytes.size + Int.SIZE_BYTES + 2).apply {
           put(rawLatexBytes)
           putInt(lineHeightHundredX)
           put(if (useInlineRendering) 1 else 0)
+          put(if (isNightMode) 1 else 0)
         }.array()
       )
     }
@@ -53,10 +56,11 @@ data class MathModel(
       internal fun createSignature(
         rawLatex: String,
         lineHeight: Float,
-        useInlineRendering: Boolean
+        useInlineRendering: Boolean,
+        isNightMode: Boolean
       ): MathModelSignature {
         val lineHeightHundredX = (lineHeight * 100f).toInt()
-        return MathModelSignature(rawLatex, lineHeightHundredX, useInlineRendering)
+        return MathModelSignature(rawLatex, lineHeightHundredX, useInlineRendering, isNightMode)
       }
     }
   }

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathModel.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathModel.kt
@@ -15,7 +15,7 @@ data class MathModel(
   val rawLatex: String,
   val lineHeight: Float,
   val useInlineRendering: Boolean,
-  val isNightMode : Boolean
+  val isNightMode: Boolean = false
 ) {
   /** Returns a Glide [Key] signature (see [MathModelSignature] for specifics). */
   fun toKeySignature(): MathModelSignature =

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathModel.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathModel.kt
@@ -15,11 +15,11 @@ data class MathModel(
   val rawLatex: String,
   val lineHeight: Float,
   val useInlineRendering: Boolean,
-  val isNightMode: Boolean = false
+  val equationColor: Int
 ) {
   /** Returns a Glide [Key] signature (see [MathModelSignature] for specifics). */
   fun toKeySignature(): MathModelSignature =
-    MathModelSignature.createSignature(rawLatex, lineHeight, useInlineRendering,isNightMode)
+    MathModelSignature.createSignature(rawLatex, lineHeight, useInlineRendering, equationColor)
 
   /**
    * Glide [Key] that provides caching support by allowing individual renderable math scenarios to
@@ -35,18 +35,18 @@ data class MathModel(
     val rawLatex: String,
     val lineHeightHundredX: Int,
     val useInlineRendering: Boolean,
-    val isNightMode: Boolean
+    val equationColor: Int
   ) : Key {
     // Impl reference: http://bumptech.github.io/glide/doc/caching.html#custom-cache-invalidation.
 
     override fun updateDiskCacheKey(messageDigest: MessageDigest) {
       val rawLatexBytes = rawLatex.encodeToByteArray()
       messageDigest.update(
-        ByteBuffer.allocate(rawLatexBytes.size + Int.SIZE_BYTES + 2).apply {
+        ByteBuffer.allocate(rawLatexBytes.size + Int.SIZE_BYTES + 1 + Int.SIZE_BYTES).apply {
           put(rawLatexBytes)
           putInt(lineHeightHundredX)
           put(if (useInlineRendering) 1 else 0)
-          put(if (isNightMode) 1 else 0)
+          putInt(equationColor)
         }.array()
       )
     }
@@ -57,10 +57,10 @@ data class MathModel(
         rawLatex: String,
         lineHeight: Float,
         useInlineRendering: Boolean,
-        isNightMode: Boolean
+        equationColor: Int
       ): MathModelSignature {
         val lineHeightHundredX = (lineHeight * 100f).toInt()
-        return MathModelSignature(rawLatex, lineHeightHundredX, useInlineRendering, isNightMode)
+        return MathModelSignature(rawLatex, lineHeightHundredX, useInlineRendering, equationColor)
       }
     }
   }

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathModel.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathModel.kt
@@ -41,8 +41,14 @@ data class MathModel(
 
     override fun updateDiskCacheKey(messageDigest: MessageDigest) {
       val rawLatexBytes = rawLatex.encodeToByteArray()
+
+      val latexSize = rawLatexBytes.size
+      val lineHeightBytes = Int.SIZE_BYTES
+      val inlineFlagBytes = 1
+      val colorBytes = Int.SIZE_BYTES
+
       messageDigest.update(
-        ByteBuffer.allocate(rawLatexBytes.size + Int.SIZE_BYTES + 1 + Int.SIZE_BYTES).apply {
+        ByteBuffer.allocate(latexSize + lineHeightBytes + inlineFlagBytes + colorBytes).apply {
           put(rawLatexBytes)
           putInt(lineHeightHundredX)
           put(if (useInlineRendering) 1 else 0)

--- a/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
@@ -1078,7 +1078,7 @@ class HtmlParserTest {
   }
 
   @Test
-  fun testHtmlContent_withMathTag_loadsTextSvg() {
+  fun testHtmlContent_withMathTag_loadsLatexDrawable() {
     val htmlParser = htmlParserFactory.create(
       resourceBucketName,
       entityType = "",
@@ -1101,9 +1101,9 @@ class HtmlParserTest {
         textView.text = htmlResult
       }
 
-      val loadedInlineImages = testGlideImageLoader.getLoadedTextSvgs()
-      assertThat(loadedInlineImages).hasSize(1)
-      assertThat(loadedInlineImages.first()).contains("math_image1.svg")
+      val loadedMathDrawables = testGlideImageLoader.getLoadedMathDrawables()
+      assertThat(loadedMathDrawables).hasSize(1)
+      assertThat(loadedMathDrawables.first().rawLatex).isEqualTo("\\frac{2}{5}")
     }
   }
 

--- a/utility/src/test/java/org/oppia/android/util/parser/html/MathTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/MathTagHandlerTest.kt
@@ -318,7 +318,8 @@ class MathTagHandlerTest {
     val imageSpans = parsedHtml.getSpansFromWholeString(ImageSpan::class)
     assertThat(imageSpans).hasLength(1)
     verify(mockImageRetriever)!!.loadMathDrawable(
-      capture(stringCaptor), capture(floatCaptor), capture(colorCaptor), capture(retrieverTypeCaptor)
+      capture(stringCaptor), capture(floatCaptor),
+      capture(colorCaptor), capture(retrieverTypeCaptor)
     )
     assertThat(stringCaptor.value).isEqualTo("\\frac{2}{5}")
     assertThat(retrieverTypeCaptor.value).isEqualTo(ImageRetriever.Type.INLINE_TEXT_IMAGE)
@@ -337,7 +338,8 @@ class MathTagHandlerTest {
     val imageSpans = parsedHtml.getSpansFromWholeString(ImageSpan::class)
     assertThat(imageSpans).hasLength(1)
     verify(mockImageRetriever)!!.loadMathDrawable(
-      capture(stringCaptor), capture(floatCaptor), capture(colorCaptor), capture(retrieverTypeCaptor)
+      capture(stringCaptor), capture(floatCaptor),
+      capture(colorCaptor), capture(retrieverTypeCaptor)
     )
     assertThat(stringCaptor.value).isEqualTo("\\frac{2}{5}")
     assertThat(retrieverTypeCaptor.value).isEqualTo(ImageRetriever.Type.INLINE_TEXT_IMAGE)
@@ -356,7 +358,8 @@ class MathTagHandlerTest {
     val imageSpans = parsedHtml.getSpansFromWholeString(ImageSpan::class)
     assertThat(imageSpans).hasLength(1)
     verify(mockImageRetriever)!!.loadMathDrawable(
-      capture(stringCaptor), capture(floatCaptor), capture(colorCaptor), capture(retrieverTypeCaptor)
+      capture(stringCaptor), capture(floatCaptor),
+      capture(colorCaptor), capture(retrieverTypeCaptor)
     )
     assertThat(stringCaptor.value).isEqualTo("\\frac{2}{5}")
     assertThat(retrieverTypeCaptor.value).isEqualTo(ImageRetriever.Type.BLOCK_IMAGE)
@@ -470,8 +473,10 @@ class MathTagHandlerTest {
 
     // Verify that both images are loaded in order.
     verify(mockImageRetriever, times(2))!!
-      .loadMathDrawable(capture(stringCaptor), capture(floatCaptor),
-        capture(colorCaptor), capture(retrieverTypeCaptor))
+      .loadMathDrawable(
+        capture(stringCaptor), capture(floatCaptor),
+        capture(colorCaptor), capture(retrieverTypeCaptor)
+      )
     assertThat(stringCaptor.allValues)
       .containsExactly("\\frac{3}{8}", "\\frac{2}{5}")
       .inOrder()

--- a/utility/src/test/java/org/oppia/android/util/parser/html/MathTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/MathTagHandlerTest.kt
@@ -451,7 +451,10 @@ class MathTagHandlerTest {
       customTagHandlers = tagHandlersWithCachedMathSupport
     )
 
-    verify(mockImageRetriever)!!.loadMathDrawable(capture(stringCaptor), capture(floatCaptor),capture(retrieverTypeCaptor))
+    verify(mockImageRetriever)!!.loadMathDrawable(
+      capture(stringCaptor), capture(floatCaptor),
+      capture(retrieverTypeCaptor)
+    )
     assertThat(stringCaptor.value).isEqualTo("\\frac{2}{5}")
     assertThat(retrieverTypeCaptor.value).isEqualTo(ImageRetriever.Type.INLINE_TEXT_IMAGE)
   }

--- a/utility/src/test/java/org/oppia/android/util/parser/html/MathTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/MathTagHandlerTest.kt
@@ -263,7 +263,7 @@ class MathTagHandlerTest {
   }
 
   @Test
-  fun testParseHtml_withMathMarkup_missingRawLatex_includesImageSpan() {
+  fun testParseHtml_withMathMarkup_missingRawLatex_doesNotIncludeImageSpan() {
     val parsedHtml =
       CustomHtmlContentHandler.fromHtml(
         html = MATH_WITHOUT_RAW_LATEX_MARKUP,
@@ -273,7 +273,7 @@ class MathTagHandlerTest {
 
     // There is an image span since the filename is still present.
     val imageSpans = parsedHtml.getSpansFromWholeString(ImageSpan::class)
-    assertThat(imageSpans).hasLength(1)
+    assertThat(imageSpans).hasLength(0)
   }
 
   @Test
@@ -444,20 +444,20 @@ class MathTagHandlerTest {
   }
 
   @Test
-  fun testParseHtml_withMathMarkup_loadsInlineImageForFilename() {
+  fun testParseHtml_withMathMarkup_loadsInlineLatexDrawable() {
     CustomHtmlContentHandler.fromHtml(
       html = MATH_MARKUP_1,
       imageRetriever = mockImageRetriever,
       customTagHandlers = tagHandlersWithCachedMathSupport
     )
 
-    verify(mockImageRetriever)!!.loadDrawable(capture(stringCaptor), capture(retrieverTypeCaptor))
-    assertThat(stringCaptor.value).isEqualTo("math_image1.svg")
+    verify(mockImageRetriever)!!.loadMathDrawable(capture(stringCaptor), capture(floatCaptor),capture(retrieverTypeCaptor))
+    assertThat(stringCaptor.value).isEqualTo("\\frac{2}{5}")
     assertThat(retrieverTypeCaptor.value).isEqualTo(ImageRetriever.Type.INLINE_TEXT_IMAGE)
   }
 
   @Test
-  fun testParseHtml_withMultipleMathTags_loadsInlineImagesForBoth() {
+  fun testParseHtml_withMultipleMathTags_loadsLatexDrawablesForBoth() {
     CustomHtmlContentHandler.fromHtml(
       html = "$MATH_MARKUP_2 and $MATH_MARKUP_1",
       imageRetriever = mockImageRetriever,
@@ -466,9 +466,9 @@ class MathTagHandlerTest {
 
     // Verify that both images are loaded in order.
     verify(mockImageRetriever, times(2))!!
-      .loadDrawable(capture(stringCaptor), capture(retrieverTypeCaptor))
+      .loadMathDrawable(capture(stringCaptor), capture(floatCaptor), capture(retrieverTypeCaptor))
     assertThat(stringCaptor.allValues)
-      .containsExactly("math_image2.svg", "math_image1.svg")
+      .containsExactly("\\frac{3}{8}", "\\frac{2}{5}")
       .inOrder()
     assertThat(retrieverTypeCaptor.allValues)
       .containsExactly(ImageRetriever.Type.INLINE_TEXT_IMAGE, ImageRetriever.Type.INLINE_TEXT_IMAGE)

--- a/utility/src/test/java/org/oppia/android/util/parser/html/MathTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/MathTagHandlerTest.kt
@@ -91,6 +91,7 @@ class MathTagHandlerTest {
   @Captor lateinit var stringCaptor: ArgumentCaptor<String>
   @Captor lateinit var retrieverTypeCaptor: ArgumentCaptor<ImageRetriever.Type>
   @Captor lateinit var floatCaptor: ArgumentCaptor<Float>
+  @Captor lateinit var colorCaptor: ArgumentCaptor<Int>
 
   @Inject lateinit var context: Context
   @Inject lateinit var consoleLogger: ConsoleLogger
@@ -317,7 +318,7 @@ class MathTagHandlerTest {
     val imageSpans = parsedHtml.getSpansFromWholeString(ImageSpan::class)
     assertThat(imageSpans).hasLength(1)
     verify(mockImageRetriever)!!.loadMathDrawable(
-      capture(stringCaptor), capture(floatCaptor), capture(retrieverTypeCaptor)
+      capture(stringCaptor), capture(floatCaptor), capture(colorCaptor), capture(retrieverTypeCaptor)
     )
     assertThat(stringCaptor.value).isEqualTo("\\frac{2}{5}")
     assertThat(retrieverTypeCaptor.value).isEqualTo(ImageRetriever.Type.INLINE_TEXT_IMAGE)
@@ -336,7 +337,7 @@ class MathTagHandlerTest {
     val imageSpans = parsedHtml.getSpansFromWholeString(ImageSpan::class)
     assertThat(imageSpans).hasLength(1)
     verify(mockImageRetriever)!!.loadMathDrawable(
-      capture(stringCaptor), capture(floatCaptor), capture(retrieverTypeCaptor)
+      capture(stringCaptor), capture(floatCaptor), capture(colorCaptor), capture(retrieverTypeCaptor)
     )
     assertThat(stringCaptor.value).isEqualTo("\\frac{2}{5}")
     assertThat(retrieverTypeCaptor.value).isEqualTo(ImageRetriever.Type.INLINE_TEXT_IMAGE)
@@ -355,7 +356,7 @@ class MathTagHandlerTest {
     val imageSpans = parsedHtml.getSpansFromWholeString(ImageSpan::class)
     assertThat(imageSpans).hasLength(1)
     verify(mockImageRetriever)!!.loadMathDrawable(
-      capture(stringCaptor), capture(floatCaptor), capture(retrieverTypeCaptor)
+      capture(stringCaptor), capture(floatCaptor), capture(colorCaptor), capture(retrieverTypeCaptor)
     )
     assertThat(stringCaptor.value).isEqualTo("\\frac{2}{5}")
     assertThat(retrieverTypeCaptor.value).isEqualTo(ImageRetriever.Type.BLOCK_IMAGE)
@@ -453,7 +454,7 @@ class MathTagHandlerTest {
 
     verify(mockImageRetriever)!!.loadMathDrawable(
       capture(stringCaptor), capture(floatCaptor),
-      capture(retrieverTypeCaptor)
+      capture(colorCaptor), capture(retrieverTypeCaptor)
     )
     assertThat(stringCaptor.value).isEqualTo("\\frac{2}{5}")
     assertThat(retrieverTypeCaptor.value).isEqualTo(ImageRetriever.Type.INLINE_TEXT_IMAGE)
@@ -469,7 +470,8 @@ class MathTagHandlerTest {
 
     // Verify that both images are loaded in order.
     verify(mockImageRetriever, times(2))!!
-      .loadMathDrawable(capture(stringCaptor), capture(floatCaptor), capture(retrieverTypeCaptor))
+      .loadMathDrawable(capture(stringCaptor), capture(floatCaptor),
+        capture(colorCaptor), capture(retrieverTypeCaptor))
     assertThat(stringCaptor.allValues)
       .containsExactly("\\frac{3}{8}", "\\frac{2}{5}")
       .inOrder()

--- a/utility/src/test/java/org/oppia/android/util/parser/image/UrlImageParserTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/image/UrlImageParserTest.kt
@@ -2,6 +2,7 @@ package org.oppia.android.util.parser.image
 
 import android.app.Application
 import android.content.Context
+import android.graphics.Color
 import android.os.Looper
 import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
@@ -121,7 +122,8 @@ class UrlImageParserTest {
     urlImageParser.loadMathDrawable(
       rawLatex = rawLatex,
       lineHeight = 20f,
-      type = INLINE_TEXT_IMAGE
+      type = INLINE_TEXT_IMAGE,
+      equationColor = Color.BLACK
     )
 
     Shadows.shadowOf(Looper.getMainLooper()).idle()
@@ -225,7 +227,10 @@ class UrlImageParserTest {
   @Test
   fun testLoadDrawable_latex_inlineType_loadsInlineLatexImage() {
     urlImageParser.loadMathDrawable(
-      rawLatex = "\\frac{2}{6}", lineHeight = 20f, type = INLINE_TEXT_IMAGE
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 20f,
+      type = INLINE_TEXT_IMAGE,
+      equationColor = Color.BLACK
     )
 
     val mathDrawables = testGlideImageLoader.getLoadedMathDrawables()
@@ -238,7 +243,10 @@ class UrlImageParserTest {
   @Test
   fun testLoadDrawable_latex_blockType_loadsBlockLatexImage() {
     urlImageParser.loadMathDrawable(
-      rawLatex = "\\frac{2}{6}", lineHeight = 20f, type = BLOCK_IMAGE
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 20f,
+      type = BLOCK_IMAGE,
+      equationColor = Color.BLACK
     )
 
     val mathDrawables = testGlideImageLoader.getLoadedMathDrawables()
@@ -251,16 +259,28 @@ class UrlImageParserTest {
   @Test
   fun testLoadDrawable_latex_multiple_loadsEachLatexImage() {
     urlImageParser.loadMathDrawable(
-      rawLatex = "\\frac{1}{6}", lineHeight = 20f, type = INLINE_TEXT_IMAGE
+      rawLatex = "\\frac{1}{6}",
+      lineHeight = 20f,
+      type = INLINE_TEXT_IMAGE,
+      equationColor = Color.BLACK
     )
     urlImageParser.loadMathDrawable(
-      rawLatex = "\\frac{2}{6}", lineHeight = 20f, type = INLINE_TEXT_IMAGE
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 20f,
+      type = INLINE_TEXT_IMAGE,
+      equationColor = Color.BLACK
     )
     urlImageParser.loadMathDrawable(
-      rawLatex = "\\frac{2}{6}", lineHeight = 19f, type = INLINE_TEXT_IMAGE
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 19f,
+      type = INLINE_TEXT_IMAGE,
+      equationColor = Color.BLACK
     )
     urlImageParser.loadMathDrawable(
-      rawLatex = "\\frac{2}{6}", lineHeight = 20f, type = BLOCK_IMAGE
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 20f,
+      type = BLOCK_IMAGE,
+      equationColor = Color.BLACK
     )
 
     val mathDrawables = testGlideImageLoader.getLoadedMathDrawables()

--- a/utility/src/test/java/org/oppia/android/util/parser/math/MathModelTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/math/MathModelTest.kt
@@ -109,8 +109,7 @@ class MathModelTest {
       equationColor = Color.BLACK
     )
 
-    val model2 =
-      MathModel(
+    val model2 = MathModel(
         rawLatex = "\\frac{2}{6}",
         lineHeight = 21.501f,
         useInlineRendering = true,

--- a/utility/src/test/java/org/oppia/android/util/parser/math/MathModelTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/math/MathModelTest.kt
@@ -123,4 +123,36 @@ class MathModelTest {
     assertThat(digest1.digest()).isNotEqualTo(digest2.digest())
     assertThat(model1).isNotEqualTo(model2)
   }
+
+  @Test
+  fun testToKeySignature_differenceModelByNightMode_returnsDifferentKeyWithDifferentDigest(){
+    val lightModel = MathModel(
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 21.5f,
+      useInlineRendering = true,
+      isNightMode = false
+    )
+
+    val darkModel = MathModel(
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 21.5f,
+      useInlineRendering = true,
+      isNightMode = true
+    )
+
+    val digest1 = MessageDigest.getInstance("SHA-256")
+    val digest2 = MessageDigest.getInstance("SHA-256")
+
+    val key1 = lightModel.toKeySignature()
+    val key2 = darkModel.toKeySignature()
+
+    key1.updateDiskCacheKey(digest1)
+    key2.updateDiskCacheKey(digest2)
+
+    // Since theme differs, cache keys must differ.
+    assertThat(key1).isNotEqualTo(key2)
+    assertThat(key1.hashCode()).isNotEqualTo(key2.hashCode())
+    assertThat(digest1.digest()).isNotEqualTo(digest2.digest())
+    assertThat(lightModel).isNotEqualTo(darkModel)
+  }
 }

--- a/utility/src/test/java/org/oppia/android/util/parser/math/MathModelTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/math/MathModelTest.kt
@@ -3,6 +3,7 @@ package org.oppia.android.util.parser.math
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import java.security.MessageDigest
+import android.graphics.Color
 
 /** Tests for [MathModel]. */
 // FunctionName: test names are conventionally named with underscores.
@@ -10,8 +11,8 @@ import java.security.MessageDigest
 class MathModelTest {
   @Test
   fun testToKeySignature_sameModelByValues_returnsSameKeyWithSameDigest() {
-    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true)
-    val model2 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true)
+    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
+    val model2 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")
 
@@ -28,8 +29,8 @@ class MathModelTest {
 
   @Test
   fun testToKeySignature_differentModelByLatex_returnsDifferentKeyWithDifferentDigest() {
-    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true)
-    val model2 = MathModel(rawLatex = "\\frac{3}{6}", lineHeight = 21.5f, useInlineRendering = true)
+    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
+    val model2 = MathModel(rawLatex = "\\frac{3}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")
 
@@ -47,8 +48,8 @@ class MathModelTest {
 
   @Test
   fun testToKeySignature_differentModelByLineHeight_returnsDifferentKeyWithDifferentDigest() {
-    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true)
-    val model2 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 20.5f, useInlineRendering = true)
+    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
+    val model2 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 20.5f, useInlineRendering = true, equationColor = Color.BLACK)
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")
 
@@ -66,9 +67,9 @@ class MathModelTest {
 
   @Test
   fun testToKeySignature_diffModelByLineHeight_withinTwoDecimals_returnsSameKeyWithSameDigest() {
-    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true)
+    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
     val model2 =
-      MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.501f, useInlineRendering = true)
+      MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.501f, useInlineRendering = true, equationColor = Color.BLACK)
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")
 
@@ -87,8 +88,8 @@ class MathModelTest {
 
   @Test
   fun testToKeySignature_diffModelByLineHeight_outsideTwoDecimals_returnsDiffKeyWithDiffDigest() {
-    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true)
-    val model2 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.6f, useInlineRendering = true)
+    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
+    val model2 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.6f, useInlineRendering = true, equationColor = Color.BLACK)
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")
 
@@ -106,9 +107,9 @@ class MathModelTest {
 
   @Test
   fun testToKeySignature_differentModelByInlineRendering_returnsDifferentKeyWithDifferentDigest() {
-    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true)
+    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
     val model2 =
-      MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = false)
+      MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = false, equationColor = Color.BLACK)
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")
 
@@ -125,34 +126,35 @@ class MathModelTest {
   }
 
   @Test
-  fun testToKeySignature_differenceModelByNightMode_returnsDifferentKeyWithDifferentDigest(){
-    val lightModel = MathModel(
+  fun testToKeySignature_differentModelByEquationColor_returnsDifferentKeyWithDifferentDigest() {
+    val Model1 = MathModel(
       rawLatex = "\\frac{2}{6}",
       lineHeight = 21.5f,
       useInlineRendering = true,
-      isNightMode = false
+      equationColor = Color.BLACK
     )
 
-    val darkModel = MathModel(
+    val Model2 = MathModel(
       rawLatex = "\\frac{2}{6}",
       lineHeight = 21.5f,
       useInlineRendering = true,
-      isNightMode = true
+      equationColor = Color.WHITE
     )
 
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")
 
-    val key1 = lightModel.toKeySignature()
-    val key2 = darkModel.toKeySignature()
+    val key1 = Model1.toKeySignature()
+    val key2 = Model2.toKeySignature()
 
     key1.updateDiskCacheKey(digest1)
     key2.updateDiskCacheKey(digest2)
 
-    // Since theme differs, cache keys must differ.
+    // Since color differs, cache keys must differ.
     assertThat(key1).isNotEqualTo(key2)
     assertThat(key1.hashCode()).isNotEqualTo(key2.hashCode())
     assertThat(digest1.digest()).isNotEqualTo(digest2.digest())
-    assertThat(lightModel).isNotEqualTo(darkModel)
+    assertThat(Model1).isNotEqualTo(Model2)
   }
+
 }

--- a/utility/src/test/java/org/oppia/android/util/parser/math/MathModelTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/math/MathModelTest.kt
@@ -110,11 +110,11 @@ class MathModelTest {
     )
 
     val model2 = MathModel(
-        rawLatex = "\\frac{2}{6}",
-        lineHeight = 21.501f,
-        useInlineRendering = true,
-        equationColor = Color.BLACK
-      )
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 21.501f,
+      useInlineRendering = true,
+      equationColor = Color.BLACK
+    )
 
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")

--- a/utility/src/test/java/org/oppia/android/util/parser/math/MathModelTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/math/MathModelTest.kt
@@ -197,14 +197,14 @@ class MathModelTest {
 
   @Test
   fun testToKeySignature_differentModelByEquationColor_returnsDifferentKeyWithDifferentDigest() {
-    val Model1 = MathModel(
+    val model1 = MathModel(
       rawLatex = "\\frac{2}{6}",
       lineHeight = 21.5f,
       useInlineRendering = true,
       equationColor = Color.BLACK
     )
 
-    val Model2 = MathModel(
+    val model2 = MathModel(
       rawLatex = "\\frac{2}{6}",
       lineHeight = 21.5f,
       useInlineRendering = true,
@@ -214,8 +214,8 @@ class MathModelTest {
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")
 
-    val key1 = Model1.toKeySignature()
-    val key2 = Model2.toKeySignature()
+    val key1 = model1.toKeySignature()
+    val key2 = model2.toKeySignature()
 
     key1.updateDiskCacheKey(digest1)
     key2.updateDiskCacheKey(digest2)
@@ -224,6 +224,6 @@ class MathModelTest {
     assertThat(key1).isNotEqualTo(key2)
     assertThat(key1.hashCode()).isNotEqualTo(key2.hashCode())
     assertThat(digest1.digest()).isNotEqualTo(digest2.digest())
-    assertThat(Model1).isNotEqualTo(Model2)
+    assertThat(model1).isNotEqualTo(model2)
   }
 }

--- a/utility/src/test/java/org/oppia/android/util/parser/math/MathModelTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/math/MathModelTest.kt
@@ -1,9 +1,9 @@
 package org.oppia.android.util.parser.math
 
+import android.graphics.Color
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import java.security.MessageDigest
-import android.graphics.Color
 
 /** Tests for [MathModel]. */
 // FunctionName: test names are conventionally named with underscores.
@@ -11,8 +11,19 @@ import android.graphics.Color
 class MathModelTest {
   @Test
   fun testToKeySignature_sameModelByValues_returnsSameKeyWithSameDigest() {
-    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
-    val model2 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
+    val model1 = MathModel(
+      rawLatex = "\\frac{2}{6}", lineHeight = 21.5f,
+      useInlineRendering = true,
+      equationColor = Color.BLACK
+    )
+
+    val model2 = MathModel(
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 21.5f,
+      useInlineRendering = true,
+      equationColor = Color.BLACK
+    )
+
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")
 
@@ -29,8 +40,20 @@ class MathModelTest {
 
   @Test
   fun testToKeySignature_differentModelByLatex_returnsDifferentKeyWithDifferentDigest() {
-    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
-    val model2 = MathModel(rawLatex = "\\frac{3}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
+    val model1 = MathModel(
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 21.5f,
+      useInlineRendering = true,
+      equationColor = Color.BLACK
+    )
+
+    val model2 = MathModel(
+      rawLatex = "\\frac{3}{6}",
+      lineHeight = 21.5f,
+      useInlineRendering = true,
+      equationColor = Color.BLACK
+    )
+
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")
 
@@ -48,8 +71,20 @@ class MathModelTest {
 
   @Test
   fun testToKeySignature_differentModelByLineHeight_returnsDifferentKeyWithDifferentDigest() {
-    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
-    val model2 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 20.5f, useInlineRendering = true, equationColor = Color.BLACK)
+    val model1 = MathModel(
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 21.5f,
+      useInlineRendering = true,
+      equationColor = Color.BLACK
+    )
+
+    val model2 = MathModel(
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 20.5f,
+      useInlineRendering = true,
+      equationColor = Color.BLACK
+    )
+
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")
 
@@ -67,9 +102,21 @@ class MathModelTest {
 
   @Test
   fun testToKeySignature_diffModelByLineHeight_withinTwoDecimals_returnsSameKeyWithSameDigest() {
-    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
+    val model1 = MathModel(
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 21.5f,
+      useInlineRendering = true,
+      equationColor = Color.BLACK
+    )
+
     val model2 =
-      MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.501f, useInlineRendering = true, equationColor = Color.BLACK)
+      MathModel(
+        rawLatex = "\\frac{2}{6}",
+        lineHeight = 21.501f,
+        useInlineRendering = true,
+        equationColor = Color.BLACK
+      )
+
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")
 
@@ -88,8 +135,20 @@ class MathModelTest {
 
   @Test
   fun testToKeySignature_diffModelByLineHeight_outsideTwoDecimals_returnsDiffKeyWithDiffDigest() {
-    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
-    val model2 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.6f, useInlineRendering = true, equationColor = Color.BLACK)
+    val model1 = MathModel(
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 21.5f,
+      useInlineRendering = true,
+      equationColor = Color.BLACK
+    )
+
+    val model2 = MathModel(
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 21.6f,
+      useInlineRendering = true,
+      equationColor = Color.BLACK
+    )
+
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")
 
@@ -107,9 +166,21 @@ class MathModelTest {
 
   @Test
   fun testToKeySignature_differentModelByInlineRendering_returnsDifferentKeyWithDifferentDigest() {
-    val model1 = MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = true, equationColor = Color.BLACK)
+    val model1 = MathModel(
+      rawLatex = "\\frac{2}{6}",
+      lineHeight = 21.5f,
+      useInlineRendering = true,
+      equationColor = Color.BLACK
+    )
+
     val model2 =
-      MathModel(rawLatex = "\\frac{2}{6}", lineHeight = 21.5f, useInlineRendering = false, equationColor = Color.BLACK)
+      MathModel(
+        rawLatex = "\\frac{2}{6}",
+        lineHeight = 21.5f,
+        useInlineRendering = false,
+        equationColor = Color.BLACK
+      )
+
     val digest1 = MessageDigest.getInstance("SHA-256")
     val digest2 = MessageDigest.getInstance("SHA-256")
 
@@ -156,5 +227,4 @@ class MathModelTest {
     assertThat(digest1.digest()).isNotEqualTo(digest2.digest())
     assertThat(Model1).isNotEqualTo(Model2)
   }
-
 }


### PR DESCRIPTION
## Explanation
Fix part of #5792: Make LaTeX rendering theme-aware and prevent cross-theme Glide cache reuse between Light and Dark modes.

## Problem

- LaTeX equations rendered incorrectly when switching between Light and Dark themes:
- Equations appeared with incorrect color in dark mode.
- Switching themes reused previously rendered bitmaps.
- The first-rendered theme determined the appearance of equations.
- This caused visibility and UI consistency issues.

## Root Cause

Two related issues were identified:
- **Theme-unaware LaTeX color**
      The equation color passed into `MathExpressionSpan `was not explicitly resolved from theme resources.
- **Glide cache reuse across themes**
     `MathModelSignature.updateDiskCacheKey() `did not include theme state.
      Glide treated Light and Dark renders as identical cache entries.

## Solution
**Make LaTeX Rendering Theme-Aware**
- Resolved equation color using` ResourcesCompat.getColor(...).`
- Used` component_color_shared_equation_color,` defined separately in:
- values/ (Light mode)
- values-night/ (Dark mode)
- Passed resolved color into `MathExpressionSpan.`
- This ensures correct equation color per theme.

 **Separate Glide Cache by Theme**
- Added isNightMode to MathModel.
- Included isNightMode in MathModelSignature.
- Updated `updateDiskCacheKey()` to incorporate theme state.

This ensures:
- Light and Dark renders generate different cache keys.
- Glide stores separate cached bitmaps per theme.
- No incorrect reuse occurs after theme switching.

## Additional Fix
- While updating the cache signature, a BufferOverflowException occurred due to insufficient ByteBuffer allocation size.
- The allocation size was corrected to accommodate all written fields.
- 

## SVG Removal
Removed legacy SVG fallback rendering for math and updated related tests to align with LaTeX-only rendering.

## Validation
Validated by:
Fresh install → Light → switch to Dark → correct rendering.
Fresh install → Dark → switch to Light → correct rendering.

Confirmed via logs:
`MathModelSignature` includes both night=false and night=true.
Glide loads separate cached resources.
No cross-theme reuse occurs.
All affected unit tests were updated and pass locally.

Screen recording is attached.
https://drive.google.com/file/d/1MIqQXQjESmsQlkhPOtJyNYsct1DqjNVf/view?usp=sharing

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [X] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [X] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [X] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [X] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [X] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).