### PR TITLE
Fix #5818: Robolectric edittext input action

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/customview/interaction/MathExpressionInteractionsViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/customview/interaction/MathExpressionInteractionsViewTest.kt
@@ -80,8 +80,8 @@ import org.oppia.android.domain.platformparameter.PlatformParameterSingletonModu
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.replaceText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.replaceText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.junit.OppiaParameterizedTestRunner

--- a/app/src/sharedTest/java/org/oppia/android/app/customview/interaction/MathExpressionInteractionsViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/customview/interaction/MathExpressionInteractionsViewTest.kt
@@ -80,7 +80,8 @@ import org.oppia.android.domain.platformparameter.PlatformParameterSingletonModu
 import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.replaceText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.junit.OppiaParameterizedTestRunner
@@ -366,7 +367,7 @@ class MathExpressionInteractionsViewTest {
 
       // Request, then clear focus after inputting text.
       onView(withId(R.id.test_math_expression_input_interaction_view))
-        .perform(EditTextInputAction.appendText("12+7"))
+        .perform(appendText("12+7"))
       testCoroutineDispatchers.runCurrent()
       scenario.onActivity { activity -> activity.getInteractionView().requestFocus() }
       testCoroutineDispatchers.runCurrent()
@@ -1690,7 +1691,7 @@ class MathExpressionInteractionsViewTest {
    */
   private fun typeExpressionInput(text: String) {
     onView(withId(R.id.test_math_expression_input_interaction_view))
-      .perform(EditTextInputAction.appendText(text))
+      .perform(appendText(text))
     testCoroutineDispatchers.runCurrent()
   }
 
@@ -1706,7 +1707,7 @@ class MathExpressionInteractionsViewTest {
     // Note that replaceText is used here since some answers can contain extra spaces (which will
     // trigger an automatic period to be entered) or Unicode (which Espresso doesn't supported).
     onView(withId(R.id.test_math_expression_input_interaction_view))
-      .perform(EditTextInputAction.replaceText(text))
+      .perform(replaceText(text))
     testCoroutineDispatchers.runCurrent()
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/customview/interaction/MathExpressionInteractionsViewTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/customview/interaction/MathExpressionInteractionsViewTest.kt
@@ -136,8 +136,6 @@ class MathExpressionInteractionsViewTest {
 
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
 
-  @Inject lateinit var editTextInputAction: EditTextInputAction
-
   @Parameter lateinit var type: String
   @Parameter lateinit var lang: String
   @Parameter lateinit var text: String
@@ -368,7 +366,7 @@ class MathExpressionInteractionsViewTest {
 
       // Request, then clear focus after inputting text.
       onView(withId(R.id.test_math_expression_input_interaction_view))
-        .perform(editTextInputAction.appendText("12+7"))
+        .perform(EditTextInputAction.appendText("12+7"))
       testCoroutineDispatchers.runCurrent()
       scenario.onActivity { activity -> activity.getInteractionView().requestFocus() }
       testCoroutineDispatchers.runCurrent()
@@ -1692,7 +1690,7 @@ class MathExpressionInteractionsViewTest {
    */
   private fun typeExpressionInput(text: String) {
     onView(withId(R.id.test_math_expression_input_interaction_view))
-      .perform(editTextInputAction.appendText(text))
+      .perform(EditTextInputAction.appendText(text))
     testCoroutineDispatchers.runCurrent()
   }
 
@@ -1708,7 +1706,7 @@ class MathExpressionInteractionsViewTest {
     // Note that replaceText is used here since some answers can contain extra spaces (which will
     // trigger an automatic period to be entered) or Unicode (which Espresso doesn't supported).
     onView(withId(R.id.test_math_expression_input_interaction_view))
-      .perform(editTextInputAction.replaceText(text))
+      .perform(EditTextInputAction.replaceText(text))
     testCoroutineDispatchers.runCurrent()
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/databinding/TextInputLayoutBindingAdaptersTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/databinding/TextInputLayoutBindingAdaptersTest.kt
@@ -66,7 +66,6 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule
 import org.oppia.android.testing.robolectric.RobolectricModule
@@ -100,7 +99,6 @@ import javax.inject.Singleton
 class TextInputLayoutBindingAdaptersTest {
   @Inject lateinit var context: Context
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-  @Inject lateinit var editTextInputAction: EditTextInputAction
 
   @Before
   fun setUp() {

--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/mathexpressionparser/MathExpressionParserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/mathexpressionparser/MathExpressionParserFragmentTest.kt
@@ -114,7 +114,6 @@ class MathExpressionParserFragmentTest {
 
   @Inject lateinit var context: Context
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-  @Inject lateinit var editTextInputAction: EditTextInputAction
   @Inject lateinit var testGlideImageLoader: TestGlideImageLoader
 
   @Before
@@ -1393,7 +1392,7 @@ class MathExpressionParserFragmentTest {
   private fun typeIntoView(@IdRes viewId: Int, text: String) {
     // First, ensure the view is visible before trying to input text.
     scrollToView(viewId)
-    onView(withId(viewId)).perform(editTextInputAction.replaceText(text))
+    onView(withId(viewId)).perform(EditTextInputAction.replaceText(text))
     testCoroutineDispatchers.runCurrent()
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/mathexpressionparser/MathExpressionParserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/mathexpressionparser/MathExpressionParserFragmentTest.kt
@@ -73,7 +73,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.replaceText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule
@@ -1392,7 +1392,7 @@ class MathExpressionParserFragmentTest {
   private fun typeIntoView(@IdRes viewId: Int, text: String) {
     // First, ensure the view is visible before trying to input text.
     scrollToView(viewId)
-    onView(withId(viewId)).perform(EditTextInputAction.replaceText(text))
+    onView(withId(viewId)).perform(replaceText(text))
     testCoroutineDispatchers.runCurrent()
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/mathexpressionparser/MathExpressionParserFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/mathexpressionparser/MathExpressionParserFragmentTest.kt
@@ -73,7 +73,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.replaceText
+import org.oppia.android.testing.espresso.EditTextInputAction.replaceText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule

--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentTest.kt
@@ -101,7 +101,7 @@ import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.assertThrows
 import org.oppia.android.testing.data.DataProviderTestMonitor
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.replaceText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasErrorText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
@@ -709,7 +709,7 @@ class PlatformParametersFragmentTest {
           position = 7,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(EditTextInputAction.replaceText("29"))
+      ).perform(replaceText("29"))
 
       verifyPlatformParameterValue(
         position = 7,
@@ -742,7 +742,7 @@ class PlatformParametersFragmentTest {
           position = 7,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(EditTextInputAction.replaceText(""))
+      ).perform(replaceText(""))
       onView(
         atPositionOnView(
           recyclerViewId = R.id.platform_parameters_recycler_view,
@@ -771,7 +771,7 @@ class PlatformParametersFragmentTest {
           position = 7,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(EditTextInputAction.replaceText(""))
+      ).perform(replaceText(""))
 
       onView(
         atPositionOnView(
@@ -793,7 +793,7 @@ class PlatformParametersFragmentTest {
           position = 7,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(EditTextInputAction.replaceText("12"))
+      ).perform(replaceText("12"))
 
       onView(
         atPositionOnView(
@@ -826,7 +826,7 @@ class PlatformParametersFragmentTest {
           position = 7,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(EditTextInputAction.replaceText("42"))
+      ).perform(replaceText("42"))
 
       val expectedValue = PlatformParameterValue.newBuilder()
         .setInteger(42)
@@ -1017,7 +1017,7 @@ class PlatformParametersFragmentTest {
           position = 1,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(EditTextInputAction.replaceText(""))
+      ).perform(replaceText(""))
 
       pressBack()
       testCoroutineDispatchers.runCurrent()
@@ -1042,7 +1042,7 @@ class PlatformParametersFragmentTest {
           position = 1,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(EditTextInputAction.replaceText(""))
+      ).perform(replaceText(""))
 
       pressBack()
       testCoroutineDispatchers.runCurrent()
@@ -1063,7 +1063,7 @@ class PlatformParametersFragmentTest {
           position = 1,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(EditTextInputAction.replaceText("25"))
+      ).perform(replaceText("25"))
 
       pressBack()
       testCoroutineDispatchers.runCurrent()
@@ -1476,7 +1476,7 @@ class PlatformParametersFragmentTest {
           position = position,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(EditTextInputAction.replaceText("25"))
+      ).perform(replaceText("25"))
       onView(withId(R.id.save_button)).check(matches(isEnabled()))
       onView(
         atPositionOnView(
@@ -1484,7 +1484,7 @@ class PlatformParametersFragmentTest {
           position = position,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(EditTextInputAction.replaceText(originalValue))
+      ).perform(replaceText(originalValue))
       onView(withId(R.id.save_button)).check(matches(not(isEnabled())))
     }
   }
@@ -1506,7 +1506,7 @@ class PlatformParametersFragmentTest {
           position = position,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(EditTextInputAction.replaceText("30"))
+      ).perform(replaceText("30"))
       verifyPlatformParameterBackgroundColor(
         position = position,
         expectedColor =
@@ -1573,7 +1573,7 @@ class PlatformParametersFragmentTest {
             position = 1,
             targetViewId = R.id.platform_parameter_input_edit_text
           )
-        ).perform(EditTextInputAction.replaceText(""))
+        ).perform(replaceText(""))
         testCoroutineDispatchers.runCurrent()
 
         val viewHolder2 = recyclerView.findViewHolderForAdapterPosition(2)

--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentTest.kt
@@ -144,7 +144,6 @@ class PlatformParametersFragmentTest {
   @Inject lateinit var platformParameterControllerDebugImpl: PlatformParameterControllerDebugImpl
   @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
   @Inject lateinit var context: Context
-  @Inject lateinit var editTextInputAction: EditTextInputAction
 
   private companion object {
     private const val TEST_REMOTE_SYNC_UP_WORKER_PERIOD_HOURS = 24
@@ -710,7 +709,7 @@ class PlatformParametersFragmentTest {
           position = 7,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(editTextInputAction.replaceText("29"))
+      ).perform(EditTextInputAction.replaceText("29"))
 
       verifyPlatformParameterValue(
         position = 7,
@@ -743,7 +742,7 @@ class PlatformParametersFragmentTest {
           position = 7,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(editTextInputAction.replaceText(""))
+      ).perform(EditTextInputAction.replaceText(""))
       onView(
         atPositionOnView(
           recyclerViewId = R.id.platform_parameters_recycler_view,
@@ -772,7 +771,7 @@ class PlatformParametersFragmentTest {
           position = 7,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(editTextInputAction.replaceText(""))
+      ).perform(EditTextInputAction.replaceText(""))
 
       onView(
         atPositionOnView(
@@ -794,7 +793,7 @@ class PlatformParametersFragmentTest {
           position = 7,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(editTextInputAction.replaceText("12"))
+      ).perform(EditTextInputAction.replaceText("12"))
 
       onView(
         atPositionOnView(
@@ -827,7 +826,7 @@ class PlatformParametersFragmentTest {
           position = 7,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(editTextInputAction.replaceText("42"))
+      ).perform(EditTextInputAction.replaceText("42"))
 
       val expectedValue = PlatformParameterValue.newBuilder()
         .setInteger(42)
@@ -1018,7 +1017,7 @@ class PlatformParametersFragmentTest {
           position = 1,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(editTextInputAction.replaceText(""))
+      ).perform(EditTextInputAction.replaceText(""))
 
       pressBack()
       testCoroutineDispatchers.runCurrent()
@@ -1043,7 +1042,7 @@ class PlatformParametersFragmentTest {
           position = 1,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(editTextInputAction.replaceText(""))
+      ).perform(EditTextInputAction.replaceText(""))
 
       pressBack()
       testCoroutineDispatchers.runCurrent()
@@ -1064,7 +1063,7 @@ class PlatformParametersFragmentTest {
           position = 1,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(editTextInputAction.replaceText("25"))
+      ).perform(EditTextInputAction.replaceText("25"))
 
       pressBack()
       testCoroutineDispatchers.runCurrent()
@@ -1477,7 +1476,7 @@ class PlatformParametersFragmentTest {
           position = position,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(editTextInputAction.replaceText("25"))
+      ).perform(EditTextInputAction.replaceText("25"))
       onView(withId(R.id.save_button)).check(matches(isEnabled()))
       onView(
         atPositionOnView(
@@ -1485,7 +1484,7 @@ class PlatformParametersFragmentTest {
           position = position,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(editTextInputAction.replaceText(originalValue))
+      ).perform(EditTextInputAction.replaceText(originalValue))
       onView(withId(R.id.save_button)).check(matches(not(isEnabled())))
     }
   }
@@ -1507,7 +1506,7 @@ class PlatformParametersFragmentTest {
           position = position,
           targetViewId = R.id.platform_parameter_input_edit_text
         )
-      ).perform(editTextInputAction.replaceText("30"))
+      ).perform(EditTextInputAction.replaceText("30"))
       verifyPlatformParameterBackgroundColor(
         position = position,
         expectedColor =
@@ -1574,7 +1573,7 @@ class PlatformParametersFragmentTest {
             position = 1,
             targetViewId = R.id.platform_parameter_input_edit_text
           )
-        ).perform(editTextInputAction.replaceText(""))
+        ).perform(EditTextInputAction.replaceText(""))
         testCoroutineDispatchers.runCurrent()
 
         val viewHolder2 = recyclerView.findViewHolderForAdapterPosition(2)

--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentTest.kt
@@ -101,7 +101,7 @@ import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.assertThrows
 import org.oppia.android.testing.data.DataProviderTestMonitor
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.replaceText
+import org.oppia.android.testing.espresso.EditTextInputAction.replaceText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasErrorText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule

--- a/app/src/sharedTest/java/org/oppia/android/app/onboarding/CreateProfileFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/onboarding/CreateProfileFragmentTest.kt
@@ -149,8 +149,6 @@ class CreateProfileFragmentTest {
   @Inject
   lateinit var context: Context
   @Inject
-  lateinit var editTextInputAction: EditTextInputAction
-  @Inject
   lateinit var testGlideImageLoader: TestGlideImageLoader
   @Inject
   lateinit var profileTestHelper: ProfileTestHelper

--- a/app/src/sharedTest/java/org/oppia/android/app/onboarding/CreateProfileFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/onboarding/CreateProfileFragmentTest.kt
@@ -100,7 +100,7 @@ import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.assertThrows
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule

--- a/app/src/sharedTest/java/org/oppia/android/app/onboarding/CreateProfileFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/onboarding/CreateProfileFragmentTest.kt
@@ -212,7 +212,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John"),
+          EditTextInputAction.appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -241,7 +241,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity(profileType = ProfileType.SUPERVISOR).use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John"),
+          EditTextInputAction.appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -265,7 +265,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John"),
+          EditTextInputAction.appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -302,7 +302,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John"),
+          EditTextInputAction.appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -339,7 +339,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John"),
+          EditTextInputAction.appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -374,7 +374,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John"),
+          EditTextInputAction.appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -390,7 +390,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John"),
+          EditTextInputAction.appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -418,7 +418,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John"),
+          EditTextInputAction.appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -456,7 +456,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John"),
+          EditTextInputAction.appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -564,7 +564,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John123"),
+          EditTextInputAction.appendText("John123"),
           closeSoftKeyboard()
         )
 
@@ -609,7 +609,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John123"),
+          EditTextInputAction.appendText("John123"),
           closeSoftKeyboard()
         )
 
@@ -628,7 +628,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John123"),
+          EditTextInputAction.appendText("John123"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -652,7 +652,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John123"),
+          EditTextInputAction.appendText("John123"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -665,7 +665,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John"),
+          EditTextInputAction.appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -680,7 +680,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John123"),
+          EditTextInputAction.appendText("John123"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -696,7 +696,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          editTextInputAction.appendText("John"),
+          EditTextInputAction.appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()

--- a/app/src/sharedTest/java/org/oppia/android/app/onboarding/CreateProfileFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/onboarding/CreateProfileFragmentTest.kt
@@ -100,7 +100,7 @@ import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.assertThrows
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule
@@ -210,7 +210,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John"),
+          appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -239,7 +239,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity(profileType = ProfileType.SUPERVISOR).use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John"),
+          appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -263,7 +263,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John"),
+          appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -300,7 +300,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John"),
+          appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -337,7 +337,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John"),
+          appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -372,7 +372,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John"),
+          appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -388,7 +388,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John"),
+          appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -416,7 +416,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John"),
+          appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -454,7 +454,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John"),
+          appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -562,7 +562,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John123"),
+          appendText("John123"),
           closeSoftKeyboard()
         )
 
@@ -607,7 +607,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John123"),
+          appendText("John123"),
           closeSoftKeyboard()
         )
 
@@ -626,7 +626,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John123"),
+          appendText("John123"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -650,7 +650,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John123"),
+          appendText("John123"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -663,7 +663,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John"),
+          appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -678,7 +678,7 @@ class CreateProfileFragmentTest {
     launchNewLearnerProfileActivity().use {
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John123"),
+          appendText("John123"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()
@@ -694,7 +694,7 @@ class CreateProfileFragmentTest {
 
       onView(withId(R.id.create_profile_nickname_edittext))
         .perform(
-          EditTextInputAction.appendText("John"),
+          appendText("John"),
           closeSoftKeyboard()
         )
       testCoroutineDispatchers.runCurrent()

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -198,7 +198,6 @@ class ExplorationActivityTest {
   @Inject lateinit var networkConnectionUtil: NetworkConnectionDebugUtil
   @Inject lateinit var context: Context
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-  @Inject lateinit var editTextInputAction: EditTextInputAction
   @Inject lateinit var fakeOppiaClock: FakeOppiaClock
   @Inject lateinit var translationController: TranslationController
   @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
@@ -943,7 +942,7 @@ class ExplorationActivityTest {
 
       scrollToViewType(StateItemViewModel.ViewType.TEXT_INPUT_INTERACTION)
       onView(withId(R.id.text_input_interaction_view)).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_answer_button)).perform(click())
@@ -2239,7 +2238,7 @@ class ExplorationActivityTest {
 
   private fun typeTextIntoInteraction(text: String, interactionViewId: Int) {
     onView(withId(interactionViewId)).perform(
-      editTextInputAction.appendText(text),
+      EditTextInputAction.appendText(text),
       closeSoftKeyboard()
     )
     testCoroutineDispatchers.runCurrent()
@@ -2458,7 +2457,7 @@ class ExplorationActivityTest {
   private fun submitFractionAnswer(answerText: String) {
     scrollToViewType(FRACTION_INPUT_INTERACTION)
     onView(withId(R.id.fraction_input_interaction_view)).perform(
-      editTextInputAction.appendText(answerText)
+      EditTextInputAction.appendText(answerText)
     )
     testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -143,7 +143,7 @@ import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.TestPlatform
 import org.oppia.android.testing.data.DataProviderTestMonitor
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.lightweightcheckpointing.ExplorationCheckpointTestHelper
@@ -942,7 +942,7 @@ class ExplorationActivityTest {
 
       scrollToViewType(StateItemViewModel.ViewType.TEXT_INPUT_INTERACTION)
       onView(withId(R.id.text_input_interaction_view)).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_answer_button)).perform(click())
@@ -2238,7 +2238,7 @@ class ExplorationActivityTest {
 
   private fun typeTextIntoInteraction(text: String, interactionViewId: Int) {
     onView(withId(interactionViewId)).perform(
-      EditTextInputAction.appendText(text),
+      appendText(text),
       closeSoftKeyboard()
     )
     testCoroutineDispatchers.runCurrent()
@@ -2457,7 +2457,7 @@ class ExplorationActivityTest {
   private fun submitFractionAnswer(answerText: String) {
     scrollToViewType(FRACTION_INPUT_INTERACTION)
     onView(withId(R.id.fraction_input_interaction_view)).perform(
-      EditTextInputAction.appendText(answerText)
+      appendText(answerText)
     )
     testCoroutineDispatchers.runCurrent()
 

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -143,7 +143,7 @@ import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.TestPlatform
 import org.oppia.android.testing.data.DataProviderTestMonitor
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.lightweightcheckpointing.ExplorationCheckpointTestHelper

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -216,7 +216,6 @@ class StateFragmentTest {
   @Inject lateinit var profileTestHelper: ProfileTestHelper
   @Inject lateinit var context: Context
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-  @Inject lateinit var editTextInputAction: EditTextInputAction
   @field:[Inject BackgroundDispatcher] lateinit var backgroundDispatcher: CoroutineDispatcher
   @Inject lateinit var explorationCheckpointTestHelper: ExplorationCheckpointTestHelper
   @Inject lateinit var translationController: TranslationController
@@ -6659,7 +6658,7 @@ class StateFragmentTest {
 
   private fun typeTextIntoInteraction(text: String, interactionViewId: Int) {
     onView(withId(interactionViewId)).perform(
-      editTextInputAction.appendText(text),
+      EditTextInputAction.appendText(text),
       closeSoftKeyboard()
     )
     testCoroutineDispatchers.runCurrent()

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -165,7 +165,7 @@ import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.TestPlatform
 import org.oppia.android.testing.data.DataProviderTestMonitor
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.replaceText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.lightweightcheckpointing.ExplorationCheckpointTestHelper
@@ -6658,7 +6658,7 @@ class StateFragmentTest {
 
   private fun typeTextIntoInteraction(text: String, interactionViewId: Int) {
     onView(withId(interactionViewId)).perform(
-      EditTextInputAction.replaceText(text),
+      replaceText(text),
       closeSoftKeyboard()
     )
     testCoroutineDispatchers.runCurrent()

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -6658,7 +6658,7 @@ class StateFragmentTest {
 
   private fun typeTextIntoInteraction(text: String, interactionViewId: Int) {
     onView(withId(interactionViewId)).perform(
-      EditTextInputAction.appendText(text),
+      EditTextInputAction.replaceText(text),
       closeSoftKeyboard()
     )
     testCoroutineDispatchers.runCurrent()

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -165,7 +165,7 @@ import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.TestPlatform
 import org.oppia.android.testing.data.DataProviderTestMonitor
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.replaceText
+import org.oppia.android.testing.espresso.EditTextInputAction.replaceText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.lightweightcheckpointing.ExplorationCheckpointTestHelper

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
@@ -141,7 +141,6 @@ class AddProfileActivityTest {
   @Inject lateinit var context: Context
   @Inject lateinit var profileTestHelper: ProfileTestHelper
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-  @Inject lateinit var editTextInputAction: EditTextInputAction
 
   @Before
   fun setUp() {
@@ -196,7 +195,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -221,7 +220,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -233,7 +232,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -263,7 +262,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -285,7 +284,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(scrollTo()).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -359,7 +358,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -371,7 +370,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -387,7 +386,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -409,7 +408,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -426,7 +425,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -442,7 +441,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -480,7 +479,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("Rajat"),
+        EditTextInputAction.appendText("Rajat"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
@@ -498,7 +497,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("Rajat"),
+        EditTextInputAction.appendText("Rajat"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -517,7 +516,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("Admin"),
+        EditTextInputAction.appendText("Admin"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -546,7 +545,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(scrollTo()).perform(
-        editTextInputAction.appendText("Admin"),
+        EditTextInputAction.appendText("Admin"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -574,7 +573,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("Admin"),
+        EditTextInputAction.appendText("Admin"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -587,7 +586,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText(" "),
+        EditTextInputAction.appendText(" "),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -609,7 +608,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(scrollTo()).perform(
-        editTextInputAction.appendText("Admin"),
+        EditTextInputAction.appendText("Admin"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -628,7 +627,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText(" "),
+        EditTextInputAction.appendText(" "),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -646,7 +645,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -676,7 +675,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -704,7 +703,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -717,7 +716,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText(" "),
+        EditTextInputAction.appendText(" "),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -737,7 +736,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(scrollTo()).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -756,7 +755,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText(" "),
+        EditTextInputAction.appendText(" "),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -775,7 +774,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -787,7 +786,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -817,7 +816,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(scrollTo()).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -835,7 +834,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -865,7 +864,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -877,7 +876,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(scrollTo()).perform(
-        editTextInputAction.appendText("3"),
+        EditTextInputAction.appendText("3"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -901,7 +900,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(scrollTo()).perform(
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo()).perform(click())
@@ -917,7 +916,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(
-        editTextInputAction.appendText("3"),
+        EditTextInputAction.appendText("3"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_pin))
@@ -934,7 +933,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -946,7 +945,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -961,7 +960,7 @@ class AddProfileActivityTest {
           withId(R.id.add_profile_activity_confirm_pin_edit_text),
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
-      ).perform(editTextInputAction.appendText("12"))
+      ).perform(EditTextInputAction.appendText("12"))
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
       onView(withId(R.id.add_profile_activity_create_button)).perform(click())
@@ -988,7 +987,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(scrollTo()).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1006,7 +1005,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1022,7 +1021,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1062,7 +1061,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -1077,7 +1076,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
@@ -1094,7 +1093,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("3"),
+        EditTextInputAction.appendText("3"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_confirm_pin))
@@ -1114,7 +1113,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(scrollTo()).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -1123,7 +1122,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(scrollTo()).perform(
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
@@ -1140,7 +1139,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("3"),
+        EditTextInputAction.appendText("3"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_confirm_pin))
@@ -1157,7 +1156,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(scrollTo()).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
@@ -1168,7 +1167,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(scrollTo()).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -1177,7 +1176,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(scrollTo()).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         pressImeActionButton()
       )
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
@@ -1196,7 +1195,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1222,7 +1221,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(scrollTo()).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_allow_download_constraint_layout))
@@ -1247,7 +1246,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1263,7 +1262,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1289,7 +1288,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1305,7 +1304,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1382,7 +1381,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -1407,7 +1406,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1434,7 +1433,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1458,7 +1457,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1470,7 +1469,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1486,7 +1485,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1531,7 +1530,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1543,7 +1542,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1553,7 +1552,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(scrollTo())
-        .perform(editTextInputAction.appendText("123"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("123"), closeSoftKeyboard())
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(click())
@@ -1575,7 +1574,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("Admin"),
+        EditTextInputAction.appendText("Admin"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1616,7 +1615,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1632,7 +1631,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1668,7 +1667,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1680,7 +1679,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -1695,7 +1694,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("321 "),
+        EditTextInputAction.appendText("321 "),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
@@ -97,7 +97,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasErrorText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasHelperText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasNoErrorText
@@ -195,7 +195,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -220,7 +220,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -232,7 +232,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -262,7 +262,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -284,7 +284,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(scrollTo()).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -358,7 +358,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -370,7 +370,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -386,7 +386,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -408,7 +408,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -425,7 +425,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -441,7 +441,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -479,7 +479,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("Rajat"),
+        appendText("Rajat"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
@@ -497,7 +497,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("Rajat"),
+        appendText("Rajat"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -516,7 +516,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("Admin"),
+        appendText("Admin"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -545,7 +545,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(scrollTo()).perform(
-        EditTextInputAction.appendText("Admin"),
+        appendText("Admin"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -573,7 +573,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("Admin"),
+        appendText("Admin"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -586,7 +586,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText(" "),
+        appendText(" "),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -608,7 +608,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(scrollTo()).perform(
-        EditTextInputAction.appendText("Admin"),
+        appendText("Admin"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -627,7 +627,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText(" "),
+        appendText(" "),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -645,7 +645,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -675,7 +675,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -703,7 +703,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -716,7 +716,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText(" "),
+        appendText(" "),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -736,7 +736,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(scrollTo()).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -755,7 +755,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText(" "),
+        appendText(" "),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -774,7 +774,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -786,7 +786,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -816,7 +816,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(scrollTo()).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -834,7 +834,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -864,7 +864,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -876,7 +876,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(scrollTo()).perform(
-        EditTextInputAction.appendText("3"),
+        appendText("3"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -900,7 +900,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(scrollTo()).perform(
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo()).perform(click())
@@ -916,7 +916,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("3"),
+        appendText("3"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_pin))
@@ -933,7 +933,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -945,7 +945,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -960,7 +960,7 @@ class AddProfileActivityTest {
           withId(R.id.add_profile_activity_confirm_pin_edit_text),
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
-      ).perform(EditTextInputAction.appendText("12"))
+      ).perform(appendText("12"))
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
       onView(withId(R.id.add_profile_activity_create_button)).perform(click())
@@ -987,7 +987,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(scrollTo()).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1005,7 +1005,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1021,7 +1021,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1061,7 +1061,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -1076,7 +1076,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
@@ -1093,7 +1093,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("3"),
+        appendText("3"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_confirm_pin))
@@ -1113,7 +1113,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(scrollTo()).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -1122,7 +1122,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(scrollTo()).perform(
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
@@ -1139,7 +1139,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("3"),
+        appendText("3"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_confirm_pin))
@@ -1156,7 +1156,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(scrollTo()).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
@@ -1167,7 +1167,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(scrollTo()).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -1176,7 +1176,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(scrollTo()).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         pressImeActionButton()
       )
       onView(withId(R.id.add_profile_activity_create_button)).perform(scrollTo())
@@ -1195,7 +1195,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1221,7 +1221,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_pin))
         )
       ).perform(scrollTo()).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.add_profile_activity_allow_download_constraint_layout))
@@ -1246,7 +1246,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1262,7 +1262,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1288,7 +1288,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1304,7 +1304,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1381,7 +1381,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -1406,7 +1406,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1433,7 +1433,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1457,7 +1457,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1469,7 +1469,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1485,7 +1485,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1530,7 +1530,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1542,7 +1542,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1552,7 +1552,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(scrollTo())
-        .perform(EditTextInputAction.appendText("123"), closeSoftKeyboard())
+        .perform(appendText("123"), closeSoftKeyboard())
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(scrollTo())
       onView(withId(R.id.add_profile_activity_pin_check_box)).perform(click())
@@ -1574,7 +1574,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("Admin"),
+        appendText("Admin"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1615,7 +1615,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1631,7 +1631,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1667,7 +1667,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_user_name))
         )
       ).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1679,7 +1679,7 @@ class AddProfileActivityTest {
         )
       ).perform(
         scrollTo(),
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -1694,7 +1694,7 @@ class AddProfileActivityTest {
           isDescendantOfA(withId(R.id.add_profile_activity_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("321 "),
+        appendText("321 "),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AddProfileActivityTest.kt
@@ -97,7 +97,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasErrorText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasHelperText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasNoErrorText

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
@@ -122,7 +122,6 @@ class AdminAuthActivityTest {
 
   @Inject lateinit var context: Context
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-  @Inject lateinit var editTextInputAction: EditTextInputAction
   @Inject lateinit var profileTestHelper: ProfileTestHelper
 
   private val internalProfileId: Int = 0
@@ -190,7 +189,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_auth_submit_button)).perform(click())
@@ -217,7 +216,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -243,7 +242,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_auth_submit_button)).perform(click())
@@ -270,7 +269,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -295,7 +294,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12354"),
+        EditTextInputAction.appendText("12354"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_auth_submit_button)).perform(click())
@@ -327,7 +326,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12354"),
+        EditTextInputAction.appendText("12354"),
         pressImeActionButton()
       )
       onView(withId(R.id.admin_auth_input_pin))
@@ -373,7 +372,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_auth_submit_button)).check(matches(isEnabled()))
@@ -397,7 +396,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -526,7 +525,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -560,7 +559,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12354"),
+        EditTextInputAction.appendText("12354"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_auth_submit_button)).perform(click())
@@ -601,7 +600,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12354"),
+        EditTextInputAction.appendText("12354"),
         pressImeActionButton()
       )
       onView(withId(R.id.admin_auth_input_pin))

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
@@ -81,7 +81,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasErrorText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminAuthActivityTest.kt
@@ -81,7 +81,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasErrorText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
@@ -189,7 +189,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_auth_submit_button)).perform(click())
@@ -216,7 +216,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -242,7 +242,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_auth_submit_button)).perform(click())
@@ -269,7 +269,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -294,7 +294,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12354"),
+        appendText("12354"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_auth_submit_button)).perform(click())
@@ -326,7 +326,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12354"),
+        appendText("12354"),
         pressImeActionButton()
       )
       onView(withId(R.id.admin_auth_input_pin))
@@ -372,7 +372,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_auth_submit_button)).check(matches(isEnabled()))
@@ -396,7 +396,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -525,7 +525,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -559,7 +559,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12354"),
+        appendText("12354"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_auth_submit_button)).perform(click())
@@ -600,7 +600,7 @@ class AdminAuthActivityTest {
           isDescendantOfA(withId(R.id.admin_auth_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12354"),
+        appendText("12354"),
         pressImeActionButton()
       )
       onView(withId(R.id.admin_auth_input_pin))

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
@@ -90,7 +90,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasErrorText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasNoErrorText
 import org.oppia.android.testing.firebase.TestAuthenticationModule

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
@@ -133,7 +133,6 @@ class AdminPinActivityTest {
   @Inject lateinit var context: Context
   @Inject lateinit var profileTestHelper: ProfileTestHelper
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-  @Inject lateinit var editTextInputAction: EditTextInputAction
 
   @Before
   fun setUp() {
@@ -198,7 +197,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -208,7 +207,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo()).perform(click())
@@ -233,7 +232,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -243,7 +242,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -269,7 +268,7 @@ class AdminPinActivityTest {
             isDescendantOfA(withId(R.id.admin_pin_input_pin))
           )
         ).perform(
-          editTextInputAction.appendText("12345"),
+          EditTextInputAction.appendText("12345"),
           closeSoftKeyboard()
         )
         testCoroutineDispatchers.runCurrent()
@@ -280,7 +279,7 @@ class AdminPinActivityTest {
           )
         ).perform(
           nestedScrollTo(),
-          editTextInputAction.appendText("12345"),
+          EditTextInputAction.appendText("12345"),
           closeSoftKeyboard()
         )
         testCoroutineDispatchers.runCurrent()
@@ -307,7 +306,7 @@ class AdminPinActivityTest {
             isDescendantOfA(withId(R.id.admin_pin_input_pin))
           )
         ).perform(
-          editTextInputAction.appendText("12345"),
+          EditTextInputAction.appendText("12345"),
           closeSoftKeyboard()
         )
         onView(
@@ -317,7 +316,7 @@ class AdminPinActivityTest {
           )
         ).perform(
           nestedScrollTo(),
-          editTextInputAction.appendText("12345"),
+          EditTextInputAction.appendText("12345"),
           pressImeActionButton()
         )
         testCoroutineDispatchers.runCurrent()
@@ -341,7 +340,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo())
@@ -365,7 +364,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo(), click())
@@ -375,7 +374,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("45"),
+        EditTextInputAction.appendText("45"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
@@ -400,7 +399,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -410,7 +409,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -444,7 +443,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -454,7 +453,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -484,7 +483,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -493,7 +492,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo()).perform(click())
@@ -503,7 +502,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("5"),
+        EditTextInputAction.appendText("5"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
@@ -527,7 +526,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -536,7 +535,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         pressImeActionButton()
       )
       onView(
@@ -545,7 +544,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("5"),
+        EditTextInputAction.appendText("5"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
@@ -586,7 +585,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -596,7 +595,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -624,7 +623,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -634,7 +633,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -661,7 +660,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -672,7 +671,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo(), click())
@@ -699,7 +698,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -709,7 +708,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -734,7 +733,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo())
@@ -759,7 +758,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo(), click())
@@ -769,7 +768,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("45"),
+        EditTextInputAction.appendText("45"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
@@ -795,7 +794,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -805,7 +804,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo(), click())
@@ -838,7 +837,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.advanceUntilIdle()
@@ -849,7 +848,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.advanceUntilIdle()
@@ -881,7 +880,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -891,7 +890,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo(), click())
@@ -902,7 +901,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        editTextInputAction.appendText("5"),
+        EditTextInputAction.appendText("5"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
@@ -928,7 +927,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -938,7 +937,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         pressImeActionButton()
       )
       onView(
@@ -948,7 +947,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        editTextInputAction.appendText("5"),
+        EditTextInputAction.appendText("5"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
@@ -972,7 +971,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -982,7 +981,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        editTextInputAction.appendText("54321"),
+        EditTextInputAction.appendText("54321"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo()).perform(click())
@@ -1015,7 +1014,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -1025,7 +1024,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        editTextInputAction.appendText("54321"),
+        EditTextInputAction.appendText("54321"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1056,7 +1055,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo())

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
@@ -90,7 +90,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasErrorText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasNoErrorText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
@@ -197,7 +197,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -207,7 +207,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo()).perform(click())
@@ -232,7 +232,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -242,7 +242,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -268,7 +268,7 @@ class AdminPinActivityTest {
             isDescendantOfA(withId(R.id.admin_pin_input_pin))
           )
         ).perform(
-          EditTextInputAction.appendText("12345"),
+          appendText("12345"),
           closeSoftKeyboard()
         )
         testCoroutineDispatchers.runCurrent()
@@ -279,7 +279,7 @@ class AdminPinActivityTest {
           )
         ).perform(
           nestedScrollTo(),
-          EditTextInputAction.appendText("12345"),
+          appendText("12345"),
           closeSoftKeyboard()
         )
         testCoroutineDispatchers.runCurrent()
@@ -306,7 +306,7 @@ class AdminPinActivityTest {
             isDescendantOfA(withId(R.id.admin_pin_input_pin))
           )
         ).perform(
-          EditTextInputAction.appendText("12345"),
+          appendText("12345"),
           closeSoftKeyboard()
         )
         onView(
@@ -316,7 +316,7 @@ class AdminPinActivityTest {
           )
         ).perform(
           nestedScrollTo(),
-          EditTextInputAction.appendText("12345"),
+          appendText("12345"),
           pressImeActionButton()
         )
         testCoroutineDispatchers.runCurrent()
@@ -340,7 +340,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo())
@@ -364,7 +364,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo(), click())
@@ -374,7 +374,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("45"),
+        appendText("45"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
@@ -399,7 +399,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -409,7 +409,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -443,7 +443,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -453,7 +453,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -483,7 +483,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -492,7 +492,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo()).perform(click())
@@ -502,7 +502,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("5"),
+        appendText("5"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
@@ -526,7 +526,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -535,7 +535,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         pressImeActionButton()
       )
       onView(
@@ -544,7 +544,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("5"),
+        appendText("5"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
@@ -585,7 +585,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -595,7 +595,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -623,7 +623,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -633,7 +633,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -660,7 +660,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -671,7 +671,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo(), click())
@@ -698,7 +698,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -708,7 +708,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -733,7 +733,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo())
@@ -758,7 +758,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo(), click())
@@ -768,7 +768,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("45"),
+        appendText("45"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
@@ -794,7 +794,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -804,7 +804,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo(), click())
@@ -837,7 +837,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.advanceUntilIdle()
@@ -848,7 +848,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.advanceUntilIdle()
@@ -880,7 +880,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -890,7 +890,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo(), click())
@@ -901,7 +901,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        EditTextInputAction.appendText("5"),
+        appendText("5"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
@@ -927,7 +927,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -937,7 +937,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         pressImeActionButton()
       )
       onView(
@@ -947,7 +947,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        EditTextInputAction.appendText("5"),
+        appendText("5"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
@@ -971,7 +971,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -981,7 +981,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        EditTextInputAction.appendText("54321"),
+        appendText("54321"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo()).perform(click())
@@ -1014,7 +1014,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -1024,7 +1024,7 @@ class AdminPinActivityTest {
         )
       ).perform(
         nestedScrollTo(),
-        EditTextInputAction.appendText("54321"),
+        appendText("54321"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -1055,7 +1055,7 @@ class AdminPinActivityTest {
           isDescendantOfA(withId(R.id.admin_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo())

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
@@ -90,7 +90,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasErrorText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasNoErrorText
 import org.oppia.android.testing.firebase.TestAuthenticationModule

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
@@ -135,7 +135,6 @@ class PinPasswordActivityTest {
   @Inject lateinit var context: Context
   @Inject lateinit var profileTestHelper: ProfileTestHelper
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-  @Inject lateinit var editTextInputAction: EditTextInputAction
   @Inject lateinit var fakeAccessibilityService: FakeAccessibilityService
 
   private val adminPin = "12345"
@@ -216,7 +215,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("12345"))
+        .perform(EditTextInputAction.appendText("12345"))
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(HomeActivity::class.java.name))
     }
@@ -235,7 +234,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("12345"))
+        .perform(EditTextInputAction.appendText("12345"))
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(ClassroomListActivity::class.java.name))
       hasExtraWithKey(PROFILE_ID_INTENT_DECORATOR)
@@ -255,7 +254,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("123"))
+        .perform(EditTextInputAction.appendText("123"))
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(HomeActivity::class.java.name))
     }
@@ -274,7 +273,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("123"))
+        .perform(EditTextInputAction.appendText("123"))
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(ClassroomListActivity::class.java.name))
       hasExtraWithKey(PROFILE_ID_INTENT_DECORATOR)
@@ -294,7 +293,7 @@ class PinPasswordActivityTest {
       testCoroutineDispatchers.runCurrent()
       closeSoftKeyboard()
       onView(withId(R.id.pin_password_input_pin_edit_text)).perform(closeSoftKeyboard())
-        .perform(editTextInputAction.appendText("54321"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("54321"), closeSoftKeyboard())
       onView(withId(R.id.pin_password_input_pin)).check(
         matches(
           hasErrorText(context.resources.getString(R.string.pin_password_incorrect_pin))
@@ -335,7 +334,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text)).perform(
-        editTextInputAction.appendText("321"), closeSoftKeyboard()
+        EditTextInputAction.appendText("321"), closeSoftKeyboard()
       )
       onView(withId(R.id.pin_password_input_pin)).check(
         matches(
@@ -357,7 +356,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text)).perform(
-        editTextInputAction.appendText("123"), closeSoftKeyboard()
+        EditTextInputAction.appendText("123"), closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin)).check(
@@ -380,7 +379,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text)).perform(
-        editTextInputAction.appendText(""),
+        EditTextInputAction.appendText(""),
         closeSoftKeyboard()
       )
       onView(withId(R.id.forgot_pin)).perform(click())
@@ -408,7 +407,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("1234"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("1234"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -427,7 +426,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("5"),
+        EditTextInputAction.appendText("5"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_settings_input_pin))
@@ -446,7 +445,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       testCoroutineDispatchers.runCurrent()
       onView(
@@ -455,7 +454,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -467,7 +466,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.reset_pin_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("32"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("32"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -486,7 +485,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.reset_pin_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("1"),
+        EditTextInputAction.appendText("1"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.reset_pin_input_pin))
@@ -505,7 +504,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -513,7 +512,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -524,7 +523,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.reset_pin_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("321"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("321"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -535,7 +534,7 @@ class PinPasswordActivityTest {
         .inRoot(isDialog())
         .perform(click())
       onView(withId(R.id.pin_password_input_pin_edit_text)).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(withText(context.getString(R.string.pin_password_incorrect_pin)))
@@ -555,7 +554,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -563,7 +562,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -575,7 +574,7 @@ class PinPasswordActivityTest {
         )
       )
         .inRoot(isDialog())
-        .perform(editTextInputAction.appendText("321"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("321"), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -585,7 +584,7 @@ class PinPasswordActivityTest {
         .inRoot(isDialog())
         .perform(click())
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("321"))
+        .perform(EditTextInputAction.appendText("321"))
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(HomeActivity::class.java.name))
     }
@@ -602,7 +601,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -610,7 +609,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("1234"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("1234"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(
         allOf(
@@ -633,7 +632,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -641,7 +640,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -663,7 +662,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -671,7 +670,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -683,7 +682,7 @@ class PinPasswordActivityTest {
         )
       )
         .inRoot(isDialog())
-        .perform(editTextInputAction.appendText("123"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("123"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -726,7 +725,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -734,7 +733,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("1234"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("1234"), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -752,7 +751,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("5"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("5"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.admin_settings_input_pin))
         .check(matches(hasNoErrorText()))
@@ -770,7 +769,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -778,7 +777,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("1234"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("1234"), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -813,7 +812,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -821,7 +820,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -847,7 +846,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -855,7 +854,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -883,7 +882,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -891,7 +890,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText(""), pressImeActionButton())
+        .perform(EditTextInputAction.appendText(""), pressImeActionButton())
       onView(withId(R.id.admin_settings_input_pin))
         .check(
           matches(
@@ -914,7 +913,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -922,7 +921,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText(""), pressImeActionButton())
+        .perform(EditTextInputAction.appendText(""), pressImeActionButton())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.admin_settings_input_pin))
         .check(
@@ -946,7 +945,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -954,7 +953,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -972,7 +971,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("1"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("1"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.admin_settings_input_pin))
         .check(matches(hasNoErrorText()))
@@ -990,7 +989,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -998,7 +997,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -1009,7 +1008,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.reset_pin_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("11"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("11"), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -1038,7 +1037,7 @@ class PinPasswordActivityTest {
       testCoroutineDispatchers.runCurrent()
       closeSoftKeyboard()
       onView(withId(R.id.pin_password_input_pin_edit_text)).perform(
-        editTextInputAction.appendText("54321"),
+        EditTextInputAction.appendText("54321"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -1240,7 +1239,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(editTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -1267,7 +1266,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.pin_password_input_pin_edit_text))
         .check(matches(withText("12345")))
@@ -1286,7 +1285,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("123"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("123"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.pin_password_input_pin_edit_text))
         .check(matches(withText("123")))
@@ -1305,7 +1304,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("1234567"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("1234567"), closeSoftKeyboard())
       onView(withId(R.id.pin_password_input_pin_edit_text))
         .check(matches(withText("12345")))
     }
@@ -1323,7 +1322,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("1234567"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("1234567"), closeSoftKeyboard())
       onView(withId(R.id.pin_password_input_pin_edit_text))
         .check(matches(withText("123")))
     }
@@ -1342,10 +1341,10 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("123"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("123"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("45"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("45"), closeSoftKeyboard())
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(HomeActivity::class.java.name))
     }
@@ -1364,10 +1363,10 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("123"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("123"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("45"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("45"), closeSoftKeyboard())
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(ClassroomListActivity::class.java.name))
     }
@@ -1386,10 +1385,10 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("12"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("12"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("3"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("3"), closeSoftKeyboard())
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(HomeActivity::class.java.name))
     }
@@ -1408,10 +1407,10 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("12"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("12"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("3"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("3"), closeSoftKeyboard())
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(ClassroomListActivity::class.java.name))
     }
@@ -1432,7 +1431,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("123"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("123"), closeSoftKeyboard())
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(IntroActivity::class.java.name))
     }
@@ -1455,7 +1454,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(editTextInputAction.appendText("123"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("123"), closeSoftKeyboard())
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(HomeActivity::class.java.name))
     }

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/PinPasswordActivityTest.kt
@@ -90,7 +90,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasErrorText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasNoErrorText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
@@ -215,7 +215,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("12345"))
+        .perform(appendText("12345"))
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(HomeActivity::class.java.name))
     }
@@ -234,7 +234,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("12345"))
+        .perform(appendText("12345"))
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(ClassroomListActivity::class.java.name))
       hasExtraWithKey(PROFILE_ID_INTENT_DECORATOR)
@@ -254,7 +254,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("123"))
+        .perform(appendText("123"))
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(HomeActivity::class.java.name))
     }
@@ -273,7 +273,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("123"))
+        .perform(appendText("123"))
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(ClassroomListActivity::class.java.name))
       hasExtraWithKey(PROFILE_ID_INTENT_DECORATOR)
@@ -293,7 +293,7 @@ class PinPasswordActivityTest {
       testCoroutineDispatchers.runCurrent()
       closeSoftKeyboard()
       onView(withId(R.id.pin_password_input_pin_edit_text)).perform(closeSoftKeyboard())
-        .perform(EditTextInputAction.appendText("54321"), closeSoftKeyboard())
+        .perform(appendText("54321"), closeSoftKeyboard())
       onView(withId(R.id.pin_password_input_pin)).check(
         matches(
           hasErrorText(context.resources.getString(R.string.pin_password_incorrect_pin))
@@ -334,7 +334,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text)).perform(
-        EditTextInputAction.appendText("321"), closeSoftKeyboard()
+        appendText("321"), closeSoftKeyboard()
       )
       onView(withId(R.id.pin_password_input_pin)).check(
         matches(
@@ -356,7 +356,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text)).perform(
-        EditTextInputAction.appendText("123"), closeSoftKeyboard()
+        appendText("123"), closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin)).check(
@@ -379,7 +379,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text)).perform(
-        EditTextInputAction.appendText(""),
+        appendText(""),
         closeSoftKeyboard()
       )
       onView(withId(R.id.forgot_pin)).perform(click())
@@ -407,7 +407,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("1234"), closeSoftKeyboard())
+        .perform(appendText("1234"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -426,7 +426,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("5"),
+        appendText("5"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.admin_settings_input_pin))
@@ -445,7 +445,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       testCoroutineDispatchers.runCurrent()
       onView(
@@ -454,7 +454,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(appendText("12345"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -466,7 +466,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.reset_pin_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("32"), closeSoftKeyboard())
+        .perform(appendText("32"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -485,7 +485,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.reset_pin_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("1"),
+        appendText("1"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.reset_pin_input_pin))
@@ -504,7 +504,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -512,7 +512,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(appendText("12345"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -523,7 +523,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.reset_pin_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("321"), closeSoftKeyboard())
+        .perform(appendText("321"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -534,7 +534,7 @@ class PinPasswordActivityTest {
         .inRoot(isDialog())
         .perform(click())
       onView(withId(R.id.pin_password_input_pin_edit_text)).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(withText(context.getString(R.string.pin_password_incorrect_pin)))
@@ -554,7 +554,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -562,7 +562,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(appendText("12345"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -574,7 +574,7 @@ class PinPasswordActivityTest {
         )
       )
         .inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("321"), closeSoftKeyboard())
+        .perform(appendText("321"), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -584,7 +584,7 @@ class PinPasswordActivityTest {
         .inRoot(isDialog())
         .perform(click())
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("321"))
+        .perform(appendText("321"))
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(HomeActivity::class.java.name))
     }
@@ -601,7 +601,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -609,7 +609,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("1234"), closeSoftKeyboard())
+        .perform(appendText("1234"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(
         allOf(
@@ -632,7 +632,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -640,7 +640,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(appendText("12345"), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -662,7 +662,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -670,7 +670,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(appendText("12345"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -682,7 +682,7 @@ class PinPasswordActivityTest {
         )
       )
         .inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("123"), closeSoftKeyboard())
+        .perform(appendText("123"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -725,7 +725,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -733,7 +733,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("1234"), closeSoftKeyboard())
+        .perform(appendText("1234"), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -751,7 +751,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("5"), closeSoftKeyboard())
+        .perform(appendText("5"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.admin_settings_input_pin))
         .check(matches(hasNoErrorText()))
@@ -769,7 +769,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -777,7 +777,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("1234"), closeSoftKeyboard())
+        .perform(appendText("1234"), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -812,7 +812,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -820,7 +820,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -846,7 +846,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -854,7 +854,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -882,7 +882,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -890,7 +890,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText(""), pressImeActionButton())
+        .perform(appendText(""), pressImeActionButton())
       onView(withId(R.id.admin_settings_input_pin))
         .check(
           matches(
@@ -913,7 +913,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -921,7 +921,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText(""), pressImeActionButton())
+        .perform(appendText(""), pressImeActionButton())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.admin_settings_input_pin))
         .check(
@@ -945,7 +945,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -953,7 +953,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -971,7 +971,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("1"), closeSoftKeyboard())
+        .perform(appendText("1"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.admin_settings_input_pin))
         .check(matches(hasNoErrorText()))
@@ -989,7 +989,7 @@ class PinPasswordActivityTest {
       )
     ).use {
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText(""), closeSoftKeyboard())
+        .perform(appendText(""), closeSoftKeyboard())
       onView(withId(R.id.forgot_pin)).perform(click())
       onView(
         allOf(
@@ -997,7 +997,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(appendText("12345"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -1008,7 +1008,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.reset_pin_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("11"), closeSoftKeyboard())
+        .perform(appendText("11"), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -1037,7 +1037,7 @@ class PinPasswordActivityTest {
       testCoroutineDispatchers.runCurrent()
       closeSoftKeyboard()
       onView(withId(R.id.pin_password_input_pin_edit_text)).perform(
-        EditTextInputAction.appendText("54321"),
+        appendText("54321"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -1239,7 +1239,7 @@ class PinPasswordActivityTest {
           isDescendantOfA(withId(R.id.admin_settings_input_pin))
         )
       ).inRoot(isDialog())
-        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(appendText("12345"), closeSoftKeyboard())
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
         .perform(click())
@@ -1266,7 +1266,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
+        .perform(appendText("12345"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.pin_password_input_pin_edit_text))
         .check(matches(withText("12345")))
@@ -1285,7 +1285,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("123"), closeSoftKeyboard())
+        .perform(appendText("123"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.pin_password_input_pin_edit_text))
         .check(matches(withText("123")))
@@ -1304,7 +1304,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("1234567"), closeSoftKeyboard())
+        .perform(appendText("1234567"), closeSoftKeyboard())
       onView(withId(R.id.pin_password_input_pin_edit_text))
         .check(matches(withText("12345")))
     }
@@ -1322,7 +1322,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("1234567"), closeSoftKeyboard())
+        .perform(appendText("1234567"), closeSoftKeyboard())
       onView(withId(R.id.pin_password_input_pin_edit_text))
         .check(matches(withText("123")))
     }
@@ -1341,10 +1341,10 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("123"), closeSoftKeyboard())
+        .perform(appendText("123"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("45"), closeSoftKeyboard())
+        .perform(appendText("45"), closeSoftKeyboard())
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(HomeActivity::class.java.name))
     }
@@ -1363,10 +1363,10 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("123"), closeSoftKeyboard())
+        .perform(appendText("123"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("45"), closeSoftKeyboard())
+        .perform(appendText("45"), closeSoftKeyboard())
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(ClassroomListActivity::class.java.name))
     }
@@ -1385,10 +1385,10 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("12"), closeSoftKeyboard())
+        .perform(appendText("12"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("3"), closeSoftKeyboard())
+        .perform(appendText("3"), closeSoftKeyboard())
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(HomeActivity::class.java.name))
     }
@@ -1407,10 +1407,10 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("12"), closeSoftKeyboard())
+        .perform(appendText("12"), closeSoftKeyboard())
       onView(isRoot()).perform(orientationLandscape())
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("3"), closeSoftKeyboard())
+        .perform(appendText("3"), closeSoftKeyboard())
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(ClassroomListActivity::class.java.name))
     }
@@ -1431,7 +1431,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("123"), closeSoftKeyboard())
+        .perform(appendText("123"), closeSoftKeyboard())
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(IntroActivity::class.java.name))
     }
@@ -1454,7 +1454,7 @@ class PinPasswordActivityTest {
     ).use {
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.pin_password_input_pin_edit_text))
-        .perform(EditTextInputAction.appendText("123"), closeSoftKeyboard())
+        .perform(appendText("123"), closeSoftKeyboard())
       testCoroutineDispatchers.runCurrent()
       intended(hasComponent(HomeActivity::class.java.name))
     }

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileLoginFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileLoginFragmentTest.kt
@@ -93,7 +93,7 @@ import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.data.DataProviderTestMonitor
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileLoginFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileLoginFragmentTest.kt
@@ -93,7 +93,7 @@ import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.data.DataProviderTestMonitor
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule
@@ -688,7 +688,7 @@ class ProfileLoginFragmentTest {
       onView(withId(R.id.admin_settings_input_pin_edit_text))
         .inRoot(isDialog())
         .check(matches(isDisplayed()))
-        .perform(EditTextInputAction.appendText("1111"), closeSoftKeyboard())
+        .perform(appendText("1111"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -720,7 +720,7 @@ class ProfileLoginFragmentTest {
     onView(withId(R.id.admin_settings_input_pin_edit_text))
       .inRoot(isDialog())
       .check(matches(isDisplayed()))
-      .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
+      .perform(appendText("12345"), closeSoftKeyboard())
 
     onView(withText(context.getString(R.string.admin_settings_submit)))
       .inRoot(isDialog())
@@ -751,7 +751,7 @@ class ProfileLoginFragmentTest {
     onView(withId(R.id.admin_settings_input_pin_edit_text))
       .inRoot(isDialog())
       .check(matches(isDisplayed()))
-      .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
+      .perform(appendText("12345"), closeSoftKeyboard())
 
     onView(withText(context.getString(R.string.admin_settings_submit)))
       .inRoot(isDialog())
@@ -760,7 +760,7 @@ class ProfileLoginFragmentTest {
     onView(withId(R.id.reset_pin_input_pin_edit_text))
       .inRoot(isDialog())
       .check(matches(isDisplayed()))
-      .perform(EditTextInputAction.appendText("111"), closeSoftKeyboard())
+      .perform(appendText("111"), closeSoftKeyboard())
 
     onView(withText(context.getString(R.string.admin_settings_submit)))
       .inRoot(isDialog())
@@ -793,7 +793,7 @@ class ProfileLoginFragmentTest {
     onView(withId(R.id.admin_settings_input_pin_edit_text))
       .inRoot(isDialog())
       .check(matches(isDisplayed()))
-      .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
+      .perform(appendText("12345"), closeSoftKeyboard())
 
     onView(withText(context.getString(R.string.admin_settings_submit)))
       .inRoot(isDialog())
@@ -802,7 +802,7 @@ class ProfileLoginFragmentTest {
     onView(withId(R.id.reset_pin_input_pin_edit_text))
       .inRoot(isDialog())
       .check(matches(isDisplayed()))
-      .perform(EditTextInputAction.appendText("111"), closeSoftKeyboard())
+      .perform(appendText("111"), closeSoftKeyboard())
 
     onView(withText(context.getString(R.string.admin_settings_submit)))
       .inRoot(isDialog())

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileLoginFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/ProfileLoginFragmentTest.kt
@@ -139,7 +139,6 @@ class ProfileLoginFragmentTest {
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
   @Inject lateinit var appStartupStateController: AppStartupStateController
   @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
-  @Inject lateinit var editTextInputAction: EditTextInputAction
 
   private lateinit var scenario: ActivityScenario<ProfileLoginActivity>
 
@@ -689,7 +688,7 @@ class ProfileLoginFragmentTest {
       onView(withId(R.id.admin_settings_input_pin_edit_text))
         .inRoot(isDialog())
         .check(matches(isDisplayed()))
-        .perform(editTextInputAction.appendText("1111"), closeSoftKeyboard())
+        .perform(EditTextInputAction.appendText("1111"), closeSoftKeyboard())
 
       onView(withText(context.getString(R.string.admin_settings_submit)))
         .inRoot(isDialog())
@@ -721,7 +720,7 @@ class ProfileLoginFragmentTest {
     onView(withId(R.id.admin_settings_input_pin_edit_text))
       .inRoot(isDialog())
       .check(matches(isDisplayed()))
-      .perform(editTextInputAction.appendText("12345"), closeSoftKeyboard())
+      .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
 
     onView(withText(context.getString(R.string.admin_settings_submit)))
       .inRoot(isDialog())
@@ -752,7 +751,7 @@ class ProfileLoginFragmentTest {
     onView(withId(R.id.admin_settings_input_pin_edit_text))
       .inRoot(isDialog())
       .check(matches(isDisplayed()))
-      .perform(editTextInputAction.appendText("12345"), closeSoftKeyboard())
+      .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
 
     onView(withText(context.getString(R.string.admin_settings_submit)))
       .inRoot(isDialog())
@@ -761,7 +760,7 @@ class ProfileLoginFragmentTest {
     onView(withId(R.id.reset_pin_input_pin_edit_text))
       .inRoot(isDialog())
       .check(matches(isDisplayed()))
-      .perform(editTextInputAction.appendText("111"), closeSoftKeyboard())
+      .perform(EditTextInputAction.appendText("111"), closeSoftKeyboard())
 
     onView(withText(context.getString(R.string.admin_settings_submit)))
       .inRoot(isDialog())
@@ -794,7 +793,7 @@ class ProfileLoginFragmentTest {
     onView(withId(R.id.admin_settings_input_pin_edit_text))
       .inRoot(isDialog())
       .check(matches(isDisplayed()))
-      .perform(editTextInputAction.appendText("12345"), closeSoftKeyboard())
+      .perform(EditTextInputAction.appendText("12345"), closeSoftKeyboard())
 
     onView(withText(context.getString(R.string.admin_settings_submit)))
       .inRoot(isDialog())
@@ -803,7 +802,7 @@ class ProfileLoginFragmentTest {
     onView(withId(R.id.reset_pin_input_pin_edit_text))
       .inRoot(isDialog())
       .check(matches(isDisplayed()))
-      .perform(editTextInputAction.appendText("111"), closeSoftKeyboard())
+      .perform(EditTextInputAction.appendText("111"), closeSoftKeyboard())
 
     onView(withText(context.getString(R.string.admin_settings_submit)))
       .inRoot(isDialog())

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameFragmentTest.kt
@@ -78,7 +78,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasErrorText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasNoErrorText
 import org.oppia.android.testing.firebase.TestAuthenticationModule

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameFragmentTest.kt
@@ -119,7 +119,6 @@ class ProfileRenameFragmentTest {
   @Inject lateinit var context: Context
   @Inject lateinit var profileTestHelper: ProfileTestHelper
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-  @Inject lateinit var editTextInputAction: EditTextInputAction
 
   @Before
   fun setUp() {
@@ -152,7 +151,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(editTextInputAction.appendText("James"))
+      ).perform(EditTextInputAction.appendText("James"))
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_save_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
@@ -174,7 +173,7 @@ class ProfileRenameFragmentTest {
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
       ).perform(
-        editTextInputAction.appendText("James"),
+        EditTextInputAction.appendText("James"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -195,7 +194,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(editTextInputAction.appendText("James"))
+      ).perform(EditTextInputAction.appendText("James"))
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
       testCoroutineDispatchers.runCurrent()
@@ -216,7 +215,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(editTextInputAction.appendText("James"))
+      ).perform(EditTextInputAction.appendText("James"))
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
       testCoroutineDispatchers.runCurrent()
@@ -246,7 +245,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(editTextInputAction.appendText("Admin"))
+      ).perform(EditTextInputAction.appendText("Admin"))
       onView(withId(R.id.profile_rename_save_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_input)).check(
@@ -274,7 +273,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(editTextInputAction.appendText("Admin"))
+      ).perform(EditTextInputAction.appendText("Admin"))
       onView(withId(R.id.profile_rename_save_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
       onView(
@@ -282,7 +281,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(editTextInputAction.appendText(" "))
+      ).perform(EditTextInputAction.appendText(" "))
       onView(withId(R.id.profile_rename_input)).check(matches(hasNoErrorText()))
     }
   }
@@ -300,7 +299,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(editTextInputAction.appendText("123"))
+      ).perform(EditTextInputAction.appendText("123"))
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_save_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
@@ -328,7 +327,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(editTextInputAction.appendText("123"))
+      ).perform(EditTextInputAction.appendText("123"))
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_save_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
@@ -337,7 +336,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(editTextInputAction.appendText(" "))
+      ).perform(EditTextInputAction.appendText(" "))
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_input)).check(matches(hasNoErrorText()))
     }
@@ -357,7 +356,7 @@ class ProfileRenameFragmentTest {
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
       ).perform(
-        editTextInputAction.appendText("test"),
+        EditTextInputAction.appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -390,7 +389,7 @@ class ProfileRenameFragmentTest {
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
       ).perform(
-        editTextInputAction.appendText("Admin"),
+        EditTextInputAction.appendText("Admin"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileRenameFragmentTest.kt
@@ -78,7 +78,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasErrorText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasNoErrorText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
@@ -151,7 +151,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(EditTextInputAction.appendText("James"))
+      ).perform(appendText("James"))
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_save_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
@@ -173,7 +173,7 @@ class ProfileRenameFragmentTest {
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
       ).perform(
-        EditTextInputAction.appendText("James"),
+        appendText("James"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -194,7 +194,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(EditTextInputAction.appendText("James"))
+      ).perform(appendText("James"))
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
       testCoroutineDispatchers.runCurrent()
@@ -215,7 +215,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(EditTextInputAction.appendText("James"))
+      ).perform(appendText("James"))
       testCoroutineDispatchers.runCurrent()
       onView(isRoot()).perform(orientationLandscape())
       testCoroutineDispatchers.runCurrent()
@@ -245,7 +245,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(EditTextInputAction.appendText("Admin"))
+      ).perform(appendText("Admin"))
       onView(withId(R.id.profile_rename_save_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_input)).check(
@@ -273,7 +273,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(EditTextInputAction.appendText("Admin"))
+      ).perform(appendText("Admin"))
       onView(withId(R.id.profile_rename_save_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
       onView(
@@ -281,7 +281,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(EditTextInputAction.appendText(" "))
+      ).perform(appendText(" "))
       onView(withId(R.id.profile_rename_input)).check(matches(hasNoErrorText()))
     }
   }
@@ -299,7 +299,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(EditTextInputAction.appendText("123"))
+      ).perform(appendText("123"))
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_save_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
@@ -327,7 +327,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(EditTextInputAction.appendText("123"))
+      ).perform(appendText("123"))
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_save_button)).perform(click())
       testCoroutineDispatchers.runCurrent()
@@ -336,7 +336,7 @@ class ProfileRenameFragmentTest {
           withId(R.id.profile_rename_input_edit_text),
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
-      ).perform(EditTextInputAction.appendText(" "))
+      ).perform(appendText(" "))
       testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.profile_rename_input)).check(matches(hasNoErrorText()))
     }
@@ -356,7 +356,7 @@ class ProfileRenameFragmentTest {
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
       ).perform(
-        EditTextInputAction.appendText("test"),
+        appendText("test"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()
@@ -389,7 +389,7 @@ class ProfileRenameFragmentTest {
           isDescendantOfA(withId(R.id.profile_rename_input))
         )
       ).perform(
-        EditTextInputAction.appendText("Admin"),
+        appendText("Admin"),
         closeSoftKeyboard()
       )
       testCoroutineDispatchers.runCurrent()

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileResetPinFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileResetPinFragmentTest.kt
@@ -82,7 +82,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasErrorText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasNoErrorText
 import org.oppia.android.testing.firebase.TestAuthenticationModule

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileResetPinFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileResetPinFragmentTest.kt
@@ -82,7 +82,7 @@ import org.oppia.android.domain.question.QuestionModule
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasErrorText
 import org.oppia.android.testing.espresso.TextInputAction.Companion.hasNoErrorText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
@@ -149,7 +149,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -158,7 +158,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -176,7 +176,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -185,7 +185,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -204,7 +204,7 @@ class ProfileResetPinFragmentTest {
         )
       ).perform(scrollTo())
         .perform(
-          EditTextInputAction.appendText("12345"),
+          appendText("12345"),
           closeSoftKeyboard()
         )
       onView(
@@ -215,7 +215,7 @@ class ProfileResetPinFragmentTest {
       ).perform(
         scrollTo()
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
 
@@ -234,7 +234,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -243,7 +243,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -260,7 +260,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         closeSoftKeyboard()
       )
       onView(
@@ -269,7 +269,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -293,7 +293,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         closeSoftKeyboard()
       )
       onView(
@@ -302,7 +302,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(scrollTo()).perform(click())
@@ -327,7 +327,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button))
@@ -338,7 +338,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("5"),
+        appendText("5"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_input_pin)).check(matches(hasNoErrorText()))
@@ -354,7 +354,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -364,7 +364,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("5"),
+        appendText("5"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -381,7 +381,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -390,7 +390,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -414,7 +414,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -423,7 +423,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -449,7 +449,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -458,7 +458,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -491,7 +491,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12345"),
+        appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -500,7 +500,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("1234"),
+        appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -510,7 +510,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("5"),
+        appendText("5"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_input_confirm_pin)).check(matches(hasNoErrorText()))
@@ -526,7 +526,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       onView(
@@ -535,7 +535,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -559,7 +559,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -569,7 +569,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("3"),
+        appendText("3"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_input_pin)).check(matches(hasNoErrorText()))
@@ -585,7 +585,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -594,7 +594,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -618,7 +618,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -627,7 +627,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -637,7 +637,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("3"),
+        appendText("3"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_input_confirm_pin)).check(matches(hasNoErrorText()))
@@ -669,7 +669,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).check(matches(not(isClickable())))
@@ -685,7 +685,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -703,7 +703,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -712,7 +712,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).check(matches(isClickable()))
@@ -728,7 +728,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -737,7 +737,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).check(matches(isClickable()))
@@ -764,7 +764,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -773,7 +773,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).check(matches(isClickable()))
@@ -799,7 +799,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("123"),
+        appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -808,7 +808,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        EditTextInputAction.appendText("12"),
+        appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).check(matches(isClickable()))

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileResetPinFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileResetPinFragmentTest.kt
@@ -125,7 +125,6 @@ class ProfileResetPinFragmentTest {
   @Inject lateinit var context: Context
   @Inject lateinit var profileTestHelper: ProfileTestHelper
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
-  @Inject lateinit var editTextInputAction: EditTextInputAction
 
   @Before
   fun setUp() {
@@ -150,7 +149,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -159,7 +158,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -177,7 +176,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -186,7 +185,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -205,7 +204,7 @@ class ProfileResetPinFragmentTest {
         )
       ).perform(scrollTo())
         .perform(
-          editTextInputAction.appendText("12345"),
+          EditTextInputAction.appendText("12345"),
           closeSoftKeyboard()
         )
       onView(
@@ -216,7 +215,7 @@ class ProfileResetPinFragmentTest {
       ).perform(
         scrollTo()
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
 
@@ -235,7 +234,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -244,7 +243,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         pressImeActionButton()
       )
       testCoroutineDispatchers.runCurrent()
@@ -261,7 +260,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         closeSoftKeyboard()
       )
       onView(
@@ -270,7 +269,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -294,7 +293,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         closeSoftKeyboard()
       )
       onView(
@@ -303,7 +302,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(scrollTo()).perform(click())
@@ -328,7 +327,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button))
@@ -339,7 +338,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("5"),
+        EditTextInputAction.appendText("5"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_input_pin)).check(matches(hasNoErrorText()))
@@ -355,7 +354,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -365,7 +364,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("5"),
+        EditTextInputAction.appendText("5"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -382,7 +381,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -391,7 +390,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -415,7 +414,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -424,7 +423,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -450,7 +449,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -459,7 +458,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -492,7 +491,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12345"),
+        EditTextInputAction.appendText("12345"),
         closeSoftKeyboard()
       )
       onView(
@@ -501,7 +500,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("1234"),
+        EditTextInputAction.appendText("1234"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -511,7 +510,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("5"),
+        EditTextInputAction.appendText("5"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_input_confirm_pin)).check(matches(hasNoErrorText()))
@@ -527,7 +526,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       onView(
@@ -536,7 +535,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -560,7 +559,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -570,7 +569,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("3"),
+        EditTextInputAction.appendText("3"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_input_pin)).check(matches(hasNoErrorText()))
@@ -586,7 +585,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -595,7 +594,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -619,7 +618,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -628,7 +627,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).perform(click())
@@ -638,7 +637,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("3"),
+        EditTextInputAction.appendText("3"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_input_confirm_pin)).check(matches(hasNoErrorText()))
@@ -670,7 +669,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).check(matches(not(isClickable())))
@@ -686,7 +685,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(isRoot()).perform(orientationLandscape())
@@ -704,7 +703,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -713,7 +712,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).check(matches(isClickable()))
@@ -729,7 +728,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -738,7 +737,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).check(matches(isClickable()))
@@ -765,7 +764,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -774,7 +773,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).check(matches(isClickable()))
@@ -800,7 +799,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_pin))
         )
       ).perform(
-        editTextInputAction.appendText("123"),
+        EditTextInputAction.appendText("123"),
         closeSoftKeyboard()
       )
       onView(
@@ -809,7 +808,7 @@ class ProfileResetPinFragmentTest {
           isDescendantOfA(withId(R.id.profile_reset_input_confirm_pin))
         )
       ).perform(
-        editTextInputAction.appendText("12"),
+        EditTextInputAction.appendText("12"),
         closeSoftKeyboard()
       )
       onView(withId(R.id.profile_reset_save_button)).check(matches(isClickable()))

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/FractionInputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/FractionInputInteractionViewTestActivityTest.kt
@@ -71,7 +71,7 @@ import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/FractionInputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/FractionInputInteractionViewTestActivityTest.kt
@@ -114,9 +114,6 @@ class FractionInputInteractionViewTestActivityTest {
   @get:Rule
   val oppiaTestRule = OppiaTestRule()
 
-  @Inject
-  lateinit var editTextInputAction: EditTextInputAction
-
   @Before
   fun setUp() {
     setUpTestApplicationComponent()

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/FractionInputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/FractionInputInteractionViewTestActivityTest.kt
@@ -153,7 +153,7 @@ class FractionInputInteractionViewTestActivityTest {
       FractionInputInteractionViewTestActivity::class.java
     )
     onView(withId(R.id.test_fraction_input_interaction_view))
-      .perform(editTextInputAction.appendText("-9"))
+      .perform(EditTextInputAction.appendText("-9"))
     activityScenario.onActivity { activity ->
       val pendingAnswer = activity.fractionInteractionViewModel.getPendingAnswer()
       assertThat(pendingAnswer.answer).isInstanceOf(InteractionObject::class.java)
@@ -172,7 +172,7 @@ class FractionInputInteractionViewTestActivityTest {
       FractionInputInteractionViewTestActivity::class.java
     )
     onView(withId(R.id.test_fraction_input_interaction_view))
-      .perform(editTextInputAction.appendText("9"))
+      .perform(EditTextInputAction.appendText("9"))
     activityScenario.onActivity { activity ->
       val pendingAnswer = activity.fractionInteractionViewModel.getPendingAnswer()
       assertThat(pendingAnswer.answer).isInstanceOf(InteractionObject::class.java)
@@ -192,7 +192,7 @@ class FractionInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "9/10"
         )
       )
@@ -216,7 +216,7 @@ class FractionInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "-9/10"
         )
       )
@@ -240,7 +240,7 @@ class FractionInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "5 9/10"
         )
       )
