### PR TITLE
Fix #6176: Add replay indicator for newly played lessons

### DIFF
--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
@@ -89,7 +89,8 @@ class ExplorationDataController @Inject constructor(
       explorationId,
       shouldSavePartialProgress = true,
       explorationCheckpoint = ExplorationCheckpoint.getDefaultInstance(),
-      isRestart = false
+      isRestart = false,
+      isReplay = false
     )
   }
 
@@ -121,7 +122,8 @@ class ExplorationDataController @Inject constructor(
       explorationId,
       shouldSavePartialProgress = true,
       explorationCheckpoint,
-      isRestart = false
+      isRestart = false,
+      isReplay = false
     )
   }
 
@@ -151,7 +153,8 @@ class ExplorationDataController @Inject constructor(
       explorationId,
       shouldSavePartialProgress = true, // Implied since only checkpoints can be restarted.
       explorationCheckpoint = ExplorationCheckpoint.getDefaultInstance(),
-      isRestart = true
+      isRestart = true,
+      isReplay = false
     )
   }
 
@@ -184,7 +187,8 @@ class ExplorationDataController @Inject constructor(
       explorationId,
       shouldSavePartialProgress = false, // Finished lessons can't be partially saved.
       explorationCheckpoint = ExplorationCheckpoint.getDefaultInstance(),
-      isRestart = false
+      isRestart = false,
+      isReplay = true
     )
   }
 
