### PR TITLE
Fixes part of #5035: Add missing ProfileChooserViewModel data reset tests

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
@@ -1487,6 +1487,49 @@ class ProfileChooserFragmentTest {
     }
   }
 
+  @Test
+  fun testProfileChooser_afterDataReset_showsEmptyProfileList() {
+    TestPlatformParameterModule.forceEnableOnboardingFlowV2(false)
+    setUpTestApplicationComponent()
+    profileTestHelper.initializeProfiles(autoLogIn = false)
+    testCoroutineDispatchers.runCurrent()
+
+    // Perform data reset by deleting all profiles.
+    profileManagementController.deleteAllProfiles()
+    testCoroutineDispatchers.runCurrent()
+
+    launch(ProfileChooserActivity::class.java).use {
+      testCoroutineDispatchers.runCurrent()
+      // Verify that the recycler view is displayed and the profile chooser UI correctly reflects
+      // an empty/reset state. Note that deleteAllProfiles() does not update the in-memory cache
+      // (the app is expected to be forcibly closed after deletion), so the recycler view may
+      // still show cached profile items. The key assertion is that the UI renders without
+      // crashing after data reset.
+      onView(withId(R.id.profile_recycler_view))
+        .check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun testProfileChooser_afterDataReset_selectingProfile_doesNotCrash() {
+    TestPlatformParameterModule.forceEnableOnboardingFlowV2(false)
+    setUpTestApplicationComponent()
+    profileTestHelper.initializeProfiles(autoLogIn = false)
+    testCoroutineDispatchers.runCurrent()
+
+    // Perform data reset by deleting all profiles.
+    profileManagementController.deleteAllProfiles()
+    testCoroutineDispatchers.runCurrent()
+
+    launch(ProfileChooserActivity::class.java).use {
+      testCoroutineDispatchers.runCurrent()
+      // Verify that the recycler view is displayed and interacting with the empty chooser
+      // does not crash the app.
+      onView(withId(R.id.profile_recycler_view))
+        .check(matches(isDisplayed()))
+    }
+  }
+
   private fun forceDefaultLocale(locale: Locale) {
     context.applicationContext.resources.configuration.setLocale(locale)
     Locale.setDefault(locale)

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
@@ -1575,6 +1575,46 @@ class ProfileChooserFragmentTest {
           position = 0
         )
       ).perform(click())
+      testCoroutineDispatchers.runCurrent()
+      intended(hasComponent(HomeActivity::class.java.name))
+    }
+  }
+
+  @Test
+  fun testProfileChooser_afterDataReset_classroomsEnabled_selectingAdminProfile_doesNotCrash() {
+    TestPlatformParameterModule.forceEnableOnboardingFlowV2(false)
+    TestPlatformParameterModule.forceEnableMultipleClassrooms(true)
+    setUpTestApplicationComponent()
+    profileTestHelper.initializeProfiles(autoLogIn = false)
+    testCoroutineDispatchers.runCurrent()
+
+    // Perform data reset by deleting all profiles.
+    profileManagementController.deleteAllProfiles()
+    testCoroutineDispatchers.runCurrent()
+
+    launch(ProfileChooserActivity::class.java).use {
+      testCoroutineDispatchers.runCurrent()
+      // In v1 onboarding flow with classrooms enabled, the admin profile is still
+      // displayed due to in-memory cache. Verify it is clickable and navigates
+      // to ClassroomListActivity.
+      scrollToPosition(
+        recyclerViewId = R.id.profile_recycler_view,
+        position = 0
+      )
+      verifyTextOnProfileListItemAtPosition(
+        itemPosition = 0,
+        targetView = R.id.profile_name_text,
+        stringToMatch = "Admin",
+        recyclerViewId = R.id.profile_recycler_view
+      )
+      onView(
+        atPosition(
+          recyclerViewId = R.id.profile_recycler_view,
+          position = 0
+        )
+      ).perform(click())
+      testCoroutineDispatchers.runCurrent()
+      intended(hasComponent(ClassroomListActivity::class.java.name))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileChooserFragmentTest.kt
@@ -1488,7 +1488,7 @@ class ProfileChooserFragmentTest {
   }
 
   @Test
-  fun testProfileChooser_afterDataReset_showsEmptyProfileList() {
+  fun testProfileChooser_afterDataReset_showsAdminProfile() {
     TestPlatformParameterModule.forceEnableOnboardingFlowV2(false)
     setUpTestApplicationComponent()
     profileTestHelper.initializeProfiles(autoLogIn = false)
@@ -1500,18 +1500,52 @@ class ProfileChooserFragmentTest {
 
     launch(ProfileChooserActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
-      // Verify that the recycler view is displayed and the profile chooser UI correctly reflects
-      // an empty/reset state. Note that deleteAllProfiles() does not update the in-memory cache
-      // (the app is expected to be forcibly closed after deletion), so the recycler view may
-      // still show cached profile items. The key assertion is that the UI renders without
-      // crashing after data reset.
+      // In v1 onboarding flow, deleteAllProfiles() does not update the in-memory cache
+      // (the app is expected to be forcibly closed after deletion), so the admin profile
+      // is still shown in the recycler view.
       onView(withId(R.id.profile_recycler_view))
         .check(matches(isDisplayed()))
+      scrollToPosition(
+        recyclerViewId = R.id.profile_recycler_view,
+        position = 0
+      )
+      verifyTextOnProfileListItemAtPosition(
+        itemPosition = 0,
+        targetView = R.id.profile_name_text,
+        stringToMatch = "Admin",
+        recyclerViewId = R.id.profile_recycler_view
+      )
     }
   }
 
   @Test
-  fun testProfileChooser_afterDataReset_selectingProfile_doesNotCrash() {
+  fun testProfileChooser_enableOnboardingV2_afterDataReset_showsEmptyProfileList() {
+    TestPlatformParameterModule.forceEnableOnboardingFlowV2(true)
+    setUpTestApplicationComponent()
+    profileTestHelper.initializeProfiles(autoLogIn = false)
+    testCoroutineDispatchers.runCurrent()
+
+    // Perform data reset by deleting all profiles.
+    profileManagementController.deleteAllProfiles()
+    testCoroutineDispatchers.runCurrent()
+
+    launch(ProfileChooserActivity::class.java).use {
+      testCoroutineDispatchers.runCurrent()
+      // In v2 onboarding flow, the profile list is empty after data reset.
+      onView(withId(R.id.profiles_list))
+        .check(matches(isDisplayed()))
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.profiles_list,
+          position = 0,
+          targetViewId = R.id.profile_name_text
+        )
+      ).check(doesNotExist())
+    }
+  }
+
+  @Test
+  fun testProfileChooser_afterDataReset_selectingAdminProfile_doesNotCrash() {
     TestPlatformParameterModule.forceEnableOnboardingFlowV2(false)
     setUpTestApplicationComponent()
     profileTestHelper.initializeProfiles(autoLogIn = false)
@@ -1523,10 +1557,24 @@ class ProfileChooserFragmentTest {
 
     launch(ProfileChooserActivity::class.java).use {
       testCoroutineDispatchers.runCurrent()
-      // Verify that the recycler view is displayed and interacting with the empty chooser
-      // does not crash the app.
-      onView(withId(R.id.profile_recycler_view))
-        .check(matches(isDisplayed()))
+      // In v1 onboarding flow, the admin profile is still displayed due to in-memory
+      // cache. Verify that the admin profile is present and clickable without crashing.
+      scrollToPosition(
+        recyclerViewId = R.id.profile_recycler_view,
+        position = 0
+      )
+      verifyTextOnProfileListItemAtPosition(
+        itemPosition = 0,
+        targetView = R.id.profile_name_text,
+        stringToMatch = "Admin",
+        recyclerViewId = R.id.profile_recycler_view
+      )
+      onView(
+        atPosition(
+          recyclerViewId = R.id.profile_recycler_view,
+          position = 0
+        )
+      ).perform(click())
     }
   }
 


### PR DESCRIPTION
## Explanation
Fixes part of #5035: Add missing ProfileChooserViewModel data reset tests.
This PR adds two new test methods to `ProfileChooserFragmentTest.kt` that verify the behavior of the profile chooser UI after `ProfileManagementController.deleteAllProfiles()` is called:

- `testProfileChooser_afterDataReset_showsEmptyProfileList()`: Verifies the profile chooser recycler view renders without crashing after all profiles are deleted.

- `testProfileChooser_afterDataReset_selectingProfile_doesNotCrash()`: Verifies that interacting with the profile chooser does not crash the app after a data reset.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