@@ -265,7 +265,7 @@ class FractionInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "-55 59/9"
         )
       )
@@ -289,7 +289,7 @@ class FractionInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "9/5"
         )
       )
@@ -306,7 +306,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "55-"
         )
       )
@@ -327,7 +327,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "--55"
         )
       )
@@ -348,7 +348,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "5/5/"
         )
       )
@@ -369,7 +369,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "/5"
         )
       )
@@ -390,7 +390,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "5 5/"
         )
       )
@@ -404,7 +404,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "5 5/"
         )
       )
@@ -428,7 +428,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "3 1/2"
         )
       )
@@ -445,7 +445,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "1/0"
         )
       )
@@ -459,7 +459,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "1/0"
         )
       )
@@ -483,7 +483,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_fraction_input_interaction_view))
         .perform(
-          editTextInputAction.appendText(
+          EditTextInputAction.appendText(
             "."
           )
         )
@@ -505,7 +505,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_fraction_input_interaction_view))
         .perform(
-          editTextInputAction.appendText(
+          EditTextInputAction.appendText(
             "12345678"
           )
         )

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/FractionInputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/FractionInputInteractionViewTestActivityTest.kt
@@ -71,7 +71,7 @@ import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule
@@ -150,7 +150,7 @@ class FractionInputInteractionViewTestActivityTest {
       FractionInputInteractionViewTestActivity::class.java
     )
     onView(withId(R.id.test_fraction_input_interaction_view))
-      .perform(EditTextInputAction.appendText("-9"))
+      .perform(appendText("-9"))
     activityScenario.onActivity { activity ->
       val pendingAnswer = activity.fractionInteractionViewModel.getPendingAnswer()
       assertThat(pendingAnswer.answer).isInstanceOf(InteractionObject::class.java)
@@ -169,7 +169,7 @@ class FractionInputInteractionViewTestActivityTest {
       FractionInputInteractionViewTestActivity::class.java
     )
     onView(withId(R.id.test_fraction_input_interaction_view))
-      .perform(EditTextInputAction.appendText("9"))
+      .perform(appendText("9"))
     activityScenario.onActivity { activity ->
       val pendingAnswer = activity.fractionInteractionViewModel.getPendingAnswer()
       assertThat(pendingAnswer.answer).isInstanceOf(InteractionObject::class.java)
@@ -189,7 +189,7 @@ class FractionInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "9/10"
         )
       )
@@ -213,7 +213,7 @@ class FractionInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "-9/10"
         )
       )
