### PR TITLE
Fix #6138: Close InputStream in rotateAndCompressBitmap to prevent resource leak

### DIFF
--- a/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
@@ -1304,11 +1304,9 @@ class ProfileManagementController @Inject constructor(
 
   private fun rotateAndCompressBitmap(uri: Uri, bitmap: Bitmap, cropSize: Int): Bitmap {
     val croppedBitmap = ThumbnailUtils.extractThumbnail(bitmap, cropSize, cropSize)
-    val inputStream = context.contentResolver.openInputStream(uri)!!
-    val orientation = ExifInterface(inputStream).getAttributeInt(
-      ExifInterface.TAG_ORIENTATION,
-      1
-    )
+    val orientation = context.contentResolver.openInputStream(uri)?.use { stream ->
+      ExifInterface(stream).getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+    } ?: ExifInterface.ORIENTATION_NORMAL
     var rotate = 0
     when (orientation) {
       ExifInterface.ORIENTATION_ROTATE_90 -> rotate = 90

--- a/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
@@ -1305,7 +1305,10 @@ class ProfileManagementController @Inject constructor(
   private fun rotateAndCompressBitmap(uri: Uri, bitmap: Bitmap, cropSize: Int): Bitmap {
     val croppedBitmap = ThumbnailUtils.extractThumbnail(bitmap, cropSize, cropSize)
     val orientation = context.contentResolver.openInputStream(uri)?.use { stream ->
-      ExifInterface(stream).getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+      ExifInterface(stream).getAttributeInt(
+        ExifInterface.TAG_ORIENTATION,
+        ExifInterface.ORIENTATION_NORMAL
+      )
     } ?: ExifInterface.ORIENTATION_NORMAL
     var rotate = 0
     when (orientation) {

--- a/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
@@ -1304,6 +1304,8 @@ class ProfileManagementController @Inject constructor(
 
   private fun rotateAndCompressBitmap(uri: Uri, bitmap: Bitmap, cropSize: Int): Bitmap {
     val croppedBitmap = ThumbnailUtils.extractThumbnail(bitmap, cropSize, cropSize)
+    // Use 'use' to ensure the InputStream is always closed after reading EXIF data.
+    // Fallback to ORIENTATION_NORMAL if the stream cannot be opened.
     val orientation = context.contentResolver.openInputStream(uri)?.use { stream ->
       ExifInterface(stream).getAttributeInt(
         ExifInterface.TAG_ORIENTATION,


### PR DESCRIPTION
## Explanation

Fix #6138: Close InputStream in rotateAndCompressBitmap to prevent resource leak.

In `ProfileManagementController.rotateAndCompressBitmap()`, an `InputStream` was opened using:

context.contentResolver.openInputStream(uri)!!

The stream was never closed and relied on a force unwrap (`!!`). This could lead to:

- A potential file descriptor leak because the InputStream was not closed.
- A possible NullPointerException if `openInputStream(uri)` returns null.

This PR wraps the stream usage in Kotlin's `use {}` block so the InputStream is automatically closed and replaces the magic number `1` with `ExifInterface.ORIENTATION_NORMAL`.

Updated implementation:

```kotlin
val orientation = context.contentResolver.openInputStream(uri)?.use { stream ->
  ExifInterface(stream).getAttributeInt(
    ExifInterface.TAG_ORIENTATION,
    ExifInterface.ORIENTATION_NORMAL
  )
} ?: ExifInterface.ORIENTATION_NORMAL
```

# Essential Checklist (mark these)

```markdown
- [x] The PR title and explanation each start with "Fix #6138: "
- [x] Any changes to scripts/assets files have their rationale included in the PR explanation.
- [x] The PR follows the style guide.
- [x] The PR does not contain any unnecessary code changes from Android Studio.
- [x] The PR is made from a branch that's not called "develop" and is up-to-date with "develop".
- [ ] The PR is assigned to the appropriate reviewers.