### PR TITLE
Fix #6141: Add workflows for issue assignment & force push checking

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,8 @@
 
 ## Essential Checklist
 <!-- Please tick the relevant boxes by putting an "x" in them. -->
-- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
+- [ ] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
+- [ ] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
 - [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
 - [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
 - [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).

--- a/.github/workflows/check_for_fixed_issues_in_pr.yml
+++ b/.github/workflows/check_for_fixed_issues_in_pr.yml
@@ -1,0 +1,76 @@
+# Jobs for determining if a PR body is correctly fixing or partly fixing one or more issues, and
+# that the PR author is assigned to work on those issues.
+
+name: Verify PR Fixed Issue Assignment
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  validate-pr:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan PR for issues being addressed
+        id: step-1
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const incorrectFormatRegex = /^Fix(?: part of)? #(\d+)$/gm;
+            const correctFormatRegex = /^Fixes(?: part of)? #(\d+)$/gm;
+            const invalidIssueNumbers = [... (context.payload.pull_request.body || '').matchAll(incorrectFormatRegex)].map((match) => match[1]);
+            const issueNumbers = [... (context.payload.pull_request.body || '').matchAll(correctFormatRegex)].map((match) => match[1]);
+            core.setOutput('issue_numbers_list_json', JSON.stringify(issueNumbers));
+            core.info(`PR #${context.payload.pull_request.number} is marked as fixing or partially fixing issue(s): ${JSON.stringify(issueNumbers)}. It also has invalid reference(s): ${JSON.stringify(invalidIssueNumbers)}.`);
+            if (invalidIssueNumbers.length !== 0) {
+              const issueRefs = invalidIssueNumbers.map((issueNumber) => `#${issueNumber}`).join(', ');
+              core.setOutput('failure_message', `the PR description should not use 'Fix #<issue>' or 'Fix part of #<issue>' syntax. Instead use 'Fixes' and 'Fixes part of', per referenced issue(s): ${issueRefs}`);
+            } else if (issueNumbers.length === 0) {
+              core.setOutput('failure_message', "the PR description must contain 'Fixes #<issue>' or 'Fixes part of #<issue>' for each issue the PR is changing, and each one on its own line with no other text");
+            }
+
+      - name: Find issue assignment(s)
+        id: step-2
+        if: ${{ steps.step-1.outputs.failure_message == '' }}
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBERS_LIST_JSON: ${{ steps.step-1.outputs.issue_numbers_list_json }}
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const issuePromises =
+              JSON.parse(process.env.ISSUE_NUMBERS_LIST_JSON).map((issueNumber) =>
+                github.rest.issues.get({ owner: context.repo.owner, repo: context.repo.repo, issue_number: issueNumber })
+                  .then((issue) => ({ issueNumber, assignees: issue.data.assignees.map(a => a.login), isValid: true }))
+                  .catch((error) => ({ issueNumber, assignees: [], isValid: false })))
+            const invalidAuthorshipIssueNumbers =
+              (await Promise.all(issuePromises))
+                .filter((result) => !result.isValid || !result.assignees.includes(author))
+                .map((result) => result.issueNumber);
+            core.info(`The following issues are being referenced in PR #${context.payload.pull_request.number} but are not assigned to the PR author (${author}): ${JSON.stringify(invalidAuthorshipIssueNumbers)}.`);
+            if (invalidAuthorshipIssueNumbers.length !== 0) {
+              const issueRefs = invalidAuthorshipIssueNumbers.map((issueNumber) => `#${issueNumber}`).join(', ');
+              const issueRefLine = invalidAuthorshipIssueNumbers.length == 1 ? `issue ${issueRefs} (or it does not exist)` : `issues ${issueRefs} (or they do not exist)`;
+              core.setOutput('failure_message', `you are not assigned to referenced ${issueRefLine}. You may only fix issues that you are assigned to to help avoid multiple team members duplicating work on the same issue`);
+            }
+
+      - name: Move PR to draft and add comment
+        id: step-3
+        if: ${{ steps.step-1.outputs.failure_message != '' || steps.step-2.outputs.failure_message != '' }}
+        uses: actions/github-script@v7
+        env:
+          FAILURE_MESSAGE_1: ${{ steps.step-1.outputs.failure_message }}
+          FAILURE_MESSAGE_2: ${{ steps.step-2.outputs.failure_message }}
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const failureReason = process.env.FAILURE_MESSAGE_1 || process.env.FAILURE_MESSAGE_2;
+            const failureMessage = `@${pr.user.login} this PR is being marked as draft because ${failureReason}.`;
+            await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number, body: failureMessage });
+            await github.graphql('mutation($id: ID!) { convertPullRequestToDraft(input: {pullRequestId: $id}) { clientMutationId } }', { id: pr.node_id });
+            core.setFailed(failureMessage);