@@ -237,7 +237,7 @@ class FractionInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "5 9/10"
         )
       )
@@ -262,7 +262,7 @@ class FractionInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "-55 59/9"
         )
       )
@@ -286,7 +286,7 @@ class FractionInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "9/5"
         )
       )
@@ -303,7 +303,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "55-"
         )
       )
@@ -324,7 +324,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "--55"
         )
       )
@@ -345,7 +345,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "5/5/"
         )
       )
@@ -366,7 +366,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "/5"
         )
       )
@@ -387,7 +387,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "5 5/"
         )
       )
@@ -401,7 +401,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "5 5/"
         )
       )
@@ -425,7 +425,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "3 1/2"
         )
       )
@@ -442,7 +442,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "1/0"
         )
       )
@@ -456,7 +456,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_fraction_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "1/0"
         )
       )
@@ -480,7 +480,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_fraction_input_interaction_view))
         .perform(
-          EditTextInputAction.appendText(
+          appendText(
             "."
           )
         )
@@ -502,7 +502,7 @@ class FractionInputInteractionViewTestActivityTest {
     ActivityScenario.launch(FractionInputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_fraction_input_interaction_view))
         .perform(
-          EditTextInputAction.appendText(
+          appendText(
             "12345678"
           )
         )

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/InputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/InputInteractionViewTestActivityTest.kt
@@ -71,7 +71,7 @@ import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/InputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/InputInteractionViewTestActivityTest.kt
@@ -71,7 +71,7 @@ import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule
@@ -150,7 +150,7 @@ class InputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_number_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "9"
         )
       )
