### PR TITLE
Fix #5959: Profile colors and positions change when selecting a profile in the Profile screen

### DIFF
--- a/app/src/main/java/org/oppia/android/app/databinding/ImageViewBindingAdapters.java
+++ b/app/src/main/java/org/oppia/android/app/databinding/ImageViewBindingAdapters.java
@@ -7,10 +7,6 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.databinding.BindingAdapter;
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.DataSource;
-import com.bumptech.glide.load.engine.GlideException;
-import com.bumptech.glide.request.RequestListener;
-import com.bumptech.glide.request.target.Target;
 import org.oppia.android.app.databinding.adapters.R;
 import org.oppia.android.app.model.ChapterPlayState;
 import org.oppia.android.app.model.ProfileAvatar;
@@ -44,33 +40,11 @@ public final class ImageViewBindingAdapters {
   public static void setProfileImage(ImageView imageView, ProfileAvatar profileAvatar) {
     if (profileAvatar != null) {
       if (profileAvatar.getAvatarTypeCase() == ProfileAvatar.AvatarTypeCase.AVATAR_COLOR_RGB) {
-        Glide.with(imageView.getContext())
-            .load(R.drawable.ic_default_avatar)
-            .listener(new RequestListener<Drawable>() {
-              @Override
-              public boolean onLoadFailed(
-                  GlideException e,
-                  Object model,
-                  Target<Drawable> target,
-                  boolean isFirstResource) {
-                return false;
-              }
-
-              @Override
-              public boolean onResourceReady(
-                  Drawable resource,
-                  Object model,
-                  Target<Drawable> target,
-                  DataSource dataSource,
-                  boolean isFirstResource
-              ) {
-                imageView.setColorFilter(
-                    profileAvatar.getAvatarColorRgb(),
-                    PorterDuff.Mode.DST_OVER
-                );
-                return false;
-              }
-            }).into(imageView);
+        imageView.setImageResource(R.drawable.ic_default_avatar);
+        imageView.setColorFilter(
+                profileAvatar.getAvatarColorRgb(),
+                PorterDuff.Mode.DST_OVER
+        );
       } else {
         Glide.with(imageView.getContext())
             .load(profileAvatar.getAvatarImageUri())

--- a/app/src/main/java/org/oppia/android/app/recyclerview/BindableAdapter.kt
+++ b/app/src/main/java/org/oppia/android/app/recyclerview/BindableAdapter.kt
@@ -211,6 +211,7 @@ class BindableAdapter<T : Any> internal constructor(
             // Attaching lifecycleOwner before view model initialization can sometimes cause a
             // NullPointerException because data might not be attached to the views yet.
             binding.lifecycleOwner = lifecycleOwner
+            binding.executePendingBindings()
           }
         }
       }
@@ -337,6 +338,7 @@ class BindableAdapter<T : Any> internal constructor(
             // Attaching lifecycleOwner before view model initialization can sometimes cause a
             // NullPointerException because data might not be attached to the views yet.
             binding.lifecycleOwner = lifecycleOwner
+            binding.executePendingBindings()
           }
         }
       }

--- a/app/src/sharedTest/java/org/oppia/android/app/databinding/ImageViewBindingAdaptersTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/databinding/ImageViewBindingAdaptersTest.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
-import android.view.View
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.test.core.app.ActivityScenario
@@ -15,9 +14,8 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
 import dagger.Component
-import org.hamcrest.Description
-import org.hamcrest.TypeSafeMatcher
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -214,9 +212,8 @@ class ImageViewBindingAdaptersTest {
         val color = 0xFF0000
         val avatar = ProfileAvatar.newBuilder().setAvatarColorRgb(color).build()
         setProfileImage(imageView, avatar)
-        onView(withId(R.id.image_view_for_data_binding)).check(
-          matches(withColorFilter(color, PorterDuff.Mode.DST_OVER))
-        )
+        val expected = PorterDuffColorFilter(color, PorterDuff.Mode.DST_OVER)
+        assertThat(imageView.colorFilter).isEqualTo(expected)
       }
     }
   }
@@ -231,9 +228,8 @@ class ImageViewBindingAdaptersTest {
         val secondColor = 0x00FF00
         val secondAvatar = ProfileAvatar.newBuilder().setAvatarColorRgb(secondColor).build()
         setProfileImage(imageView, secondAvatar)
-        onView(withId(R.id.image_view_for_data_binding)).check(
-          matches(withColorFilter(secondColor, PorterDuff.Mode.DST_OVER))
-        )
+        val expected = PorterDuffColorFilter(secondColor, PorterDuff.Mode.DST_OVER)
+        assertThat(imageView.colorFilter).isEqualTo(expected)
       }
     }
   }
