### PR TITLE
Fix name handling for test file in oppia_android_test

### DIFF
--- a/oppia_android_application.bzl
+++ b/oppia_android_application.bzl
@@ -36,7 +36,7 @@ def _convert_module_aab_to_structured_zip_impl(ctx):
     input_file = ctx.attr.input_file.files.to_list()[0]
 
     command = """
-    # Extract AAB to working directory.
+    # Extract the input AAB file into a temporary working directory.
     WORKING_DIR=$(mktemp -d)
     unzip -q -d $WORKING_DIR {0}
 

--- a/oppia_android_test.bzl
+++ b/oppia_android_test.bzl
@@ -32,7 +32,7 @@ def oppia_android_layer_level_test(
     """
     if name not in filtered_tests:
         oppia_android_test(
-            name = name[:name.find(".kt")] if "/" in name else name,
+            name =name.replace(".kt", "") if "/" in name else name,
             srcs = [processed_src or name] + additional_srcs,
             test_class = (
                 test_class or _remove_prefix_suffix(name, test_path_prefix, ".kt").replace("/", ".")


### PR DESCRIPTION
Fix name handling for test file in oppia_android_test

<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [ ] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [ ] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [ ] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