@@ -223,7 +227,8 @@ class ExplorationDataController @Inject constructor(
     explorationId: String,
     shouldSavePartialProgress: Boolean,
     explorationCheckpoint: ExplorationCheckpoint,
-    isRestart: Boolean
+    isRestart: Boolean,
+    isReplay: Boolean
   ): DataProvider<Any?> {
     return explorationProgressController.beginExplorationAsync(
       LegacyProfileId.newBuilder().apply { internalId = internalProfileId }.build(),
@@ -233,7 +238,8 @@ class ExplorationDataController @Inject constructor(
       explorationId,
       shouldSavePartialProgress,
       explorationCheckpoint,
-      isRestart
+      isRestart,
+      isReplay
     )
   }
 

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
@@ -216,6 +216,7 @@ class ExplorationDataController @Inject constructor(
    * @param isRestart whether starting this exploration is erasing a previous checkpoint. In cases
    *     where this is ``true``, [explorationCheckpoint] is expected to be the default proto
    *     instance.
+   * @param isReplay whether the user is replaying this lesson after having previously completed it
    * @return a [DataProvider] to observe whether initiating the play request, or future play
    *     requests, succeeded
    */

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
@@ -166,7 +166,8 @@ class ExplorationProgressController @Inject constructor(
     explorationId: String,
     shouldSavePartialProgress: Boolean,
     explorationCheckpoint: ExplorationCheckpoint,
-    isRestart: Boolean
+    isRestart: Boolean,
+    isReplay: Boolean
   ): DataProvider<Any?> {
     val ephemeralStateFlow = createAsyncResultStateFlow<EphemeralState>()
     val sessionId = UUID.randomUUID().toString().also {
@@ -185,6 +186,7 @@ class ExplorationProgressController @Inject constructor(
         shouldSavePartialProgress,
         explorationCheckpoint,
         isRestart,
+        isReplay,
         ephemeralStateFlow,
         sessionId,
         beginExplorationResultFlow
@@ -511,6 +513,7 @@ class ExplorationProgressController @Inject constructor(
                 ControllerState(
                   ExplorationProgress(),
                   message.isRestart,
+                  message.isReplay,
                   // The [message.explorationCheckpoint] is [ExplorationCheckpoint.getDefaultInstance()]
                   // in the following 3 cases.
                   //  - New exploration is started.
@@ -1346,6 +1349,7 @@ class ExplorationProgressController @Inject constructor(
   private class ControllerState(
     val explorationProgress: ExplorationProgress,
     val isRestart: Boolean,
+    val isReplay: Boolean,
     val isResume: Boolean,
     val sessionId: String,
     val ephemeralStateFlow: MutableStateFlow<AsyncResult<EphemeralState>>,
@@ -1395,7 +1399,8 @@ class ExplorationProgressController @Inject constructor(
         exploration,
         explorationProgress.currentClassroomId,
         explorationProgress.currentTopicId,
-        explorationProgress.currentStoryId
+        explorationProgress.currentStoryId,
+        isReplay
       )
       availableCardCount = explorationProgress.stateDeck.getViewedStateCount()
     }
@@ -1510,6 +1515,7 @@ class ExplorationProgressController @Inject constructor(
       val shouldSavePartialProgress: Boolean,
       val explorationCheckpoint: ExplorationCheckpoint,
       val isRestart: Boolean,
+      val isReplay: Boolean,
       val ephemeralStateFlow: MutableStateFlow<AsyncResult<EphemeralState>>,
       override val sessionId: String,
       override val callbackFlow: MutableStateFlow<AsyncResult<Any?>>

--- a/domain/src/main/java/org/oppia/android/domain/oppialogger/analytics/LearnerAnalyticsLogger.kt
+++ b/domain/src/main/java/org/oppia/android/domain/oppialogger/analytics/LearnerAnalyticsLogger.kt
@@ -70,6 +70,7 @@ class LearnerAnalyticsLogger @Inject constructor(
    * @param exploration the [Exploration] for which a play session is starting
    * @param topicId the ID of the topic to which the story indicated by [storyId] belongs
    * @param storyId the ID of the story to which [exploration] belongs
+   * @param isReplay whether the exploration is being replayed
    */
   fun beginExploration(
     installationId: String?,
@@ -78,7 +79,8 @@ class LearnerAnalyticsLogger @Inject constructor(
     exploration: Exploration,
     classroomId: String,
     topicId: String,
-    storyId: String
+    storyId: String,
+    isReplay: Boolean
   ): ExplorationAnalyticsLogger {
     return ExplorationAnalyticsLogger(
       installationId,
@@ -89,6 +91,7 @@ class LearnerAnalyticsLogger @Inject constructor(
       storyId,
       exploration.id,
       exploration.version,
+      isReplay,
       oppiaLogger,
       analyticsController,
       loggingIdentifierController
@@ -193,6 +196,7 @@ class LearnerAnalyticsLogger @Inject constructor(
     storyId: String,
     explorationId: String,
     explorationVersion: Int,
+    isReplay: Boolean,
     private val oppiaLogger: OppiaLogger,
     private val analyticsController: AnalyticsController,
     private val loggingIdentifierController: LoggingIdentifierController
@@ -222,6 +226,7 @@ class LearnerAnalyticsLogger @Inject constructor(
           this.storyId = storyId
           this.explorationVersion = explorationVersion
           this.learnerDetails = learnerDetails
+          this.isReplay = isReplay
         }.build()
       }?.ensureNonEmpty()
     }

--- a/domain/src/test/java/org/oppia/android/domain/exploration/BUILD.bazel
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/BUILD.bazel
@@ -32,6 +32,7 @@ oppia_android_test(
         "//domain/src/main/java/org/oppia/android/domain/oppialogger/analytics:prod_module",
         "//testing",
         "//testing/src/main/java/org/oppia/android/testing/data:data_provider_test_monitor",
+        "//testing/src/main/java/org/oppia/android/testing/logging:event_log_subject",
         "//testing/src/main/java/org/oppia/android/testing/platformparameter:test_module",
         "//testing/src/main/java/org/oppia/android/testing/robolectric:test_module",
         "//testing/src/main/java/org/oppia/android/testing/threading:test_module",

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationDataControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationDataControllerTest.kt
@@ -49,10 +49,12 @@ import org.oppia.android.domain.topic.TEST_STORY_ID_0
 import org.oppia.android.domain.topic.TEST_STORY_ID_2
 import org.oppia.android.domain.topic.TEST_TOPIC_ID_0
 import org.oppia.android.domain.topic.TEST_TOPIC_ID_1
+import org.oppia.android.testing.FakeAnalyticsEventLogger
 import org.oppia.android.testing.FakeExceptionLogger
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.data.DataProviderTestMonitor
 import org.oppia.android.testing.firebase.TestAuthenticationModule
+import org.oppia.android.testing.logging.EventLogSubject.Companion.assertThat
 import org.oppia.android.testing.platformparameter.TestPlatformParameterModule
 import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestCoroutineDispatchers
@@ -84,6 +86,7 @@ import javax.inject.Singleton
 class ExplorationDataControllerTest {
   @Inject lateinit var explorationDataController: ExplorationDataController
   @Inject lateinit var fakeExceptionLogger: FakeExceptionLogger
+  @Inject lateinit var fakeAnalyticsEventLogger: FakeAnalyticsEventLogger
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
   @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
   @Inject lateinit var explorationCheckpointController: ExplorationCheckpointController
@@ -195,6 +198,56 @@ class ExplorationDataControllerTest {
       )
 
     monitorFactory.waitForNextSuccessfulResult(startProvider)
+  }
+
+  @Test
+  fun testStartPlayingNewExploration_logsStartExplorationEvent() {
+    startPlayingNewExploration(
+      TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, TEST_EXPLORATION_ID_2
+    )
+
+    // The first events should be starting a card then the exploration (it's out of order).
+    val events = fakeAnalyticsEventLogger.getOldestEvents(2)
+    assertThat(events).hasSize(2)
+    assertThat(events[1]).hasStartExplorationContextThat { hasIsReplayThat().isFalse() }
+  }
+
+  @Test
+  fun testReplayExploration_logsStartExplorationEventWithIsReplayTrue() {
+    replayExploration(TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, TEST_EXPLORATION_ID_2)
+
+    // The first events should be starting a card then the exploration (it's out of order).
+    val events = fakeAnalyticsEventLogger.getOldestEvents(2)
+    assertThat(events).hasSize(2)
+    assertThat(events[1]).hasStartExplorationContextThat { hasIsReplayThat().isTrue() }
+  }
+
+  @Test
+  fun testResumeExploration_logsResumeExplorationEvent() {
+    startPlayingNewExploration(
+      TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, TEST_EXPLORATION_ID_2
+    )
+    stopExploration(isCompletion = false)
+    fakeAnalyticsEventLogger.clearAllEvents()
+
+    resumeExploration(TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, TEST_EXPLORATION_ID_2)
+
+    val event = fakeAnalyticsEventLogger.getOldestEvent()
+    assertThat(event).hasResumeExplorationContext()
+  }
+
+  @Test
+  fun testRestartExploration_logsStartOverExplorationEvent() {
+    startPlayingNewExploration(
+      TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, TEST_EXPLORATION_ID_2
+    )
+    stopExploration(isCompletion = false)
+    fakeAnalyticsEventLogger.clearAllEvents()
+
+    restartExploration(TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, TEST_EXPLORATION_ID_2)
+
+    val event = fakeAnalyticsEventLogger.getOldestEvent()
+    assertThat(event).hasStartOverExplorationContext()
   }
 
   @Test
@@ -427,6 +480,20 @@ class ExplorationDataControllerTest {
   private fun stopExploration(isCompletion: Boolean = true) {
     val stopProvider = explorationDataController.stopPlayingExploration(isCompletion)
     monitorFactory.waitForNextSuccessfulResult(stopProvider)
+  }
+
+  private fun resumeExploration(
+    classroomId: String,
+    topicId: String,
+    storyId: String,
+    explorationId: String
+  ) {
+    val checkpoint = retrieveExplorationCheckpoint(explorationId)
+    val resumeProvider =
+      explorationDataController.resumeExploration(
+        profileId.internalId, classroomId, topicId, storyId, explorationId, checkpoint
+      )
+    monitorFactory.waitForNextSuccessfulResult(resumeProvider)
   }
 
   // TODO(#89): Move this to a common test application component.

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationDataControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationDataControllerTest.kt
@@ -206,7 +206,10 @@ class ExplorationDataControllerTest {
       TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, TEST_EXPLORATION_ID_2
     )
 
-    // The first events should be starting a card then the exploration (it's out of order).
+    // Starting an exploration will log a bunch of analytics events, but the order is a bit specific
+    // in that the event for starting a specific card is actually logged before the exploration
+    // event. This doesn't necessarily have a significant impact on analytics but it does cause a
+    // bit of ordering quirkiness in tests. See next test as well.
     val events = fakeAnalyticsEventLogger.getOldestEvents(2)
     assertThat(events).hasSize(2)
     assertThat(events[1]).hasStartExplorationContextThat().hasIsReplayThat().isFalse()
@@ -216,7 +219,8 @@ class ExplorationDataControllerTest {
   fun testReplayExploration_logsStartExplorationEventWithIsReplayTrue() {
     replayExploration(TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, TEST_EXPLORATION_ID_2)
 
-    // The first events should be starting a card then the exploration (it's out of order).
+    // The second event is the exploration start event due to some out-of-order event logging. See
+    // the previous test for a longer explanation as to why this is the case.
     val events = fakeAnalyticsEventLogger.getOldestEvents(2)
     assertThat(events).hasSize(2)
     assertThat(events[1]).hasStartExplorationContextThat().hasIsReplayThat().isTrue()

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationDataControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationDataControllerTest.kt
@@ -209,7 +209,7 @@ class ExplorationDataControllerTest {
     // The first events should be starting a card then the exploration (it's out of order).
     val events = fakeAnalyticsEventLogger.getOldestEvents(2)
     assertThat(events).hasSize(2)
-    assertThat(events[1]).hasStartExplorationContextThat { hasIsReplayThat().isFalse() }
+    assertThat(events[1]).hasStartExplorationContextThat().hasIsReplayThat().isFalse()
   }
 
   @Test
@@ -219,7 +219,7 @@ class ExplorationDataControllerTest {
     // The first events should be starting a card then the exploration (it's out of order).
     val events = fakeAnalyticsEventLogger.getOldestEvents(2)
     assertThat(events).hasSize(2)
-    assertThat(events[1]).hasStartExplorationContextThat { hasIsReplayThat().isTrue() }
+    assertThat(events[1]).hasStartExplorationContextThat().hasIsReplayThat().isTrue()
   }
 
   @Test

--- a/domain/src/test/java/org/oppia/android/domain/oppialogger/analytics/LearnerAnalyticsLoggerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/oppialogger/analytics/LearnerAnalyticsLoggerTest.kt
@@ -654,6 +654,35 @@ class LearnerAnalyticsLoggerTest {
       hasSessionIdThat().isEqualTo(DEFAULT_INITIAL_SESSION_ID)
       hasVersionThat().isEqualTo(5)
       hasStateNameThat().isEqualTo(TEST_EXP_5_STATE_THREE_NAME)
+      hasIsReplayThat().isFalse()
+      hasLearnerDetailsThat {
+        hasLearnerIdThat().isEqualTo(TEST_LEARNER_ID)
+        hasInstallationIdThat().isEqualTo(TEST_INSTALL_ID)
+      }
+    }
+  }
+
+  @Test
+  fun testExpLogger_logStartExploration_forReplayedExploration_logsEventWithIsReplay() {
+    val exploration5 = loadExploration(TEST_EXPLORATION_ID_5)
+    val expLogger = learnerAnalyticsLogger.beginExploration(exploration5, isReplay = true)
+    expLogger.startCard(exploration5.getStateByName(TEST_EXP_5_STATE_THREE_NAME))
+    testCoroutineDispatchers.runCurrent()
+
+    expLogger.logStartExploration()
+    testCoroutineDispatchers.runCurrent()
+
+    val eventLog = fakeAnalyticsEventLogger.getMostRecentEvent()
+    assertThat(eventLog).isEssentialPriority()
+    assertThat(eventLog).hasStartExplorationContextThat {
+      hasClassroomIdThat().isEqualTo(TEST_CLASSROOM_ID)
+      hasTopicIdThat().isEqualTo(TEST_TOPIC_ID)
+      hasStoryIdThat().isEqualTo(TEST_STORY_ID)
+      hasExplorationIdThat().isEqualTo(TEST_EXPLORATION_ID_5)
+      hasSessionIdThat().isEqualTo(DEFAULT_INITIAL_SESSION_ID)
+      hasVersionThat().isEqualTo(5)
+      hasStateNameThat().isEqualTo(TEST_EXP_5_STATE_THREE_NAME)
+      hasIsReplayThat().isTrue()
       hasLearnerDetailsThat {
         hasLearnerIdThat().isEqualTo(TEST_LEARNER_ID)
         hasInstallationIdThat().isEqualTo(TEST_INSTALL_ID)
@@ -2296,9 +2325,10 @@ class LearnerAnalyticsLoggerTest {
     learnerId: String? = TEST_LEARNER_ID,
     classroomId: String = TEST_CLASSROOM_ID,
     topicId: String = TEST_TOPIC_ID,
-    storyId: String = TEST_STORY_ID
+    storyId: String = TEST_STORY_ID,
+    isReplay: Boolean = false
   ) = beginExploration(
-    installationId, profileId, learnerId, exploration, classroomId, topicId, storyId
+    installationId, profileId, learnerId, exploration, classroomId, topicId, storyId, isReplay
   )
 
   private fun List<ShadowLog.LogItem>.getMostRecentWithTag(tag: String) = last { it.tag == tag }

--- a/model/src/main/proto/oppia_logger.proto
+++ b/model/src/main/proto/oppia_logger.proto
@@ -396,6 +396,9 @@ message EventLog {
 
     // Defined attributes that are common among all learner analytics related event log contexts.
     LearnerDetailsContext learner_details = 7;
+
+    // Indicates whether the exploration is currently being replayed by a user who has previously completed it.
+    bool is_replay = 10;
   }
 
   // Represents the event context for switching a lesson's content language mid-lesson. Note that

--- a/testing/src/main/java/org/oppia/android/testing/logging/EventLogSubject.kt
+++ b/testing/src/main/java/org/oppia/android/testing/logging/EventLogSubject.kt
@@ -1738,6 +1738,9 @@ class EventLogSubject private constructor(
      */
     fun hasVersionThat(): IntegerSubject = assertThat(actual.explorationVersion)
 
+    /** Returns a [BooleanSubject] to test [EventLog.ExplorationContext.getIsReplay]. */
+    fun hasIsReplayThat(): BooleanSubject = assertThat(actual.isReplay)
+
     /**
      * Returns a [StringSubject] to test [EventLog.ExplorationContext.getStateName].
      *

--- a/testing/src/test/java/org/oppia/android/testing/logging/EventLogSubjectTest.kt
+++ b/testing/src/test/java/org/oppia/android/testing/logging/EventLogSubjectTest.kt
@@ -4523,6 +4523,17 @@ class EventLogSubjectTest {
   }
 
   @Test
+  fun testExplorationContextSubject_hasIsReplayThat_passes() {
+    val context = ExplorationContext.newBuilder()
+      .setIsReplay(true)
+      .build()
+
+    ExplorationContextSubject.assertThat(context)
+      .hasIsReplayThat()
+      .isTrue()
+  }
+
+  @Test
   fun testExplorationContextSubject_hasStateNameThat_passes() {
     val context = ExplorationContext.newBuilder()
       .setStateName("Introduction")
@@ -4534,7 +4545,7 @@ class EventLogSubjectTest {
   }
 
   @Test
-  fun testExplorationContextSubject_hasLearnerDetailsThat__executesBlockWithCorrectSubject() {
+  fun testExplorationContextSubject_hasLearnerDetailsThat_executesBlockWithCorrectSubject() {
     val learnerDetails = LearnerDetailsContext.newBuilder()
       .setLearnerId("learner_001")
       .build()

--- a/utility/src/main/java/org/oppia/android/util/logging/EventBundleCreator.kt
+++ b/utility/src/main/java/org/oppia/android/util/logging/EventBundleCreator.kt
@@ -455,6 +455,7 @@ class EventBundleCreator @Inject constructor(
         store.putNonSensitiveValue("session_id", sessionId)
         store.putNonSensitiveValue("exploration_version", explorationVersion.toString())
         store.putNonSensitiveValue("state_name", stateName)
+        store.putNonSensitiveValue("is_replay", isReplay.toString())
         store.putProperties("learner_details", learnerDetails, ::LearnerDetailsContext)
       }
     }

--- a/utility/src/main/java/org/oppia/android/util/logging/EventTypeToHumanReadableNameConverter.kt
+++ b/utility/src/main/java/org/oppia/android/util/logging/EventTypeToHumanReadableNameConverter.kt
@@ -52,7 +52,7 @@ class EventTypeToHumanReadableNameConverter @Inject constructor() {
       ActivityContextCase.PAUSE_VOICE_OVER_CONTEXT -> "click_pause_voiceover_button"
       ActivityContextCase.APP_IN_BACKGROUND_CONTEXT -> "send_app_to_background"
       ActivityContextCase.APP_IN_FOREGROUND_CONTEXT -> "bring_app_to_foreground"
-      ActivityContextCase.START_EXPLORATION_CONTEXT -> "start_exploration_context"
+      ActivityContextCase.START_EXPLORATION_CONTEXT -> "start_exploration"
       ActivityContextCase.EXIT_EXPLORATION_CONTEXT -> "leave_exploration"
       ActivityContextCase.FINISH_EXPLORATION_CONTEXT -> "complete_exploration"
       ActivityContextCase.PROGRESS_SAVING_SUCCESS_CONTEXT -> "progress_saving_success"

--- a/utility/src/test/java/org/oppia/android/util/logging/EventBundleCreatorTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/logging/EventBundleCreatorTest.kt
@@ -50,6 +50,7 @@ import org.oppia.android.app.model.EventLog.Context.ActivityContextCase.REVEAL_H
 import org.oppia.android.app.model.EventLog.Context.ActivityContextCase.REVEAL_SOLUTION_CONTEXT
 import org.oppia.android.app.model.EventLog.Context.ActivityContextCase.SOLUTION_UNLOCKED_CONTEXT
 import org.oppia.android.app.model.EventLog.Context.ActivityContextCase.START_CARD_CONTEXT
+import org.oppia.android.app.model.EventLog.Context.ActivityContextCase.START_EXPLORATION_CONTEXT
 import org.oppia.android.app.model.EventLog.Context.ActivityContextCase.START_OVER_EXPLORATION_CONTEXT
 import org.oppia.android.app.model.EventLog.Context.ActivityContextCase.SUBMIT_ANSWER_CONTEXT
 import org.oppia.android.app.model.EventLog.Context.ActivityContextCase.SWITCH_IN_LESSON_LANGUAGE
@@ -574,7 +575,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("open_exploration_player_screen")
-    assertThat(bundle).hasSize(18)
+    assertThat(bundle).hasSize(19)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(OPEN_EXPLORATION_ACTIVITY.number)
@@ -585,6 +586,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
     assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
@@ -599,7 +601,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("open_exploration_player_screen")
-    assertThat(bundle).hasSize(20)
+    assertThat(bundle).hasSize(21)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(OPEN_EXPLORATION_ACTIVITY.number)
@@ -610,6 +612,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
     assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
@@ -988,7 +991,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("start_exploration_card")
-    assertThat(bundle).hasSize(19)
+    assertThat(bundle).hasSize(20)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(START_CARD_CONTEXT.number)
@@ -999,6 +1002,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1014,7 +1018,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("start_exploration_card")
-    assertThat(bundle).hasSize(21)
+    assertThat(bundle).hasSize(22)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(START_CARD_CONTEXT.number)
@@ -1025,6 +1029,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1042,7 +1047,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("end_exploration_card")
-    assertThat(bundle).hasSize(19)
+    assertThat(bundle).hasSize(20)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(END_CARD_CONTEXT.number)
@@ -1053,6 +1058,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1068,7 +1074,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("end_exploration_card")
-    assertThat(bundle).hasSize(21)
+    assertThat(bundle).hasSize(22)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(END_CARD_CONTEXT.number)
@@ -1079,6 +1085,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1096,7 +1103,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("unlock_hint")
-    assertThat(bundle).hasSize(19)
+    assertThat(bundle).hasSize(20)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(HINT_UNLOCKED_CONTEXT.number)
@@ -1107,6 +1114,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1122,7 +1130,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("unlock_hint")
-    assertThat(bundle).hasSize(21)
+    assertThat(bundle).hasSize(22)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(HINT_UNLOCKED_CONTEXT.number)
@@ -1133,6 +1141,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1150,7 +1159,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("reveal_hint")
-    assertThat(bundle).hasSize(19)
+    assertThat(bundle).hasSize(20)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(REVEAL_HINT_CONTEXT.number)
@@ -1161,6 +1170,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1176,7 +1186,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("reveal_hint")
-    assertThat(bundle).hasSize(21)
+    assertThat(bundle).hasSize(22)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(REVEAL_HINT_CONTEXT.number)
@@ -1186,6 +1196,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1203,7 +1214,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("view_existing_hint")
-    assertThat(bundle).hasSize(19)
+    assertThat(bundle).hasSize(20)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(VIEW_EXISTING_HINT_CONTEXT.number)
@@ -1214,6 +1225,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1229,7 +1241,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("view_existing_hint")
-    assertThat(bundle).hasSize(21)
+    assertThat(bundle).hasSize(22)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(VIEW_EXISTING_HINT_CONTEXT.number)
@@ -1240,6 +1252,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1257,7 +1270,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("unlock_solution")
-    assertThat(bundle).hasSize(18)
+    assertThat(bundle).hasSize(19)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(SOLUTION_UNLOCKED_CONTEXT.number)
@@ -1268,6 +1281,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
     assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
@@ -1282,7 +1296,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("unlock_solution")
-    assertThat(bundle).hasSize(20)
+    assertThat(bundle).hasSize(21)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(SOLUTION_UNLOCKED_CONTEXT.number)
@@ -1293,6 +1307,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
     assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
@@ -1309,7 +1324,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("reveal_solution")
-    assertThat(bundle).hasSize(18)
+    assertThat(bundle).hasSize(19)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(REVEAL_SOLUTION_CONTEXT.number)
@@ -1320,6 +1335,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
     assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
@@ -1334,7 +1350,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("reveal_solution")
-    assertThat(bundle).hasSize(20)
+    assertThat(bundle).hasSize(21)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(REVEAL_SOLUTION_CONTEXT.number)
@@ -1344,6 +1360,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
     assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
@@ -1360,7 +1377,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("view_existing_solution")
-    assertThat(bundle).hasSize(18)
+    assertThat(bundle).hasSize(19)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(VIEW_EXISTING_SOLUTION_CONTEXT.number)
@@ -1371,6 +1388,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
     assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
@@ -1385,7 +1403,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("view_existing_solution")
-    assertThat(bundle).hasSize(20)
+    assertThat(bundle).hasSize(21)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(VIEW_EXISTING_SOLUTION_CONTEXT.number)
@@ -1396,6 +1414,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
     assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
@@ -1412,7 +1431,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("submit_answer")
-    assertThat(bundle).hasSize(20)
+    assertThat(bundle).hasSize(21)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(SUBMIT_ANSWER_CONTEXT.number)
@@ -1423,6 +1442,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1439,7 +1459,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("submit_answer")
-    assertThat(bundle).hasSize(22)
+    assertThat(bundle).hasSize(23)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(SUBMIT_ANSWER_CONTEXT.number)
@@ -1450,6 +1470,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1468,7 +1489,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("click_play_voiceover_button")
-    assertThat(bundle).hasSize(20)
+    assertThat(bundle).hasSize(21)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(PLAY_VOICE_OVER_CONTEXT.number)
@@ -1479,6 +1500,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1495,7 +1517,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("click_play_voiceover_button")
-    assertThat(bundle).hasSize(22)
+    assertThat(bundle).hasSize(23)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(PLAY_VOICE_OVER_CONTEXT.number)
@@ -1506,6 +1528,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1524,7 +1547,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("click_pause_voiceover_button")
-    assertThat(bundle).hasSize(20)
+    assertThat(bundle).hasSize(21)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(PAUSE_VOICE_OVER_CONTEXT.number)
@@ -1535,6 +1558,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1551,7 +1575,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("click_pause_voiceover_button")
-    assertThat(bundle).hasSize(22)
+    assertThat(bundle).hasSize(23)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(PAUSE_VOICE_OVER_CONTEXT.number)
@@ -1562,6 +1586,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1648,6 +1673,74 @@ class EventBundleCreatorTest {
   }
 
   @Test
+  fun testFillEventBundle_startExplorationEvent_studyOff_fillsOnlyNonSensitiveFieldsAndRetsName() {
+    setUpTestApplicationComponentWithoutLearnerAnalyticsStudy()
+    val bundle = Bundle()
+
+    val eventLog = createEventLog(context = createStartExplorationContext(isReplay = false))
+
+    val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
+    assertThat(typeName).isEqualTo("start_exploration")
+    assertThat(bundle).hasSize(19)
+    assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
+    assertThat(bundle).string("priority").isEqualTo("essential")
+    assertThat(bundle).integer("event_type").isEqualTo(START_EXPLORATION_CONTEXT.number)
+    assertThat(bundle).integer("android_sdk").isEqualTo(TEST_ANDROID_SDK_VERSION)
+    assertThat(bundle).string("app_version_name").isEqualTo(TEST_APP_VERSION_NAME)
+    assertThat(bundle).integer("app_version_code").isEqualTo(TEST_APP_VERSION_CODE)
+    assertThat(bundle).string("classroom_id").isEqualTo(TEST_CLASSROOM_ID)
+    assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
+    assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
+    assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
+    assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
+    assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
+    assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
+  }
+
+  @Test
+  fun testFillEventBundle_startExplorationEvent_studyOn_fillsAllFieldsAndReturnsName() {
+    setUpTestApplicationComponentWithLearnerAnalyticsStudy()
+    val bundle = Bundle()
+
+    val eventLog = createEventLog(context = createStartExplorationContext(isReplay = false))
+
+    val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
+    assertThat(typeName).isEqualTo("start_exploration")
+    assertThat(bundle).hasSize(21)
+    assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
+    assertThat(bundle).string("priority").isEqualTo("essential")
+    assertThat(bundle).integer("event_type").isEqualTo(START_EXPLORATION_CONTEXT.number)
+    assertThat(bundle).integer("android_sdk").isEqualTo(TEST_ANDROID_SDK_VERSION)
+    assertThat(bundle).string("app_version_name").isEqualTo(TEST_APP_VERSION_NAME)
+    assertThat(bundle).integer("app_version_code").isEqualTo(TEST_APP_VERSION_CODE)
+    assertThat(bundle).string("classroom_id").isEqualTo(TEST_CLASSROOM_ID)
+    assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
+    assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
+    assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
+    assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
+    assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
+    assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
+    assertThat(bundle).string("ld_learner_id").isEqualTo(TEST_LEARNER_ID)
+    assertThat(bundle).string("ld_install_id").isEqualTo(TEST_INSTALLATION_ID)
+  }
+
+  @Test
+  fun testFillEventBundle_startExplorationEvent_studyOff_isReplay_includesIsReplayAsTrue() {
+    setUpTestApplicationComponentWithoutLearnerAnalyticsStudy()
+    val bundle = Bundle()
+
+    val eventLog = createEventLog(context = createStartExplorationContext(isReplay = true))
+
+    val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
+    assertThat(typeName).isEqualTo("start_exploration")
+    assertThat(bundle).hasSize(19)
+    assertThat(bundle).integer("event_type").isEqualTo(START_EXPLORATION_CONTEXT.number)
+    assertThat(bundle).string("is_replay").isEqualTo("true")
+  }
+
+  @Test
   fun testFillEventBundle_exitExplorationEvent_studyOff_fillsOnlyNonSensitiveFieldsAndRetsName() {
     setUpTestApplicationComponentWithoutLearnerAnalyticsStudy()
     val bundle = Bundle()
@@ -1656,7 +1749,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("leave_exploration")
-    assertThat(bundle).hasSize(18)
+    assertThat(bundle).hasSize(19)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(EXIT_EXPLORATION_CONTEXT.number)
@@ -1667,6 +1760,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
     assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
@@ -1681,7 +1775,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("leave_exploration")
-    assertThat(bundle).hasSize(20)
+    assertThat(bundle).hasSize(21)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(EXIT_EXPLORATION_CONTEXT.number)
@@ -1692,6 +1786,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
     assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
@@ -1708,7 +1803,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("complete_exploration")
-    assertThat(bundle).hasSize(18)
+    assertThat(bundle).hasSize(19)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(FINISH_EXPLORATION_CONTEXT.number)
@@ -1719,6 +1814,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
     assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
@@ -1733,7 +1829,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("complete_exploration")
-    assertThat(bundle).hasSize(20)
+    assertThat(bundle).hasSize(21)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(FINISH_EXPLORATION_CONTEXT.number)
@@ -1744,6 +1840,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
     assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
@@ -1910,7 +2007,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("reach_invested_engagement")
-    assertThat(bundle).hasSize(18)
+    assertThat(bundle).hasSize(19)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(REACH_INVESTED_ENGAGEMENT.number)
@@ -1921,6 +2018,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
     assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
@@ -1935,7 +2033,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("reach_invested_engagement")
-    assertThat(bundle).hasSize(20)
+    assertThat(bundle).hasSize(21)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(REACH_INVESTED_ENGAGEMENT.number)
@@ -1946,6 +2044,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("is_replay").isEqualTo("false")
     assertThat(bundle).string("session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("state_name").isEqualTo(TEST_STATE_NAME)
@@ -1962,7 +2061,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("click_switch_language_in_lesson")
-    assertThat(bundle).hasSize(20)
+    assertThat(bundle).hasSize(21)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(SWITCH_IN_LESSON_LANGUAGE.number)
@@ -1973,6 +2072,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -1989,7 +2089,7 @@ class EventBundleCreatorTest {
 
     val typeName = eventBundleCreator.fillEventBundle(eventLog, bundle)
     assertThat(typeName).isEqualTo("click_switch_language_in_lesson")
-    assertThat(bundle).hasSize(22)
+    assertThat(bundle).hasSize(23)
     assertThat(bundle).longInt("timestamp").isEqualTo(TEST_TIMESTAMP_1)
     assertThat(bundle).string("priority").isEqualTo("essential")
     assertThat(bundle).integer("event_type").isEqualTo(SWITCH_IN_LESSON_LANGUAGE.number)
@@ -2000,6 +2100,7 @@ class EventBundleCreatorTest {
     assertThat(bundle).string("ed_topic_id").isEqualTo(TEST_TOPIC_ID)
     assertThat(bundle).string("ed_story_id").isEqualTo(TEST_STORY_ID)
     assertThat(bundle).string("ed_exploration_id").isEqualTo(TEST_EXPLORATION_ID)
+    assertThat(bundle).string("ed_is_replay").isEqualTo("false")
     assertThat(bundle).string("ed_session_id").isEqualTo(TEST_LEARNER_SESSION_ID)
     assertThat(bundle).string("ed_exploration_version").isEqualTo(TEST_EXPLORATION_VERSION_STR)
     assertThat(bundle).string("ed_state_name").isEqualTo(TEST_STATE_NAME)
@@ -2314,6 +2415,11 @@ class EventBundleCreatorTest {
     learnerDetails: LearnerDetailsContext = createLearnerDetailsContext()
   ) = createEventContext(learnerDetails, EventContextBuilder::setAppInForegroundContext)
 
+  private fun createStartExplorationContext(
+    isReplay: Boolean,
+    explorationContext: ExplorationContext = createExplorationContext(isReplay = isReplay)
+  ) = createEventContext(explorationContext, EventContextBuilder::setStartExplorationContext)
+
   private fun createExitExplorationContext(
     explorationContext: ExplorationContext = createExplorationContext()
   ) = createEventContext(explorationContext, EventContextBuilder::setExitExplorationContext)
@@ -2370,7 +2476,8 @@ class EventBundleCreatorTest {
     sessionId: String = TEST_LEARNER_SESSION_ID,
     explorationVersion: Int = TEST_EXPLORATION_VERSION,
     stateName: String = TEST_STATE_NAME,
-    learnerDetails: LearnerDetailsContext = createLearnerDetailsContext()
+    learnerDetails: LearnerDetailsContext = createLearnerDetailsContext(),
+    isReplay: Boolean = false
   ) = ExplorationContext.newBuilder().apply {
     this.classroomId = classroomId
     this.topicId = topicId
@@ -2380,6 +2487,7 @@ class EventBundleCreatorTest {
     this.explorationVersion = explorationVersion
     this.stateName = stateName
     this.learnerDetails = learnerDetails
+    this.isReplay = isReplay
   }.build()
 
   private fun createLearnerDetailsContext(


### PR DESCRIPTION
## Explanation
Fixes #6176

This PR introduces a new property to the `start_exploration` event called `is_replay` to indicate whether the lesson is being played from the context of having already fully completed a lesson. Fortunately the wiring was already in place for this so it was a simple matter of adding the property and updating corresponding fields.

Specific things of note:
- `ExplorationDataControllerTest` didn't previously validate the events it inadvertently logged, so this has been updated to include tests for existing behaviors.
- The `start_exploration_context` event has been renamed to `start_exploration`. This can break analytics queries in theory but they can always be updated to use the `event_type` property (which relies on the proto enum ordinal which survives renames like this). This rename brings the event into consistency with the other similar "start exploration" event names.
- I added tests in `EventBundleCreatorTest` for the `start_exploration` event since these weren't covered before.

This addresses a key blocker for the upcoming PACE pilot since it helps fill in the gap for the final bit of analytics support needed.

Finally, I want to note that almost this entire PR was generated by Gemini CLI with some carefully curated prompts and a few back-and-forths. I also needed to fix some of the code after and generally clean it up, but it actually did work with tests after a few back-and-forths. I think it required a couple hours of CLI running with a pro model to derive this PR (so likely not faster than it could be done by hand, but I was working on a few other changes at the same time so the context overhead to me was quite small fortunately).

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
This PR affects analytics behaviors which can only affect the UX for the learner analytics and event list (developer-only) dashboard, and likely won't at that because they won't surface this specific property.