@@ -173,7 +173,7 @@ class InputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_number_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "9.5"
         )
       )
@@ -195,7 +195,7 @@ class InputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_number_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "-9.5"
         )
       )
@@ -215,7 +215,7 @@ class InputInteractionViewTestActivityTest {
       InputInteractionViewTestActivity::class.java
     )
     onView(withId(R.id.test_number_input_interaction_view))
-      .perform(EditTextInputAction.appendText("9"))
+      .perform(appendText("9"))
     activityScenario.onActivity { activity ->
       activity.requestedOrientation = Configuration.ORIENTATION_LANDSCAPE
     }
@@ -230,7 +230,7 @@ class InputInteractionViewTestActivityTest {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
-          EditTextInputAction.appendText(
+          appendText(
             "/"
           )
         )
@@ -270,7 +270,7 @@ class InputInteractionViewTestActivityTest {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
-          EditTextInputAction.appendText(
+          appendText(
             "-12345678.6787687678"
           )
         )
@@ -295,7 +295,7 @@ class InputInteractionViewTestActivityTest {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
-          EditTextInputAction.appendText(
+          appendText(
             "1234567886787687678"
           )
         )
@@ -320,7 +320,7 @@ class InputInteractionViewTestActivityTest {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
-          EditTextInputAction.appendText(
+          appendText(
             "-"
           )
         )
@@ -344,7 +344,7 @@ class InputInteractionViewTestActivityTest {
   fun testNumericInput_withNegativeSymbolNotAt0_numberFormatErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view))
-      .perform(EditTextInputAction.appendText("55-"))
+      .perform(appendText("55-"))
     onView(withId(R.id.number_input_error))
       .check(
         matches(
@@ -362,7 +362,7 @@ class InputInteractionViewTestActivityTest {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "--55"
         )
       )
@@ -383,7 +383,7 @@ class InputInteractionViewTestActivityTest {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "5.5."
         )
       )
@@ -403,7 +403,7 @@ class InputInteractionViewTestActivityTest {
   fun testNumericInput_withDecimalAtStart_numberStartingWithFloatingPointError() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view))
-      .perform(EditTextInputAction.appendText(".5"))
+      .perform(appendText(".5"))
     onView(withId(R.id.number_input_error))
       .check(
         matches(

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/InputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/InputInteractionViewTestActivityTest.kt
@@ -153,7 +153,7 @@ class InputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_number_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "9"
         )
       )
@@ -176,7 +176,7 @@ class InputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_number_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "9.5"
         )
       )
