### PR TITLE
Fix #5847: Replace shell binary check with Kotlin script and tests

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -212,6 +212,13 @@ jobs:
         run: |
           bazel run //scripts:string_resource_validation_check -- $(pwd)
 
+      - name: Binary File Check
+        # The expression if: ${{ !cancelled() }} runs a job or step regardless of its success or failure while responding to cancellations,
+        # serving as a cancellation-compliant alternative to if: ${{ always() }} in concurrent workflows.
+        if: ${{ !cancelled() }}
+        run: |
+          bazel run //scripts:binary_file_check -- $(pwd) scripts/assets/binary_file_exemptions.pb
+
   # Note that caching is intentionally not enabled for this check since licenses should always be
   # verified without any potential influence from earlier builds (i.e. always from a clean build to
   # ensure the results exactly match the current state of the repository).

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -340,13 +340,6 @@ BINARY_FILE_EXEMPTION_ASSETS = generate_binary_file_assets_list_from_text_protos
     binary_file_exemptions_name = ["binary_file_exemptions"],
 )
 
-kt_jvm_library(
-    name = "binary_file_check_assets",
-    testonly = True,
-    data = BINARY_FILE_EXEMPTION_ASSETS,
-    visibility = [":oppia_script_test_visibility"],
-)
-
 kt_jvm_binary(
     name = "binary_file_check",
     testonly = True,

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -8,6 +8,7 @@ load(
     "//scripts:script_assets.bzl",
     "generate_accessibility_label_assets_list_from_text_protos",
     "generate_android_lint_assets_list_from_text_protos",
+    "generate_binary_file_assets_list_from_text_protos",
     "generate_kdoc_validity_assets_list_from_text_protos",
     "generate_maven_assets_list_from_text_protos",
     "generate_regex_assets_list_from_text_protos",
@@ -332,4 +333,24 @@ kt_jvm_binary(
     data = ANDROID_LINT_EXEMPTION_ASSETS,
     main_class = "org.oppia.android.scripts.lint.AndroidLintRunnerKt",
     runtime_deps = ["//scripts/src/java/org/oppia/android/scripts/lint:android_lint_runner"],
+)
+
+BINARY_FILE_EXEMPTION_ASSETS = generate_binary_file_assets_list_from_text_protos(
+    name = "binary_file_exemption_assets",
+    binary_file_exemptions_name = ["binary_file_exemptions"],
+)
+
+kt_jvm_library(
+    name = "binary_file_check_assets",
+    testonly = True,
+    data = BINARY_FILE_EXEMPTION_ASSETS,
+    visibility = [":oppia_script_test_visibility"],
+)
+
+kt_jvm_binary(
+    name = "binary_file_check",
+    testonly = True,
+    data = BINARY_FILE_EXEMPTION_ASSETS,
+    main_class = "org.oppia.android.scripts.binary.BinaryFileCheckKt",
+    runtime_deps = ["//scripts/src/java/org/oppia/android/scripts/binary:binary_file_check_lib"],
 )

--- a/scripts/assets/binary_file_exemptions.textproto
+++ b/scripts/assets/binary_file_exemptions.textproto
@@ -1,0 +1,64 @@
+# Exemptions for binary files that are expected to be present in the repository.
+# Each exempted file uses its full relative path from the repository root.
+# Entries are maintained in lexicographical order.
+
+binary_file_exemption {
+  exempted_file_path: ".gitsecret/keys/pubring.kbx"
+}
+binary_file_exemption {
+  exempted_file_path: ".gitsecret/keys/pubring.kbx~"
+}
+binary_file_exemption {
+  exempted_file_path: ".gitsecret/keys/trustdb.gpg"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/drawable-nodpi/review_placeholder.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/drawable-nodpi/testing_fraction.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/drawable-nodpi/topic_fractions_01.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/drawable-nodpi/topic_fractions_02.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/drawable-nodpi/topic_fractions_03.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/drawable-nodpi/topic_fractions_04.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/drawable-nodpi/topic_fractions_05.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/drawable-nodpi/topic_fractions_06.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/drawable-nodpi/topic_fractions_07.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/drawable-nodpi/topic_fractions_08.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/drawable-nodpi/topic_ratios_01.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/mipmap-hdpi/launcher_icon.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/mipmap-mdpi/launcher_icon.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/mipmap-xhdpi/launcher_icon.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/mipmap-xxhdpi/launcher_icon.png"
+}
+binary_file_exemption {
+  exempted_file_path: "app/src/main/res/mipmap-xxxhdpi/launcher_icon.png"
+}
+binary_file_exemption {
+  exempted_file_path: "config/oppia-dev-workflow-remote-cache-credentials.json.secret"
+}

--- a/scripts/assets/binary_file_exemptions.textproto
+++ b/scripts/assets/binary_file_exemptions.textproto
@@ -1,7 +1,6 @@
 # Exemptions for binary files that are expected to be present in the repository.
 # Each exempted file uses its full relative path from the repository root.
 # Entries are maintained in lexicographical order.
-
 binary_file_exemption {
   exempted_file_path: ".gitsecret/keys/pubring.kbx"
 }

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 
 # Pre-commit hook for running local checks before committing.
-# The binary file check is now handled by a Kotlin script in CI
-# (see .github/workflows/static_checks.yml).
-#
-# To install this hook, symlink or copy this file to .git/hooks/pre-commit:
-#   ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
-#   chmod +x .git/hooks/pre-commit
 
 echo "Running pre-commit checks..."
-echo "Note: Binary file checks are handled by CI (scripts:binary_file_check)."
 echo "Pre-commit hook completed."

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,35 +1,13 @@
 #!/bin/bash
 
-# Pre-commit hook to check for binary files.
+# Pre-commit hook for running local checks before committing.
+# The binary file check is now handled by a Kotlin script in CI
+# (see .github/workflows/static_checks.yml).
+#
+# To install this hook, symlink or copy this file to .git/hooks/pre-commit:
+#   ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
+#   chmod +x .git/hooks/pre-commit
 
-# Find the common ancestor between develop and the current branch
-base_commit=$(git merge-base 'origin/develop' HEAD)
-
-# Get the list of staged changes (files ready to be committed)
-staged_files=$(git diff --cached --name-only)
-
-# Get the list of changed files compared to the base commit
-changed_files=$(git diff --name-only "$base_commit" HEAD)
-
-# Combine both lists of files, ensuring no duplicates
-all_files=$(echo -e "$staged_files\n$changed_files" | sort -u)
-
-function checkForBinaries() {
-  binaryFilesCount=0
-
-  # Iterate over all files (both staged and changed)
-  for file in $all_files; do
-    if [ -f "$file" ] && file --mime "$file" | grep -q 'binary'; then
-      ((binaryFilesCount++))
-      printf "\n\033[33m%s\033[0m" "$file"
-    fi
-  done
-
-  if [[ "${binaryFilesCount}" -gt 0 ]]; then
-    printf "\n\nPlease remove the %d detected binary file(s)." "$binaryFilesCount"
-    printf "\nBINARY FILES CHECK FAILED"
-    exit 1
-  fi
-}
-
-checkForBinaries
+echo "Running pre-commit checks..."
+echo "Note: Binary file checks are handled by CI (scripts:binary_file_check)."
+echo "Pre-commit hook completed."

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Pre-commit hook for running local checks before committing.
-
-echo "Running pre-commit checks..."
-echo "Pre-commit hook completed."

--- a/scripts/script_assets.bzl
+++ b/scripts/script_assets.bzl
@@ -184,3 +184,27 @@ def generate_android_lint_assets_list_from_text_protos(
         proto_dep_bazel_target_prefix = "//scripts/src/java/org/oppia/android/scripts/proto",
         proto_package = "proto",
     )
+
+def generate_binary_file_assets_list_from_text_protos(
+        name,
+        binary_file_exemptions_name):
+    """
+    Converts a single list of text proto assets to binary.
+
+    Args:
+        name: str. The name of this generation instance. This will be a prefix for derived targets.
+        binary_file_exemptions_name: list of str. The list of binary file exemptions file name.
+
+    Returns:
+        list of str. The list of new proto binary asset files that were generated.
+    """
+    return generate_proto_binary_assets(
+        name = name,
+        names = binary_file_exemptions_name,
+        proto_dep_name = "script_exemptions",
+        proto_type_name = "BinaryFileExemptions",
+        name_prefix = "binary_file_exemptions",
+        asset_dir = "assets",
+        proto_dep_bazel_target_prefix = "//scripts/src/java/org/oppia/android/scripts/proto",
+        proto_package = "proto",
+    )

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,9 +13,6 @@
 # Move file from script folder to .git/hooks folder
 cp scripts/pre-push.sh .git/hooks/pre-push
 
-# Copy the pre-commit hook from script to .git/hooks folder
-cp scripts/pre-commit.sh .git/hooks/pre-commit
-
 # Create a folder where all the set up files will be downloaded
 mkdir -p ../oppia-android-tools
 cd ../oppia-android-tools

--- a/scripts/src/java/org/oppia/android/scripts/binary/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/binary/BUILD.bazel
@@ -1,0 +1,17 @@
+"""
+Libraries corresponding to binary file checks, such as ensuring that no unexpected binary files
+are present in the repository.
+"""
+
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "binary_file_check_lib",
+    testonly = True,
+    srcs = ["BinaryFileCheck.kt"],
+    visibility = ["//scripts:oppia_script_binary_visibility"],
+    deps = [
+        "//scripts/src/java/org/oppia/android/scripts/common:repository_file",
+        "//scripts/src/java/org/oppia/android/scripts/proto:script_exemptions_java_proto",
+    ],
+)

--- a/scripts/src/java/org/oppia/android/scripts/binary/BinaryFileCheck.kt
+++ b/scripts/src/java/org/oppia/android/scripts/binary/BinaryFileCheck.kt
@@ -113,7 +113,7 @@ class BinaryFileCheck(
 
     if (unknownExtensionFiles.isNotEmpty()) {
       println(
-        "========== Files with unrecognized extensions: ${unknownExtensionFiles.size} =========="
+        "========== Binary files found: ${unknownExtensionFiles.size} =========="
       )
       unknownExtensionFiles.forEach { file ->
         val ext = file.extension
@@ -121,9 +121,10 @@ class BinaryFileCheck(
       }
       println()
       println(
-        "If these are text files, add their extension to the ALLOWED_TEXT_EXTENSIONS list in" +
-          " BinaryFileCheck.kt. If they are legitimate binary files, add their full path to" +
-          " scripts/assets/binary_file_exemptions.textproto."
+        "If you meant to add these files, please add an exemption to" +
+          " scripts/assets/binary_file_exemptions.textproto." +
+          " If these are text files, add their extension to the" +
+          " ALLOWED_TEXT_EXTENSIONS list in BinaryFileCheck.kt."
       )
       println()
     }

--- a/scripts/src/java/org/oppia/android/scripts/binary/BinaryFileCheck.kt
+++ b/scripts/src/java/org/oppia/android/scripts/binary/BinaryFileCheck.kt
@@ -1,0 +1,240 @@
+package org.oppia.android.scripts.binary
+
+import org.oppia.android.scripts.common.RepositoryFile
+import org.oppia.android.scripts.proto.BinaryFileExemptions
+import java.io.File
+import java.io.FileInputStream
+
+/**
+ * Script for ensuring that no unexpected binary files are present in the repository.
+ *
+ * Usage:
+ *   bazel run //scripts:binary_file_check -- <path_to_directory_root>
+ *     <path_to_binary_file_exemptions_pb>
+ *
+ * Arguments:
+ * - path_to_directory_root: directory path to the root of the Oppia Android repository.
+ * - path_to_binary_file_exemptions_pb: relative path to the binary file exemptions proto file.
+ *
+ * Example:
+ *   bazel run //scripts:binary_file_check -- $(pwd)
+ *     scripts/assets/binary_file_exemptions.pb
+ */
+fun main(vararg args: String) {
+  val repoPath = "${args[0]}/"
+  val binaryFileExemptionProtoPath = args[1]
+  if (BinaryFileCheck(repoPath, binaryFileExemptionProtoPath).execute()) {
+    println("BINARY FILE CHECK PASSED")
+  } else throw Exception("BINARY FILE CHECK FAILED")
+}
+
+/**
+ * Class for checking that the repository does not contain unexpected binary files.
+ *
+ * This uses a two-layer approach:
+ * 1. Extension allowlist: files with known text extensions pass this check immediately.
+ *    Files with unknown extensions are flagged as binary (fail-safe).
+ * 2. Content validation: files with allowed extensions are checked for binary content by
+ *    verifying that all bytes are valid text characters (printable ASCII, whitespace, or
+ *    Unicode letters/digits).
+ *
+ * @param repoPath the path of the repo to be analyzed
+ * @param binaryFileExemptionProtoPath the location of the binary file exemptions proto file
+ */
+class BinaryFileCheck(
+  private val repoPath: String,
+  private val binaryFileExemptionProtoPath: String
+) {
+  /**
+   * Executes the binary file check and returns whether it was a success (i.e. no unexpected
+   * binary files were found).
+   */
+  fun execute(): Boolean {
+    val repoRoot = File(repoPath).absoluteFile.normalize()
+    val exemptions = loadBinaryFileExemptionsProto(binaryFileExemptionProtoPath)
+    val exemptedFilePaths = exemptions.binaryFileExemptionList
+      .mapTo(mutableSetOf()) { it.exemptedFilePath }
+
+    // Validate that all exempted paths point to real files.
+    val missingExemptedFiles = exemptedFilePaths
+      .map { File(repoRoot, it) }
+      .filterNot(File::exists)
+    if (missingExemptedFiles.isNotEmpty()) {
+      println(
+        "========== Stale binary file exemptions: ${missingExemptedFiles.size} =========="
+      )
+      missingExemptedFiles.forEach { file ->
+        println("- Exempted file path does not exist: ${file.toRelativeString(repoRoot)}.")
+      }
+      println()
+      println(
+        "Please remove the stale entries from the binary file exemptions list."
+      )
+    }
+
+    // Collect all files (no extension filter so we get everything).
+    val allFiles = RepositoryFile.collectSearchFiles(
+      repoPath = repoPath,
+      expectedExtension = "",
+      exemptionsList = emptyList()
+    )
+
+    val binaryFiles = mutableListOf<File>()
+    val unknownExtensionFiles = mutableListOf<File>()
+
+    for (file in allFiles) {
+      val relativePath = file.toRelativeString(repoRoot)
+
+      // Skip exempted files.
+      if (relativePath in exemptedFilePaths) continue
+
+      val extension = file.extension.lowercase()
+
+      if (extension.isEmpty() && file.name.startsWith(".")) {
+        // Dotfiles without extensions (e.g., .gitignore) — check content.
+        if (containsBinaryContent(file)) {
+          binaryFiles.add(file)
+        }
+      } else if (extension.isEmpty()) {
+        // Files without extension (e.g., LICENSE, WORKSPACE) — check content.
+        if (containsBinaryContent(file)) {
+          binaryFiles.add(file)
+        }
+      } else if (extension in ALLOWED_TEXT_EXTENSIONS) {
+        // Known text extension — validate content.
+        if (containsBinaryContent(file)) {
+          binaryFiles.add(file)
+        }
+      } else {
+        // Unknown extension — treated as binary (fail-safe).
+        unknownExtensionFiles.add(file)
+      }
+    }
+
+    if (unknownExtensionFiles.isNotEmpty()) {
+      println(
+        "========== Files with unrecognized extensions: ${unknownExtensionFiles.size} =========="
+      )
+      unknownExtensionFiles.forEach { file ->
+        val ext = file.extension
+        println("- ${file.toRelativeString(repoRoot)} (.$ext)")
+      }
+      println()
+      println(
+        "If these are text files, add their extension to the ALLOWED_TEXT_EXTENSIONS list in" +
+          " BinaryFileCheck.kt. If they are legitimate binary files, add their full path to" +
+          " scripts/assets/binary_file_exemptions.textproto."
+      )
+      println()
+    }
+
+    if (binaryFiles.isNotEmpty()) {
+      println(
+        "========== Files with binary content: ${binaryFiles.size} =========="
+      )
+      binaryFiles.forEach { file ->
+        println("- ${file.toRelativeString(repoRoot)}")
+      }
+      println()
+      println(
+        "These files have allowed text extensions but contain binary content." +
+          " If they are legitimate binary files, add their full path to" +
+          " scripts/assets/binary_file_exemptions.textproto."
+      )
+      println()
+    }
+
+    return missingExemptedFiles.isEmpty() &&
+      binaryFiles.isEmpty() &&
+      unknownExtensionFiles.isEmpty()
+  }
+
+  companion object {
+    /**
+     * Set of file extensions that are recognized as text files.
+     *
+     * Files with extensions not in this list are treated as binary (fail-safe). If a new text
+     * file type is added to the repository, its extension should be added here.
+     */
+    val ALLOWED_TEXT_EXTENSIONS = setOf(
+      // Kotlin/Java
+      "kt", "kts", "java",
+      // Build
+      "bazel", "bzl", "gradle", "bazelrc", "bazelproject", "bazelversion",
+      // Config/properties
+      "properties", "cfg", "conf", "ini",
+      // Markup/data
+      "xml", "json", "yaml", "yml",
+      // Proto
+      "proto", "textproto",
+      // Documentation
+      "md", "txt", "rst",
+      // Scripts/shell
+      "sh", "bat", "cmd",
+      // Web
+      "html", "css", "js", "ts",
+      // Python
+      "py",
+      // Version/ignore/config files
+      "gitignore", "gitattributes", "editorconfig",
+      // Certificate/key text formats
+      "pem", "crt",
+      // Android/proguard
+      "pro",
+      // Logs
+      "log",
+      // Other
+      "csv", "svg", "sql", "toml", "patch",
+    )
+
+    /**
+     * Checks whether a file contains binary content by inspecting its bytes.
+     *
+     * A file is considered binary if any of its characters are outside the set of:
+     * - ASCII printable characters (0x20–0x7E)
+     * - Common whitespace: tab (0x09), newline (0x0A), carriage return (0x0D)
+     * - Unicode letters ([Char.isLetter])
+     * - Unicode digits ([Char.isDigit])
+     *
+     * @param file the file to check
+     * @return true if the file contains binary content, false otherwise
+     */
+    fun containsBinaryContent(file: File): Boolean {
+      // Empty files are not binary.
+      if (file.length() == 0L) return false
+
+      return file.bufferedReader(Charsets.UTF_8).use { reader ->
+        val buffer = CharArray(8192)
+        var charsRead: Int
+        while (reader.read(buffer).also { charsRead = it } != -1) {
+          for (i in 0 until charsRead) {
+            if (!isValidTextCharacter(buffer[i])) {
+              return@use true
+            }
+          }
+        }
+        false
+      }
+    }
+
+    private fun isValidTextCharacter(char: Char): Boolean {
+      return when {
+        char == '\t' || char == '\n' || char == '\r' -> true // Common whitespace
+        char.code in 0x20..0x7E -> true // ASCII printable
+        char.isWhitespace() -> true // Unicode whitespace (e.g., non-breaking space U+00A0)
+        char.isDefined() && !char.isISOControl() -> true // Any defined, non-control Unicode
+        else -> false
+      }
+    }
+  }
+}
+
+private fun loadBinaryFileExemptionsProto(
+  protoPath: String
+): BinaryFileExemptions {
+  val protoBinaryFile = File(protoPath)
+  val builder = BinaryFileExemptions.getDefaultInstance().newBuilderForType()
+  return FileInputStream(protoBinaryFile).use {
+    builder.mergeFrom(it)
+  }.build() as BinaryFileExemptions
+}

--- a/scripts/src/java/org/oppia/android/scripts/proto/script_exemptions.proto
+++ b/scripts/src/java/org/oppia/android/scripts/proto/script_exemptions.proto
@@ -111,3 +111,27 @@ message TodoOpenExemption {
   // The line number of the exempted TODO.
   repeated int32 line_number = 2;
 }
+
+// Exemptions for the binary file check. Exemptions indicate files that are expected to be binary
+// and should not be flagged by the binary file check. Each exemption uses the full relative
+// filepath from the repository root (not the file type/extension).
+message BinaryFileExemptions {
+  // List of all the binary file exemptions.
+  // Also, note that the file paths in the textproto file are maintained in lexicographical order.
+  // While adding any new file, please add it only at the correct lexicographical position, so that
+  // the list remains sorted.
+  //
+  // For example, to exempt an image file from the binary file check, add:
+  // ```
+  // binary_file_exemption {
+  //   exempted_file_path: "app/src/main/res/drawable/ic_logo.png"
+  // }
+  // ```
+  repeated BinaryFileExemption binary_file_exemption = 1;
+
+  // Represents an individual binary file exemption.
+  message BinaryFileExemption {
+    // The relative path to the file from the root directory.
+    string exempted_file_path = 1;
+  }
+}

--- a/scripts/src/java/org/oppia/android/scripts/proto/script_exemptions.proto
+++ b/scripts/src/java/org/oppia/android/scripts/proto/script_exemptions.proto
@@ -117,16 +117,6 @@ message TodoOpenExemption {
 // filepath from the repository root (not the file type/extension).
 message BinaryFileExemptions {
   // List of all the binary file exemptions.
-  // Also, note that the file paths in the textproto file are maintained in lexicographical order.
-  // While adding any new file, please add it only at the correct lexicographical position, so that
-  // the list remains sorted.
-  //
-  // For example, to exempt an image file from the binary file check, add:
-  // ```
-  // binary_file_exemption {
-  //   exempted_file_path: "app/src/main/res/drawable/ic_logo.png"
-  // }
-  // ```
   repeated BinaryFileExemption binary_file_exemption = 1;
 
   // Represents an individual binary file exemption.

--- a/scripts/src/javatests/org/oppia/android/scripts/binary/BUILD.bazel
+++ b/scripts/src/javatests/org/oppia/android/scripts/binary/BUILD.bazel
@@ -9,7 +9,6 @@ kt_jvm_test(
     name = "BinaryFileCheckTest",
     srcs = ["BinaryFileCheckTest.kt"],
     deps = [
-        "//scripts:binary_file_check_assets",
         "//scripts/src/java/org/oppia/android/scripts/binary:binary_file_check_lib",
         "//testing:assertion_helpers",
         "//third_party:com_google_truth_truth",

--- a/scripts/src/javatests/org/oppia/android/scripts/binary/BUILD.bazel
+++ b/scripts/src/javatests/org/oppia/android/scripts/binary/BUILD.bazel
@@ -1,0 +1,18 @@
+"""
+Tests corresponding to binary file checks, such as ensuring that no unexpected binary files
+are present in the repository.
+"""
+
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "BinaryFileCheckTest",
+    srcs = ["BinaryFileCheckTest.kt"],
+    deps = [
+        "//scripts:binary_file_check_assets",
+        "//scripts/src/java/org/oppia/android/scripts/binary:binary_file_check_lib",
+        "//testing:assertion_helpers",
+        "//third_party:com_google_truth_truth",
+        "//third_party:org_jetbrains_kotlin_kotlin-test-junit",
+    ],
+)

--- a/scripts/src/javatests/org/oppia/android/scripts/binary/BinaryFileCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/binary/BinaryFileCheckTest.kt
@@ -1,0 +1,267 @@
+package org.oppia.android.scripts.binary
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.oppia.android.scripts.proto.BinaryFileExemptions
+import org.oppia.android.scripts.proto.BinaryFileExemptions.BinaryFileExemption
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+
+/** Tests for [BinaryFileCheck]. */
+// Function name: test names are conventionally named with underscores.
+@Suppress("FunctionName")
+class BinaryFileCheckTest {
+  private val outContent: ByteArrayOutputStream = ByteArrayOutputStream()
+  private val originalOut: PrintStream = System.out
+
+  @field:[Rule JvmField] val tempFolder = TemporaryFolder()
+
+  private lateinit var repoDir: File
+
+  @Before
+  fun setUp() {
+    System.setOut(PrintStream(outContent))
+    repoDir = tempFolder.newFolder("repo")
+  }
+
+  @After
+  fun restoreStreams() {
+    System.setOut(originalOut)
+  }
+
+  @Test
+  fun testCheck_emptyDirectory_passes() {
+    val checkPassed = runScript()
+
+    assertThat(checkPassed).isTrue()
+  }
+
+  @Test
+  fun testCheck_textFileWithAllowedExtension_passes() {
+    createRepoFile("example.kt", "package org.oppia.android\nclass Example")
+
+    val checkPassed = runScript()
+
+    assertThat(checkPassed).isTrue()
+  }
+
+  @Test
+  fun testCheck_textprotoFile_passes() {
+    // This was the original false positive case from issue #5847.
+    createRepoFile(
+      "example.textproto",
+      """
+      test_file_exemption {
+        exempted_file_path: "app/src/main/java/Example.kt"
+        test_file_not_required: true
+      }
+      """.trimIndent()
+    )
+
+    val checkPassed = runScript()
+
+    assertThat(checkPassed).isTrue()
+  }
+
+  @Test
+  fun testCheck_jsonFile_passes() {
+    createRepoFile("config.json", """{"key": "value", "number": 42}""")
+
+    val checkPassed = runScript()
+
+    assertThat(checkPassed).isTrue()
+  }
+
+  @Test
+  fun testCheck_xmlFile_passes() {
+    createRepoFile(
+      "config.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+        <string name="app_name">Oppia</string>
+      </resources>
+      """.trimIndent()
+    )
+
+    val checkPassed = runScript()
+
+    assertThat(checkPassed).isTrue()
+  }
+
+  @Test
+  fun testCheck_markdownFile_passes() {
+    createRepoFile("README.md", "# Title\n\nSome documentation text.")
+
+    val checkPassed = runScript()
+
+    assertThat(checkPassed).isTrue()
+  }
+
+  @Test
+  fun testCheck_emptyFileWithAllowedExtension_passes() {
+    createRepoFile("empty.kt", "")
+
+    val checkPassed = runScript()
+
+    assertThat(checkPassed).isTrue()
+  }
+
+  @Test
+  fun testCheck_fileWithUnicodeLetters_passes() {
+    createRepoFile(
+      "unicode.kt",
+      "package org.oppia\n// Comment with Unicode: résumé naïve café"
+    )
+
+    val checkPassed = runScript()
+
+    assertThat(checkPassed).isTrue()
+  }
+
+  @Test
+  fun testCheck_fileWithUnicodeDigits_passes() {
+    createRepoFile("digits.txt", "Unicode digits: \u0661\u0662\u0663 \u0E51\u0E52\u0E53")
+
+    val checkPassed = runScript()
+
+    assertThat(checkPassed).isTrue()
+  }
+
+  @Test
+  fun testCheck_fileWithUnknownExtension_fails() {
+    createRepoFile("file.xyz", "some content")
+
+    val checkPassed = runScript()
+
+    assertThat(checkPassed).isFalse()
+    assertThat(outContent.toString()).contains("Files with unrecognized extensions: 1")
+    assertThat(outContent.toString()).contains("file.xyz (.xyz)")
+    assertThat(outContent.toString()).contains("add their extension to the ALLOWED_TEXT_EXTENSIONS")
+  }
+
+  @Test
+  fun testCheck_pngFileNotExempted_fails() {
+    createRepoFileBytes(
+      "icon.png",
+      byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+    )
+
+    val checkPassed = runScript()
+
+    assertThat(checkPassed).isFalse()
+    assertThat(outContent.toString()).contains("Files with unrecognized extensions: 1")
+    assertThat(outContent.toString()).contains("icon.png (.png)")
+  }
+
+  @Test
+  fun testCheck_fileWithNullBytes_fails() {
+    createRepoFileBytes("corrupt.kt", "package org.oppia\u0000binary content".toByteArray())
+
+    val checkPassed = runScript()
+
+    assertThat(checkPassed).isFalse()
+    assertThat(outContent.toString()).contains("Files with binary content: 1")
+    assertThat(outContent.toString()).contains("corrupt.kt")
+  }
+
+  @Test
+  fun testCheck_exemptedBinaryFileExists_passes() {
+    createRepoFileBytes(
+      "icon.png",
+      byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47)
+    )
+
+    val exemption = BinaryFileExemption.newBuilder().apply {
+      this.exemptedFilePath = "icon.png"
+    }.build()
+
+    val checkPassed = runScript(exemption)
+
+    assertThat(checkPassed).isTrue()
+  }
+
+  @Test
+  fun testCheck_exemptedFileDoesNotExist_fails() {
+    val exemption = BinaryFileExemption.newBuilder().apply {
+      this.exemptedFilePath = "nonexistent/file.png"
+    }.build()
+
+    val checkPassed = runScript(exemption)
+
+    assertThat(checkPassed).isFalse()
+    assertThat(outContent.toString()).contains("Stale binary file exemptions: 1")
+    assertThat(outContent.toString()).contains("nonexistent/file.png")
+    assertThat(outContent.toString()).contains("remove the stale entries")
+  }
+
+  @Test
+  fun testCheck_multipleTextFiles_allPass() {
+    createRepoFile("file.kt", "package org.oppia")
+    createRepoFile("file.java", "package org.oppia;")
+    createRepoFile("file.xml", "<root/>")
+    createRepoFile("file.json", "{}")
+    createRepoFile("file.textproto", "field: \"value\"")
+    createRepoFile("file.md", "# Title")
+    createRepoFile("file.sh", "#!/bin/bash")
+    createRepoFile("file.yaml", "key: value")
+    createRepoFile("file.proto", "syntax = \"proto3\";")
+    createRepoFile("file.bazel", "load()")
+    createRepoFile("file.txt", "plain text")
+
+    val checkPassed = runScript()
+
+    assertThat(checkPassed).isTrue()
+  }
+
+  @Test
+  fun testCheck_mixOfGoodAndBadFiles_reportsOnlyBadOnes() {
+    createRepoFile("good.kt", "package org.oppia")
+    createRepoFile("bad.xyz", "some content")
+    createRepoFileBytes("corrupt.kt", "package\u0000binary".toByteArray())
+
+    val checkPassed = runScript()
+
+    assertThat(checkPassed).isFalse()
+    assertThat(outContent.toString()).contains("Files with unrecognized extensions: 1")
+    assertThat(outContent.toString()).contains("bad.xyz")
+    assertThat(outContent.toString()).contains("Files with binary content: 1")
+    assertThat(outContent.toString()).contains("corrupt.kt")
+  }
+
+  /** Creates a text file in the repo directory. */
+  private fun createRepoFile(name: String, content: String): File {
+    val file = File(repoDir, name)
+    file.parentFile?.mkdirs()
+    file.writeText(content)
+    return file
+  }
+
+  /** Creates a file with raw bytes in the repo directory. */
+  private fun createRepoFileBytes(name: String, bytes: ByteArray): File {
+    val file = File(repoDir, name)
+    file.parentFile?.mkdirs()
+    file.writeBytes(bytes)
+    return file
+  }
+
+  private fun runScript(vararg exemptions: BinaryFileExemption): Boolean {
+    // Store the .pb file outside the repo directory so it doesn't get scanned.
+    val exemptionsFile = File(tempFolder.root, "binary_file_exemptions.pb")
+    val exemptionsProto = BinaryFileExemptions.newBuilder().apply {
+      addAllBinaryFileExemption(exemptions.toList())
+    }.build()
+    exemptionsProto.writeTo(exemptionsFile.outputStream())
+
+    val check = BinaryFileCheck(
+      repoPath = repoDir.absolutePath + "/",
+      binaryFileExemptionProtoPath = exemptionsFile.absolutePath
+    )
+    return check.execute()
+  }
+}

--- a/scripts/src/javatests/org/oppia/android/scripts/binary/BinaryFileCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/binary/BinaryFileCheckTest.kt
@@ -52,7 +52,6 @@ class BinaryFileCheckTest {
 
   @Test
   fun testCheck_textprotoFile_passes() {
-    // This was the original false positive case from issue #5847.
     createRepoFile(
       "example.textproto",
       """
@@ -140,9 +139,9 @@ class BinaryFileCheckTest {
     val checkPassed = runScript()
 
     assertThat(checkPassed).isFalse()
-    assertThat(outContent.toString()).contains("Files with unrecognized extensions: 1")
+    assertThat(outContent.toString()).contains("Binary files found: 1")
     assertThat(outContent.toString()).contains("file.xyz (.xyz)")
-    assertThat(outContent.toString()).contains("add their extension to the ALLOWED_TEXT_EXTENSIONS")
+    assertThat(outContent.toString()).contains("please add an exemption to")
   }
 
   @Test
@@ -155,7 +154,7 @@ class BinaryFileCheckTest {
     val checkPassed = runScript()
 
     assertThat(checkPassed).isFalse()
-    assertThat(outContent.toString()).contains("Files with unrecognized extensions: 1")
+    assertThat(outContent.toString()).contains("Binary files found: 1")
     assertThat(outContent.toString()).contains("icon.png (.png)")
   }
 
@@ -228,7 +227,7 @@ class BinaryFileCheckTest {
     val checkPassed = runScript()
 
     assertThat(checkPassed).isFalse()
-    assertThat(outContent.toString()).contains("Files with unrecognized extensions: 1")
+    assertThat(outContent.toString()).contains("Binary files found: 1")
     assertThat(outContent.toString()).contains("bad.xyz")
     assertThat(outContent.toString()).contains("Files with binary content: 1")
     assertThat(outContent.toString()).contains("corrupt.kt")


### PR DESCRIPTION
Fixes #5847

## Explanation

Fixes #5847: The existing binary file check in `pre-commit.sh` uses `file --mime | grep binary`, which produces false positives on text files like `.textproto`, `.json`, `.xml`, and `.md`. This PR replaces that unreliable shell-based check with a robust Kotlin script (`BinaryFileCheck.kt`) that uses a two-layer detection approach:

1. **Extension allowlist**: Files with known text extensions (`.kt`, `.java`, `.xml`, `.json`, `.textproto`, `.proto`, `.md`, `.sh`, `.bazel`, `.pro`, etc.) pass extension validation. Files with unknown extensions are flagged as binary (fail-safe).
2. **Content validation**: Files with allowed extensions are scanned for binary content by checking that all characters are valid text characters (printable ASCII, Unicode whitespace, or any defined non-control Unicode character).

A filepath-based exemption list (`binary_file_exemptions.textproto`) is used to allow legitimate binary files (e.g., PNG images, GPG keys). Stale exemptions (paths that no longer exist) cause the check to fail, keeping the list up to date.

**Changes to `scripts/assets`**: Added `binary_file_exemptions.textproto` containing the 20 existing legitimate binary files in the repository (PNG images in `drawable-nodpi/` and `mipmap-*/`, GPG key files in `.gitsecret/`, and the encrypted remote cache credentials config).

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only

Not applicable. This PR only modifies scripts, build configs, and CI workflows with no UI changes.