### PR TITLE
Fix part of #3926: Add support for GitHub merge queues plus a bunch of other CI improvements

### DIFF
--- a/.github/actions/set-up-android-bazel-build-environment/action.yml
+++ b/.github/actions/set-up-android-bazel-build-environment/action.yml
@@ -20,6 +20,15 @@ runs:
         fi
       shell: bash
 
+    # Extract the versions from build_vars.bzl, removing spaces and quotes.
+    - name: Parse build variables
+      run: |
+        SDK_VERSION=$(grep 'BUILD_SDK_VERSION' ${{ github.action_path }}/../../../build_vars.bzl | cut -d '=' -f 2 | tr -d ' "')
+        BUILD_TOOLS_VERSION=$(grep 'BUILD_TOOLS_VERSION' ${{ github.action_path }}/../../../build_vars.bzl | cut -d '=' -f 2 | tr -d ' "')
+        echo "SDK_VERSION=$SDK_VERSION" >> $GITHUB_ENV
+        echo "BUILD_TOOLS_VERSION=$BUILD_TOOLS_VERSION" >> $GITHUB_ENV
+      shell: bash
+
     - name: Set up new Android SDK directory
       run: |
         mkdir -p $HOME/android-sdk
@@ -55,14 +64,14 @@ runs:
         $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager --install "platform-tools"
       shell: bash
 
-    - name: Install SDK 35
+    - name: Install SDK
       run: |
-        $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager --install "platforms;android-35"
+        $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager --install "platforms;android-${{ env.SDK_VERSION }}"
       shell: bash
 
-    - name: Install build tools 34.0.0
+    - name: Install build tools
       run: |
-        $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager --install "build-tools;34.0.0"
+        $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager --install "build-tools;${{ env.BUILD_TOOLS_VERSION }}"
       shell: bash
 
     - name: Configure Bazel to use specific sandbox tmpfs

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -9,9 +9,12 @@ on:
     branches:
       # Push events on develop branch
       - develop
+  merge_group:
+    branches:
+      - develop
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       CACHE_DIRECTORY: ~/.bazel_cache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
       # with Bazel since Bazel can share the most recent cache from an unrelated build and still
       # benefit from incremental build performance (assuming that actions/cache aggressively removes
       # older caches due to the 5GB cache limit size & Bazel's large cache size).
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}

--- a/.github/workflows/check_for_fixed_issues_in_pr.yml
+++ b/.github/workflows/check_for_fixed_issues_in_pr.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - name: Scan PR for issues being addressed
         id: step-1
+        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' }}
         uses: actions/github-script@v8
         with:
           script: |
@@ -36,7 +37,7 @@ jobs:
 
       - name: Find issue assignment(s)
         id: step-2
-        if: ${{ steps.step-1.outputs.failure_message == '' }}
+        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' && steps.step-1.outputs.failure_message == '' }}
         uses: actions/github-script@v8
         env:
           ISSUE_NUMBERS_LIST_JSON: ${{ steps.step-1.outputs.issue_numbers_list_json }}

--- a/.github/workflows/check_for_fixed_issues_in_pr.yml
+++ b/.github/workflows/check_for_fixed_issues_in_pr.yml
@@ -22,8 +22,8 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const incorrectFormatRegex = /^Fix(?: part of)? #(\d+)\w*$/gm;
-            const correctFormatRegex = /^Fixes(?: part of)? #(\d+)\w*$/gm;
+            const incorrectFormatRegex = /^Fix(?: part of)? #(\d+)[^\S\r\n]*$/gm;
+            const correctFormatRegex = /^Fixes(?: part of)? #(\d+)[^\S\r\n]*$/gm;
             const invalidIssueNumbers = [... (context.payload.pull_request.body || '').matchAll(incorrectFormatRegex)].map((match) => match[1]);
             const issueNumbers = [... (context.payload.pull_request.body || '').matchAll(correctFormatRegex)].map((match) => match[1]);
             core.setOutput('issue_numbers_list_json', JSON.stringify(issueNumbers));