@@ -198,7 +198,7 @@ class InputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_number_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "-9.5"
         )
       )
@@ -218,7 +218,7 @@ class InputInteractionViewTestActivityTest {
       InputInteractionViewTestActivity::class.java
     )
     onView(withId(R.id.test_number_input_interaction_view))
-      .perform(editTextInputAction.appendText("9"))
+      .perform(EditTextInputAction.appendText("9"))
     activityScenario.onActivity { activity ->
       activity.requestedOrientation = Configuration.ORIENTATION_LANDSCAPE
     }
@@ -233,7 +233,7 @@ class InputInteractionViewTestActivityTest {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
-          editTextInputAction.appendText(
+          EditTextInputAction.appendText(
             "/"
           )
         )
@@ -273,7 +273,7 @@ class InputInteractionViewTestActivityTest {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
-          editTextInputAction.appendText(
+          EditTextInputAction.appendText(
             "-12345678.6787687678"
           )
         )
@@ -298,7 +298,7 @@ class InputInteractionViewTestActivityTest {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
-          editTextInputAction.appendText(
+          EditTextInputAction.appendText(
             "1234567886787687678"
           )
         )
@@ -323,7 +323,7 @@ class InputInteractionViewTestActivityTest {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java).use {
       onView(withId(R.id.test_number_input_interaction_view))
         .perform(
-          editTextInputAction.appendText(
+          EditTextInputAction.appendText(
             "-"
           )
         )
@@ -347,7 +347,7 @@ class InputInteractionViewTestActivityTest {
   fun testNumericInput_withNegativeSymbolNotAt0_numberFormatErrorIsDisplayed() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view))
-      .perform(editTextInputAction.appendText("55-"))
+      .perform(EditTextInputAction.appendText("55-"))
     onView(withId(R.id.number_input_error))
       .check(
         matches(
@@ -365,7 +365,7 @@ class InputInteractionViewTestActivityTest {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "--55"
         )
       )
@@ -386,7 +386,7 @@ class InputInteractionViewTestActivityTest {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "5.5."
         )
       )
@@ -406,7 +406,7 @@ class InputInteractionViewTestActivityTest {
   fun testNumericInput_withDecimalAtStart_numberStartingWithFloatingPointError() {
     ActivityScenario.launch(InputInteractionViewTestActivity::class.java)
     onView(withId(R.id.test_number_input_interaction_view))
-      .perform(editTextInputAction.appendText(".5"))
+      .perform(EditTextInputAction.appendText(".5"))
     onView(withId(R.id.number_input_error))
       .check(
         matches(

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/InputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/InputInteractionViewTestActivityTest.kt
@@ -114,9 +114,6 @@ class InputInteractionViewTestActivityTest {
   @get:Rule
   val oppiaTestRule = OppiaTestRule()
 
-  @Inject
-  lateinit var editTextInputAction: EditTextInputAction
-
   @Before
   fun setUp() {
     setUpTestApplicationComponent()

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/RatioInputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/RatioInputInteractionViewTestActivityTest.kt
@@ -78,7 +78,7 @@ import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule
@@ -177,7 +177,7 @@ class RatioInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_ratio_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "1:2"
         )
       )

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/RatioInputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/RatioInputInteractionViewTestActivityTest.kt
@@ -121,9 +121,6 @@ class RatioInputInteractionViewTestActivityTest {
   @get:Rule
   val oppiaTestRule = OppiaTestRule()
 
-  @Inject
-  lateinit var editTextInputAction: EditTextInputAction
-
   @Before
   fun setUp() {
     setUpTestApplicationComponent()

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/RatioInputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/RatioInputInteractionViewTestActivityTest.kt
@@ -78,7 +78,7 @@ import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/RatioInputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/RatioInputInteractionViewTestActivityTest.kt
@@ -180,7 +180,7 @@ class RatioInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_ratio_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "1:2"
         )
       )

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/TextInputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/TextInputInteractionViewTestActivityTest.kt
@@ -70,7 +70,7 @@ import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/TextInputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/TextInputInteractionViewTestActivityTest.kt
@@ -154,7 +154,7 @@ class TextInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_text_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "abc"
         )
       )
@@ -175,7 +175,7 @@ class TextInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_text_input_interaction_view))
       .perform(
-        editTextInputAction.appendText(
+        EditTextInputAction.appendText(
           "abc"
         )
       )

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/TextInputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/TextInputInteractionViewTestActivityTest.kt
@@ -70,7 +70,7 @@ import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.DisableAccessibilityChecks
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule
@@ -151,7 +151,7 @@ class TextInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_text_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "abc"
         )
       )
@@ -172,7 +172,7 @@ class TextInputInteractionViewTestActivityTest {
     )
     onView(withId(R.id.test_text_input_interaction_view))
       .perform(
-        EditTextInputAction.appendText(
+        appendText(
           "abc"
         )
       )

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/TextInputInteractionViewTestActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/TextInputInteractionViewTestActivityTest.kt
@@ -113,9 +113,6 @@ class TextInputInteractionViewTestActivityTest {
   @get:Rule
   val oppiaTestRule = OppiaTestRule()
 
-  @Inject
-  lateinit var editTextInputAction: EditTextInputAction
-
   @Before
   fun setUp() {
     setUpTestApplicationComponent()

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -127,7 +127,7 @@ import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.TestPlatform
 import org.oppia.android.testing.data.DataProviderTestMonitor
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -127,7 +127,7 @@ import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.TestPlatform
 import org.oppia.android.testing.data.DataProviderTestMonitor
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule
@@ -635,7 +635,7 @@ class QuestionPlayerActivityTest {
 
   private fun typeTextIntoInteraction(text: String, interactionViewId: Int) {
     onView(withId(interactionViewId)).perform(
-      EditTextInputAction.appendText(text),
+      appendText(text),
       closeSoftKeyboard()
     )
     testCoroutineDispatchers.runCurrent()

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -172,7 +172,6 @@ class QuestionPlayerActivityTest {
   // TODO(#503): add tests for QuestionPlayerActivity (use StateFragmentTest for a reference).
   // TODO(#1273): add tests for Hints and Solution in Question Player.
 
-  @Inject lateinit var editTextInputAction: EditTextInputAction
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
   @Inject lateinit var profileTestHelper: ProfileTestHelper
   @Inject lateinit var context: Context
@@ -636,7 +635,7 @@ class QuestionPlayerActivityTest {
 
   private fun typeTextIntoInteraction(text: String, interactionViewId: Int) {
     onView(withId(interactionViewId)).perform(
-      editTextInputAction.appendText(text),
+      EditTextInputAction.appendText(text),
       closeSoftKeyboard()
     )
     testCoroutineDispatchers.runCurrent()

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -140,7 +140,7 @@ import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.data.DataProviderTestMonitor
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.espresso.KonfettiViewMatcher.Companion.hasActiveConfetti
 import org.oppia.android.testing.espresso.KonfettiViewMatcher.Companion.hasExpectedNumberOfActiveSystems
 import org.oppia.android.testing.firebase.TestAuthenticationModule
@@ -2643,7 +2643,7 @@ class StateFragmentLocalTest {
   }
 
   private fun typeTextIntoInteraction(text: String, interactionViewId: Int) {
-    onView(withId(interactionViewId)).perform(EditTextInputAction.appendText(text))
+    onView(withId(interactionViewId)).perform(appendText(text))
     testCoroutineDispatchers.runCurrent()
   }
 

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -198,7 +198,7 @@ class StateFragmentLocalTest {
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
   @Inject lateinit var context: Context
   @field:[Inject BackgroundDispatcher] lateinit var backgroundDispatcher: CoroutineDispatcher
-  @Inject lateinit var editTextInputAction: EditTextInputAction
+
   @Inject lateinit var accessibilityManager: FakeAccessibilityService
   @Inject lateinit var translationController: TranslationController
   @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
@@ -2643,7 +2643,7 @@ class StateFragmentLocalTest {
   }
 
   private fun typeTextIntoInteraction(text: String, interactionViewId: Int) {
-    onView(withId(interactionViewId)).perform(editTextInputAction.appendText(text))
+    onView(withId(interactionViewId)).perform(EditTextInputAction.appendText(text))
     testCoroutineDispatchers.runCurrent()
   }
 

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -140,7 +140,7 @@ import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.TestImageLoaderModule
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.data.DataProviderTestMonitor
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.espresso.KonfettiViewMatcher.Companion.hasActiveConfetti
 import org.oppia.android.testing.espresso.KonfettiViewMatcher.Companion.hasExpectedNumberOfActiveSystems
 import org.oppia.android.testing.firebase.TestAuthenticationModule

--- a/app/src/test/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityLocalTest.kt
@@ -87,7 +87,7 @@ import org.oppia.android.domain.question.WrongAnswerScorePenalty
 import org.oppia.android.domain.topic.TEST_SKILL_ID_1
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
 import org.oppia.android.testing.espresso.KonfettiViewMatcher.Companion.hasActiveConfetti
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule

--- a/app/src/test/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityLocalTest.kt
@@ -361,7 +361,7 @@ class QuestionPlayerActivityLocalTest {
     onView(withId(R.id.question_recycler_view))
       .perform(scrollToViewType(StateItemViewModel.ViewType.TEXT_INPUT_INTERACTION))
     onView(withId(R.id.text_input_interaction_view)).perform(
-      editTextInputAction.appendText("1/2"),
+      EditTextInputAction.appendText("1/2"),
       closeSoftKeyboard()
     )
     testCoroutineDispatchers.runCurrent()
@@ -376,7 +376,7 @@ class QuestionPlayerActivityLocalTest {
     onView(withId(R.id.question_recycler_view))
       .perform(scrollToViewType(StateItemViewModel.ViewType.TEXT_INPUT_INTERACTION))
     onView(withId(R.id.text_input_interaction_view)).perform(
-      editTextInputAction.appendText("1/4"),
+      EditTextInputAction.appendText("1/4"),
       closeSoftKeyboard()
     )
     testCoroutineDispatchers.runCurrent()
@@ -403,7 +403,7 @@ class QuestionPlayerActivityLocalTest {
   private fun submitWrongAnswerToQuestionPlayerFractionInput() {
     onView(withId(R.id.question_recycler_view))
       .perform(scrollToViewType(StateItemViewModel.ViewType.TEXT_INPUT_INTERACTION))
-    onView(withId(R.id.text_input_interaction_view)).perform(editTextInputAction.appendText("1"))
+    onView(withId(R.id.text_input_interaction_view)).perform(EditTextInputAction.appendText("1"))
     testCoroutineDispatchers.runCurrent()
 
     onView(withId(R.id.question_recycler_view))

--- a/app/src/test/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityLocalTest.kt
@@ -142,9 +142,6 @@ class QuestionPlayerActivityLocalTest {
   @Inject
   lateinit var context: Context
 
-  @Inject
-  lateinit var editTextInputAction: EditTextInputAction
-
   private val SKILL_ID_LIST = arrayListOf(TEST_SKILL_ID_1)
 
   @Before

--- a/app/src/test/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityLocalTest.kt
@@ -87,7 +87,7 @@ import org.oppia.android.domain.question.WrongAnswerScorePenalty
 import org.oppia.android.domain.topic.TEST_SKILL_ID_1
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.TestLogReportingModule
-import org.oppia.android.testing.espresso.EditTextInputAction
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
 import org.oppia.android.testing.espresso.KonfettiViewMatcher.Companion.hasActiveConfetti
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
@@ -358,7 +358,7 @@ class QuestionPlayerActivityLocalTest {
     onView(withId(R.id.question_recycler_view))
       .perform(scrollToViewType(StateItemViewModel.ViewType.TEXT_INPUT_INTERACTION))
     onView(withId(R.id.text_input_interaction_view)).perform(
-      EditTextInputAction.appendText("1/2"),
+      appendText("1/2"),
       closeSoftKeyboard()
     )
     testCoroutineDispatchers.runCurrent()
@@ -373,7 +373,7 @@ class QuestionPlayerActivityLocalTest {
     onView(withId(R.id.question_recycler_view))
       .perform(scrollToViewType(StateItemViewModel.ViewType.TEXT_INPUT_INTERACTION))
     onView(withId(R.id.text_input_interaction_view)).perform(
-      EditTextInputAction.appendText("1/4"),
+      appendText("1/4"),
       closeSoftKeyboard()
     )
     testCoroutineDispatchers.runCurrent()
@@ -400,7 +400,7 @@ class QuestionPlayerActivityLocalTest {
   private fun submitWrongAnswerToQuestionPlayerFractionInput() {
     onView(withId(R.id.question_recycler_view))
       .perform(scrollToViewType(StateItemViewModel.ViewType.TEXT_INPUT_INTERACTION))
-    onView(withId(R.id.text_input_interaction_view)).perform(EditTextInputAction.appendText("1"))
+    onView(withId(R.id.text_input_interaction_view)).perform(appendText("1"))
     testCoroutineDispatchers.runCurrent()
 
     onView(withId(R.id.question_recycler_view))

--- a/scripts/assets/test_file_exemptions.textproto
+++ b/scripts/assets/test_file_exemptions.textproto
@@ -4276,10 +4276,6 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "testing/src/main/java/org/oppia/android/testing/espresso/EditTextInputAction.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "testing/src/main/java/org/oppia/android/testing/espresso/GenericViewMatchers.kt"
   test_file_not_required: true
 }

--- a/scripts/assets/test_file_exemptions.textproto
+++ b/scripts/assets/test_file_exemptions.textproto
@@ -4276,6 +4276,10 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "testing/src/main/java/org/oppia/android/testing/espresso/EditTextInputAction.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt"
   is_extra_test_file: true
 }

--- a/scripts/assets/test_file_exemptions.textproto
+++ b/scripts/assets/test_file_exemptions.textproto
@@ -4887,3 +4887,11 @@ test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/ReturnToQuestionButtonListener.kt"
   test_file_not_required: true
 }
+test_file_exemption {
+  exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersInjector.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt"
+  is_extra_test_file: true
+}

--- a/scripts/assets/test_file_exemptions.textproto
+++ b/scripts/assets/test_file_exemptions.textproto
@@ -15,10 +15,6 @@ test_file_exemption {
   override_min_coverage_percent_required: 0
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedActivity.kt"
-  source_file_is_incompatible_with_code_coverage: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/activity/ActivityIntentFactoriesModule.kt"
   test_file_not_required: true
 }
@@ -279,6 +275,10 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/classroom/classroomlist/AllClassroomsHeaderText.kt"
   test_file_not_required: true
 }
@@ -292,10 +292,6 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/classroom/promotedlist/PromotedStoryList.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -383,6 +379,14 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/AppRestartDialogFragment.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/AppRestartDialogFragmentPresenter.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/AppRestartListener.kt"
   test_file_not_required: true
 }
@@ -427,23 +431,15 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/ForceDownloadRemoteParametersButtonClickListener.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/ForceDownloadRemoteParametersDialogFragment.kt"
   test_file_not_required: true
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/ForceDownloadRemoteParametersDialogFragmentPresenter.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/ForceDownloadRemoteParametersButtonClickListener.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/AppRestartDialogFragment.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/AppRestartDialogFragmentPresenter.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -455,7 +451,7 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/SavePendingChangesDialogListener.kt"
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/RouteToFeatureFlagsListener.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -479,15 +475,15 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/RouteToPlatformParametersListener.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/RouteToViewEventLogsListener.kt"
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/RouteToFeatureFlagsListener.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/RouteToPlatformParametersListener.kt"
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/SavePendingChangesDialogListener.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -510,6 +506,34 @@ test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/devoptionsitemviewmodel/DeveloperOptionsViewLogsViewModel.kt"
   test_file_not_required: true
 }
+test_file_exemption {
+    exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagItemViewModel.kt"
+    test_file_not_required: true
+ }
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsActivity.kt"
+  source_file_is_incompatible_with_code_coverage: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsActivityPresenter.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsFragment.kt"
+  source_file_is_incompatible_with_code_coverage: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsFragmentPresenter.kt"
+   test_file_not_required: true
+ }
+test_file_exemption {
+   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsViewModel.kt"
+   test_file_not_required: true
+ }
+test_file_exemption {
+   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/testing/FeatureFlagsTestActivity.kt"
+   test_file_not_required: true
+ }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/forcenetworktype/ForceNetworkTypeActivity.kt"
   source_file_is_incompatible_with_code_coverage: true
@@ -538,64 +562,6 @@ test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/forcenetworktype/testing/ForceNetworkTypeTestActivity.kt"
   test_file_not_required: true
 }
-
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsActivity.kt"
-  source_file_is_incompatible_with_code_coverage: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsActivityPresenter.kt"
-  test_file_not_required: true
-}
-
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsFragment.kt"
-  source_file_is_incompatible_with_code_coverage: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsFragmentPresenter.kt"
-   test_file_not_required: true
- }
-test_file_exemption {
-   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsViewModel.kt"
-   test_file_not_required: true
- }
-test_file_exemption {
-    exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagItemViewModel.kt"
-    test_file_not_required: true
- }
-test_file_exemption {
-   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/testing/FeatureFlagsTestActivity.kt"
-   test_file_not_required: true
- }
-test_file_exemption {
-   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersActivity.kt"
-   source_file_is_incompatible_with_code_coverage: true
- }
-test_file_exemption {
-   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersActivityPresenter.kt"
-   test_file_not_required: true
- }
-test_file_exemption {
-   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragment.kt"
-   source_file_is_incompatible_with_code_coverage: true
- }
-test_file_exemption {
-   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentPresenter.kt"
-    test_file_not_required: true
-  }
-test_file_exemption {
-    exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersViewModel.kt"
-    test_file_not_required: true
-  }
-test_file_exemption {
-     exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParameterItemViewModel.kt"
-     test_file_not_required: true
-  }
-test_file_exemption {
-    exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/testing/PlatformParametersTestActivity.kt"
-    test_file_not_required: true
-  }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/markchapterscompleted/ChapterSummaryViewModel.kt"
   test_file_not_required: true
@@ -716,6 +682,34 @@ test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/mathexpressionparser/MathExpressionParserViewModel.kt"
   test_file_not_required: true
 }
+test_file_exemption {
+     exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParameterItemViewModel.kt"
+     test_file_not_required: true
+  }
+test_file_exemption {
+   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersActivity.kt"
+   source_file_is_incompatible_with_code_coverage: true
+ }
+test_file_exemption {
+   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersActivityPresenter.kt"
+   test_file_not_required: true
+ }
+test_file_exemption {
+   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragment.kt"
+   source_file_is_incompatible_with_code_coverage: true
+ }
+test_file_exemption {
+   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentPresenter.kt"
+    test_file_not_required: true
+  }
+test_file_exemption {
+    exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersViewModel.kt"
+    test_file_not_required: true
+  }
+test_file_exemption {
+    exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/testing/PlatformParametersTestActivity.kt"
+    test_file_not_required: true
+  }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/testing/DeveloperOptionsTestActivity.kt"
   test_file_not_required: true
@@ -1029,6 +1023,10 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/hintsandsolution/HintsDialogSolutionViewModel.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/hintsandsolution/ReturnToLessonViewModel.kt"
   test_file_not_required: true
 }
@@ -1147,6 +1145,10 @@ test_file_exemption {
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/home/recentlyplayed/PromotedStoryViewModel.kt"
   test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedActivity.kt"
+  source_file_is_incompatible_with_code_coverage: true
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedActivityPresenter.kt"
@@ -1325,11 +1327,11 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/onboarding/AudioLanguageFragmentPresenter.kt"
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/onboarding/AppLanguageViewModel.kt"
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/onboarding/AppLanguageViewModel.kt"
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/onboarding/AudioLanguageFragmentPresenter.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -1801,6 +1803,10 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/FlashbackButtonViewModel.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/FractionInteractionViewModel.kt"
   test_file_not_required: true
 }
@@ -1841,6 +1847,10 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/ReturnToQuestionViewModel.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/ReturnToTopicButtonViewModel.kt"
   test_file_not_required: true
 }
@@ -1850,6 +1860,10 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionSubmittedItemViewModel.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -1865,6 +1879,10 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/StateSolutionViewModel.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SubmitButtonViewModel.kt"
   test_file_not_required: true
 }
@@ -1873,15 +1891,19 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionSubmittedItemViewModel.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/TextInputViewModel.kt"
   test_file_not_required: true
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/ContinueNavigationButtonListener.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/FlashbackButtonListener.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/FlashbackToolbarListener.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -1898,6 +1920,10 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/ReplayButtonListener.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/ReturnToQuestionButtonListener.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -1918,6 +1944,10 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/SubmitNavigationButtonListener.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/testing/InteractionObjectTestBuilder.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -2013,6 +2043,10 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/profile/AdminPinRecoveryDialog.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/profile/AdminPinViewModel.kt"
   test_file_not_required: true
 }
@@ -2034,10 +2068,6 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/profile/DynamicProfileItemMarginsDecorator.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/profile/AdminPinRecoveryDialog.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -2233,12 +2263,12 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivity.kt"
-  source_file_is_incompatible_with_code_coverage: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/settings/profile/ProfileDeleteSuccessDialogFragment.kt"
   test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivity.kt"
+  source_file_is_incompatible_with_code_coverage: true
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivityPresenter.kt"
@@ -2528,10 +2558,6 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/TextInputLayoutBindingAdaptersTestActivity.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/BindableAdapterTestDataModel.kt"
   test_file_not_required: true
 }
@@ -2561,10 +2587,6 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/ColorBindingAdaptersTestFragment.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/TextInputLayoutBindingAdaptersTestFragment.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -2726,6 +2748,14 @@ test_file_exemption {
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/TextInputInteractionViewTestActivity.kt"
   source_file_is_incompatible_with_code_coverage: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/TextInputLayoutBindingAdaptersTestActivity.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/TextInputLayoutBindingAdaptersTestFragment.kt"
+  test_file_not_required: true
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/TextViewBindingAdaptersTestActivity.kt"
@@ -3176,90 +3206,6 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/activity/PlatformParameterInitializationIntegrationTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/home/HomeActivityLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/profile/ProfileChooserFragmentLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/story/StoryActivityLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/info/TopicInfoFragmentLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/CompletedStoryListSpanTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/HomeSpanTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/OngoingTopicListSpanTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/PlatformParameterIntegrationDebugTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/ProfileChooserSpanTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/ProfileProgressSpanCountTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/RecentlyPlayedSpanTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/TopicRevisionSpanTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/PlatformParameterIntegrationTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/player/state/StateFragmentAccessibilityTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/player/split/PlayerSplitScreenTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt"
   test_file_not_required: true
 }
@@ -3306,6 +3252,90 @@ test_file_exemption {
 test_file_exemption {
   exempted_file_path: "app/src/sharedTest/java/org/oppia/android/app/utility/TabMatcher.kt"
   test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/activity/PlatformParameterInitializationIntegrationTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/home/HomeActivityLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/profile/ProfileChooserFragmentLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/story/StoryActivityLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/CompletedStoryListSpanTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/HomeSpanTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/OngoingTopicListSpanTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/PlatformParameterIntegrationDebugTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/PlatformParameterIntegrationTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/ProfileChooserSpanTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/ProfileProgressSpanCountTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/RecentlyPlayedSpanTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/TopicRevisionSpanTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/player/split/PlayerSplitScreenTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/player/state/StateFragmentAccessibilityTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/info/TopicInfoFragmentLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityLocalTest.kt",
+  is_extra_test_file: true
 }
 test_file_exemption {
   exempted_file_path: "data/src/main/java/org/oppia/android/data/backends/gae/BaseUrl.kt"
@@ -3948,6 +3978,10 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImpl.kt"
+  source_file_is_incompatible_with_code_coverage: true
+}
+test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerInjector.kt"
   test_file_not_required: true
 }
@@ -3956,16 +3990,12 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterDebugModule.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerProdImpl.kt"
   source_file_is_incompatible_with_code_coverage: true
 }
 test_file_exemption {
-  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImpl.kt"
-  source_file_is_incompatible_with_code_coverage: true
+  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterDebugModule.kt"
+  test_file_not_required: true
 }
 test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterModule.kt"
@@ -3984,10 +4014,6 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/testing/TestPlatformParameterConfigRetriever.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/syncup/PlatformParameterSyncUpWorkManagerInitializer.kt"
   source_file_is_incompatible_with_code_coverage: true
 }
@@ -4001,6 +4027,10 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/syncup/PlatformParameterSyncUpWorkerModule.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/testing/TestPlatformParameterConfigRetriever.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -4113,10 +4143,6 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/workmanager/WorkManagerConfigurationModule.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/testing/InteractionObjectTestBuilder.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -4400,6 +4426,10 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersInjector.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersRobolectricImpl.kt"
   test_file_not_required: true
 }
@@ -4414,6 +4444,10 @@ test_file_exemption {
 test_file_exemption {
   exempted_file_path: "testing/src/main/java/org/oppia/android/testing/time/FakeSystemClock.kt"
   test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt"
+  is_extra_test_file: true
 }
 test_file_exemption {
   exempted_file_path: "testing/src/test/java/org/oppia/android/testing/junit/InitializeDefaultLocaleRuleCustomContextTest.kt",
@@ -4492,11 +4526,11 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "utility/src/main/java/org/oppia/android/util/extensions/ContextExtensions.kt"
+  exempted_file_path: "utility/src/main/java/org/oppia/android/util/enumfilter/EnumFilterUtil.kt"
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "utility/src/main/java/org/oppia/android/util/enumfilter/EnumFilterUtil.kt"
+  exempted_file_path: "utility/src/main/java/org/oppia/android/util/extensions/ContextExtensions.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -4848,50 +4882,14 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "utility/src/test/java/org/oppia/android/util/math/AlgebraicExpressionParserTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
   exempted_file_path: "utility/src/test/java/org/oppia/android/util/math/AlgebraicEquationParserTest.kt",
   is_extra_test_file: true
 }
 test_file_exemption {
-  exempted_file_path: "utility/src/test/java/org/oppia/android/util/math/NumericExpressionParserTest.kt",
+  exempted_file_path: "utility/src/test/java/org/oppia/android/util/math/AlgebraicExpressionParserTest.kt",
   is_extra_test_file: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/FlashbackButtonViewModel.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/FlashbackButtonListener.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/ReturnToQuestionViewModel.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/FlashbackToolbarListener.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/StateSolutionViewModel.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/hintsandsolution/HintsDialogSolutionViewModel.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/ReturnToQuestionButtonListener.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersInjector.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt"
+  exempted_file_path: "utility/src/test/java/org/oppia/android/util/math/NumericExpressionParserTest.kt",
   is_extra_test_file: true
 }

--- a/scripts/assets/test_file_exemptions.textproto
+++ b/scripts/assets/test_file_exemptions.textproto
@@ -15,6 +15,10 @@ test_file_exemption {
   override_min_coverage_percent_required: 0
 }
 test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedActivity.kt"
+  source_file_is_incompatible_with_code_coverage: true
+}
+test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/activity/ActivityIntentFactoriesModule.kt"
   test_file_not_required: true
 }
@@ -275,10 +279,6 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/classroom/classroomlist/AllClassroomsHeaderText.kt"
   test_file_not_required: true
 }
