### PR TITLE
Fixes part of #5440 : Change ProfileId defaulting to be an invalid profile

### DIFF
--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -127,7 +127,7 @@ message ProfileAvatar {
   }
 }
 
-// TODO(#5440) : Delete once migration to Profile Id is completed.
+// TODO(#5440): Delete once migration to Profile Id is completed.
 // Opaque data structure to pass ID.
 message LegacyProfileId {
   /**

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -127,6 +127,7 @@ message ProfileAvatar {
   }
 }
 
+// TODO : Delete once migration to Profile Id is completed.
 // Opaque data structure to pass ID.
 message LegacyProfileId {
   /**
@@ -134,6 +135,15 @@ message LegacyProfileId {
    * Should not be used directory outside of the profile system.
    */
   int32 internal_id = 1;
+}
+
+// Opaque data structure to pass ID
+message ProfileId {
+  /**
+   * Unique ID used to identify a single profile.
+   * Should not be used directory outside of the profile system.
+   */
+  optional int32 internal_id = 1;
 }
 
 // Used in BindableAdapter for ProfileChooserFragment.

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -127,7 +127,7 @@ message ProfileAvatar {
   }
 }
 
-// TODO : Delete once migration to Profile Id is completed.
+// TODO(#5440) : Delete once migration to Profile Id is completed.
 // Opaque data structure to pass ID.
 message LegacyProfileId {
   /**

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -137,11 +137,12 @@ message LegacyProfileId {
   int32 internal_id = 1;
 }
 
-// Opaque data structure to pass ID
+// Opaque wrapper for passing profile identifiers between components.
 message ProfileId {
   /**
-   * Unique ID used to identify a single profile.
-   * Should not be used directory outside of the profile system.
+   * Internal identifier for a specific profile. This ID is only meaningful within
+   * the profile system and should not be accessed or used directly by external components.
+   * Optional to allow for uninitialized or invalid profile references.
    */
   optional int32 internal_id = 1;
 }

--- a/utility/src/main/java/org/oppia/android/util/profile/BUILD.bazel
+++ b/utility/src/main/java/org/oppia/android/util/profile/BUILD.bazel
@@ -37,3 +37,14 @@ kt_android_library(
         "//utility/src/main/java/org/oppia/android/util/extensions:bundle_extensions",
     ],
 )
+
+kt_android_library(
+    name = "profile_id_migration_util",
+    srcs = [
+        "ProfileIdMigrationUtil.kt",
+    ],
+    visibility = ["//:oppia_api_visibility"],
+    deps = [
+        "//model/src/main/proto:profile_java_proto_lite",
+    ],
+)

--- a/utility/src/main/java/org/oppia/android/util/profile/ProfileIdMigrationUtil.kt
+++ b/utility/src/main/java/org/oppia/android/util/profile/ProfileIdMigrationUtil.kt
@@ -1,0 +1,12 @@
+package org.oppia.android.util.profile
+
+import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
+
+/** Migrates [LegacyProfileId] to the new [ProfileId] proto structure. */
+fun LegacyProfileId.migrate(): ProfileId =
+  ProfileId.newBuilder().mergeFrom(this.toByteString()).build()
+
+/** Converts [ProfileId] back to [LegacyProfileId] for compatibility during migration. */
+fun ProfileId.toLegacy(): LegacyProfileId =
+  LegacyProfileId.newBuilder().mergeFrom(this.toByteString()).build()

--- a/utility/src/main/java/org/oppia/android/util/profile/ProfileIdMigrationUtil.kt
+++ b/utility/src/main/java/org/oppia/android/util/profile/ProfileIdMigrationUtil.kt
@@ -4,9 +4,9 @@ import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.ProfileId
 
 /** Migrates [LegacyProfileId] to the new [ProfileId] proto structure. */
-fun LegacyProfileId.migrate(): ProfileId =
+fun LegacyProfileId.toProfileId(): ProfileId =
   ProfileId.newBuilder().mergeFrom(this.toByteString()).build()
 
 /** Converts [ProfileId] back to [LegacyProfileId] for compatibility during migration. */
