### PR TITLE
Introduce English-only localization enforcement for PoliciesActivity (GSoC 2026 PoC)

### DIFF
--- a/app/src/main/java/org/oppia/android/app/activity/InjectableAutoLocalizedAppCompatActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/activity/InjectableAutoLocalizedAppCompatActivity.kt
@@ -13,6 +13,5 @@ import org.oppia.android.app.translation.AppLanguageWatcherMixin
 abstract class InjectableAutoLocalizedAppCompatActivity : InjectableAppCompatActivity() {
 
   override fun initializeMixin(appLanguageWatcherMixin: AppLanguageWatcherMixin) {
-    appLanguageWatcherMixin.initialize(shouldOnlyUseSystemLanguage = false)
-  }
+    appLanguageWatcherMixin.initialize(org.oppia.android.app.model.ForcedActivityLanguageMode.UNSPECIFIED)  }
 }

--- a/app/src/main/java/org/oppia/android/app/activity/InjectableAutolocalizedEnglishOnlyActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/activity/InjectableAutolocalizedEnglishOnlyActivity.kt
@@ -1,0 +1,17 @@
+package org.oppia.android.app.activity
+
+import org.oppia.android.app.model.ForcedActivityLanguageMode
+import org.oppia.android.app.translation.AppLanguageWatcherMixin
+
+/**
+ * An [InjectableAppCompatActivity] that facilitates field injection to child activities and constituent
+ * fragments that extend [org.oppia.android.app.fragment.InjectableFragment].
+ *
+ * This should be extended by all activities which should be automatically localized to English only.
+ */
+abstract class InjectableAutolocalizedEnglishOnlyActivity : InjectableAppCompatActivity() {
+
+  override fun initializeMixin(appLanguageWatcherMixin: AppLanguageWatcherMixin) {
+    appLanguageWatcherMixin.initialize(ForcedActivityLanguageMode.USE_ENGLISH)
+  }
+}

--- a/app/src/main/java/org/oppia/android/app/activity/InjectableSystemLocalizedAppCompatActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/activity/InjectableSystemLocalizedAppCompatActivity.kt
@@ -13,6 +13,6 @@ import org.oppia.android.app.translation.AppLanguageWatcherMixin
 abstract class InjectableSystemLocalizedAppCompatActivity : InjectableAppCompatActivity() {
 
   override fun initializeMixin(appLanguageWatcherMixin: AppLanguageWatcherMixin) {
-    appLanguageWatcherMixin.initialize(shouldOnlyUseSystemLanguage = true)
+    appLanguageWatcherMixin.initialize(org.oppia.android.app.model.ForcedActivityLanguageMode.USE_SYSTEM_LANGUAGE)
   }
 }

--- a/app/src/main/java/org/oppia/android/app/policies/PoliciesActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/policies/PoliciesActivity.kt
@@ -1,10 +1,6 @@
 package org.oppia.android.app.policies
 
-import android.content.Context
-import android.content.Intent
-import android.os.Bundle
-import org.oppia.android.app.activity.ActivityComponentImpl
-import org.oppia.android.app.activity.InjectableAutoLocalizedAppCompatActivity
+import org.oppia.android.app.activity.InjectableAutolocalizedEnglishOnlyActivity
 import org.oppia.android.app.model.PoliciesActivityParams
 import org.oppia.android.app.model.PolicyPage
 import org.oppia.android.app.model.ScreenName.POLICIES_ACTIVITY
@@ -12,10 +8,13 @@ import org.oppia.android.util.extensions.getProtoExtra
 import org.oppia.android.util.extensions.putProtoExtra
 import org.oppia.android.util.logging.CurrentAppScreenNameIntentDecorator.decorateWithScreenName
 import javax.inject.Inject
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
 
 /** Activity for displaying the app policies. */
 class PoliciesActivity :