@@ -292,6 +292,10 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/classroom/promotedlist/PromotedStoryList.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/classroom/ThumbnailImage.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -379,14 +383,6 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/AppRestartDialogFragment.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/AppRestartDialogFragmentPresenter.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/AppRestartListener.kt"
   test_file_not_required: true
 }
@@ -431,15 +427,23 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/ForceDownloadRemoteParametersButtonClickListener.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/ForceDownloadRemoteParametersDialogFragment.kt"
   test_file_not_required: true
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/ForceDownloadRemoteParametersDialogFragmentPresenter.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/ForceDownloadRemoteParametersButtonClickListener.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/AppRestartDialogFragment.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/AppRestartDialogFragmentPresenter.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -451,7 +455,7 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/RouteToFeatureFlagsListener.kt"
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/SavePendingChangesDialogListener.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -475,15 +479,15 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/RouteToPlatformParametersListener.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/RouteToViewEventLogsListener.kt"
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/SavePendingChangesDialogListener.kt"
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/RouteToFeatureFlagsListener.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/RouteToPlatformParametersListener.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -506,34 +510,6 @@ test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/devoptionsitemviewmodel/DeveloperOptionsViewLogsViewModel.kt"
   test_file_not_required: true
 }
-test_file_exemption {
-    exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagItemViewModel.kt"
-    test_file_not_required: true
- }
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsActivity.kt"
-  source_file_is_incompatible_with_code_coverage: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsActivityPresenter.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsFragment.kt"
-  source_file_is_incompatible_with_code_coverage: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsFragmentPresenter.kt"
-   test_file_not_required: true
- }
-test_file_exemption {
-   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsViewModel.kt"
-   test_file_not_required: true
- }
-test_file_exemption {
-   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/testing/FeatureFlagsTestActivity.kt"
-   test_file_not_required: true
- }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/forcenetworktype/ForceNetworkTypeActivity.kt"
   source_file_is_incompatible_with_code_coverage: true
@@ -562,6 +538,64 @@ test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/forcenetworktype/testing/ForceNetworkTypeTestActivity.kt"
   test_file_not_required: true
 }
+
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsActivity.kt"
+  source_file_is_incompatible_with_code_coverage: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsActivityPresenter.kt"
+  test_file_not_required: true
+}
+
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsFragment.kt"
+  source_file_is_incompatible_with_code_coverage: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsFragmentPresenter.kt"
+   test_file_not_required: true
+ }
+test_file_exemption {
+   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsViewModel.kt"
+   test_file_not_required: true
+ }
+test_file_exemption {
+    exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagItemViewModel.kt"
+    test_file_not_required: true
+ }
+test_file_exemption {
+   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/featureflags/testing/FeatureFlagsTestActivity.kt"
+   test_file_not_required: true
+ }
+test_file_exemption {
+   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersActivity.kt"
+   source_file_is_incompatible_with_code_coverage: true
+ }
+test_file_exemption {
+   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersActivityPresenter.kt"
+   test_file_not_required: true
+ }
+test_file_exemption {
+   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragment.kt"
+   source_file_is_incompatible_with_code_coverage: true
+ }
+test_file_exemption {
+   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentPresenter.kt"
+    test_file_not_required: true
+  }
+test_file_exemption {
+    exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersViewModel.kt"
+    test_file_not_required: true
+  }
+test_file_exemption {
+     exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParameterItemViewModel.kt"
+     test_file_not_required: true
+  }
+test_file_exemption {
+    exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/testing/PlatformParametersTestActivity.kt"
+    test_file_not_required: true
+  }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/markchapterscompleted/ChapterSummaryViewModel.kt"
   test_file_not_required: true
@@ -682,34 +716,6 @@ test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/mathexpressionparser/MathExpressionParserViewModel.kt"
   test_file_not_required: true
 }
-test_file_exemption {
-     exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParameterItemViewModel.kt"
-     test_file_not_required: true
-  }
-test_file_exemption {
-   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersActivity.kt"
-   source_file_is_incompatible_with_code_coverage: true
- }
-test_file_exemption {
-   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersActivityPresenter.kt"
-   test_file_not_required: true
- }
-test_file_exemption {
-   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragment.kt"
-   source_file_is_incompatible_with_code_coverage: true
- }
-test_file_exemption {
-   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersFragmentPresenter.kt"
-    test_file_not_required: true
-  }
-test_file_exemption {
-    exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/PlatformParametersViewModel.kt"
-    test_file_not_required: true
-  }
-test_file_exemption {
-    exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/platformparameters/testing/PlatformParametersTestActivity.kt"
-    test_file_not_required: true
-  }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/devoptions/testing/DeveloperOptionsTestActivity.kt"
   test_file_not_required: true
@@ -1023,10 +1029,6 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/hintsandsolution/HintsDialogSolutionViewModel.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/hintsandsolution/ReturnToLessonViewModel.kt"
   test_file_not_required: true
 }
@@ -1145,10 +1147,6 @@ test_file_exemption {
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/home/recentlyplayed/PromotedStoryViewModel.kt"
   test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedActivity.kt"
-  source_file_is_incompatible_with_code_coverage: true
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedActivityPresenter.kt"
@@ -1327,11 +1325,11 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/onboarding/AppLanguageViewModel.kt"
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/onboarding/AudioLanguageFragmentPresenter.kt"
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/onboarding/AudioLanguageFragmentPresenter.kt"
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/onboarding/AppLanguageViewModel.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -1803,10 +1801,6 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/FlashbackButtonViewModel.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/FractionInteractionViewModel.kt"
   test_file_not_required: true
 }
@@ -1847,10 +1841,6 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/ReturnToQuestionViewModel.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/ReturnToTopicButtonViewModel.kt"
   test_file_not_required: true
 }