-fun ProfileId.toLegacy(): LegacyProfileId =
+fun ProfileId.toLegacyProfileId(): LegacyProfileId =
   LegacyProfileId.newBuilder().mergeFrom(this.toByteString()).build()

--- a/utility/src/test/java/org/oppia/android/util/profile/BUILD.bazel
+++ b/utility/src/test/java/org/oppia/android/util/profile/BUILD.bazel
@@ -64,3 +64,22 @@ oppia_android_test(
         "//utility/src/main/java/org/oppia/android/util/profile:profile_name_validator",
     ],
 )
+
+oppia_android_test(
+    name = "ProfileIdMigrationUtilTest",
+    srcs = ["ProfileIdMigrationUtilTest.kt"],
+    custom_package = "org.oppia.android.util.profile",
+    test_class = "org.oppia.android.util.profile.ProfileIdMigrationUtilTest",
+    test_manifest = "//utility:test_manifest",
+    deps = [
+        "//model/src/main/proto:profile_java_proto_lite",
+        "//testing/src/main/java/org/oppia/android/testing/junit:oppia_parameterized_test_runner",
+        "//testing/src/main/java/org/oppia/android/testing/junit:parameterized_robolectric_test_runner",
+        "//third_party:androidx_test_ext_junit",
+        "//third_party:com_google_truth_truth",
+        "//third_party:junit_junit",
+        "//third_party:org_robolectric_robolectric",
+        "//third_party:robolectric_android-all",
+        "//utility/src/main/java/org/oppia/android/util/profile:profile_id_migration_util",
+    ],
+)