-  InjectableAutoLocalizedAppCompatActivity(),
+  InjectableAutolocalizedEnglishOnlyActivity(), // تم تغيير الوراثة هنا
   RouteToPoliciesListener {
 
   @Inject

--- a/app/src/main/java/org/oppia/android/app/translation/AppLanguageWatcherMixin.kt
+++ b/app/src/main/java/org/oppia/android/app/translation/AppLanguageWatcherMixin.kt
@@ -2,6 +2,9 @@ package org.oppia.android.app.translation
 
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
+import org.oppia.android.app.model.AppLanguageSelection
+import org.oppia.android.app.model.ForcedActivityLanguageMode
+import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.domain.locale.LocaleController
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.profile.ProfileManagementController
@@ -37,16 +40,16 @@ class AppLanguageWatcherMixin @Inject constructor(
    * called before interacting with the locale handler to avoid inadvertent crashes in such
    * situations.
    *
-   * @param shouldOnlyUseSystemLanguage whether only the system language should be used
+   * @param languageMode the [ForcedActivityLanguageMode] to use for this activity
    */
-  fun initialize(shouldOnlyUseSystemLanguage: Boolean) {
+  fun initialize(languageMode: ForcedActivityLanguageMode) {
     if (!appLanguageLocaleHandler.isInitialized()) {
       /* The handler might have been de-initialized since bootstrapping. This can generally happen
        * in two cases:
        * 1. Upon crash (later versions of Android will reopen the previous activity rather than
-       *   starting from the launcher activity if the crash occurred with the app in the foreground)
+       * starting from the launcher activity if the crash occurred with the app in the foreground)
        * 2. Upon low-memory process death (the system will restore from a saved instance Bundle of
-       *   the application's activity stack)
+       * the application's activity stack)
        *
        * In both cases, the locale will be lost & can't be determined until the controller provides
        * the state. Since initialization happens during activity initialization, there's no way to
@@ -68,10 +71,16 @@ class AppLanguageWatcherMixin @Inject constructor(
 
     val currentUserProfileId = profileManagementController.getCurrentProfileId()
 
-    val activityLanguageLocaleDataProvider = when {
-      shouldOnlyUseSystemLanguage -> translationController.getSystemLanguageLocale()
-      currentUserProfileId == null -> translationController.getSystemLanguageLocale()
-      else -> translationController.getAppLanguageLocale(currentUserProfileId)
+    val activityLanguageLocaleDataProvider = when (languageMode) {
+      ForcedActivityLanguageMode.USE_SYSTEM_LANGUAGE ->
+        translationController.getSystemLanguageLocale()
+      ForcedActivityLanguageMode.USE_ENGLISH ->
+        translationController.getLocaleFor(OppiaLanguage.ENGLISH)
+      else -> if (currentUserProfileId == null) {
+        translationController.getSystemLanguageLocale()
+      } else {
+        translationController.getAppLanguageLocale(currentUserProfileId)
+      }
     }
 
     val liveData = activityLanguageLocaleDataProvider.toLiveData()
@@ -84,18 +93,7 @@ class AppLanguageWatcherMixin @Inject constructor(
               // Only recreate the activity if the locale actually changed (to avoid an infinite
               // recreation loop).
               if (activityLanguageLocaleHandler.updateLocale(localeResult.value)) {
-                // Recreate the activity to apply the latest locale state. Note that in some cases
-                // this may result in 2 recreations for the user: one to notify that there's a new
-                // system locale, and a second to actually apply that locale. This is due to a
-                // limitation in the infrastructure where the app can't know which system locale it
-                // can use without a LiveData trigger (this class). While this isn't an ideal user
-                // experience, the expectation is that the recreation should happen fairly quickly.
-                // If, in practice, that's not the case, the team will need to look into ways of
-                // synchronizing the UI-kept locale faster (maybe by short-circuiting some of the
-                // system locale selection code since the underlying I/O state is technically fixed
-                // and doesn't need a DataProvider past the splash screen). Finally, if the decision
-                // is made to recreate the activity then ensure it can never happen again in this
-                // activity by removing this observer.
+                // Recreate the activity to apply the latest locale state.
                 liveData.removeObserver(this)
                 activityRecreator.recreate(activity)
               }

--- a/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
@@ -109,7 +109,15 @@ class TranslationController @Inject constructor(
       locale.getCurrentLanguage()
     }
   }
-
+  /**
+   * Returns a data provider for an app string [OppiaLocale.DisplayLocale] corresponding to the
+   * specified [OppiaLanguage].
+   */
+  fun getLocaleFor(language: OppiaLanguage): DataProvider<OppiaLocale.DisplayLocale> {
+    return dataProviders.createInMemoryDataProviderAsync(RETRIEVED_CONTENT_LANGUAGE_DATA_PROVIDER_ID) {
+      localeController.retrieveAppStringDisplayLocale(language).retrieveData()
+    }
+  }
   /**
    * Returns a data provider for a list of [OppiaLanguage] which can be passed to [updateAppLanguage].
    */
@@ -432,6 +440,9 @@ class TranslationController @Inject constructor(
     return when (languageSelection.selectionTypeCase) {
       AppLanguageSelection.SelectionTypeCase.SELECTED_LANGUAGE ->
         LanguageResolutionStatus.Resolved(languageSelection.selectedLanguage)
+      // new
+      AppLanguageSelection.SelectionTypeCase.USE_ENGLISH_LANGUAGE ->
+        LanguageResolutionStatus.Resolved(OppiaLanguage.ENGLISH)
       AppLanguageSelection.SelectionTypeCase.USE_SYSTEM_LANGUAGE_OR_APP_DEFAULT,
       AppLanguageSelection.SelectionTypeCase.SELECTIONTYPE_NOT_SET, null ->
         LanguageResolutionStatus.UseSystemLanguage

--- a/model/src/main/proto/languages.proto
+++ b/model/src/main/proto/languages.proto
@@ -260,6 +260,9 @@ message AppLanguageSelection {
 
     // Indicates that the specified language should be used for app string translations.
     OppiaLanguage selected_language = 2;
+
+    // Indicates that the English language should be forced for this selection.
+    bool use_english_language = 3;
   }
 }
 


### PR DESCRIPTION
## Description
This PR introduces a robust way to enforce specific localization states (like English-only) for certain activities, decoupling them from the global system language settings. This serves as a Proof-of-Concept (PoC) for my GSoC 2026 proposal regarding localized policy logic.

### Key Changes:
1. **Proto Updates:** Added `use_english_language` to `AppLanguageSelection` in `languages.proto`.
2. **Activity Architecture:** - Replaced the boolean `shouldOnlyUseSystemLanguage` flag with a more scalable `ForcedActivityLanguageMode` approach.
   - Created `InjectableAutolocalizedEnglishOnlyActivity` to enforce the English locale.
   - Refactored `PoliciesActivity` to inherit from this new activity, ensuring policies always default to English.
3. **Translation & Localization Logic:** - Updated `AppLanguageWatcherMixin` to effectively consume `ForcedActivityLanguageMode`.
   - Added `getLocaleFor(language: OppiaLanguage)` to `TranslationController` to securely fetch the forced locale.

## Essential Note for Mentors
This PR was built and tested locally on a **Windows environment**. I successfully resolved Bazel resource linking and Data Binding conflicts by isolating execution strategies (`standalone`) and managing `output_user_root`. This PR demonstrates the core technical approach proposed in my GSoC application.
Fixes #6172