--- a/.github/workflows/check_for_fixed_issues_in_pr.yml
+++ b/.github/workflows/check_for_fixed_issues_in_pr.yml
@@ -22,8 +22,8 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const incorrectFormatRegex = /^Fix(?: part of)? #(\d+)$/gm;
-            const correctFormatRegex = /^Fixes(?: part of)? #(\d+)$/gm;
+            const incorrectFormatRegex = /^Fix(?: part of)? #(\d+)\w*$/gm;
+            const correctFormatRegex = /^Fixes(?: part of)? #(\d+)\w*$/gm;
             const invalidIssueNumbers = [... (context.payload.pull_request.body || '').matchAll(incorrectFormatRegex)].map((match) => match[1]);
             const issueNumbers = [... (context.payload.pull_request.body || '').matchAll(correctFormatRegex)].map((match) => match[1]);
             core.setOutput('issue_numbers_list_json', JSON.stringify(issueNumbers));

--- a/.github/workflows/check_for_fixed_issues_in_pr.yml
+++ b/.github/workflows/check_for_fixed_issues_in_pr.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Scan PR for issues being addressed
         id: step-1
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const incorrectFormatRegex = /^Fix(?: part of)? #(\d+)$/gm;
@@ -37,7 +37,7 @@ jobs:
       - name: Find issue assignment(s)
         id: step-2
         if: ${{ steps.step-1.outputs.failure_message == '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           ISSUE_NUMBERS_LIST_JSON: ${{ steps.step-1.outputs.issue_numbers_list_json }}
         with:
@@ -62,7 +62,7 @@ jobs:
       - name: Move PR to draft and add comment
         id: step-3
         if: ${{ steps.step-1.outputs.failure_message != '' || steps.step-2.outputs.failure_message != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           FAILURE_MESSAGE_1: ${{ steps.step-1.outputs.failure_message }}
           FAILURE_MESSAGE_2: ${{ steps.step-2.outputs.failure_message }}

--- a/.github/workflows/check_for_forced_push_prs.yml
+++ b/.github/workflows/check_for_forced_push_prs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Detect and close (on change)
-        if: ${{ github.event.action == 'synchronize' }}
+        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' && github.event.action == 'synchronize' }}
         uses: actions/github-script@v8
         with:
           script: |
@@ -24,13 +24,13 @@ jobs:
             const status = (await github.rest.repos.compareCommits({ owner, repo, base: before, head: after })).data.status;
             if (status === 'diverged' || status === 'behind') {
               core.setFailed(`Force push detected (history has been altered). Commit history status: ${status}.`);
-              const closeMessage = 'Closing PR: Force pushing is not allowed in this repository. This PR has been automatically closed. Please create a new PR with a clean commit history and manually copy over any unresolved reviewer comment threads from this PR.';
+              const closeMessage = 'Closing PR: Force pushing is not allowed in this repository. This PR has been automatically closed. Please create a new PR with a clean commit history and manually copy over any unresolved reviewer comment threads from this PR. For more information, please make sure to review this part of the wiki which provides guidance on merging PRs: https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#step-3-address-review-comments-until-all-reviewers-give-lgtm.';
               await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body: closeMessage });
               await github.rest.pulls.update({ owner, repo, pull_number: pr.number, state: 'closed' });
             } else core.info(`Standard push detected. Commit history status: ${status}. No action taken.`);
 
       - name: Detect and close reopened force-pushed PRs
-        if: ${{ github.event.action == 'reopened' }}
+        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' && github.event.action == 'reopened' }}
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/check_for_forced_push_prs.yml
+++ b/.github/workflows/check_for_forced_push_prs.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Detect and close (on change)
         if: ${{ github.event.action == 'synchronize' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { before, after, pull_request: pr } = context.payload;
@@ -31,7 +31,7 @@ jobs:
 
       - name: Detect and close reopened force-pushed PRs
         if: ${{ github.event.action == 'reopened' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Wait for unit tests to checks
-        uses: ArcticLampyrid/action-wait-for-workflow@v1.2.0
+        uses: ArcticLampyrid/action-wait-for-workflow@v1.3.0
         with:
           workflow: unit_tests.yml
           sha: auto
@@ -39,7 +39,7 @@ jobs:
     env:
       CACHE_DIRECTORY: ~/.bazel_cache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
         with:
           version: 6.5.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: scripts_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -139,14 +139,14 @@ jobs:
     env:
       CACHE_DIRECTORY: ~/.bazel_cache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Bazel
         uses: abhinavsingh/setup-bazel@v3
         with:
           version: 6.5.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: scripts_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -195,7 +195,7 @@ jobs:
       # with Bazel since Bazel can share the most recent cache from an unrelated build and still
       # benefit from incremental build performance (assuming that actions/cache aggressively removes
       # older caches due to the 5GB cache limit size & Bazel's large cache size).
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: test_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -265,14 +265,14 @@ jobs:
           bazel run //scripts:run_coverage -- $(pwd) $CHANGED_FILES --format=PROTO --processTimeout=15
 
       - name: Upload Coverage Report Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report-${{ env.SHARD_NAME }} # Saving with unique names to avoid conflict
           path: coverage_reports
 
       - name: Upload bazel target file
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: code-coverage-bazel-targets-${{ env.SHARD_NAME }}
           path: bazel_targets.txt
@@ -287,10 +287,10 @@ jobs:
     env:
       CACHE_DIRECTORY: ~/.bazel_cache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Download Coverage Report Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: coverage-report-artifact
           pattern: coverage-report-*
@@ -307,7 +307,7 @@ jobs:
         with:
           version: 6.5.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: scripts_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -324,7 +324,7 @@ jobs:
           bazel run //scripts:coverage_reporter -- $(pwd) pb_files.txt
 
       - name: Upload Generated Markdown Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }} # IMPORTANT: Upload reports regardless of success or failure status
         with:
           name: final-coverage-report

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -10,9 +10,12 @@ on:
     branches:
       # Push events on develop branch
       - develop
+  merge_group:
+    branches:
+      - develop
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -86,15 +89,33 @@ jobs:
           echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
         shell: bash
 
+      - name: Check PR for [RunAllTests]
+        id: check_pr
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [[ "${{ github.event.pull_request.title }}" == *"[RunAllTests]"* ]]; then echo "run_all=true" >> $GITHUB_OUTPUT; fi
+
+      # Search all PR commit messages included in the merge group for any that require running all tests upon merging.
+      - name: Check merge group for [RunAllTests]
+        id: check_mg
+        if: ${{ github.event_name == 'merge_group' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MESSAGES=$(gh api repos/${{ github.repository }}/compare/${{ github.event.merge_group.base_sha }}...${{ github.sha }} --jq '.commits[].commit.message')
+          if echo "$MESSAGES" | grep -Fq "[RunAllTests]"; then echo "run_all=true" >> $GITHUB_OUTPUT; fi
+
       - name: Compute file matrix
         id: compute-file-matrix
         env:
-          compute_all_files: ${{ contains(github.event.pull_request.title, '[RunAllTests]') }}
+          compute_all_files: ${{ steps.check_pr.outputs.run_all == 'true' || steps.check_mg.outputs.run_all == 'true' }}
           # See: https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request. Defer to origin/develop outside a PR (such as develop's main CI runs).
-          base_commit_hash: ${{ github.event.pull_request.base.sha || 'origin/develop' }}
+          base_commit_hash: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'origin/develop' }}
         # https://unix.stackexchange.com/a/338124 for reference on creating a JSON-friendly
-        # comma-separated list of test targets for the matrix.
+        # comma-separated list of test targets for the matrix. Note that the extra fetch is to
+        # enusre that the base commit is fully fetched locally so that it can be diffed against.
         run: |
+          git fetch origin $base_commit_hash --depth=1
           bazel run //scripts:compute_changed_files -- $(pwd) $(pwd)/changed_files.log $base_commit_hash compute_all_files=$compute_all_files
           FILE_BUCKET_LIST=$(cat ./changed_files.log | sed 's/^\|$/"/g' | paste -sd, -)
           echo "Changed files (note that this might be all files if configured to run all or on the develop branch): $FILE_BUCKET_LIST"

--- a/.github/workflows/comment_coverage_report.yml
+++ b/.github/workflows/comment_coverage_report.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Wait for code coverage to complete
         id: wait-for-coverage
-        uses: ArcticLampyrid/action-wait-for-workflow@v1.2.0
+        uses: ArcticLampyrid/action-wait-for-workflow@v1.3.0
         with:
           workflow: code_coverage.yml
           sha: auto
@@ -48,15 +48,15 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     steps:
-      - name: Find the latest Code Coverage Report Comment 
-        uses: actions/github-script@v6
+      - name: Find the latest Code Coverage Report Comment
+        uses: actions/github-script@v8
         with:
            script: |
              const comments = await github.paginate(github.rest.issues.listComments, {
                owner: context.repo.owner,
                repo: context.repo.repo,
                issue_number: ${{ github.event.pull_request.number }},
-             });            
+             });
 
              for (let i = comments.length - 1; i >= 0; i--) {
                if (comments[i].body.includes("## Coverage Report")) {
@@ -65,10 +65,10 @@ jobs:
                  return
                }
              }
-    
+
       - name: Find CI workflow run for PR
         id: find-workflow-run
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         continue-on-error: true
         with:
           script: |
@@ -94,19 +94,19 @@ jobs:
             core.setOutput('run-id', run.id);
 
       - name: Download Generated Markdown Report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         if: ${{ !cancelled() }} # IMPORTANT: Upload reports regardless of success or failure status
         with:
           name: final-coverage-report
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ steps.find-workflow-run.outputs.run-id }}
-      
+
       - name: Compare Current Coverage Report with the Latest Coverage Report