@@ -1860,10 +1850,6 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionSubmittedItemViewModel.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -1879,10 +1865,6 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/StateSolutionViewModel.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SubmitButtonViewModel.kt"
   test_file_not_required: true
 }
@@ -1891,19 +1873,15 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionSubmittedItemViewModel.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/TextInputViewModel.kt"
   test_file_not_required: true
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/ContinueNavigationButtonListener.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/FlashbackButtonListener.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/FlashbackToolbarListener.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -1920,10 +1898,6 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/ReplayButtonListener.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/ReturnToQuestionButtonListener.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -1944,10 +1918,6 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/SubmitNavigationButtonListener.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/testing/InteractionObjectTestBuilder.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -2043,10 +2013,6 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/profile/AdminPinRecoveryDialog.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/profile/AdminPinViewModel.kt"
   test_file_not_required: true
 }
@@ -2068,6 +2034,10 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/profile/DynamicProfileItemMarginsDecorator.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/profile/AdminPinRecoveryDialog.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -2263,12 +2233,12 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/settings/profile/ProfileDeleteSuccessDialogFragment.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivity.kt"
   source_file_is_incompatible_with_code_coverage: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/settings/profile/ProfileDeleteSuccessDialogFragment.kt"
+  test_file_not_required: true
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditActivityPresenter.kt"
@@ -2558,6 +2528,10 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/TextInputLayoutBindingAdaptersTestActivity.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/BindableAdapterTestDataModel.kt"
   test_file_not_required: true
 }
@@ -2587,6 +2561,10 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/ColorBindingAdaptersTestFragment.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/TextInputLayoutBindingAdaptersTestFragment.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -2748,14 +2726,6 @@ test_file_exemption {
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/TextInputInteractionViewTestActivity.kt"
   source_file_is_incompatible_with_code_coverage: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/TextInputLayoutBindingAdaptersTestActivity.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/TextInputLayoutBindingAdaptersTestFragment.kt"
-  test_file_not_required: true
 }
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/testing/TextViewBindingAdaptersTestActivity.kt"
@@ -3206,6 +3176,90 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/activity/PlatformParameterInitializationIntegrationTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/home/HomeActivityLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/profile/ProfileChooserFragmentLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/story/StoryActivityLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/info/TopicInfoFragmentLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityLocalTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/CompletedStoryListSpanTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/HomeSpanTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/OngoingTopicListSpanTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/PlatformParameterIntegrationDebugTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/ProfileChooserSpanTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/ProfileProgressSpanCountTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/RecentlyPlayedSpanTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/TopicRevisionSpanTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/PlatformParameterIntegrationTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/player/state/StateFragmentAccessibilityTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/player/split/PlayerSplitScreenTest.kt",
+  is_extra_test_file: true
+}
+test_file_exemption {
   exempted_file_path: "app/src/sharedTest/java/org/oppia/android/app/recyclerview/RecyclerViewMatcher.kt"
   test_file_not_required: true
 }
@@ -3252,90 +3306,6 @@ test_file_exemption {
 test_file_exemption {
   exempted_file_path: "app/src/sharedTest/java/org/oppia/android/app/utility/TabMatcher.kt"
   test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/activity/PlatformParameterInitializationIntegrationTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/home/HomeActivityLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/profile/ProfileChooserFragmentLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/story/StoryActivityLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/CompletedStoryListSpanTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/HomeSpanTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/OngoingTopicListSpanTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/PlatformParameterIntegrationDebugTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/PlatformParameterIntegrationTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/ProfileChooserSpanTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/ProfileProgressSpanCountTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/RecentlyPlayedSpanTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/TopicRevisionSpanTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/player/split/PlayerSplitScreenTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/testing/player/state/StateFragmentAccessibilityTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/info/TopicInfoFragmentLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityLocalTest.kt",
-  is_extra_test_file: true
-}
-test_file_exemption {
-  exempted_file_path: "app/src/test/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityLocalTest.kt",
-  is_extra_test_file: true
 }
 test_file_exemption {
   exempted_file_path: "data/src/main/java/org/oppia/android/data/backends/gae/BaseUrl.kt"
@@ -3978,10 +3948,6 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImpl.kt"
-  source_file_is_incompatible_with_code_coverage: true
-}
-test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerInjector.kt"
   test_file_not_required: true
 }
@@ -3990,12 +3956,16 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterDebugModule.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerProdImpl.kt"
   source_file_is_incompatible_with_code_coverage: true
 }
 test_file_exemption {
-  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterDebugModule.kt"
-  test_file_not_required: true
+  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterControllerDebugImpl.kt"
+  source_file_is_incompatible_with_code_coverage: true
 }
 test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/PlatformParameterModule.kt"
@@ -4014,6 +3984,10 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/testing/TestPlatformParameterConfigRetriever.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/syncup/PlatformParameterSyncUpWorkManagerInitializer.kt"
   source_file_is_incompatible_with_code_coverage: true
 }
@@ -4027,10 +4001,6 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/syncup/PlatformParameterSyncUpWorkerModule.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/testing/TestPlatformParameterConfigRetriever.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -4143,6 +4113,10 @@ test_file_exemption {
 }
 test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/workmanager/WorkManagerConfigurationModule.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/testing/InteractionObjectTestBuilder.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -4426,10 +4400,6 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersInjector.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
   exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersRobolectricImpl.kt"
   test_file_not_required: true
 }
@@ -4444,10 +4414,6 @@ test_file_exemption {
 test_file_exemption {
   exempted_file_path: "testing/src/main/java/org/oppia/android/testing/time/FakeSystemClock.kt"
   test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt"
-  is_extra_test_file: true
 }
 test_file_exemption {
   exempted_file_path: "testing/src/test/java/org/oppia/android/testing/junit/InitializeDefaultLocaleRuleCustomContextTest.kt",
@@ -4526,11 +4492,11 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "utility/src/main/java/org/oppia/android/util/enumfilter/EnumFilterUtil.kt"
+  exempted_file_path: "utility/src/main/java/org/oppia/android/util/extensions/ContextExtensions.kt"
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "utility/src/main/java/org/oppia/android/util/extensions/ContextExtensions.kt"
+  exempted_file_path: "utility/src/main/java/org/oppia/android/util/enumfilter/EnumFilterUtil.kt"
   test_file_not_required: true
 }
 test_file_exemption {
@@ -4882,14 +4848,42 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "utility/src/test/java/org/oppia/android/util/math/AlgebraicEquationParserTest.kt",
+  exempted_file_path: "utility/src/test/java/org/oppia/android/util/math/AlgebraicExpressionParserTest.kt",
   is_extra_test_file: true
 }
 test_file_exemption {
-  exempted_file_path: "utility/src/test/java/org/oppia/android/util/math/AlgebraicExpressionParserTest.kt",
+  exempted_file_path: "utility/src/test/java/org/oppia/android/util/math/AlgebraicEquationParserTest.kt",
   is_extra_test_file: true
 }
 test_file_exemption {
   exempted_file_path: "utility/src/test/java/org/oppia/android/util/math/NumericExpressionParserTest.kt",
   is_extra_test_file: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/FlashbackButtonViewModel.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/FlashbackButtonListener.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/ReturnToQuestionViewModel.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/FlashbackToolbarListener.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/StateSolutionViewModel.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/hintsandsolution/HintsDialogSolutionViewModel.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
+  exempted_file_path: "app/src/main/java/org/oppia/android/app/player/state/listener/ReturnToQuestionButtonListener.kt"
+  test_file_not_required: true
 }

--- a/scripts/assets/test_file_exemptions.textproto
+++ b/scripts/assets/test_file_exemptions.textproto
@@ -4280,10 +4280,6 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt"
-  is_extra_test_file: true
-}
-test_file_exemption {
   exempted_file_path: "testing/src/main/java/org/oppia/android/testing/espresso/GenericViewMatchers.kt"
   test_file_not_required: true
 }

--- a/scripts/assets/test_file_exemptions.textproto
+++ b/scripts/assets/test_file_exemptions.textproto
@@ -4396,6 +4396,10 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersInjector.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersEspressoImpl.kt"
   test_file_not_required: true
 }

