### PR TITLE
Fix #6140: Add some clarification to Oppiabot stale messaging

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -22,7 +22,8 @@ markComment: >
   If no further activity occurs within **7 days**, it will be automatically closed so that others can take up the issue.
 
   If you are still working on this PR, please make a follow-up commit within **3 days** (and submit it for review, if applicable).
-  Please also let us know if you are stuck so we can help you! If you're unsure how to reassign this issue, please make sure to
+  Please also let us know if you are stuck so we can help you! 
+  If you're unsure how to reassign this PR to a reviewer, please make sure to
   review the wiki page that details the [Guidance on submitting PRs](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section).
 
 # Limit the number of actions per hour, from 1-30. Default is 30

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -22,7 +22,8 @@ markComment: >
   If no further activity occurs within **7 days**, it will be automatically closed so that others can take up the issue.
 
   If you are still working on this PR, please make a follow-up commit within **3 days** (and submit it for review, if applicable).
-  Please also let us know if you are stuck so we can help you!
+  Please also let us know if you are stuck so we can help you! If you're unsure how to reassign this issue, please make sure to
+  review the wiki page that details the [Guidance on submitting PRs](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section).
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30


### PR DESCRIPTION
## Explanation
Fixes #6140

This adds a link to https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section to the automated stale message put on PRs that haven't been updated in a while. The hope is that this reminds new contributors to read and understand that section in particular (since if they don't know how to assign a PR they will inevitably get this message).

This also means that as reviewers we have less pressure to respond to PRs that have simply been created with no clear signal as to whether they're ready for review.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- GitHub process change only that doesn't affect the app.