-        run: |        
+        run: |
           if [ -f latest_code_coverage_comment.md ]; then
             sed -i -e '$a\' CoverageReport.md
             sed -i -e '$a\' latest_code_coverage_comment.md
-          
+
             if diff -B CoverageReport.md latest_code_coverage_comment.md > /dev/null; then
               echo "No changes detected; skipping coverage comment."
               echo "skip_coverage_comment=true" >> $GITHUB_ENV
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload Coverage Report as PR Comment
         if: ${{ env.skip_coverage_comment == 'false' }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: 'CoverageReport.md'

--- a/.github/workflows/developer_onboarding_notification.yml
+++ b/.github/workflows/developer_onboarding_notification.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set Environment Variables
         env:
@@ -27,7 +27,7 @@ jobs:
 
       - name: Count Merged Pull Requests
         id: count_merged_pull_requests
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -41,13 +41,13 @@ jobs:
             core.exportVariable('PR_COUNT', prCount);
 
       - name: Comment on the Merged Pull Request
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const prCount = parseInt(process.env.PR_COUNT);
             const author = process.env.AUTHOR;
-            const mention = 'adhiamboperes'; 
+            const mention = 'adhiamboperes';
             const prNumber = context.payload.pull_request.number;
 
             let message;
@@ -62,7 +62,7 @@ jobs:
               `This means you may be eligible to join the Oppia dev team as a collaborator! 🎉 If you're interested, please fill out [this form](https://forms.gle/NxPjimCMqsSTNUgu5) and become an even more integral part of the community. 🌱\n\n` +
               `Looking forward to seeing even more contributions from you. The developer onboarding lead: @${mention} is here if you need any help! Keep up the great work! 🚀`;
             }