--- a/.github/workflows/check_for_forced_push_prs.yml
+++ b/.github/workflows/check_for_forced_push_prs.yml
@@ -1,0 +1,46 @@
+# Jobs for detecting and closing PRs with permanently changed commit histories, including for forks.
+
+name: Close Force-Pushed PRs
+
+on:
+  pull_request_target:
+    types: [synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-force-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect and close (on change)
+        if: ${{ github.event.action == 'synchronize' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { before, after, pull_request: pr } = context.payload;
+            const { owner, repo } = context.repo;
+            // One of: 'diverged' (rebased, amended, or squashed), 'behind' (dropped commits), or 'ahead' (standard fast-forward).
+            const status = (await github.rest.repos.compareCommits({ owner, repo, base: before, head: after })).data.status;
+            if (status === 'diverged' || status === 'behind') {
+              core.setFailed(`Force push detected (history has been altered). Commit history status: ${status}.`);
+              const closeMessage = 'Closing PR: Force pushing is not allowed in this repository. This PR has been automatically closed. Please create a new PR with a clean commit history and manually copy over any unresolved reviewer comment threads from this PR.';
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body: closeMessage });
+              await github.rest.pulls.update({ owner, repo, pull_number: pr.number, state: 'closed' });
+            } else core.info(`Standard push detected. Commit history status: ${status}. No action taken.`);
+
+      - name: Detect and close reopened force-pushed PRs
+        if: ${{ github.event.action == 'reopened' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: pr.number });
+            const hasForcePushComment = comments.some(comment => comment.user.login === 'github-actions[bot]' && comment.body.includes('Closing PR:'));
+            if (hasForcePushComment) {
+              core.setFailed('Attempted to reopen a previously force-pushed PR.');
+              const closeMessage = 'Closing PR: This PR cannot be reopened because its commit history was previously rewritten via a force push.';
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body: closeMessage });
+              await github.rest.pulls.update({ owner, repo, pull_number: pr.number, state: 'closed' });
+            } else core.info('No prior force-push comments found. Reopen permitted.');


### PR DESCRIPTION
## Explanation
Fixes #6141

This PR introduces two new GitHub Actions workflows:
1. A workflow to check for force pushes.
2. A workflow to verify issue assignments in PRs.

The force push workflow operates by checking the most recent commit on GitHub against the incoming commit and if the histories aren't compatible then it concludes there must be a force push involved (due to either dropped commits or a squash). In both cases it leaves a comment and closes the PR. Since we cannot reliably detect force pushes in retrospect, the workflow also checks if it previously commented with a closure comment and recloses the PR if it's reopened (to avoid easy circumvention). This does not stop users from force pushing before the PR is created, nor does it stop creating a new PR using the same branch (both of which are likely fine).

The issue assignment workflow:
- First checks for 'Fixes #<issue>' and 'Fixes part of #<issue>' in the PR description.
  - If these are incorrectly formatted (e.g. not on one line or uses 'Fix' rather than 'Fixes') then it will fail. We mandate this formatting requirement now.
  - If there are no issues being marked as fixed then it will also fail. This, too, is a new requirement: all PRs must be marked as fixing a specific issue or part of one.
- Then checks all of the issues being marked as fixed or partially fixed for assignment. If the PR author is not one of the issue assignees the check fails.
- If the check fails then it will move the PR into draft. This has some nice benefits:
  - It's a bit softer of a signal than outright closing the PR since the author can easily remedy the issue.
  - It enables creating drafts for not-yet-assigned issues which contributors sometimes do, and that seems fine. The workflow won't run for draft PRs.
  - It pairs nicely with the stale PR check. If a PR that shouldn't be created is created, it will move to draft. If the author then abandons the PR it will eventually be closed. This actually eliminates the full set of human steps involved in these PRs being automatically cleaned up.

For testing:
- The force push workflow was verified here: https://github.com/BenHenning/oppia-android/pull/32.
- The issue validation workflow was verified here: https://github.com/BenHenning/oppia-android/pull/29.

Both will only start running once this PR is merged since they use `pull_request_target` (which is necessary because they need to run even when contributors don't have permissions to run CI workflows as new contributors are the most likely to run into these problems).

Finally, I'm noting that a lot of this PR was generated by Gemini but then heavily refined, reduced, and simplified by me. I think I changed just about every line but Gemini did build the bulk of the workflows and probably saved me close to an hour of time by my guess.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- Workflow-only change that affects development practices and not the app itself.