--- a/scripts/assets/test_file_exemptions.textproto
+++ b/scripts/assets/test_file_exemptions.textproto
@@ -4276,8 +4276,8 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
-  exempted_file_path: "testing/src/main/java/org/oppia/android/testing/espresso/EditTextInputAction.kt"
-  test_file_not_required: true
+  exempted_file_path: "testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt"
+  is_extra_test_file: true
 }
 test_file_exemption {
   exempted_file_path: "testing/src/main/java/org/oppia/android/testing/espresso/GenericViewMatchers.kt"

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -100,6 +100,7 @@ TEST_DEPS = [
     "//model/src/main/proto:performance_metrics_event_logger_java_proto_lite",
     "//testing/src/main/java/org/oppia/android/testing/data:async_result_subject",
     "//testing/src/main/java/org/oppia/android/testing/data:data_provider_test_monitor",
+    "//testing/src/main/java/org/oppia/android/testing/espresso:edit_text_input_action",
     "//testing/src/main/java/org/oppia/android/testing/espresso:text_input_action",
     "//testing/src/main/java/org/oppia/android/testing/platformparameter:test_module",
     "//testing/src/main/java/org/oppia/android/testing/robolectric:test_module",

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -104,6 +104,7 @@ TEST_DEPS = [
     "//testing/src/main/java/org/oppia/android/testing/espresso:text_input_action",
     "//testing/src/main/java/org/oppia/android/testing/platformparameter:test_module",
     "//testing/src/main/java/org/oppia/android/testing/robolectric:test_module",
+    "//testing/src/main/java/org/oppia/android/testing/threading:test_coroutine_dispatchers_injector",
     "//testing/src/main/java/org/oppia/android/testing/threading:test_module",
     "//testing/src/main/java/org/oppia/android/testing/time:test_module",
     "//third_party:androidx_lifecycle_lifecycle-livedata-ktx",

--- a/testing/src/main/java/org/oppia/android/testing/espresso/BUILD.bazel
+++ b/testing/src/main/java/org/oppia/android/testing/espresso/BUILD.bazel
@@ -12,7 +12,7 @@ kt_android_library(
     ],
     visibility = ["//:oppia_testing_visibility"],
     deps = [
-        "//testing/src/main/java/org/oppia/android/testing/threading:test_coroutine_dispatchers",
+        "//testing/src/main/java/org/oppia/android/testing/threading:test_coroutine_dispatchers_injector",
         "//third_party:androidx_test_espresso_espresso-core",
     ],
 )

--- a/testing/src/main/java/org/oppia/android/testing/espresso/EditTextInputAction.kt
+++ b/testing/src/main/java/org/oppia/android/testing/espresso/EditTextInputAction.kt
@@ -9,7 +9,6 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.typeText
 import org.hamcrest.Matcher
 import org.oppia.android.testing.threading.TestCoroutineDispatchersInjector
-import javax.inject.Inject
 
 /**
  * Action for inputting text into an EditText in a test infrastructure-specific way.
@@ -18,47 +17,45 @@ import javax.inject.Inject
  * 'android:digits' or other filters. See https://github.com/robolectric/robolectric/issues/5110
  * for specifics.
  */
-class EditTextInputAction @Inject constructor() {
-  companion object {
-    /**
-     * Returns a [ViewAction] that appends the specified string into the view targeted by the
-     * [ViewAction].
-     */
-    fun appendText(text: String): ViewAction = updateText(
-      text, baseAction = typeText(text), isAppend = true
-    )
+object EditTextInputAction {
+  /**
+   * Returns a [ViewAction] that appends the specified string into the view targeted by the
+   * [ViewAction].
+   */
+  fun appendText(text: String): ViewAction = updateText(
+    text, baseAction = typeText(text), isAppend = true
+  )
 
-    /**
-     * Returns a [ViewAction] that replaces the current text in the specified view with the specified
-     * string.
-     *
-     * Note that this should only be used over [appendText] in the following cases:
-     * 1. When there's existing text to first erase before adding new text
-     * 2. When Unicode text needs to be inputted (since otherwise Espresso will fail to type the text)
-     */
-    fun replaceText(text: String): ViewAction = updateText(
-      text, baseAction = ViewActions.replaceText(text), isAppend = false
-    )
+  /**
+   * Returns a [ViewAction] that replaces the current text in the specified view with the specified
+   * string.
+   *
+   * Note that this should only be used over [appendText] in the following cases:
+   * 1. When there's existing text to first erase before adding new text
+   * 2. When Unicode text needs to be inputted (since otherwise Espresso will fail to type the text)
+   */
+  fun replaceText(text: String): ViewAction = updateText(
+    text, baseAction = ViewActions.replaceText(text), isAppend = false
+  )
 
-    private fun updateText(text: String, baseAction: ViewAction, isAppend: Boolean): ViewAction {
-      return object : ViewAction {
-        override fun getDescription(): String = baseAction.description
+  private fun updateText(text: String, baseAction: ViewAction, isAppend: Boolean): ViewAction {
+    return object : ViewAction {
+      override fun getDescription(): String = baseAction.description
 
-        override fun getConstraints(): Matcher<View> = baseAction.constraints
+      override fun getConstraints(): Matcher<View> = baseAction.constraints
 
-        override fun perform(uiController: UiController?, view: View?) {
-          // Appending text only works on Robolectric, whereas Espresso needs to use typeText().
-          if (Build.FINGERPRINT.contains("robolectric", ignoreCase = true)) {
-            val editText = view as? EditText
-            if (isAppend) {
-              editText?.append(text)
-            } else {
-              editText?.setText(text)
-            }
-            TestCoroutineDispatchersInjector.getDispatcher().runCurrent()
+      override fun perform(uiController: UiController?, view: View?) {
+        // Appending text only works on Robolectric, whereas Espresso needs to use typeText().
+        if (Build.FINGERPRINT.contains("robolectric", ignoreCase = true)) {
+          val editText = view as? EditText
+          if (isAppend) {
+            editText?.append(text)
           } else {
-            baseAction.perform(uiController, view)
+            editText?.setText(text)
           }
+          TestCoroutineDispatchersInjector.getDispatcher().runCurrent()
+        } else {
+          baseAction.perform(uiController, view)
         }
       }
     }

--- a/testing/src/main/java/org/oppia/android/testing/espresso/EditTextInputAction.kt
+++ b/testing/src/main/java/org/oppia/android/testing/espresso/EditTextInputAction.kt
@@ -9,6 +9,7 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.typeText
 import org.hamcrest.Matcher
 import org.oppia.android.testing.threading.TestCoroutineDispatchersInjector
+import javax.inject.Inject
 
 /**
  * Action for inputting text into an EditText in a test infrastructure-specific way.
@@ -17,7 +18,7 @@ import org.oppia.android.testing.threading.TestCoroutineDispatchersInjector
  * 'android:digits' or other filters. See https://github.com/robolectric/robolectric/issues/5110
  * for specifics.
  */
-class EditTextInputAction {
+class EditTextInputAction @Inject constructor() {
   companion object {
     /**
      * Returns a [ViewAction] that appends the specified string into the view targeted by the

--- a/testing/src/main/java/org/oppia/android/testing/espresso/EditTextInputAction.kt
+++ b/testing/src/main/java/org/oppia/android/testing/espresso/EditTextInputAction.kt
@@ -6,11 +6,9 @@ import android.widget.EditText
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions
-import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.action.ViewActions.typeText
 import org.hamcrest.Matcher
-import org.oppia.android.testing.threading.TestCoroutineDispatchers
-import javax.inject.Inject
+import org.oppia.android.testing.threading.TestCoroutineDispatchersInjector
 
 /**
  * Action for inputting text into an EditText in a test infrastructure-specific way.
@@ -19,50 +17,47 @@ import javax.inject.Inject
  * 'android:digits' or other filters. See https://github.com/robolectric/robolectric/issues/5110
  * for specifics.
  */
-class EditTextInputAction @Inject constructor(
-  val testCoroutineDispatchers: TestCoroutineDispatchers
-) {
-  // TODO(#1720): Move this to a companion object & use a test-only singleton injector to retrieve
-  // the TestCoroutineDispatchers so that the outer class doesn't need to be injected.
-  /**
-   * Returns a [ViewAction] that appends the specified string into the view targeted by the
-   * [ViewAction].
-   */
-  fun appendText(text: String): ViewAction = updateText(
-    text, baseAction = typeText(text), isAppend = true
-  )
+class EditTextInputAction {
+  companion object {
+    /**
+     * Returns a [ViewAction] that appends the specified string into the view targeted by the
+     * [ViewAction].
+     */
+    fun appendText(text: String): ViewAction = updateText(
+      text, baseAction = typeText(text), isAppend = true
+    )
 
-  /**
-   * Returns a [ViewAction] that replaces the current text in the specified view with the specified
-   * string.
-   *
-   * Note that this should only be used over [appendText] in the following cases:
-   * 1. When there's existing text to first erase before adding new text
-   * 2. When Unicode text needs to be inputted (since otherwise Espresso will fail to type the text)
-   */
-  fun replaceText(text: String): ViewAction = updateText(
-    text, baseAction = ViewActions.replaceText(text), isAppend = false
-  )
+    /**
+     * Returns a [ViewAction] that replaces the current text in the specified view with the specified
+     * string.
+     *
+     * Note that this should only be used over [appendText] in the following cases:
+     * 1. When there's existing text to first erase before adding new text
+     * 2. When Unicode text needs to be inputted (since otherwise Espresso will fail to type the text)
+     */
+    fun replaceText(text: String): ViewAction = updateText(
+      text, baseAction = ViewActions.replaceText(text), isAppend = false
+    )
 
-  private fun updateText(text: String, baseAction: ViewAction, isAppend: Boolean): ViewAction {
+    private fun updateText(text: String, baseAction: ViewAction, isAppend: Boolean): ViewAction {
+      return object : ViewAction {
+        override fun getDescription(): String = baseAction.description
 
-    return object : ViewAction {
-      override fun getDescription(): String = baseAction.description
+        override fun getConstraints(): Matcher<View> = baseAction.constraints
 
-      override fun getConstraints(): Matcher<View> = baseAction.constraints
-
-      override fun perform(uiController: UiController?, view: View?) {
-        // Appending text only works on Robolectric, whereas Espresso needs to use typeText().
-        if (Build.FINGERPRINT.contains("robolectric", ignoreCase = true)) {
-          val editText = view as? EditText
-          if (isAppend) {
-            editText?.append(text)
+        override fun perform(uiController: UiController?, view: View?) {
+          // Appending text only works on Robolectric, whereas Espresso needs to use typeText().
+          if (Build.FINGERPRINT.contains("robolectric", ignoreCase = true)) {
+            val editText = view as? EditText
+            if (isAppend) {
+              editText?.append(text)
+            } else {
+              editText?.setText(text)
+            }
+            TestCoroutineDispatchersInjector.getDispatcher().runCurrent()
           } else {
-            editText?.setText(text)
+            baseAction.perform(uiController, view)
           }
-          testCoroutineDispatchers.runCurrent()
-        } else {
-          baseAction.perform(uiController, view)
         }
       }
     }

--- a/testing/src/main/java/org/oppia/android/testing/threading/BUILD.bazel
+++ b/testing/src/main/java/org/oppia/android/testing/threading/BUILD.bazel
@@ -40,9 +40,23 @@ kt_android_library(
     testonly = True,
     srcs = [
         "TestCoroutineDispatchers.kt",
-        "TestCoroutineDispatchersInjector.kt",
     ],
     visibility = ["//:oppia_testing_visibility"],
+)
+
+kt_android_library(
+    name = "test_coroutine_dispatchers_injector",
+    testonly = True,
+    srcs = [
+        "TestCoroutineDispatchersInjector.kt",
+    ],
+    visibility = [
+        "//testing:__pkg__",
+        "//testing/src/main/java/org/oppia/android/testing:__subpackages__",
+    ],
+    deps = [
+        ":test_coroutine_dispatchers",
+    ],
 )
 
 kt_android_library(
@@ -108,6 +122,7 @@ kt_android_library(
         ":espresso_impl",
         ":robolectric_impl",
         ":test_coroutine_dispatchers",
+        ":test_coroutine_dispatchers_injector",
         "//:dagger",
         "//utility/src/main/java/org/oppia/android/util/threading:annotations",
     ],

--- a/testing/src/main/java/org/oppia/android/testing/threading/BUILD.bazel
+++ b/testing/src/main/java/org/oppia/android/testing/threading/BUILD.bazel
@@ -40,6 +40,7 @@ kt_android_library(
     testonly = True,
     srcs = [
         "TestCoroutineDispatchers.kt",
+        "TestCoroutineDispatchersInjector.kt",
     ],
     visibility = ["//:oppia_testing_visibility"],
 )
@@ -106,6 +107,7 @@ kt_android_library(
         ":annotations",
         ":espresso_impl",
         ":robolectric_impl",
+        ":test_coroutine_dispatchers",
         "//:dagger",
         "//utility/src/main/java/org/oppia/android/util/threading:annotations",
     ],

--- a/testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersInjector.kt
+++ b/testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersInjector.kt
@@ -1,27 +1,19 @@
 package org.oppia.android.testing.threading
 
 /**
- * A test-only injector to retrieve [TestCoroutineDispatchers] statically.
- *
- * This is used to avoid injecting [TestCoroutineDispatchers] into utility classes that should be
- * usage-site agnostic.
+ * A static injector for [TestCoroutineDispatchers] to allow them to be accessed in some static
+ * contexts (like [EditTextInputAction]).
  */
 object TestCoroutineDispatchersInjector {
-  private var testCoroutineDispatchers: TestCoroutineDispatchers? = null
+  private lateinit var dispatchers: TestCoroutineDispatchers
 
-  /**
-   * Initializes the static [TestCoroutineDispatchers] instance.
-   *
-   * This should only be called by [TestDispatcherModule].
-   */
+  /** Initializes the injector with the provided [dispatchers]. */
   fun initialize(dispatchers: TestCoroutineDispatchers) {
-    testCoroutineDispatchers = dispatchers
+    this.dispatchers = dispatchers
   }
 
-  /** Returns the current [TestCoroutineDispatchers]. */
+  /** Returns the injected [TestCoroutineDispatchers]. */
   fun getDispatcher(): TestCoroutineDispatchers {
-    return checkNotNull(testCoroutineDispatchers) {
-      "TestCoroutineDispatchers not initialized. Ensure the test environment is set up correctly."
-    }
+    return dispatchers
   }
 }

--- a/testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersInjector.kt
+++ b/testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersInjector.kt
@@ -1,8 +1,16 @@
 package org.oppia.android.testing.threading
 
+// TODO(#6160): Migrate TestCoroutineDispatchersInjector to the proper injector/provider pattern
+//  (similar to OppiaClockInjector/OppiaClockInjectorProvider). This class should not be used in
+//  any new locations.
 /**
  * A static injector for [TestCoroutineDispatchers] to allow them to be accessed in some static
- * contexts (like [EditTextInputAction]).
+ * contexts (like [org.oppia.android.testing.espresso.EditTextInputAction]).
+ *
+ * This is a temporary solution. The correct approach is to introduce a
+ * [TestCoroutineDispatchersInjector] interface and a [TestCoroutineDispatchersInjectorProvider]
+ * interface, implement them in test applications, and access the dispatchers via
+ * [ApplicationProvider]. See [OppiaClockInjector] and [OppiaClockInjectorProvider] for reference.
  */
 object TestCoroutineDispatchersInjector {
   private lateinit var dispatchers: TestCoroutineDispatchers

--- a/testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersInjector.kt
+++ b/testing/src/main/java/org/oppia/android/testing/threading/TestCoroutineDispatchersInjector.kt
@@ -1,0 +1,27 @@
+package org.oppia.android.testing.threading
+
+/**
+ * A test-only injector to retrieve [TestCoroutineDispatchers] statically.
+ *
+ * This is used to avoid injecting [TestCoroutineDispatchers] into utility classes that should be
+ * usage-site agnostic.
+ */
+object TestCoroutineDispatchersInjector {
+  private var testCoroutineDispatchers: TestCoroutineDispatchers? = null
+
+  /**
+   * Initializes the static [TestCoroutineDispatchers] instance.
+   *
+   * This should only be called by [TestDispatcherModule].
+   */
+  fun initialize(dispatchers: TestCoroutineDispatchers) {
+    testCoroutineDispatchers = dispatchers
+  }
+
+  /** Returns the current [TestCoroutineDispatchers]. */
+  fun getDispatcher(): TestCoroutineDispatchers {
+    return checkNotNull(testCoroutineDispatchers) {
+      "TestCoroutineDispatchers not initialized. Ensure the test environment is set up correctly."
+    }
+  }
+}

--- a/testing/src/main/java/org/oppia/android/testing/threading/TestDispatcherModule.kt
+++ b/testing/src/main/java/org/oppia/android/testing/threading/TestDispatcherModule.kt
@@ -55,7 +55,13 @@ class TestDispatcherModule {
     robolectricImplProvider: Provider<TestCoroutineDispatchersRobolectricImpl>,
     espressoImplProvider: Provider<TestCoroutineDispatchersEspressoImpl>
   ): TestCoroutineDispatchers {
-    return if (isOnRobolectric) robolectricImplProvider.get() else espressoImplProvider.get()
+    val dispatchers = if (isOnRobolectric) {
+      robolectricImplProvider.get()
+    } else {
+      espressoImplProvider.get()
+    }
+    TestCoroutineDispatchersInjector.initialize(dispatchers)
+    return dispatchers
   }
 
   @Provides

--- a/testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt
+++ b/testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt
@@ -38,7 +38,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("123")
 
-        appendText("45").perform(null, editText)
+        EditTextInputAction.Companion.appendText("45").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("12345")
       }
@@ -52,7 +52,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("")
 
-        appendText("hello").perform(null, editText)
+        EditTextInputAction.Companion.appendText("hello").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("hello")
       }
@@ -66,7 +66,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("123")
 
-        appendText("").perform(null, editText)
+        EditTextInputAction.Companion.appendText("").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("123")
       }
@@ -80,7 +80,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("abc")
 
-        appendText("@#$").perform(null, editText)
+        EditTextInputAction.Companion.appendText("@#$").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("abc@#$")
       }
@@ -94,7 +94,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("Hello ")
 
-        appendText("\uD83C\uDF0D").perform(null, editText)
+        EditTextInputAction.Companion.appendText("\uD83C\uDF0D").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("Hello \uD83C\uDF0D")
       }
@@ -108,7 +108,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("123")
 
-        replaceText("9").perform(null, editText)
+        EditTextInputAction.Companion.replaceText("9").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("9")
       }
@@ -122,7 +122,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("old text")
 
-        replaceText("").perform(null, editText)
+        EditTextInputAction.Companion.replaceText("").perform(null, editText)
 
         assertThat(editText.text.toString()).isEmpty()
       }
@@ -136,7 +136,8 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("old text")
 
-        replaceText("\u0645\u0631\u062D\u0628\u0627").perform(null, editText)
+        EditTextInputAction.Companion.replaceText("\u0645\u0631\u062D\u0628\u0627")
+          .perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("\u0645\u0631\u062D\u0628\u0627")
       }

--- a/testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt
+++ b/testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt
@@ -9,6 +9,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.testing.TextInputActionTestActivity
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.Companion.replaceText
 import org.oppia.android.testing.threading.TestCoroutineDispatchers
 import org.oppia.android.testing.threading.TestCoroutineDispatchersInjector
 import org.robolectric.annotation.Config
@@ -38,7 +40,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("123")
 
-        EditTextInputAction.Companion.appendText("45").perform(null, editText)
+        appendText("45").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("12345")
       }
@@ -52,7 +54,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("")
 
-        EditTextInputAction.Companion.appendText("hello").perform(null, editText)
+        appendText("hello").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("hello")
       }
@@ -66,7 +68,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("123")
 
-        EditTextInputAction.Companion.appendText("").perform(null, editText)
+        appendText("").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("123")
       }
@@ -80,7 +82,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("abc")
 
-        EditTextInputAction.Companion.appendText("@#$").perform(null, editText)
+        appendText("@#$").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("abc@#$")
       }
@@ -94,7 +96,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("Hello ")
 
-        EditTextInputAction.Companion.appendText("\uD83C\uDF0D").perform(null, editText)
+        appendText("\uD83C\uDF0D").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("Hello \uD83C\uDF0D")
       }
@@ -108,7 +110,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("123")
 
-        EditTextInputAction.Companion.replaceText("9").perform(null, editText)
+        replaceText("9").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("9")
       }
@@ -122,7 +124,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("old text")
 
-        EditTextInputAction.Companion.replaceText("").perform(null, editText)
+        replaceText("").perform(null, editText)
 
         assertThat(editText.text.toString()).isEmpty()
       }
@@ -136,8 +138,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("old text")
 
-        EditTextInputAction.Companion.replaceText("\u0645\u0631\u062D\u0628\u0627")
-          .perform(null, editText)
+        replaceText("\u0645\u0631\u062D\u0628\u0627").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("\u0645\u0631\u062D\u0628\u0627")
       }

--- a/testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt
+++ b/testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt
@@ -38,7 +38,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("123")
 
-        EditTextInputAction.appendText("45").perform(null, editText)
+        appendText("45").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("12345")
       }
@@ -52,7 +52,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("")
 
-        EditTextInputAction.appendText("hello").perform(null, editText)
+        appendText("hello").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("hello")
       }
@@ -66,7 +66,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("123")
 
-        EditTextInputAction.appendText("").perform(null, editText)
+        appendText("").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("123")
       }
@@ -80,7 +80,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("abc")
 
-        EditTextInputAction.appendText("@#$").perform(null, editText)
+        appendText("@#$").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("abc@#$")
       }
@@ -94,7 +94,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("Hello ")
 
-        EditTextInputAction.appendText("\uD83C\uDF0D").perform(null, editText)
+        appendText("\uD83C\uDF0D").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("Hello \uD83C\uDF0D")
       }
@@ -108,7 +108,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("123")
 
-        EditTextInputAction.replaceText("9").perform(null, editText)
+        replaceText("9").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("9")
       }
@@ -122,7 +122,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("old text")
 
-        EditTextInputAction.replaceText("").perform(null, editText)
+        replaceText("").perform(null, editText)
 
         assertThat(editText.text.toString()).isEmpty()
       }
@@ -136,7 +136,7 @@ class EditTextInputActionRobolectricTest {
         val editText = EditText(activity)
         editText.setText("old text")
 
-        EditTextInputAction.replaceText("\u0645\u0631\u062D\u0628\u0627").perform(null, editText)
+        replaceText("\u0645\u0631\u062D\u0628\u0627").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("\u0645\u0631\u062D\u0628\u0627")
       }

--- a/testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt
+++ b/testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt
@@ -9,8 +9,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.testing.TextInputActionTestActivity
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.appendText
-import org.oppia.android.testing.espresso.EditTextInputAction.Companion.replaceText
+import org.oppia.android.testing.espresso.EditTextInputAction.appendText
+import org.oppia.android.testing.espresso.EditTextInputAction.replaceText
 import org.oppia.android.testing.threading.TestCoroutineDispatchers
 import org.oppia.android.testing.threading.TestCoroutineDispatchersInjector
 import org.robolectric.annotation.Config

--- a/testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt
+++ b/testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt
@@ -46,6 +46,62 @@ class EditTextInputActionRobolectricTest {
   }
 
   @Test
+  fun testAppendText_withEmptyInitialText_setsTextCorrectly() {
+    runWithLaunchedActivity {
+      onActivity { activity ->
+        val editText = EditText(activity)
+        editText.setText("")
+
+        EditTextInputAction.appendText("hello").perform(null, editText)
+
+        assertThat(editText.text.toString()).isEqualTo("hello")
+      }
+    }
+  }
+
+  @Test
+  fun testAppendText_withEmptyAppendedText_keepsOriginalText() {
+    runWithLaunchedActivity {
+      onActivity { activity ->
+        val editText = EditText(activity)
+        editText.setText("123")
+
+        EditTextInputAction.appendText("").perform(null, editText)
+
+        assertThat(editText.text.toString()).isEqualTo("123")
+      }
+    }
+  }
+
+  @Test
+  fun testAppendText_withSpecialCharacters_appendsCorrectly() {
+    runWithLaunchedActivity {
+      onActivity { activity ->
+        val editText = EditText(activity)
+        editText.setText("abc")
+
+        EditTextInputAction.appendText("@#$").perform(null, editText)
+
+        assertThat(editText.text.toString()).isEqualTo("abc@#$")
+      }
+    }
+  }
+
+  @Test
+  fun testAppendText_withUnicodeText_appendsCorrectly() {
+    runWithLaunchedActivity {
+      onActivity { activity ->
+        val editText = EditText(activity)
+        editText.setText("Hello ")
+
+        EditTextInputAction.appendText("\uD83C\uDF0D").perform(null, editText)
+
+        assertThat(editText.text.toString()).isEqualTo("Hello \uD83C\uDF0D")
+      }
+    }
+  }
+
+  @Test
   fun testReplaceText_replaces_value_in_robolectric() {
     runWithLaunchedActivity {
       onActivity { activity ->
@@ -55,6 +111,34 @@ class EditTextInputActionRobolectricTest {
         EditTextInputAction.replaceText("9").perform(null, editText)
 
         assertThat(editText.text.toString()).isEqualTo("9")
+      }
+    }
+  }
+
+  @Test
+  fun testReplaceText_withEmptyString_clearsText() {
+    runWithLaunchedActivity {
+      onActivity { activity ->
+        val editText = EditText(activity)
+        editText.setText("old text")
+
+        EditTextInputAction.replaceText("").perform(null, editText)
+
+        assertThat(editText.text.toString()).isEmpty()
+      }
+    }
+  }
+
+  @Test
+  fun testReplaceText_withUnicodeText_replacesCorrectly() {
+    runWithLaunchedActivity {
+      onActivity { activity ->
+        val editText = EditText(activity)
+        editText.setText("old text")
+
+        EditTextInputAction.replaceText("\u0645\u0631\u062D\u0628\u0627").perform(null, editText)
+
+        assertThat(editText.text.toString()).isEqualTo("\u0645\u0631\u062D\u0628\u0627")
       }
     }
   }

--- a/testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt
+++ b/testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionRobolectricTest.kt
@@ -1,0 +1,69 @@
+package org.oppia.android.testing.espresso
+
+import android.widget.EditText
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.oppia.android.testing.TextInputActionTestActivity
+import org.oppia.android.testing.threading.TestCoroutineDispatchers
+import org.oppia.android.testing.threading.TestCoroutineDispatchersInjector
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+
+@RunWith(AndroidJUnit4::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+@Config(manifest = Config.NONE)
+class EditTextInputActionRobolectricTest {
+
+  @Before
+  fun setUp() {
+    val mockDispatcher = object : TestCoroutineDispatchers {
+      override fun registerIdlingResource() {}
+      override fun unregisterIdlingResource() {}
+      override fun runCurrent() {}
+      override fun advanceTimeBy(delayTimeMillis: Long) {}
+      override fun advanceUntilIdle() {}
+    }
+    TestCoroutineDispatchersInjector.initialize(mockDispatcher)
+  }
+
+  @Test
+  fun testAppendText_appends_value_in_robolectric() {
+    runWithLaunchedActivity {
+      onActivity { activity ->
+        val editText = EditText(activity)
+        editText.setText("123")
+
+        EditTextInputAction.appendText("45").perform(null, editText)
+
+        assertThat(editText.text.toString()).isEqualTo("12345")
+      }
+    }
+  }
+
+  @Test
+  fun testReplaceText_replaces_value_in_robolectric() {
+    runWithLaunchedActivity {
+      onActivity { activity ->
+        val editText = EditText(activity)
+        editText.setText("123")
+
+        EditTextInputAction.replaceText("9").perform(null, editText)
+
+        assertThat(editText.text.toString()).isEqualTo("9")
+      }
+    }
+  }
+
+  private fun runWithLaunchedActivity(
+    testBlock: ActivityScenario<TextInputActionTestActivity>.() -> Unit
+  ) {
+    ActivityScenario.launch<TextInputActionTestActivity>(
+      TextInputActionTestActivity.createIntent(ApplicationProvider.getApplicationContext())
+    ).use(testBlock)
+  }
+}

--- a/testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionTest.kt
+++ b/testing/src/test/java/org/oppia/android/testing/espresso/EditTextInputActionTest.kt
@@ -19,7 +19,7 @@ import org.robolectric.annotation.LooperMode
 @RunWith(AndroidJUnit4::class)
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(manifest = Config.NONE)
-class EditTextInputActionRobolectricTest {
+class EditTextInputActionTest {
 
   @Before
   fun setUp() {


### PR DESCRIPTION
Fixes #5818

## Explanation

Fixes #5818: Refactors `EditTextInputAction` to remove its dependency on constructor injection of `TestCoroutineDispatchers`, which caused Robolectric edit text input actions to be difficult to invoke reliably in tests.

This change introduces `TestCoroutineDispatchersInjector`, which provides a static access point for test coroutine dispatchers. `EditTextInputAction` is updated to retrieve dispatchers through this injector instead of relying on injected fields.

As a result, `EditTextInputAction` methods can now be invoked directly from tests without requiring `@Inject` setup, resolving the existing TODO in the file and simplifying test usage across Robolectric-based tests.

### Key changes
- Added `TestCoroutineDispatchersInjector` to hold a static reference to
  `TestCoroutineDispatchers`.
- Updated `TestDispatcherModule` to initialize the injector.
- Refactored `EditTextInputAction` to access dispatchers via the static injector.
- Updated test usages to call `EditTextInputAction` methods directly.
- Removed `EditTextInputAction` injection from test classes.


This is a duplicate of https://github.com/oppia/oppia-android/pull/6082, which contains previous reviews but was closed due to force-pushing.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only

This PR does not introduce any UI-related changes. It only affects test infrastructure and
Robolectric-based test utilities. As a result, no UI verification, screenshots, or accessibility
checks are required.