--- a/utility/src/test/java/org/oppia/android/util/profile/ProfileIdMigrationUtilTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/profile/ProfileIdMigrationUtilTest.kt
@@ -1,0 +1,56 @@
+package org.oppia.android.util.profile
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
+import org.oppia.android.testing.junit.OppiaParameterizedTestRunner
+import org.oppia.android.testing.junit.OppiaParameterizedTestRunner.SelectRunnerPlatform
+import org.oppia.android.testing.junit.ParameterizedRobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+
+@Suppress("FunctionName")
+@RunWith(OppiaParameterizedTestRunner::class)
+@SelectRunnerPlatform(ParameterizedRobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+@Config(manifest = Config.NONE)
+class ProfileIdMigrationUtilTest {
+
+  @Test
+  fun testMigrate_legacyProfileIdWithValidId_migratesCorrectly() {
+    val legacyProfileId = LegacyProfileId.newBuilder().setInternalId(5).build()
+    val profileId = legacyProfileId.migrate()
+    assertThat(profileId.hasInternalId()).isTrue()
+    assertThat(profileId.internalId).isEqualTo(5)
+  }
+
+  @Test
+  fun testMigrate_legacyProfileIdWithZeroId_preservesZeroAsValidId() {
+    val legacyProfileId = LegacyProfileId.newBuilder().setInternalId(0).build()
+    val profileId = legacyProfileId.migrate()
+    assertThat(profileId.hasInternalId()).isTrue()
+    assertThat(profileId.internalId).isEqualTo(0)
+  }
+
+  @Test
+  fun testMigrate_uninitializedProfileId_hasNoInternalId() {
+    val profileId = ProfileId.newBuilder().build()
+    assertThat(profileId.hasInternalId()).isFalse()
+  }
+
+  @Test
+  fun testToLegacy_profileIdWithInternalId_convertsCorrectly() {
+    val profileId = ProfileId.newBuilder().setInternalId(10).build()
+    val legacyProfileId = profileId.toLegacy()
+    assertThat(legacyProfileId.internalId).isEqualTo(10)
+  }
+
+  @Test
+  fun testToLegacy_uninitializedProfileId_convertsToZero() {
+    val profileId = ProfileId.newBuilder().build()
+    val legacyProfileId = profileId.toLegacy()
+    assertThat(legacyProfileId.internalId).isEqualTo(0)
+  }
+}

--- a/utility/src/test/java/org/oppia/android/util/profile/ProfileIdMigrationUtilTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/profile/ProfileIdMigrationUtilTest.kt
@@ -2,18 +2,12 @@ package org.oppia.android.util.profile
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.ProfileId
-import org.oppia.android.testing.junit.OppiaParameterizedTestRunner
-import org.oppia.android.testing.junit.OppiaParameterizedTestRunner.SelectRunnerPlatform
-import org.oppia.android.testing.junit.ParameterizedRobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 
 @Suppress("FunctionName")
-@RunWith(OppiaParameterizedTestRunner::class)
-@SelectRunnerPlatform(ParameterizedRobolectricTestRunner::class)
 @LooperMode(LooperMode.Mode.PAUSED)
 @Config(manifest = Config.NONE)
 class ProfileIdMigrationUtilTest {
@@ -21,7 +15,7 @@ class ProfileIdMigrationUtilTest {
   @Test
   fun testMigrate_legacyProfileIdWithValidId_migratesCorrectly() {
     val legacyProfileId = LegacyProfileId.newBuilder().setInternalId(5).build()
-    val profileId = legacyProfileId.migrate()
+    val profileId = legacyProfileId.toProfileId()
     assertThat(profileId.hasInternalId()).isTrue()
     assertThat(profileId.internalId).isEqualTo(5)
   }
@@ -29,7 +23,7 @@ class ProfileIdMigrationUtilTest {
   @Test
   fun testMigrate_legacyProfileIdWithZeroId_convertsToNull() {
     val legacyProfileId = LegacyProfileId.newBuilder().setInternalId(0).build()
-    val profileId = legacyProfileId.migrate()
+    val profileId = legacyProfileId.toProfileId()
     assertThat(profileId.hasInternalId()).isFalse()
   }
 
@@ -42,14 +36,14 @@ class ProfileIdMigrationUtilTest {
   @Test
   fun testToLegacy_profileIdWithInternalId_convertsCorrectly() {
     val profileId = ProfileId.newBuilder().setInternalId(10).build()
-    val legacyProfileId = profileId.toLegacy()
+    val legacyProfileId = profileId.toLegacyProfileId()
     assertThat(legacyProfileId.internalId).isEqualTo(10)
   }
 
   @Test
   fun testToLegacy_uninitializedProfileId_convertsToZero() {
     val profileId = ProfileId.newBuilder().build()
-    val legacyProfileId = profileId.toLegacy()
+    val legacyProfileId = profileId.toLegacyProfileId()
     assertThat(legacyProfileId.internalId).isEqualTo(0)
   }
 }

--- a/utility/src/test/java/org/oppia/android/util/profile/ProfileIdMigrationUtilTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/profile/ProfileIdMigrationUtilTest.kt
@@ -27,11 +27,10 @@ class ProfileIdMigrationUtilTest {
   }
 
   @Test
-  fun testMigrate_legacyProfileIdWithZeroId_preservesZeroAsValidId() {
+  fun testMigrate_legacyProfileIdWithZeroId_convertsToNull() {
     val legacyProfileId = LegacyProfileId.newBuilder().setInternalId(0).build()
     val profileId = legacyProfileId.migrate()
-    assertThat(profileId.hasInternalId()).isTrue()
-    assertThat(profileId.internalId).isEqualTo(0)
+    assertThat(profileId.hasInternalId()).isFalse()
   }
 
   @Test


### PR DESCRIPTION
## Explanation
Fixes part of #5440
 - Create new proto structure for ProfileId using optional keyword.
 - Create utlity functions to be used during migration with the purpose of switching from one profileId proto to another.
 - Add new build target as a library in `utility/src/main/java/org/oppia/android/util/profile/BUILD.bazel` for file `ProfileIdMigrationUtil`.
 - Add test suite for migration utility.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).