@@ -255,23 +251,6 @@ class ImageViewBindingAdaptersTest {
     ActivityScenario.launch<ImageViewBindingAdaptersTestActivity>(intent).use { scenario ->
       testCoroutineDispatchers.runCurrent()
       scenario.testBlock()
-    }
-  }
-
-  private fun withColorFilter(
-    color: Int,
-    mode: PorterDuff.Mode
-  ): TypeSafeMatcher<View> {
-    return object : TypeSafeMatcher<View>() {
-      override fun describeTo(description: Description) {
-        description.appendText("with color filter: color=$color, mode=$mode")
-      }
-
-      override fun matchesSafely(view: View): Boolean {
-        val imageView = view as? ImageView ?: return false
-        val expected = PorterDuffColorFilter(color, mode)
-        return imageView.colorFilter == expected
-      }
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/databinding/ImageViewBindingAdaptersTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/databinding/ImageViewBindingAdaptersTest.kt
@@ -3,6 +3,9 @@ package org.oppia.android.app.databinding
 import android.app.Application
 import android.content.Context
 import android.content.Intent
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
+import android.view.View
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.test.core.app.ActivityScenario
@@ -13,6 +16,8 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Component
+import org.hamcrest.Description
+import org.hamcrest.TypeSafeMatcher
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -28,9 +33,11 @@ import org.oppia.android.app.application.ApplicationModule
 import org.oppia.android.app.application.ApplicationStartupListenerModule
 import org.oppia.android.app.application.testing.TestingBuildFlavorModule
 import org.oppia.android.app.databinding.ImageViewBindingAdapters.setPlayStateDrawable
+import org.oppia.android.app.databinding.ImageViewBindingAdapters.setProfileImage
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.model.ChapterPlayState
+import org.oppia.android.app.model.ProfileAvatar
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.testing.ImageViewBindingAdaptersTestActivity
@@ -174,6 +181,63 @@ class ImageViewBindingAdaptersTest {
     }
   }
 
+  @Test
+  fun testSetProfileImage_nullAvatar_doesNotCrash() {
+    runWithLaunchedActivity {
+      onActivity {
+        val imageView: ImageView = getImageView(it)
+        setProfileImage(imageView, null)
+        // Verify no crash occurred; the view remains in its default state.
+      }
+    }
+  }
+
+  @Test
+  fun testSetProfileImage_colorAvatar_setsDefaultDrawable() {
+    runWithLaunchedActivity {
+      onActivity {
+        val imageView: ImageView = getImageView(it)
+        val avatar = ProfileAvatar.newBuilder().setAvatarColorRgb(0xFF0000).build()
+        setProfileImage(imageView, avatar)
+        onView(withId(R.id.image_view_for_data_binding)).check(
+          matches(withDrawable(R.drawable.ic_default_avatar))
+        )
+      }
+    }
+  }
+
+  @Test
+  fun testSetProfileImage_colorAvatar_appliesColorFilter() {
+    runWithLaunchedActivity {
+      onActivity {
+        val imageView: ImageView = getImageView(it)
+        val color = 0xFF0000
+        val avatar = ProfileAvatar.newBuilder().setAvatarColorRgb(color).build()
+        setProfileImage(imageView, avatar)
+        onView(withId(R.id.image_view_for_data_binding)).check(
+          matches(withColorFilter(color, PorterDuff.Mode.DST_OVER))
+        )
+      }
+    }
+  }
+
+  @Test
+  fun testSetProfileImage_colorAvatar_rebindWithDifferentColor_updatesColorFilter() {
+    runWithLaunchedActivity {
+      onActivity {
+        val imageView: ImageView = getImageView(it)
+        val firstAvatar = ProfileAvatar.newBuilder().setAvatarColorRgb(0xFF0000).build()
+        setProfileImage(imageView, firstAvatar)
+        val secondColor = 0x00FF00
+        val secondAvatar = ProfileAvatar.newBuilder().setAvatarColorRgb(secondColor).build()
+        setProfileImage(imageView, secondAvatar)
+        onView(withId(R.id.image_view_for_data_binding)).check(
+          matches(withColorFilter(secondColor, PorterDuff.Mode.DST_OVER))
+        )
+      }
+    }
+  }
+
   private fun getImageView(
     imageViewBindingAdaptersTestActivity: ImageViewBindingAdaptersTestActivity
   ): ImageView {
@@ -191,6 +255,23 @@ class ImageViewBindingAdaptersTest {
     ActivityScenario.launch<ImageViewBindingAdaptersTestActivity>(intent).use { scenario ->
       testCoroutineDispatchers.runCurrent()
       scenario.testBlock()
+    }
+  }
+
+  private fun withColorFilter(
+    color: Int,
+    mode: PorterDuff.Mode
+  ): TypeSafeMatcher<View> {
+    return object : TypeSafeMatcher<View>() {
+      override fun describeTo(description: Description) {
+        description.appendText("with color filter: color=$color, mode=$mode")
+      }
+
+      override fun matchesSafely(view: View): Boolean {
+        val imageView = view as? ImageView ?: return false
+        val expected = PorterDuffColorFilter(color, mode)
+        return imageView.colorFilter == expected
+      }
     }
   }
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #5959 " in the explanation so that GitHub can auto-close the issue
  - when this PR is merged there will be no flickering while choosing the profile and user can navigate smoothly.
 

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
- Mobile (Without Loaded Avatar Image)

https://github.com/user-attachments/assets/480e7a61-9831-468d-84b4-4742cb3b48ba

- Mobile (With Loaded Avatar Image)

https://github.com/user-attachments/assets/84c576b0-ea33-494a-90e4-488b0884f43d
 
- Tablet


https://github.com/user-attachments/assets/d5d61275-b487-4a99-aac5-329c11d2e4ab

 - Failing tests (without Fix)
 
<img width="1920" height="1080" alt="Screenshot from 2026-03-09 17-48-21" src="https://github.com/user-attachments/assets/a33465cf-8671-4be3-8c4d-e9d0d8b47e18" />

<img width="1920" height="1080" alt="Screenshot from 2026-03-09 17-48-31" src="https://github.com/user-attachments/assets/6abebee0-fd42-4424-abe4-968c541adda1" />



<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing

