### PR TITLE
Fix #5935: Prevent submitted answer and feedback text from flashing previous card's content

### DIFF
--- a/app/src/main/java/org/oppia/android/app/customview/PromotedStoryCardView.kt
+++ b/app/src/main/java/org/oppia/android/app/customview/PromotedStoryCardView.kt
@@ -27,13 +27,23 @@ class PromotedStoryCardView @JvmOverloads constructor(
   @Inject
   lateinit var resourceHandler: AppLanguageResourceHandler
 
+  private var promotedStoryIndex: Int = -1
   private var isSpotlit = false
 
   /** Sets the index at which this custom view is located inside the recycler view. */
   fun setPromotedStoryIndex(index: Int) {
+    promotedStoryIndex = index
+    maybeRequestSpotlight()
+  }
+
+  private fun maybeRequestSpotlight() {
     // This view can get attached multiple times and we must make sure that the spotlight is
     // requested only once. Only spotlight the item at the first index of the recycler view.
-    if (!isSpotlit && index == 0) {
+    if (!isSpotlit &&
+      promotedStoryIndex == 0 &&
+      ::resourceHandler.isInitialized &&
+      ::fragment.isInitialized
+    ) {
       isSpotlit = true
       val spotlightTarget = SpotlightTarget(
         this,
@@ -56,5 +66,6 @@ class PromotedStoryCardView @JvmOverloads constructor(
       FragmentManager.findFragment<Fragment>(this) as ViewComponentFactory
     val viewComponent = viewComponentFactory.createViewComponent(this) as ViewComponentImpl
     viewComponent.inject(this)
+    maybeRequestSpotlight()
   }
 }

--- a/app/src/main/java/org/oppia/android/app/home/promotedlist/ComingSoonTopicsListView.kt
+++ b/app/src/main/java/org/oppia/android/app/home/promotedlist/ComingSoonTopicsListView.kt
@@ -97,17 +97,8 @@ class ComingSoonTopicsListView @JvmOverloads constructor(
   private fun createAdapter(): BindableAdapter<ComingSoonTopicsViewModel> {
     return singleTypeBuilderFactory.create<ComingSoonTopicsViewModel>()
       .registerViewDataBinderWithSameModelType(
-        inflateDataBinding = { inflater, parent, attachToParent ->
-          bindingInterface.provideComingSoonTopicViewInflatedView(
-            inflater, parent, attachToParent
-          )
-        },
-        setViewModel = { binding, viewModel ->
-          bindingInterface.provideComingSoonTopicsViewViewModel(
-            binding,
-            viewModel
-          )
-        }
+        inflateDataBinding = bindingInterface::provideComingSoonTopicViewInflatedView,
+        setViewModel = bindingInterface::provideComingSoonTopicsViewViewModel
       ).build()
   }
 }

--- a/app/src/main/java/org/oppia/android/app/home/promotedlist/ComingSoonTopicsListView.kt
+++ b/app/src/main/java/org/oppia/android/app/home/promotedlist/ComingSoonTopicsListView.kt
@@ -2,7 +2,6 @@ package org.oppia.android.app.home.promotedlist
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.RecyclerView
@@ -97,17 +96,15 @@ class ComingSoonTopicsListView @JvmOverloads constructor(
 
   private fun createAdapter(): BindableAdapter<ComingSoonTopicsViewModel> {
     return singleTypeBuilderFactory.create<ComingSoonTopicsViewModel>()
-      .registerViewBinder(
-        inflateView = { parent ->
+      .registerViewDataBinderWithSameModelType(
+        inflateDataBinding = { inflater, parent, attachToParent ->
           bindingInterface.provideComingSoonTopicViewInflatedView(
-            LayoutInflater.from(parent.context),
-            parent,
-            attachToParent = false
+            inflater, parent, attachToParent
           )
         },
-        bindView = { view, viewModel ->
+        setViewModel = { binding, viewModel ->
           bindingInterface.provideComingSoonTopicsViewViewModel(
-            view,
+            binding,
             viewModel
           )
         }

--- a/app/src/main/java/org/oppia/android/app/home/promotedlist/PromotedStoryListView.kt
+++ b/app/src/main/java/org/oppia/android/app/home/promotedlist/PromotedStoryListView.kt
@@ -2,7 +2,6 @@ package org.oppia.android.app.home.promotedlist
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.RecyclerView
@@ -91,17 +90,15 @@ class PromotedStoryListView @JvmOverloads constructor(
 
   private fun createAdapter(): BindableAdapter<PromotedStoryViewModel> {
     return singleTypeBuilderFactory.create<PromotedStoryViewModel>()
-      .registerViewBinder(
-        inflateView = { parent ->
+      .registerViewDataBinderWithSameModelType(
+        inflateDataBinding = { inflater, parent, attachToParent ->
           bindingInterface.providePromotedStoryCardInflatedView(
-            LayoutInflater.from(parent.context),
-            parent,
-            attachToParent = false
+            inflater, parent, attachToParent
           )
         },
-        bindView = { view, viewModel ->
+        setViewModel = { binding, viewModel ->
           bindingInterface.providePromotedStoryViewModel(
-            view,
+            binding,
             viewModel
           )
         }

--- a/app/src/main/java/org/oppia/android/app/home/promotedlist/PromotedStoryListView.kt
+++ b/app/src/main/java/org/oppia/android/app/home/promotedlist/PromotedStoryListView.kt
@@ -91,17 +91,8 @@ class PromotedStoryListView @JvmOverloads constructor(
   private fun createAdapter(): BindableAdapter<PromotedStoryViewModel> {
     return singleTypeBuilderFactory.create<PromotedStoryViewModel>()
       .registerViewDataBinderWithSameModelType(
-        inflateDataBinding = { inflater, parent, attachToParent ->
-          bindingInterface.providePromotedStoryCardInflatedView(
-            inflater, parent, attachToParent
-          )
-        },
-        setViewModel = { binding, viewModel ->
-          bindingInterface.providePromotedStoryViewModel(
-            binding,
-            viewModel
-          )
-        }
+        inflateDataBinding = bindingInterface::providePromotedStoryCardInflatedView,
+        setViewModel = bindingInterface::providePromotedStoryViewModel
       ).build()
   }
 }

--- a/app/src/main/java/org/oppia/android/app/player/state/DragDropSortInteractionView.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/DragDropSortInteractionView.kt
@@ -2,7 +2,6 @@ package org.oppia.android.app.player.state
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.ViewConfiguration
 import androidx.core.view.isVisible
@@ -193,16 +192,14 @@ class DragDropSortInteractionView @JvmOverloads constructor(
     itemsInSamePositionAllowed: Boolean
   ): BindableAdapter<DragDropInteractionContentViewModel> {
     return singleTypeBuilderFactory.create<DragDropInteractionContentViewModel>()
-      .registerViewBinder(
-        inflateView = { parent ->
+      .registerViewDataBinderWithSameModelType(
+        inflateDataBinding = { inflater, parent, attachToParent ->
           viewBindingShim.provideDragDropSortInteractionInflatedView(
-            LayoutInflater.from(parent.context),
-            parent,
-            /* attachToParent= */ false
+            inflater, parent, attachToParent
           )
         },
-        bindView = { view, viewModel ->
-          viewBindingShim.setDragDropInteractionItemsBinding(view)
+        setViewModel = { binding, viewModel ->
+          viewBindingShim.setDragDropInteractionItemsBinding(binding)
           viewBindingShim.getDragDropInteractionItemsBindingRecyclerView().adapter =
             createNestedAdapter()
           adapter?.let { viewBindingShim.setDragDropInteractionItemsBindingAdapter(it) }
@@ -220,16 +217,14 @@ class DragDropSortInteractionView @JvmOverloads constructor(
 
   private fun createNestedAdapter(): BindableAdapter<String> {
     return singleTypeBuilderFactory.create<String>()
-      .registerViewBinder(
-        inflateView = { parent ->
+      .registerViewDataBinderWithSameModelType(
+        inflateDataBinding = { inflater, parent, attachToParent ->
           viewBindingShim.provideDragDropSingleItemInflatedView(
-            LayoutInflater.from(parent.context),
-            parent,
-            /* attachToParent= */ false
+            inflater, parent, attachToParent
           )
         },
-        bindView = { view, viewModel ->
-          viewBindingShim.setDragDropSingleItemBinding(view)
+        setViewModel = { binding, viewModel ->
+          viewBindingShim.setDragDropSingleItemBinding(binding)
           viewBindingShim.setDragDropSingleItemBindingHtmlContent(
             htmlParserFactory,
             resourceBucketName,

--- a/app/src/main/java/org/oppia/android/app/player/state/DragDropSortInteractionView.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/DragDropSortInteractionView.kt
@@ -193,11 +193,7 @@ class DragDropSortInteractionView @JvmOverloads constructor(
   ): BindableAdapter<DragDropInteractionContentViewModel> {
     return singleTypeBuilderFactory.create<DragDropInteractionContentViewModel>()
       .registerViewDataBinderWithSameModelType(
-        inflateDataBinding = { inflater, parent, attachToParent ->
-          viewBindingShim.provideDragDropSortInteractionInflatedView(
-            inflater, parent, attachToParent
-          )
-        },
+        inflateDataBinding = viewBindingShim::provideDragDropSortInteractionInflatedView,
         setViewModel = { binding, viewModel ->
           viewBindingShim.setDragDropInteractionItemsBinding(binding)
           viewBindingShim.getDragDropInteractionItemsBindingRecyclerView().adapter =
@@ -218,11 +214,7 @@ class DragDropSortInteractionView @JvmOverloads constructor(
   private fun createNestedAdapter(): BindableAdapter<String> {
     return singleTypeBuilderFactory.create<String>()
       .registerViewDataBinderWithSameModelType(
-        inflateDataBinding = { inflater, parent, attachToParent ->
-          viewBindingShim.provideDragDropSingleItemInflatedView(
-            inflater, parent, attachToParent
-          )
-        },
+        inflateDataBinding = viewBindingShim::provideDragDropSingleItemInflatedView,
         setViewModel = { binding, viewModel ->
           viewBindingShim.setDragDropSingleItemBinding(binding)
           viewBindingShim.setDragDropSingleItemBindingHtmlContent(

--- a/app/src/main/java/org/oppia/android/app/player/state/SelectionInteractionView.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/SelectionInteractionView.kt
@@ -2,7 +2,6 @@ package org.oppia.android.app.player.state
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import androidx.databinding.ObservableList
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -97,17 +96,15 @@ class SelectionInteractionView @JvmOverloads constructor(
     return when (selectionItemInputType) {
       SelectionItemInputType.CHECKBOXES ->
         singleTypeBuilderFactory.create<SelectionInteractionContentViewModel>()
-          .registerViewBinder(
-            inflateView = { parent ->
+          .registerViewDataBinderWithSameModelType(
+            inflateDataBinding = { inflater, parent, attachToParent ->
               bindingInterface.provideSelectionInteractionViewInflatedView(
-                LayoutInflater.from(parent.context),
-                parent,
-                /* attachToParent= */ false
+                inflater, parent, attachToParent
               )
             },
-            bindView = { view, viewModel ->
+            setViewModel = { binding, viewModel ->
               bindingInterface.provideSelectionInteractionViewModel(
-                view,
+                binding,
                 viewModel,
                 htmlParserFactory,
                 resourceBucketName,
@@ -120,17 +117,15 @@ class SelectionInteractionView @JvmOverloads constructor(
           .build()
       SelectionItemInputType.RADIO_BUTTONS ->
         singleTypeBuilderFactory.create<SelectionInteractionContentViewModel>()
-          .registerViewBinder(
-            inflateView = { parent ->
+          .registerViewDataBinderWithSameModelType(
+            inflateDataBinding = { inflater, parent, attachToParent ->
               bindingInterface.provideMultipleChoiceInteractionItemsInflatedView(
-                LayoutInflater.from(parent.context),
-                parent,
-                /* attachToParent= */ false
+                inflater, parent, attachToParent
               )
             },
-            bindView = { view, viewModel ->
+            setViewModel = { binding, viewModel ->
               bindingInterface.provideMultipleChoiceInteractionItemsViewModel(
-                view,
+                binding,
                 viewModel,
                 htmlParserFactory,
                 resourceBucketName,

--- a/app/src/main/java/org/oppia/android/app/player/state/SelectionInteractionView.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/SelectionInteractionView.kt
@@ -97,11 +97,7 @@ class SelectionInteractionView @JvmOverloads constructor(
       SelectionItemInputType.CHECKBOXES ->
         singleTypeBuilderFactory.create<SelectionInteractionContentViewModel>()
           .registerViewDataBinderWithSameModelType(
-            inflateDataBinding = { inflater, parent, attachToParent ->
-              bindingInterface.provideSelectionInteractionViewInflatedView(
-                inflater, parent, attachToParent
-              )
-            },
+            inflateDataBinding = bindingInterface::provideSelectionInteractionViewInflatedView,
             setViewModel = { binding, viewModel ->
               bindingInterface.provideSelectionInteractionViewModel(
                 binding,
@@ -118,11 +114,7 @@ class SelectionInteractionView @JvmOverloads constructor(
       SelectionItemInputType.RADIO_BUTTONS ->
         singleTypeBuilderFactory.create<SelectionInteractionContentViewModel>()
           .registerViewDataBinderWithSameModelType(
-            inflateDataBinding = { inflater, parent, attachToParent ->
-              bindingInterface.provideMultipleChoiceInteractionItemsInflatedView(
-                inflater, parent, attachToParent
-              )
-            },
+            inflateDataBinding = bindingInterface::provideMultipleChoiceInteractionItemsInflatedView,
             setViewModel = { binding, viewModel ->
               bindingInterface.provideMultipleChoiceInteractionItemsViewModel(
                 binding,

--- a/app/src/main/java/org/oppia/android/app/player/state/SelectionInteractionView.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/SelectionInteractionView.kt
@@ -114,7 +114,8 @@ class SelectionInteractionView @JvmOverloads constructor(
       SelectionItemInputType.RADIO_BUTTONS ->
         singleTypeBuilderFactory.create<SelectionInteractionContentViewModel>()
           .registerViewDataBinderWithSameModelType(
-            inflateDataBinding = bindingInterface::provideMultipleChoiceInteractionItemsInflatedView,
+            inflateDataBinding =
+              bindingInterface::provideMultipleChoiceInteractionItemsInflatedView,
             setViewModel = { binding, viewModel ->
               bindingInterface.provideMultipleChoiceInteractionItemsViewModel(
                 binding,

--- a/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
@@ -3,7 +3,6 @@ package org.oppia.android.app.player.state
 import android.app.Application
 import android.content.Context
 import android.graphics.Typeface
-import android.view.LayoutInflater
 import android.view.View
 import android.view.animation.AccelerateInterpolator
 import android.view.animation.AlphaAnimation
@@ -11,7 +10,6 @@ import android.view.animation.AnimationSet
 import android.view.animation.DecelerateInterpolator
 import android.widget.TextView
 import androidx.core.content.ContextCompat.getColor
-import androidx.databinding.DataBindingUtil
 import androidx.databinding.ObservableBoolean
 import androidx.databinding.ObservableField
 import androidx.databinding.ObservableList
@@ -1302,34 +1300,27 @@ class StatePlayerRecyclerViewAssembler private constructor(
 
     /** Adds support for displaying state content to the learner. */
     fun addContentSupport(): Builder {
-      adapterBuilder.registerViewBinder(
+      adapterBuilder.registerViewDataBinder(
         viewType = StateItemViewModel.ViewType.CONTENT,
-        inflateView = { parent ->
-          ContentItemBinding.inflate(
-            LayoutInflater.from(parent.context),
-            parent,
-            /* attachToParent= */ false
-          ).root
-        },
-        bindView = { view, viewModel ->
-          val binding = DataBindingUtil.findBinding<ContentItemBinding>(view)!!
-          val contentViewModel = viewModel as ContentViewModel
-          binding.viewModel = contentViewModel
+        inflateDataBinding = ContentItemBinding::inflate,
+        setViewModel = { binding, viewModel ->
+          binding.viewModel = viewModel
           binding.htmlContent =
             htmlParserFactory.create(
               resourceBucketName,
               entityType,
-              contentViewModel.gcsEntityId,
+              viewModel.gcsEntityId,
               imageCenterAlign = true,
               customOppiaTagActionListener = customTagListener,
               displayLocale = resourceHandler.getDisplayLocale()
             ).parseOppiaHtml(
-              contentViewModel.htmlContent.toString(),
+              viewModel.htmlContent.toString(),
               binding.contentTextView,
               supportsLinks = true,
-              supportsConceptCards = contentViewModel.supportsConceptCards
+              supportsConceptCards = viewModel.supportsConceptCards
             )
-        }
+        },
+        transformViewModel = { it as ContentViewModel }
       )
       featureSets += PlayerFeatureSet(contentSupport = true)
       return this
@@ -1337,34 +1328,27 @@ class StatePlayerRecyclerViewAssembler private constructor(
 
     /** Adds support for displaying feedback to the user when they submit an answer. */
     fun addFeedbackSupport(): Builder {
-      adapterBuilder.registerViewBinder(
+      adapterBuilder.registerViewDataBinder(
         viewType = StateItemViewModel.ViewType.FEEDBACK,
-        inflateView = { parent ->
-          FeedbackItemBinding.inflate(
-            LayoutInflater.from(parent.context),
-            parent,
-            /* attachToParent= */ false
-          ).root
-        },
-        bindView = { view, viewModel ->
-          val binding = DataBindingUtil.findBinding<FeedbackItemBinding>(view)!!
-          val feedbackViewModel = viewModel as FeedbackViewModel
-          binding.viewModel = feedbackViewModel
+        inflateDataBinding = FeedbackItemBinding::inflate,
+        setViewModel = { binding, viewModel ->
+          binding.viewModel = viewModel
           binding.htmlContent =
             htmlParserFactory.create(
               resourceBucketName,
               entityType,
-              feedbackViewModel.gcsEntityId,
+              viewModel.gcsEntityId,
               imageCenterAlign = true,
               customOppiaTagActionListener = customTagListener,
               displayLocale = resourceHandler.getDisplayLocale()
             ).parseOppiaHtml(
-              feedbackViewModel.htmlContent.toString(),
+              viewModel.htmlContent.toString(),
               binding.feedbackTextView,
               supportsLinks = true,
-              supportsConceptCards = feedbackViewModel.supportsConceptCards
+              supportsConceptCards = viewModel.supportsConceptCards
             )
-        }
+        },
+        transformViewModel = { it as FeedbackViewModel }
       )
       featureSets += PlayerFeatureSet(feedbackSupport = true)
       return this
@@ -1442,18 +1426,12 @@ class StatePlayerRecyclerViewAssembler private constructor(
 
     /** Adds support for displaying previously submitted answers. */
     fun addPastAnswersSupport(): Builder {
-      adapterBuilder.registerViewBinder(
+      adapterBuilder.registerViewDataBinder(
         viewType = StateItemViewModel.ViewType.SUBMITTED_ANSWER,
-        inflateView = { parent ->
-          SubmittedAnswerItemBinding.inflate(
-            LayoutInflater.from(parent.context), parent, /* attachToParent= */ false
-          ).root
-        },
-        bindView = { view, viewModel ->
-          val binding = DataBindingUtil.findBinding<SubmittedAnswerItemBinding>(view)!!
-          val submittedAnswerViewModel = viewModel as SubmittedAnswerViewModel
-          binding.viewModel = submittedAnswerViewModel
-          val userAnswer = submittedAnswerViewModel.submittedUserAnswer
+        inflateDataBinding = SubmittedAnswerItemBinding::inflate,
+        setViewModel = { binding, viewModel ->
+          binding.viewModel = viewModel
+          val userAnswer = viewModel.submittedUserAnswer
           when (userAnswer.textualAnswerCase) {
             UserAnswer.TextualAnswerCase.ITEM_SELECTION_ANSWER -> {
               showSelectionSubmittedAnswer(binding)
@@ -1469,16 +1447,16 @@ class StatePlayerRecyclerViewAssembler private constructor(
               val htmlParser = htmlParserFactory.create(
                 resourceBucketName,
                 entityType,
-                submittedAnswerViewModel.gcsEntityId,
+                viewModel.gcsEntityId,
                 imageCenterAlign = false,
                 customOppiaTagActionListener = customTagListener,
                 displayLocale = resourceHandler.getDisplayLocale()
               )
-              submittedAnswerViewModel.setSubmittedAnswer(
+              viewModel.setSubmittedAnswer(
                 htmlParser.parseOppiaHtml(
                   userAnswer.htmlAnswer,
                   binding.submittedAnswerTextView,
-                  supportsConceptCards = submittedAnswerViewModel.supportsConceptCards
+                  supportsConceptCards = viewModel.supportsConceptCards
                 ),
                 accessibleAnswer
               )
@@ -1488,18 +1466,19 @@ class StatePlayerRecyclerViewAssembler private constructor(
               binding.submittedListAnswer = userAnswer.listOfHtmlAnswers
               binding.submittedAnswerRecyclerView.adapter =
                 createListAnswerAdapter(
-                  submittedAnswerViewModel.gcsEntityId,
-                  submittedAnswerViewModel.supportsConceptCards
+                  viewModel.gcsEntityId,
+                  viewModel.supportsConceptCards
                 )
             }
             else -> {
               showSingleAnswer(binding)
-              submittedAnswerViewModel.setSubmittedAnswer(
+              viewModel.setSubmittedAnswer(
                 userAnswer.plainAnswer, accessibleAnswer = userAnswer.contentDescription
               )
             }
           }
-        }
+        },
+        transformViewModel = { it as SubmittedAnswerViewModel }
       )
       featureSets += PlayerFeatureSet(pastAnswerSupport = true)
       return this
@@ -1566,14 +1545,9 @@ class StatePlayerRecyclerViewAssembler private constructor(
       supportsConceptCards: Boolean
     ): BindableAdapter<StringList> {
       return singleTypeBuilderFactory.create<StringList>()
-        .registerViewBinder(
-          inflateView = { parent ->
-            SubmittedAnswerListItemBinding.inflate(
-              LayoutInflater.from(parent.context), parent, /* attachToParent= */ false
-            ).root
-          },
-          bindView = { view, viewModel ->
-            val binding = DataBindingUtil.findBinding<SubmittedAnswerListItemBinding>(view)!!
+        .registerViewDataBinderWithSameModelType(
+          inflateDataBinding = SubmittedAnswerListItemBinding::inflate,
+          setViewModel = { binding, viewModel ->
             binding.answerItem = viewModel
             binding.submittedHtmlAnswerRecyclerView.adapter =
               createNestedAdapter(gcsEntityId, supportsConceptCards)
@@ -1587,14 +1561,9 @@ class StatePlayerRecyclerViewAssembler private constructor(
       supportsConceptCards: Boolean
     ): BindableAdapter<String> {
       return singleTypeBuilderFactory.create<String>()
-        .registerViewBinder(
-          inflateView = { parent ->
-            SubmittedHtmlAnswerItemBinding.inflate(
-              LayoutInflater.from(parent.context), parent, /* attachToParent= */ false
-            ).root
-          },
-          bindView = { view, viewModel ->
-            val binding = DataBindingUtil.findBinding<SubmittedHtmlAnswerItemBinding>(view)!!
+        .registerViewDataBinderWithSameModelType(
+          inflateDataBinding = SubmittedHtmlAnswerItemBinding::inflate,
+          setViewModel = { binding, viewModel ->
             binding.htmlContent =
               htmlParserFactory.create(
                 resourceBucketName,
@@ -1619,15 +1588,9 @@ class StatePlayerRecyclerViewAssembler private constructor(
       return when (selectionItemInputType) {
         SelectionItemInputType.CHECKBOXES -> {
           singleTypeBuilderFactory.create<SelectionSubmittedItemViewModel>()
-            .registerViewBinder(
-              inflateView = { parent ->
-                ItemSelectionSubmittedAnswerItemsBinding.inflate(
-                  LayoutInflater.from(parent.context), parent, /* attachToParent= */ false
-                ).root
-              },
-              bindView = { view, viewModel ->
-                val binding = DataBindingUtil
-                  .findBinding<ItemSelectionSubmittedAnswerItemsBinding>(view)!!
+            .registerViewDataBinderWithSameModelType(
+              inflateDataBinding = ItemSelectionSubmittedAnswerItemsBinding::inflate,
+              setViewModel = { binding, viewModel ->
                 binding.htmlContent =
                   htmlParserFactory.create(
                     resourceBucketName,
@@ -1654,15 +1617,9 @@ class StatePlayerRecyclerViewAssembler private constructor(
 
         SelectionItemInputType.RADIO_BUTTONS -> {
           singleTypeBuilderFactory.create<SelectionSubmittedItemViewModel>()
-            .registerViewBinder(
-              inflateView = { parent ->
-                MultipleChoiceSubmittedAnswerItemsBinding.inflate(
-                  LayoutInflater.from(parent.context), parent, /* attachToParent= */ false
-                ).root
-              },
-              bindView = { view, viewModel ->
-                val binding = DataBindingUtil
-                  .findBinding<MultipleChoiceSubmittedAnswerItemsBinding>(view)!!
+            .registerViewDataBinderWithSameModelType(
+              inflateDataBinding = MultipleChoiceSubmittedAnswerItemsBinding::inflate,
+              setViewModel = { binding, viewModel ->
                 binding.htmlContent =
                   htmlParserFactory.create(
                     resourceBucketName,

--- a/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
@@ -1350,8 +1350,6 @@ class StatePlayerRecyclerViewAssembler private constructor(
           val binding = DataBindingUtil.findBinding<FeedbackItemBinding>(view)!!
           val feedbackViewModel = viewModel as FeedbackViewModel
           binding.viewModel = feedbackViewModel
-          binding.htmlContent = ""
-          binding.executePendingBindings()
           binding.htmlContent =
             htmlParserFactory.create(
               resourceBucketName,
@@ -1455,7 +1453,6 @@ class StatePlayerRecyclerViewAssembler private constructor(
           val binding = DataBindingUtil.findBinding<SubmittedAnswerItemBinding>(view)!!
           val submittedAnswerViewModel = viewModel as SubmittedAnswerViewModel
           binding.viewModel = submittedAnswerViewModel
-          binding.executePendingBindings()
           val userAnswer = submittedAnswerViewModel.submittedUserAnswer
           when (userAnswer.textualAnswerCase) {
             UserAnswer.TextualAnswerCase.ITEM_SELECTION_ANSWER -> {

--- a/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StatePlayerRecyclerViewAssembler.kt
@@ -1350,6 +1350,8 @@ class StatePlayerRecyclerViewAssembler private constructor(
           val binding = DataBindingUtil.findBinding<FeedbackItemBinding>(view)!!
           val feedbackViewModel = viewModel as FeedbackViewModel
           binding.viewModel = feedbackViewModel
+          binding.htmlContent = ""
+          binding.executePendingBindings()
           binding.htmlContent =
             htmlParserFactory.create(
               resourceBucketName,
@@ -1453,6 +1455,7 @@ class StatePlayerRecyclerViewAssembler private constructor(
           val binding = DataBindingUtil.findBinding<SubmittedAnswerItemBinding>(view)!!
           val submittedAnswerViewModel = viewModel as SubmittedAnswerViewModel
           binding.viewModel = submittedAnswerViewModel
+          binding.executePendingBindings()
           val userAnswer = submittedAnswerViewModel.submittedUserAnswer
           when (userAnswer.textualAnswerCase) {
             UserAnswer.TextualAnswerCase.ITEM_SELECTION_ANSWER -> {

--- a/app/src/main/java/org/oppia/android/app/recyclerview/BindableAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/recyclerview/BindableAdapter.kt
@@ -3,7 +3,6 @@ package org.oppia.android.app.recyclerview
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
@@ -139,6 +138,10 @@ class BindableAdapter<T : Any> internal constructor(
     /**
      * Registers a [View] inflater and bind function for views in the recycler view.
      *
+     * Note that callers which use data binding internally (e.g. via [DataBindingUtil]) should use
+     * [registerViewDataBinderWithSameModelType] instead. Using this method with data binding will
+     * result in flickering due to deferred binding execution. See #5935.
+     *
      * The inflateView and bindView functions passed in here must not hold any references to UI
      * objects except those that own the RecyclerView.
      *
@@ -162,19 +165,16 @@ class BindableAdapter<T : Any> internal constructor(
         object : BindableViewHolder<T>(inflatedView) {
           override fun bind(data: T) {
             bindView(inflatedView, data)
-            // Force immediate binding execution after bindView completes. Some views registered
-            // via registerViewBinder use data binding internally (e.g. via DataBindingUtil) and
-            // set properties like htmlContent that are deferred by the binding framework. Without
-            // this call, RecyclerView may briefly display stale content from a recycled view
-            // before the binding framework flushes updates on the next frame. See: #5935.
-            DataBindingUtil.findBinding<ViewDataBinding>(inflatedView)?.executePendingBindings()
           }
         }
       }
       return this
     }
 
-    /** See [registerViewDataBinder]. */
+    /**
+     * See [registerViewDataBinder]. Binding changes are automatically synchronized after each
+     * rebind to prevent flickering from deferred data binding execution (see #5935 and #6093).
+     */
     fun <DB : ViewDataBinding> registerViewDataBinderWithSameModelType(
       inflateDataBinding: (LayoutInflater, ViewGroup, Boolean) -> DB,
       setViewModel: (DB, T) -> Unit
@@ -188,6 +188,9 @@ class BindableAdapter<T : Any> internal constructor(
     /**
      * Behaves in the same way as [registerViewBinder] except the inflate and bind methods
      * correspond to a [View] data-binding typed [DB].
+     *
+     * Binding changes are automatically synchronized after each rebind to prevent flickering from
+     * deferred data binding execution (see #5935 and #6093).
      *
      * @param inflateDataBinding a function that inflates the root view of a data-bound layout (e.g.
      *     MyDataBinding::inflate). This may also be a function that initializes the data-binding
@@ -218,6 +221,7 @@ class BindableAdapter<T : Any> internal constructor(
             // Attaching lifecycleOwner before view model initialization can sometimes cause a
             // NullPointerException because data might not be attached to the views yet.
             binding.lifecycleOwner = lifecycleOwner
+            synchronizeBindingWithRebind(binding)
           }
         }
       }
@@ -261,6 +265,11 @@ class BindableAdapter<T : Any> internal constructor(
      * specified here must be properly returned in the [ComputeViewType] function passed into
      * [Factory.create].
      *
+     * Note that callers which use data binding internally (e.g. via [DataBindingUtil]) should use
+     * [registerViewDataBinder] or [registerViewDataBinderWithSameModelType] instead. Using this
+     * method with data binding will result in flickering due to deferred binding execution. See
+     * #5935.
+     *
      * The inflateView and bindView functions passed in here must not hold any references to UI
      * objects except those that own the RecyclerView.
      *
@@ -287,12 +296,6 @@ class BindableAdapter<T : Any> internal constructor(
         object : BindableViewHolder<T>(inflatedView) {
           override fun bind(data: T) {
             bindView(inflatedView, data)
-            // Force immediate binding execution after bindView completes. Some views registered
-            // via registerViewBinder use data binding internally (e.g. via DataBindingUtil) and
-            // set properties like htmlContent that are deferred by the binding framework. Without
-            // this call, RecyclerView may briefly display stale content from a recycled view
-            // before the binding framework flushes updates on the next frame. See: #5935.
-            DataBindingUtil.findBinding<ViewDataBinding>(inflatedView)?.executePendingBindings()
           }
         }
       }
@@ -300,7 +303,10 @@ class BindableAdapter<T : Any> internal constructor(
       return this
     }
 
-    /** See [registerViewDataBinder]. */
+    /**
+     * See [registerViewDataBinder]. Binding changes are automatically synchronized after each
+     * rebind to prevent flickering from deferred data binding execution (see #5935 and #6093).
+     */
     fun <DB : ViewDataBinding> registerViewDataBinderWithSameModelType(
       viewType: E,
       inflateDataBinding: (LayoutInflater, ViewGroup, Boolean) -> DB,
@@ -315,6 +321,9 @@ class BindableAdapter<T : Any> internal constructor(
     /**
      * Behaves in the same way as [registerViewBinder] except the inflate and bind methods
      * correspond to a [View] data-binding typed [DB].
+     *
+     * Binding changes are automatically synchronized after each rebind to prevent flickering from
+     * deferred data binding execution (see #5935 and #6093).
      *
      * @param viewType the type of the view being bound
      * @param inflateDataBinding a function that inflates the root view of a data-bound layout (e.g.
@@ -350,6 +359,7 @@ class BindableAdapter<T : Any> internal constructor(
             // Attaching lifecycleOwner before view model initialization can sometimes cause a
             // NullPointerException because data might not be attached to the views yet.
             binding.lifecycleOwner = lifecycleOwner
+            synchronizeBindingWithRebind(binding)
           }
         }
       }
@@ -382,4 +392,17 @@ class BindableAdapter<T : Any> internal constructor(
       ): MultiTypeBuilder<T, E> = MultiTypeBuilder(T::class, computeViewType, fragment)
     }
   }
+}
+
+/**
+ * Forces the specified [ViewDataBinding] to immediately execute any pending binding changes.
+ *
+ * This is necessary because the data binding framework defers property updates (such as setting
+ * text via binding adapters) until the next animation frame. When a [RecyclerView] recycles a view
+ * holder, the old bound values remain visible until the deferred update runs, causing a brief flash
+ * of stale content. Calling [ViewDataBinding.executePendingBindings] after rebinding ensures the new
+ * values are applied synchronously. See #5935 and #6093.
+ */
+private fun synchronizeBindingWithRebind(binding: ViewDataBinding) {
+  binding.executePendingBindings()
 }

--- a/app/src/main/java/org/oppia/android/app/recyclerview/BindableAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/recyclerview/BindableAdapter.kt
@@ -3,6 +3,7 @@ package org.oppia.android.app.recyclerview
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
@@ -161,6 +162,12 @@ class BindableAdapter<T : Any> internal constructor(
         object : BindableViewHolder<T>(inflatedView) {
           override fun bind(data: T) {
             bindView(inflatedView, data)
+            // Force immediate binding execution after bindView completes. Some views registered
+            // via registerViewBinder use data binding internally (e.g. via DataBindingUtil) and
+            // set properties like htmlContent that are deferred by the binding framework. Without
+            // this call, RecyclerView may briefly display stale content from a recycled view
+            // before the binding framework flushes updates on the next frame. See: #5935.
+            DataBindingUtil.findBinding<ViewDataBinding>(inflatedView)?.executePendingBindings()
           }
         }
       }
@@ -280,6 +287,12 @@ class BindableAdapter<T : Any> internal constructor(
         object : BindableViewHolder<T>(inflatedView) {
           override fun bind(data: T) {
             bindView(inflatedView, data)
+            // Force immediate binding execution after bindView completes. Some views registered
+            // via registerViewBinder use data binding internally (e.g. via DataBindingUtil) and
+            // set properties like htmlContent that are deferred by the binding framework. Without
+            // this call, RecyclerView may briefly display stale content from a recycled view
+            // before the binding framework flushes updates on the next frame. See: #5935.
+            DataBindingUtil.findBinding<ViewDataBinding>(inflatedView)?.executePendingBindings()
           }
         }
       }

--- a/app/src/main/java/org/oppia/android/app/shim/ViewBindingShim.kt
+++ b/app/src/main/java/org/oppia/android/app/shim/ViewBindingShim.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.ImageButton
 import android.widget.LinearLayout
+import androidx.databinding.ViewDataBinding
 import androidx.recyclerview.widget.RecyclerView
 import org.oppia.android.app.home.promotedlist.ComingSoonTopicsViewModel
 import org.oppia.android.app.home.promotedlist.PromotedStoryViewModel
@@ -28,17 +29,17 @@ interface ViewBindingShim {
 
   /**
    * Handles binding inflation for [DragDropSortInteractionView]'s SortInteraction and returns the
-   * binding's view.
+   * binding.
    */
   fun provideDragDropSortInteractionInflatedView(
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View
+  ): ViewDataBinding
 
   /** Handles setting [DragDropInteractionItemsBinding]. */
   fun setDragDropInteractionItemsBinding(
-    view: View
+    binding: ViewDataBinding
   )
 
   /** Handles setting [DragDropInteractionItemsBinding]'s adapter. */
@@ -65,17 +66,17 @@ interface ViewBindingShim {
 
   /**
    * Handles binding inflation for [DragDropSortInteractionView]'s SingleItemInteraction and returns
-   * the binding's view.
+   * the binding.
    */
   fun provideDragDropSingleItemInflatedView(
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View
+  ): ViewDataBinding
 
   /** Handles setting [DragDropSingleItemBinding]. */
   fun setDragDropSingleItemBinding(
-    view: View
+    binding: ViewDataBinding
   )
 
   /** Handles setting [DragDropSingleItemBinding]'s html content. */
@@ -97,14 +98,14 @@ interface ViewBindingShim {
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View
+  ): ViewDataBinding
 
   /**
    * Handles binding inflation for [org.oppia.android.app.home.promotedlist.PromotedStoryListView]
-   * and returns the view model.
+   * and sets the view model.
    */
   fun providePromotedStoryViewModel(
-    view: View,
+    binding: ViewDataBinding,
     viewModel: PromotedStoryViewModel
   )
 
@@ -113,30 +114,30 @@ interface ViewBindingShim {
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View
+  ): ViewDataBinding
 
-  /** Handles binding inflation for [ComingSoonTopicsListView] and returns the view model. */
+  /** Handles binding inflation for [ComingSoonTopicsListView] and sets the view model. */
   fun provideComingSoonTopicsViewViewModel(
-    view: View,
+    binding: ViewDataBinding,
     viewModel: ComingSoonTopicsViewModel
   )
 
   /**
    * Handles binding inflation for [SelectionInteractionView]'s ItemSelectionInteraction and
-   * returns the binding's root.
+   * returns the binding.
    */
   fun provideSelectionInteractionViewInflatedView(
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View
+  ): ViewDataBinding
 
   /**
-   * Handles binding inflation for [SelectionInteractionView]'s ItemSelectionInteraction and
-   * returns the binding's view model.
+   * Handles binding for [SelectionInteractionView]'s ItemSelectionInteraction and
+   * sets the view model.
    */
   fun provideSelectionInteractionViewModel(
-    view: View,
+    binding: ViewDataBinding,
     viewModel: SelectionInteractionContentViewModel,
     htmlParserFactory: HtmlParser.Factory,
     resourceBucketName: String,
@@ -147,20 +148,20 @@ interface ViewBindingShim {
 
   /**
    * Handles binding inflation for [SelectionInteractionView]'s MultipleChoiceInteraction and
-   * returns the binding's view.
+   * returns the binding.
    */
   fun provideMultipleChoiceInteractionItemsInflatedView(
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View
+  ): ViewDataBinding
 
   /**
-   * Handles binding inflation for [SelectionInteractionView]'s MultipleChoiceInteraction and
-   * returns the binding's view model.
+   * Handles binding for [SelectionInteractionView]'s MultipleChoiceInteraction and
+   * sets the view model.
    */
   fun provideMultipleChoiceInteractionItemsViewModel(
-    view: View,
+    binding: ViewDataBinding,
     viewModel: SelectionInteractionContentViewModel,
     htmlParserFactory: HtmlParser.Factory,
     resourceBucketName: String,
@@ -171,39 +172,39 @@ interface ViewBindingShim {
 
   /**
    * Handles binding inflation for [SurveyMultipleChoiceOptionView]'s MultipleChoiceOption and
-   * returns the binding's view.
+   * returns the binding.
    */
   fun provideMultipleChoiceItemsInflatedView(
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View
+  ): ViewDataBinding
 
   /**
-   * Handles binding inflation for [SurveyMultipleChoiceOptionView]'s MultipleChoiceOption and
-   * returns the binding's view model.
+   * Handles binding for [SurveyMultipleChoiceOptionView]'s MultipleChoiceOption and
+   * sets the view model.
    */
   fun provideMultipleChoiceOptionViewModel(
-    view: View,
+    binding: ViewDataBinding,
     viewModel: MultipleChoiceOptionContentViewModel
   )
 
   /**
    * Handles binding inflation for [SurveyNpsItemOptionView]'s MultipleChoiceOption and
-   * returns the binding's view.
+   * returns the binding.
    */
   fun provideNpsItemsInflatedView(
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View
+  ): ViewDataBinding
 
   /**
-   * Handles binding inflation for [SurveyNpsItemOptionView]'s MultipleChoiceOption and
-   * returns the binding's view model.
+   * Handles binding for [SurveyNpsItemOptionView]'s MultipleChoiceOption and
+   * sets the view model.
    */
   fun provideNpsItemsViewModel(
-    view: View,
+    binding: ViewDataBinding,
     viewModel: MultipleChoiceOptionContentViewModel
   )
 }

--- a/app/src/main/java/org/oppia/android/app/shim/ViewBindingShimImpl.kt
+++ b/app/src/main/java/org/oppia/android/app/shim/ViewBindingShimImpl.kt
@@ -6,7 +6,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.ImageButton
 import android.widget.LinearLayout
-import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
 import androidx.recyclerview.widget.RecyclerView
 import org.oppia.android.app.databinding.R
 import org.oppia.android.app.databinding.databinding.ComingSoonTopicViewBinding
@@ -46,54 +46,52 @@ class ViewBindingShimImpl @Inject constructor(
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View {
+  ): ViewDataBinding {
     return PromotedStoryCardBinding.inflate(
       LayoutInflater.from(parent.context), parent, attachToParent
-    ).root
+    )
   }
 
   override fun providePromotedStoryViewModel(
-    view: View,
+    binding: ViewDataBinding,
     viewModel: PromotedStoryViewModel
   ) {
-    val binding =
-      DataBindingUtil.findBinding<PromotedStoryCardBinding>(view)!!
-    binding.viewModel = viewModel
+    val promotedBinding = binding as PromotedStoryCardBinding
+    promotedBinding.viewModel = viewModel
   }
 
   override fun provideComingSoonTopicViewInflatedView(
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View {
+  ): ViewDataBinding {
     return ComingSoonTopicViewBinding.inflate(
       LayoutInflater.from(parent.context), parent, attachToParent
-    ).root
+    )
   }
 
   override fun provideComingSoonTopicsViewViewModel(
-    view: View,
+    binding: ViewDataBinding,
     viewModel: ComingSoonTopicsViewModel
   ) {
-    val binding =
-      DataBindingUtil.findBinding<ComingSoonTopicViewBinding>(view)!!
-    binding.viewModel = viewModel
+    val comingSoonBinding = binding as ComingSoonTopicViewBinding
+    comingSoonBinding.viewModel = viewModel
   }
 
   override fun provideSelectionInteractionViewInflatedView(
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View {
+  ): ViewDataBinding {
     return ItemSelectionInteractionItemsBinding.inflate(
       LayoutInflater.from(parent.context),
       parent,
       /* attachToParent= */ false
-    ).root
+    )
   }
 
   override fun provideSelectionInteractionViewModel(
-    view: View,
+    binding: ViewDataBinding,
     viewModel: SelectionInteractionContentViewModel,
     htmlParserFactory: HtmlParser.Factory,
     resourceBucketName: String,
@@ -101,9 +99,8 @@ class ViewBindingShimImpl @Inject constructor(
     entityId: String,
     writtenTranslationContext: WrittenTranslationContext
   ) {
-    val binding =
-      DataBindingUtil.findBinding<ItemSelectionInteractionItemsBinding>(view)!!
-    binding.htmlContent =
+    val selectionBinding = binding as ItemSelectionInteractionItemsBinding
+    selectionBinding.htmlContent =
       htmlParserFactory.create(
         resourceBucketName,
         entityType,
@@ -112,25 +109,25 @@ class ViewBindingShimImpl @Inject constructor(
         displayLocale = appLanguageResourceHandler.getDisplayLocale()
       ).parseOppiaHtml(
         translationController.extractString(viewModel.htmlContent, writtenTranslationContext),
-        binding.itemSelectionContentsTextView
+        selectionBinding.itemSelectionContentsTextView
       )
-    binding.viewModel = viewModel
+    selectionBinding.viewModel = viewModel
   }
 
   override fun provideMultipleChoiceInteractionItemsInflatedView(
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View {
+  ): ViewDataBinding {
     return MultipleChoiceInteractionItemsBinding.inflate(
       LayoutInflater.from(parent.context),
       parent,
       false
-    ).root
+    )
   }
 
   override fun provideMultipleChoiceInteractionItemsViewModel(
-    view: View,
+    binding: ViewDataBinding,
     viewModel: SelectionInteractionContentViewModel,
     htmlParserFactory: HtmlParser.Factory,
     resourceBucketName: String,
@@ -138,80 +135,76 @@ class ViewBindingShimImpl @Inject constructor(
     entityId: String,
     writtenTranslationContext: WrittenTranslationContext
   ) {
-    val binding =
-      DataBindingUtil.findBinding<MultipleChoiceInteractionItemsBinding>(view)!!
-    binding.htmlContent =
+    val multipleChoiceBinding = binding as MultipleChoiceInteractionItemsBinding
+    multipleChoiceBinding.htmlContent =
       htmlParserFactory.create(
         resourceBucketName, entityType, entityId, /* imageCenterAlign= */ false,
         displayLocale = appLanguageResourceHandler.getDisplayLocale()
       ).parseOppiaHtml(
         translationController.extractString(viewModel.htmlContent, writtenTranslationContext),
-        binding.multipleChoiceContentTextView
+        multipleChoiceBinding.multipleChoiceContentTextView
       )
-    binding.viewModel = viewModel
+    multipleChoiceBinding.viewModel = viewModel
   }
 
   override fun provideMultipleChoiceItemsInflatedView(
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View {
+  ): ViewDataBinding {
     return SurveyMultipleChoiceItemBinding.inflate(
       LayoutInflater.from(parent.context),
       parent,
       false
-    ).root
+    )
   }
 
   override fun provideMultipleChoiceOptionViewModel(
-    view: View,
+    binding: ViewDataBinding,
     viewModel: MultipleChoiceOptionContentViewModel
   ) {
-    val binding =
-      DataBindingUtil.findBinding<SurveyMultipleChoiceItemBinding>(view)!!
-    binding.optionContent = viewModel.optionContent
-    binding.viewModel = viewModel
+    val surveyBinding = binding as SurveyMultipleChoiceItemBinding
+    surveyBinding.optionContent = viewModel.optionContent
+    surveyBinding.viewModel = viewModel
   }
 
   override fun provideNpsItemsInflatedView(
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View {
+  ): ViewDataBinding {
     return SurveyNpsItemBinding.inflate(
       LayoutInflater.from(parent.context),
       parent,
       false
-    ).root
+    )
   }
 
   override fun provideNpsItemsViewModel(
-    view: View,
+    binding: ViewDataBinding,
     viewModel: MultipleChoiceOptionContentViewModel
   ) {
-    val binding =
-      DataBindingUtil.findBinding<SurveyNpsItemBinding>(view)!!
-    binding.scoreContent = viewModel.optionContent
-    binding.viewModel = viewModel
+    val npsBinding = binding as SurveyNpsItemBinding
+    npsBinding.scoreContent = viewModel.optionContent
+    npsBinding.viewModel = viewModel
   }
 
   override fun provideDragDropSortInteractionInflatedView(
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View {
+  ): ViewDataBinding {
     return DragDropInteractionItemsBinding.inflate(
       LayoutInflater.from(parent.context), parent, /* attachToParent= */ false
-    ).root
+    )
   }
 
   private lateinit var dragDropInteractionItemsBinding: DragDropInteractionItemsBinding
 
   override fun setDragDropInteractionItemsBinding(
-    view: View
+    binding: ViewDataBinding
   ) {
-    dragDropInteractionItemsBinding =
-      DataBindingUtil.findBinding<DragDropInteractionItemsBinding>(view)!!
+    dragDropInteractionItemsBinding = binding as DragDropInteractionItemsBinding
   }
 
   override fun setDragDropInteractionItemsBindingAdapter(
@@ -246,20 +239,19 @@ class ViewBindingShimImpl @Inject constructor(
     inflater: LayoutInflater,
     parent: ViewGroup,
     attachToParent: Boolean
-  ): View {
+  ): ViewDataBinding {
     return DragDropSingleItemBinding.inflate(
       LayoutInflater.from(parent.context), parent, /* attachToParent= */ false
-    ).root
+    )
   }
 
   // TODO(#1692): Fix implementation to not use cache binding.
   private lateinit var dragDropSingleItemBinding: DragDropSingleItemBinding
 
   override fun setDragDropSingleItemBinding(
-    view: View
+    binding: ViewDataBinding
   ) {
-    dragDropSingleItemBinding =
-      DataBindingUtil.findBinding<DragDropSingleItemBinding>(view)!!
+    dragDropSingleItemBinding = binding as DragDropSingleItemBinding
   }
 
   override fun setDragDropSingleItemBindingHtmlContent(

--- a/app/src/main/java/org/oppia/android/app/story/StoryFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/story/StoryFragmentPresenter.kt
@@ -13,7 +13,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearSmoothScroller
@@ -161,40 +160,32 @@ class StoryFragmentPresenter @Inject constructor(
         setViewModel = StoryHeaderViewBinding::setViewModel,
         transformViewModel = { it as StoryHeaderViewModel }
       )
-      .registerViewBinder(
+      .registerViewDataBinder(
         viewType = ViewType.VIEW_TYPE_CHAPTER,
-        inflateView = { parent ->
-          StoryChapterViewBinding.inflate(
-            LayoutInflater.from(parent.context),
-            parent,
-            /* attachToParent= */ false
-          ).root
-        },
-        bindView = { view, viewModel ->
-          val binding = DataBindingUtil.findBinding<StoryChapterViewBinding>(view)!!
-          val storyItemViewModel = viewModel as StoryChapterSummaryViewModel
-          binding.viewModel = storyItemViewModel
+        inflateDataBinding = StoryChapterViewBinding::inflate,
+        setViewModel = { binding, viewModel ->
+          binding.viewModel = viewModel
           binding.htmlContent =
             htmlParserFactory.create(
               resourceBucketName,
               entityType,
-              storyItemViewModel.storyId,
+              viewModel.storyId,
               imageCenterAlign = true,
               displayLocale = resourceHandler.getDisplayLocale()
-            ).parseOppiaHtml(storyItemViewModel.description, binding.chapterSummary)
-          if (storyItemViewModel.chapterSummary.chapterPlayState
+            ).parseOppiaHtml(viewModel.description, binding.chapterSummary)
+          if (viewModel.chapterSummary.chapterPlayState
             == ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES
           ) {
             val missingPrerequisiteSummary = resourceHandler.getStringInLocaleWithWrapping(
               R.string.chapter_prerequisite_title_label,
-              storyItemViewModel.index.toString(),
-              storyItemViewModel.missingPrerequisiteChapterTitle
+              viewModel.index.toString(),
+              viewModel.missingPrerequisiteChapterTitle
             )
             val chapterLockedSpannable = SpannableString(missingPrerequisiteSummary)
             if (!accessibilityService.isScreenReaderEnabled()) {
               val clickableSpan = object : ClickableSpan() {
                 override fun onClick(widget: View) {
-                  smoothScrollToPosition(storyItemViewModel.index - 1)
+                  smoothScrollToPosition(viewModel.index - 1)
                 }
 
                 override fun updateDrawState(ds: TextPaint) {
@@ -218,7 +209,8 @@ class StoryFragmentPresenter @Inject constructor(
             binding.htmlContent = chapterLockedSpannable
             binding.chapterSummary.movementMethod = LinkMovementMethod.getInstance()
           }
-        }
+        },
+        transformViewModel = { it as StoryChapterSummaryViewModel }
       )
       .build()
   }

--- a/app/src/main/java/org/oppia/android/app/survey/SurveyFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/survey/SurveyFragmentPresenter.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LiveData
 import com.google.android.flexbox.FlexDirection
@@ -143,26 +142,19 @@ class SurveyFragmentPresenter @Inject constructor(
         setViewModel = SurveyMarketFitQuestionLayoutBinding::setViewModel,
         transformViewModel = { it as MarketFitItemsViewModel }
       )
-      .registerViewBinder(
+      .registerViewDataBinder(
         viewType = SurveyAnswerItemViewModel.ViewType.NPS_OPTIONS,
-        inflateView = { parent ->
-          SurveyNpsScoreLayoutBinding.inflate(
-            LayoutInflater.from(parent.context),
-            parent,
-            /* attachToParent= */ false
-          ).root
-        },
-        bindView = { view, viewModel ->
-          val binding = DataBindingUtil.findBinding<SurveyNpsScoreLayoutBinding>(view)!!
-          val npsViewModel = viewModel as NpsItemsViewModel
-          binding.viewModel = npsViewModel
+        inflateDataBinding = SurveyNpsScoreLayoutBinding::inflate,
+        setViewModel = { binding, viewModel ->
+          binding.viewModel = viewModel
 
           val flexLayoutManager = FlexboxLayoutManager(activity)
           flexLayoutManager.flexDirection = FlexDirection.ROW
           flexLayoutManager.justifyContent = JustifyContent.CENTER
 
           binding.surveyNpsButtonsContainer.layoutManager = flexLayoutManager
-        }
+        },
+        transformViewModel = { it as NpsItemsViewModel }
       )
       .registerViewDataBinder(
         viewType = SurveyAnswerItemViewModel.ViewType.FREE_FORM_ANSWER,

--- a/app/src/main/java/org/oppia/android/app/survey/SurveyMultipleChoiceOptionView.kt
+++ b/app/src/main/java/org/oppia/android/app/survey/SurveyMultipleChoiceOptionView.kt
@@ -59,17 +59,8 @@ class SurveyMultipleChoiceOptionView @JvmOverloads constructor(
   private fun createAdapter(): BindableAdapter<MultipleChoiceOptionContentViewModel> {
     return singleTypeBuilderFactory.create<MultipleChoiceOptionContentViewModel>()
       .registerViewDataBinderWithSameModelType(
-        inflateDataBinding = { inflater, parent, attachToParent ->
-          bindingInterface.provideMultipleChoiceItemsInflatedView(
-            inflater, parent, attachToParent
-          )
-        },
-        setViewModel = { binding, viewModel ->
-          bindingInterface.provideMultipleChoiceOptionViewModel(
-            binding,
-            viewModel
-          )
-        }
+        inflateDataBinding = bindingInterface::provideMultipleChoiceItemsInflatedView,
+        setViewModel = bindingInterface::provideMultipleChoiceOptionViewModel
       )
       .build()
   }

--- a/app/src/main/java/org/oppia/android/app/survey/SurveyMultipleChoiceOptionView.kt
+++ b/app/src/main/java/org/oppia/android/app/survey/SurveyMultipleChoiceOptionView.kt
@@ -2,7 +2,6 @@ package org.oppia.android.app.survey
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import androidx.databinding.ObservableList
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -59,17 +58,15 @@ class SurveyMultipleChoiceOptionView @JvmOverloads constructor(
 
   private fun createAdapter(): BindableAdapter<MultipleChoiceOptionContentViewModel> {
     return singleTypeBuilderFactory.create<MultipleChoiceOptionContentViewModel>()
-      .registerViewBinder(
-        inflateView = { parent ->
+      .registerViewDataBinderWithSameModelType(
+        inflateDataBinding = { inflater, parent, attachToParent ->
           bindingInterface.provideMultipleChoiceItemsInflatedView(
-            LayoutInflater.from(parent.context),
-            parent,
-            /* attachToParent= */ false
+            inflater, parent, attachToParent
           )
         },
-        bindView = { view, viewModel ->
+        setViewModel = { binding, viewModel ->
           bindingInterface.provideMultipleChoiceOptionViewModel(
-            view,
+            binding,
             viewModel
           )
         }

--- a/app/src/main/java/org/oppia/android/app/survey/SurveyNpsItemOptionView.kt
+++ b/app/src/main/java/org/oppia/android/app/survey/SurveyNpsItemOptionView.kt
@@ -2,7 +2,6 @@ package org.oppia.android.app.survey
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import androidx.databinding.ObservableList
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -59,17 +58,15 @@ class SurveyNpsItemOptionView @JvmOverloads constructor(
 
   private fun createAdapter(): BindableAdapter<MultipleChoiceOptionContentViewModel> {
     return singleTypeBuilderFactory.create<MultipleChoiceOptionContentViewModel>()
-      .registerViewBinder(
-        inflateView = { parent ->
+      .registerViewDataBinderWithSameModelType(
+        inflateDataBinding = { inflater, parent, attachToParent ->
           bindingInterface.provideNpsItemsInflatedView(
-            LayoutInflater.from(parent.context),
-            parent,
-            /* attachToParent= */ false
+            inflater, parent, attachToParent
           )
         },
-        bindView = { view, viewModel ->
+        setViewModel = { binding, viewModel ->
           bindingInterface.provideNpsItemsViewModel(
-            view,
+            binding,
             viewModel
           )
         }

--- a/app/src/main/java/org/oppia/android/app/survey/SurveyNpsItemOptionView.kt
+++ b/app/src/main/java/org/oppia/android/app/survey/SurveyNpsItemOptionView.kt
@@ -59,17 +59,8 @@ class SurveyNpsItemOptionView @JvmOverloads constructor(
   private fun createAdapter(): BindableAdapter<MultipleChoiceOptionContentViewModel> {
     return singleTypeBuilderFactory.create<MultipleChoiceOptionContentViewModel>()
       .registerViewDataBinderWithSameModelType(
-        inflateDataBinding = { inflater, parent, attachToParent ->
-          bindingInterface.provideNpsItemsInflatedView(
-            inflater, parent, attachToParent
-          )
-        },
-        setViewModel = { binding, viewModel ->
-          bindingInterface.provideNpsItemsViewModel(
-            binding,
-            viewModel
-          )
-        }
+        inflateDataBinding = bindingInterface::provideNpsItemsInflatedView,
+        setViewModel = bindingInterface::provideNpsItemsViewModel
       )
       .build()
   }

--- a/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
@@ -121,16 +121,10 @@ class TopicLessonsFragmentPresenter @Inject constructor(
         else -> throw IllegalArgumentException("Encountered unexpected view model: $viewModel")
       }
     }
-      .registerViewBinder(
+      .registerViewDataBinderWithSameModelType(
         viewType = ViewType.VIEW_TYPE_TITLE_TEXT,
-        inflateView = { parent ->
-          TopicLessonsTitleBinding.inflate(
-            LayoutInflater.from(parent.context),
-            parent,
-            /* attachToParent= */ false
-          ).root
-        },
-        bindView = { _, _ -> }
+        inflateDataBinding = TopicLessonsTitleBinding::inflate,
+        setViewModel = { _, _ -> }
       )
       .registerViewDataBinder(
         viewType = ViewType.VIEW_TYPE_STORY_ITEM,

--- a/app/src/main/res/layout/test_text_view_for_string_with_data_binding.xml
+++ b/app/src/main/res/layout/test_text_view_for_string_with_data_binding.xml
@@ -9,7 +9,7 @@
   </data>
 
   <TextView
-    android:id="@+id/text_view_for_string_no_data_binding"
+    android:id="@+id/text_view_for_string_with_data_binding"
     style="@style/TextViewStart"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -5942,6 +5942,60 @@ class StateFragmentTest {
     }
   }
 
+  @Test
+  fun testStateFragment_moveFromState2ToState3_submittedAnswerShowsState3Answer() {
+    setUpTestWithLanguageSwitchingFeatureOff()
+    launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
+      startPlayingExploration()
+      playThroughPrototypeState1()
+
+      // State 2: submit "1/2" (fraction answer).
+      typeFractionText("1/2")
+      clickSubmitAnswerButton()
+      scrollToViewType(SUBMITTED_ANSWER)
+      onView(withId(R.id.submitted_answer_text_view)).check(matches(withText("1/2")))
+      clickContinueNavigationButton()
+
+      // State 3: RecyclerView recycles State 2's submitted answer view.
+      selectMultipleChoiceOption(optionPosition = 2, expectedOptionText = "Eagle")
+      clickSubmitAnswerButton()
+
+      // Regression test for #5935: submitted answer must show State 3's answer, not "1/2" from
+      // State 2's recycled view.
+      scrollToViewType(SUBMITTED_ANSWER)
+      verifyMultipleChoiceSubmittedAnswer(
+        optionPosition = 2,
+        expectedOptionText = "Eagle",
+        labelTextId = R.string.submitted_answer_label_text
+      )
+    }
+  }
+
+  @Test
+  fun testStateFragment_submitFractionAnswerInState2_moveToState3_feedbackShowsState3Feedback() {
+    setUpTestWithLanguageSwitchingFeatureOff()
+    launchForExploration(TEST_EXPLORATION_ID_2, shouldSavePartialProgress = false).use {
+      startPlayingExploration()
+      playThroughPrototypeState1()
+
+      // State 2: submit "1/2" and verify feedback is shown.
+      typeFractionText("1/2")
+      clickSubmitAnswerButton()
+      scrollToViewType(FEEDBACK)
+      onView(withId(R.id.feedback_text_view)).check(matches(isDisplayed()))
+      clickContinueNavigationButton()
+
+      // State 3: RecyclerView recycles State 2's feedback view.
+      selectMultipleChoiceOption(optionPosition = 2, expectedOptionText = "Eagle")
+      clickSubmitAnswerButton()
+
+      // Regression test for #5935: feedback must be visible and correspond to State 3, not carry
+      // over stale content from State 2's recycled feedback view.
+      scrollToViewType(FEEDBACK)
+      onView(withId(R.id.feedback_text_view)).check(matches(isDisplayed()))
+    }
+  }
+
   private fun moveToFlashbackState() {
     playThroughPrototypeState1()
     playThroughPrototypeState2()

--- a/app/src/sharedTest/java/org/oppia/android/app/recyclerview/BindableAdapterTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/recyclerview/BindableAdapterTest.kt
@@ -635,9 +635,9 @@ class BindableAdapterTest {
     layout(0, 0, 1000, 1000)
   }
 
-  private fun RecyclerView.lookUpTextWithDataBindingAt(position: Int): String {
+  private fun RecyclerView.lookUpTextWithDataBindingAt(position: Int): String? {
     return (findViewHolderForAdapterPosition(position)?.itemView as? TextView)
-      ?.text?.toString() ?: ""
+      ?.text?.toString()
   }
 
   private enum class ViewModelType {

--- a/app/src/sharedTest/java/org/oppia/android/app/recyclerview/BindableAdapterTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/recyclerview/BindableAdapterTest.kt
@@ -3,6 +3,7 @@ package org.oppia.android.app.recyclerview
 import android.app.Application
 import android.content.Context
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
@@ -433,6 +434,64 @@ class BindableAdapterTest {
     }
   }
 
+  @Test
+  fun testSingleTypeAdapter_withDataBinding_initialData_bindsViewSynchronously() {
+    // Set up the adapter to be used for this test.
+    TestModule.testAdapterFactory = { singleTypeFactory, _ ->
+      createSingleViewTypeWithDataBindingBindableAdapter(singleTypeFactory)
+    }
+
+    launch(BindableAdapterTestActivity::class.java).use { scenario ->
+      scenario.onActivity { activity ->
+        val liveData = getRecyclerViewListLiveData(activity)
+        liveData.value = listOf(STR_VALUE_0)
+      }
+      testCoroutineDispatchers.runCurrent()
+
+      // Verify that the initial data binding value is synchronously available after layout.
+      scenario.onActivity { activity ->
+        val recyclerView: RecyclerView =
+          getTestFragment(activity).view!!.findViewById(R.id.test_recycler_view)
+        recyclerView.measureAndLayout()
+        val displayedText = recyclerView.lookUpTextWithDataBindingAt(position = 0)
+        assertThat(displayedText).isEqualTo(STR_VALUE_0.boundStringValue)
+      }
+    }
+  }
+
+  @Test
+  fun testSingleTypeAdapter_withDataBinding_updateData_rebindsViewSynchronouslyWithoutRunCurrent() {
+    // Set up the adapter to be used for this test.
+    TestModule.testAdapterFactory = { singleTypeFactory, _ ->
+      createSingleViewTypeWithDataBindingBindableAdapter(singleTypeFactory)
+    }
+
+    launch(BindableAdapterTestActivity::class.java).use { scenario ->
+      // First, bind initial data and let it settle.
+      scenario.onActivity { activity ->
+        val liveData = getRecyclerViewListLiveData(activity)
+        liveData.value = listOf(STR_VALUE_0)
+      }
+      testCoroutineDispatchers.runCurrent()
+
+      // Now update the data directly on the adapter (bypassing LiveData to avoid data binding
+      // deferral) and only perform layout (no runCurrent). The new text should appear immediately
+      // because registerViewDataBinder calls executePendingBindings() after each rebind, ensuring
+      // synchronous binding execution. Without this, the recycled view would briefly flash stale
+      // content from the previous binding. See #5935 and #6093.
+      scenario.onActivity { activity ->
+        val recyclerView: RecyclerView =
+          getTestFragment(activity).view!!.findViewById(R.id.test_recycler_view)
+        @Suppress("UNCHECKED_CAST")
+        val adapter = recyclerView.adapter as BindableAdapter<BindableAdapterTestDataModel>
+        adapter.setData(listOf(STR_VALUE_1))
+        recyclerView.measureAndLayout()
+        val displayedText = recyclerView.lookUpTextWithDataBindingAt(position = 0)
+        assertThat(displayedText).isEqualTo(STR_VALUE_1.boundStringValue)
+      }
+    }
+  }
+
   private fun setUpTestApplicationComponent() {
     ApplicationProvider.getApplicationContext<TestApplication>().inject(this)
   }
@@ -566,6 +625,19 @@ class BindableAdapterTest {
     return activity.supportFragmentManager.findFragmentByTag(
       BINDABLE_TEST_FRAGMENT_TAG
     ) as BindableAdapterTestFragment
+  }
+
+  private fun RecyclerView.measureAndLayout() {
+    measure(
+      View.MeasureSpec.makeMeasureSpec(1000, View.MeasureSpec.EXACTLY),
+      View.MeasureSpec.makeMeasureSpec(1000, View.MeasureSpec.EXACTLY)
+    )
+    layout(0, 0, 1000, 1000)
+  }
+
+  private fun RecyclerView.lookUpTextWithDataBindingAt(position: Int): String {
+    return (findViewHolderForAdapterPosition(position)?.itemView as? TextView)
+      ?.text?.toString() ?: ""
   }
 
   private enum class ViewModelType {


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Replaces #6088 (previous PR had unrelated commits due to accidental merge instead of rebase).
Fixes #5935 
When submitting an answer, the submitted answer and feedback text briefly flashed the previous card's content before updating to the correct one. This happened because RecyclerView reuses old views and data binding updates aren't instant.

Fixed by calling `executePendingBindings()` to force immediate binding updates before HTML parsing starts. This clears the old recycled view content right away instead of showing it during the parsing delay.                          

Tested on device - no more flash. 

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
  The video has been slowed down to 0.2x speed to make the issue and solution more visible.                                                                                                   
                                                                                                                                                                                              
  **Before**                                                                                                                                                                                  

https://github.com/user-attachments/assets/3a241518-7e70-4c39-b3ce-3cbb9d99ef8e

                                                                                                                                                                                           
  **After**                                                                                                                                                                                   

https://github.com/user-attachments/assets/e6c7d788-29ca-46af-9ed4-64ef43279303



  ## Test Verification Screenshots

  ### BindableAdapterTest
  **Without fix (FAILS):**
<img width="1920" height="1135" alt="Screenshot from 2026-03-11 14-48-30" src="https://github.com/user-attachments/assets/f527b9be-7071-4b9b-a1ee-67e51d0353bd" />


  **With fix (PASSES):**
<img width="1920" height="1135" alt="Screenshot from 2026-03-11 14-49-13" src="https://github.com/user-attachments/assets/4fe492aa-31f9-43ac-97eb-5956619d298b" />


  ### StateFragmentTest
  This test still passes without the fix because Robolectric handles data binding updates synchronously, so the stale content flash doesn't reproduce in the test environment.