### PR TITLE
Fix #6103: Add support for `is_checkpoint` state property

### DIFF
--- a/domain/src/main/assets/test_exp_id_2.json
+++ b/domain/src/main/assets/test_exp_id_2.json
@@ -458,7 +458,8 @@
         },
         "solicit_answer_details": false,
         "next_content_id_index": -1,
-        "linked_skill_id": "test_skill_id_1"
+        "linked_skill_id": "test_skill_id_1",
+        "card_is_checkpoint": true
       },
       "Fractions": {
         "content": {
@@ -999,7 +1000,8 @@
         },
         "solicit_answer_details": false,
         "next_content_id_index": -1,
-        "linked_skill_id": null
+        "linked_skill_id": null,
+        "card_is_checkpoint": true
       },
       "RatioInput": {
         "content": {

--- a/domain/src/main/assets/test_exp_id_2.textproto
+++ b/domain/src/main/assets/test_exp_id_2.textproto
@@ -609,6 +609,7 @@ states {
       }
     }
     linked_skill_id: "test_skill_id_1"
+    is_checkpoint: true
   }
 }
 states {
@@ -1264,6 +1265,7 @@ states {
         }
       }
     }
+    is_checkpoint: true
   }
 }
 states {

--- a/domain/src/main/java/org/oppia/android/domain/util/StateRetriever.kt
+++ b/domain/src/main/java/org/oppia/android/domain/util/StateRetriever.kt
@@ -58,6 +58,9 @@ class StateRetriever @Inject constructor() {
       stateJson.optString("linked_skill_id").takeIf {
         it.isNotEmpty() && it != "null"
       }?.let { linkedSkillId = it }
+      if (stateJson.has("card_is_checkpoint")) {
+        isCheckpoint = stateJson.getBoolean("card_is_checkpoint")
+      }
     }.build()
 
   // Creates an interaction from JSON

--- a/domain/src/test/java/org/oppia/android/domain/util/StateRetrieverTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/util/StateRetrieverTest.kt
@@ -654,6 +654,22 @@ class StateRetrieverTest {
     assertThat(state.linkedSkillId).isEqualTo("test_skill_id_2")
   }
 
+  @Test
+  fun testParseState_withoutCardIsCheckpoint_doesNotSetIsCheckpoint() {
+    val state = loadStateFromJson(stateName = "Fractions", explorationName = TEST_EXPLORATION_ID_2)
+
+    assertThat(state.isCheckpoint).isFalse()
+  }
+
+  @Test
+  fun testParseState_withCardIsCheckpoint_setsNotSetIsCheckpoint() {
+    val state = loadStateFromJson(
+      stateName = "MultipleChoice", explorationName = TEST_EXPLORATION_ID_2
+    )
+
+    assertThat(state.isCheckpoint).isTrue()
+  }
+
   /**
    * Return the first [RuleSpec] in the specified [State] matching the specified rule type, or fails
    * if one cannot be found.

--- a/model/src/main/proto/exploration.proto
+++ b/model/src/main/proto/exploration.proto
@@ -84,6 +84,9 @@ message State {
 
   // Corresponds to the global skill ID being taught/evaluated by the interaction of this state.
   string linked_skill_id = 9;
+
+  // Indicates whether the card represented by this state was marked as a checkpoint by an editor.
+  bool is_checkpoint = 10;
 }
 
 // Structure for customization args for ParamChange objects.


### PR DESCRIPTION
## Explanation

Fixes #6103

This adds support for the `is_checkpoint` property for both proto and JSON versions of lessons. No actual functionality is being added that uses these properties yet, but this is a prerequisite for the 4.1 GSoC project.

The property is defined in `state_domain` in Oppia web here: https://github.com/oppia/oppia/blob/eb568ce34748c60bbd68416d8dee332ff7782e38/core/domain/state_domain.py#L3791-L3792. I've also added the property to the experimental proto API in commit https://github.com/oppia/oppia-proto-api/commit/1eca22026838ea37f3f4f88dcca31c5110062262 and to the lesson download script in commit 6950ff8072b2c84818058411a4d37da692eada34.

I've verified this in this branch by adding a temporary test to `ExplorationProgressControllerTest` that verifies the property is set correctly and checked that this works for both JSON and proto (plus the JSON-specific tests for the `StateRetriever` change). I verified the lesson download script by actually downloading lessons and verifying that the proto v1 lessons do, indeed, have checkpoints set for some states (meaning the whole pipeline correctly passed through the property as expected).

Finally, I set the multiple choice and number input states as checkpoints for now since they split up the already small exploration pretty well into 3 parts, but obviously this can be tweaked in the future (plus other dev-only lessons can be updated).

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
This introduces new foundational support for a property that will eventually affect the UX of the app (per #4652) but this PR does not directly change the UI or UX of the app.