-              
+
             if (prCount === 1 || prCount === 2) {
               await github.rest.issues.createComment({
                 owner: process.env.OWNER,

--- a/.github/workflows/issue_checks.yml
+++ b/.github/workflows/issue_checks.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           version: 6.5.0
 
+      - name: Pre-Build Check Scripts
+        if: ${{ github.event.action == 'closed' }}
+        run: |
+          bazel build //scripts:todo_issue_resolved_check //scripts:todo_issue_comment_check
+
       - name: TODO Issue Resolved Check
         id: todoIssueResolvedCheck
         if: ${{ github.event.action == 'closed' }}

--- a/.github/workflows/issue_checks.yml
+++ b/.github/workflows/issue_checks.yml
@@ -4,7 +4,7 @@ name: Issue Checks
 
 on:
   issues:
-    types: [closed, reopened]
+    types: [closed]
 
 permissions:
   issues: write
@@ -21,36 +21,44 @@ jobs:
         with:
           version: 6.5.0
 
-      - name: Pre-Build Check Scripts
-        if: ${{ github.event.action == 'closed' }}
+      - name: Pre-build required scripts
+        id: pre-build-scripts
         run: |
           bazel build //scripts:todo_issue_resolved_check //scripts:todo_issue_comment_check
 
-      - name: TODO Issue Resolved Check
-        id: todoIssueResolvedCheck
-        if: ${{ github.event.action == 'closed' }}
+      - name: Check whether issue still has open TODOs in code
+        id: check-for-todo-references
         run: |
           bazel run //scripts:todo_issue_resolved_check -- $(pwd) ${{ github.event.issue.number }} ${{ github.sha }}
 
-      - name: Reopen Issue
-        if: failure() && steps.todoIssueResolvedCheck.outcome == 'failure'
+      # Always reopen the issue on even build failures since those could hide a TODO not yet being fully resolved.
+      - name: Reopen issue
+        if: ${{ failure() }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           gh issue reopen ${{ github.event.issue.number }}
 
       - name: Check for duplicate comment
-        id: duplicateCommentCheck
-        if: failure() && steps.todoIssueResolvedCheck.outcome == 'failure'
+        id: check-for-duplicate-comment
+        if: ${{ failure() && steps.check-for-todo-references.outcome == 'failure' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           gh issue view ${{ github.event.issue.number }} --json comments --jq '.comments[-1].body' > $(pwd)/latest_comment.txt
           bazel run //scripts:todo_issue_comment_check -- $(pwd) latest_comment.txt script_failures.txt
 
-      - name: Add Comment
-        if: failure() && steps.duplicateCommentCheck.outcome == 'failure'
+      - name: Add comment for unresolved TODO
+        if: ${{ failure() && steps.check-for-duplicate-comment.outcome == 'failure' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           gh issue comment ${{ github.event.issue.number }} -F $(pwd)/script_failures.txt
+
+      - name: Add comment for failing script builds
+        if: ${{ failure() && steps.pre-build-scripts.outcome == 'failure' }}
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            TODO script unexpectedly failed to run. Cautiously reopening the issue.

--- a/.github/workflows/issue_checks.yml
+++ b/.github/workflows/issue_checks.yml
@@ -14,7 +14,7 @@ jobs:
     name: Closed TODO Issue Check
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Bazel
         uses: abhinavsingh/setup-bazel@v3

--- a/.github/workflows/lesson_checks.yml
+++ b/.github/workflows/lesson_checks.yml
@@ -18,7 +18,7 @@ jobs:
           version: 6.5.0
 
       - name: Check out introduce-asset-download-script branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: introduce-asset-download-script
 

--- a/.github/workflows/oppiabot.yml
+++ b/.github/workflows/oppiabot.yml
@@ -6,6 +6,9 @@ on:
   pull_request_target:
     branches:
       - develop
+  merge_group:
+    branches:
+      - develop
 
 jobs:
   oppiabot:

--- a/.github/workflows/oppiabot.yml
+++ b/.github/workflows/oppiabot.yml
@@ -14,7 +14,7 @@ jobs:
   oppiabot:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: CLA Check
         uses: oppia/oppiabot@1.4.0
         with:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -21,9 +21,9 @@ jobs:
     name: Check CODEOWNERS & Repository files
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
-      - uses: mszostok/codeowners-validator@v0.5.1
+      - uses: mszostok/codeowners-validator@v0.7.4
         with:
           checks: "duppatterns,files,syntax"
           experimental_checks: "notowned"
@@ -53,7 +53,7 @@ jobs:
     name: Lint Tests
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Create oppia android tools directory
         run: mkdir -p $HOME/oppia-android-tools
@@ -100,7 +100,7 @@ jobs:
     env:
       CACHE_DIRECTORY: ~/.bazel_cache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -109,7 +109,7 @@ jobs:
         with:
           version: 6.5.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: scripts_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -222,7 +222,7 @@ jobs:
     name: Maven Dependencies Checks
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Bazel
         uses: abhinavsingh/setup-bazel@v3

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -8,9 +8,12 @@ on:
   push:
     branches:
       - develop
+  merge_group:
+    branches:
+      - develop
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -28,7 +31,7 @@ jobs:
   check_base_branch:
     name: Check base branch
     runs-on: ubuntu-24.04
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
       - name: "Branch is not based on develop or release branch"
         if: ${{ github.base_ref != 'develop' && !startsWith(github.base_ref, 'release-') }}

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Compute PR matrix
         id: compute-pull-request-matrix
@@ -42,8 +42,8 @@ jobs:
       ENABLE_CACHING: false
       CACHE_DIRECTORY: ~/.bazel_cache
     steps:
-      - name: Find the latest APK & AAB Analysis Comment 
-        uses: actions/github-script@v6
+      - name: Find the latest APK & AAB Analysis Comment
+        uses: actions/github-script@v8
         id: find_latest_apk_aab_comment
         with:
            script: |
@@ -51,7 +51,7 @@ jobs:
                owner: context.repo.owner,
                repo: context.repo.repo,
                issue_number: ${{ matrix.prInfo.number }},
-             });            
+             });
 
              for (let i = comments.length - 1; i >= 0; i--) {
                if (comments[i].body.includes("# APK & AAB differences analysis")) {
@@ -61,13 +61,13 @@ jobs:
 
                  require('fs').writeFileSync('latest_aab_comment_body.log', commentBody, 'utf8');
                  core.setOutput("latest_aab_comment_created_at", commentDate);
-                
+
                  return
                }
              }
 
       - name: Track Commits following the latest APK & AAB Analysis Comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         id: track_commits
         with:
            script: |
@@ -76,13 +76,13 @@ jobs:
                repo: context.repo.repo,
                pull_number: ${{ matrix.prInfo.number }},
              });
-            
+
              const latestCommentDate = "${{ steps.find_latest_apk_aab_comment.outputs.latest_aab_comment_created_at }}";
              const recentCommits = commits.filter(commit => {
                const commitDate = new Date(commit.commit.committer.date);
                return commitDate > new Date("${{ steps.find_latest_apk_aab_comment.outputs.latest_aab_comment_created_at }}");
              });
-            
+
              const recentCommitsCount = recentCommits.length;
              if(recentCommitsCount > 0 || !latestCommentDate) {
                core.setOutput("new_commits", "true");
@@ -90,7 +90,7 @@ jobs:
                console.log("No new commits since the last APK & AAB report; Skipping redundant analysis.");
                core.setOutput("new_commits", "false");
              }
-          
+
       - name: Compute PR head owner/repo reference
         if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
@@ -98,7 +98,7 @@ jobs:
           PR_HEAD_REPO_OWNER: ${{ matrix.prInfo.headRepositoryOwner.login }}
         run: |
           echo "PR_HEAD=$PR_HEAD_REPO_OWNER/$PR_HEAD_REPO" >> "$GITHUB_ENV"
-         
+
       - name: Print PR information for this run
         if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
@@ -120,7 +120,7 @@ jobs:
       # with Bazel since Bazel can share the most recent cache from an unrelated build and still
       # benefit from incremental build performance (assuming that actions/cache aggressively removes
       # older caches due to the 5GB cache limit size & Bazel's large cache size).
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         id: cache
         with:
@@ -169,7 +169,7 @@ jobs:
       # chained PRs).
       - name: Check out develop repository
         if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: develop
 
@@ -187,7 +187,7 @@ jobs:
         if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
           PR_BASE_REF_NAME: ${{ matrix.prInfo.baseRefName }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.PR_BASE_REF_NAME }}
@@ -197,7 +197,7 @@ jobs:
         if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
           PR_HEAD_REF_NAME: ${{ matrix.prInfo.headRefName }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           repository: ${{ env.PR_HEAD }}
@@ -266,12 +266,12 @@ jobs:
         if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
           PR_NUMBER: ${{ matrix.prInfo.number }}
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ env.PR_NUMBER }}
           body: ${{ steps.compute-comment-body.outputs.comment_body }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         with:
           name: ${{ env.FULL_BUILD_SUMMARY_FILE_NAME }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,9 +11,12 @@ on:
     branches:
       # Push events on develop branch
       - develop
+  merge_group:
+    branches:
+      - develop
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -76,15 +79,33 @@ jobs:
           echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
         shell: bash
 
+      - name: Check PR for [RunAllTests]
+        id: check_pr
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [[ "${{ github.event.pull_request.title }}" == *"[RunAllTests]"* ]]; then echo "run_all=true" >> $GITHUB_OUTPUT; fi
+
+      # Search all PR commit messages included in the merge group for any that require running all tests upon merging.
+      - name: Check merge group for [RunAllTests]
+        id: check_mg
+        if: ${{ github.event_name == 'merge_group' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MESSAGES=$(gh api repos/${{ github.repository }}/compare/${{ github.event.merge_group.base_sha }}...${{ github.sha }} --jq '.commits[].commit.message')
+          if echo "$MESSAGES" | grep -Fq "[RunAllTests]"; then echo "run_all=true" >> $GITHUB_OUTPUT; fi
+
       - name: Compute test matrix
         id: compute-test-matrix
         env:
-          compute_all_targets: ${{ contains(github.event.pull_request.title, '[RunAllTests]') }}
+          compute_all_targets: ${{ steps.check_pr.outputs.run_all == 'true' || steps.check_mg.outputs.run_all == 'true' }}
           # See: https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request. Defer to origin/develop outside a PR (such as develop's main CI runs).
-          base_commit_hash: ${{ github.event.pull_request.base.sha || 'origin/develop' }}
+          base_commit_hash: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'origin/develop' }}
         # https://unix.stackexchange.com/a/338124 for reference on creating a JSON-friendly
-        # comma-separated list of test targets for the matrix.
+        # comma-separated list of test targets for the matrix. Note that the extra fetch is to
+        # enusre that the base commit is fully fetched locally so that it can be diffed against.
         run: |
+          git fetch origin $base_commit_hash --depth=1
           bazel run //scripts:compute_affected_tests -- $(pwd) $(pwd)/affected_targets.log $base_commit_hash compute_all_tests=$compute_all_targets
           TEST_BUCKET_LIST=$(cat ./affected_targets.log | sed 's/^\|$/"/g' | paste -sd, -)
           echo "Affected tests (note that this might be all tests if configured to run all or on the develop branch): $TEST_BUCKET_LIST"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       CACHE_DIRECTORY: ~/.bazel_cache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
         with:
           version: 6.5.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: scripts_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -129,14 +129,14 @@ jobs:
     env:
       CACHE_DIRECTORY: ~/.bazel_cache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Bazel
         uses: abhinavsingh/setup-bazel@v3
         with:
           version: 6.5.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: scripts_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -181,7 +181,7 @@ jobs:
       # with Bazel since Bazel can share the most recent cache from an unrelated build and still
       # benefit from incremental build performance (assuming that actions/cache aggressively removes
       # older caches due to the 5GB cache limit size & Bazel's large cache size).
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: test_cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
@@ -264,7 +264,7 @@ jobs:
 
       - name: Upload bazel target file
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-tests-bazel-targets-${{ env.SHARD_NAME }}
           path: bazel_targets.txt

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -24,7 +24,7 @@ jobs:
     name: Check Wiki Table of Contents
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Bazel
         uses: abhinavsingh/setup-bazel@v3
@@ -45,7 +45,7 @@ jobs:
         os: [ubuntu-24.04]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Add remote


### PR DESCRIPTION
## Explanation
Fixes part of #3926

This PR introduces support for GitHub merge queues by:
- Enabling merge groups as a trigger for all required workflows (GitHub doesn't currently support configuring differrent required workflows for PRs vs. merge groups so the two must match).
- Of all the required workflows, those that depend on PR-specific properties (like title or base branch) have been updated to support merge group varieties.
  - For unit tests & code coverage this is far more complex because of the diffing behavior and how the synthetic PR branch differs in history from the linear merge group branch.
  - This is further complicated by '[RunAllTests]' needing to trigger a full CI run since it can be _any_ of the commits in the merge group.
  - For the check base branch CI check it should just be skipped.

Besides adding support for merge groups, this PR does a bunch of other things:
- It updates the setup Android workflow to read the SDK and build tools versions from `build_vars.bzl` so that we never need to update it again to keep things in sync (Bazel still requires an update).
- It updates the new workflows introduced in #6142 to specifically ignore the `translatewiki-prs` branch since it does not need to use the PR template nor is it prohibited from force pushes (this was missed in the original implementation).
- It refines the message for force push closes per @harshsomankar123-tech's suggestion at https://github.com/oppia/oppia-android/pull/6142#issuecomment-4042316908.
- It fixes a weird quirk with the script that reopens TODOs. If the script fails to build it will actually still continue running which leads to the issue being reopened (see https://github.com/oppia/oppia-android/issues/6141#issuecomment-4050631928).  This is being mitigated in two ways:
  - First by introducing a prior step to try and pre-build the script. If this fails then `todoIssueResolvedCheck` will be skipped which will lead to the other subsequent steps failing to run (because they rely on the workflow being `failure` status).
  - Building robustness in if there is a build failure. The issue is still reopened and a new message is left indicating that something probably went wrong. Hopefully we don't see this happen often but it's a nice catch to avoid issues being incorrectly closed when they haven't been fully resolved due to a CI flake.
  - One other change: 'reopened' was dropped because it was never actually used.
- It updates all of the third-party CI dependencies to their very latest (which actually made me realize we should be using something else for Bazel but the full audit of that is probably more work than this whole PR so I skipped it--see #6149).
- It fixes a problem that we noticed with the PR issue description check mysteriously auto-marking PRs as draft that seemed to correctly reference issues. We discovered this is because of an overly strict regex match on the template where it wasn't allowing trailing whitespace. Both regexes have been updated to allow all non-newline whitespaces (equivalent to the `\h` regex class which isn't supported in native JavaScript).

**Important**: I did not test these changes, and simply running through CI on this PR won't be sufficient. However I'm fairly sure most of these changes won't cause problems and should work without issue except maybe the merge groups (which we will see once merge queues are enabled after this PR is merged and another PR is sent to be merged). We may discover certain dependency upgrades causing problems. If that happens we can fix them forward since it shouldn't really be necessary to revert this PR.

For actual merge queues I am planning to set them up so that PRs are merged 3 times per day (every 8 hours) so try and maximize the chance of more than one PR being merged at once (though I think we average fewer than 1 PRs per day so this probably won't happen). This may be tweaked in the future to be much longer (I'm considering 24 hours) since merge queues actually overall increase the CI burden on the project (and this is causing some fairly substantial issues on Oppia web right now).

Finally, a fairly significant amount of this PR was either authored by Gemini (for the new logic portions) or otherwise helped in investigation (for merge queues and the TODO check bits). The version checks I did myself fully since there wasn't much advantage to an LLM there, and I basically rewrote everything that was suggested in one way or another. The tool was helpful in bouncing ideas mostly, though I will note it caught the potential deep fetch issue for the compute affected targets check for unit tests & code coverage--I likely would have missed that an would have needed to do a follow-up fix once we tried to use merge queues and saw it fail.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- This is a CI infrastructure-only change that won't impact the end user experience in the app.