### PR TITLE
Fixes part of #4742: Disable continue button animation on completed states

### DIFF
--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -54,7 +54,6 @@ import org.hamcrest.Matchers.containsString
 import org.hamcrest.TypeSafeMatcher
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -384,8 +383,6 @@ class StateFragmentLocalTest {
     }
   }
 
-  // TODO(#4742): Figure out why tests for continue navigation item animation are failing.
-  @Ignore("Continue navigation animation behavior fails during testing")
   @Test
   fun testContNavBtnAnim_openMathExp_playThroughSecondState_checkContBtnDoesNotAnimateAfter45Sec() {
     launchForExploration(TEST_EXPLORATION_ID_5).use {
@@ -416,8 +413,6 @@ class StateFragmentLocalTest {
     }
   }
 
-  // TODO(#4742): Figure out why tests for continue navigation item animation are failing.
-  @Ignore("Continue navigation animation behavior fails during testing")
   @Test
   fun testConIntAnim_openFractions_expId1_checkButtonDoesNotAnimate() {
     launchForExploration(TEST_EXPLORATION_ID_2).use {

--- a/domain/src/main/java/org/oppia/android/domain/state/StateDeck.kt
+++ b/domain/src/main/java/org/oppia/android/domain/state/StateDeck.kt
@@ -149,7 +149,7 @@ class StateDeck constructor(
       .setHasPreviousState(!isCurrentStateInitial())
       .setCompletedState(CompletedState.newBuilder().addAllAnswer(currentDialogInteractions))
       .setContinueButtonAnimationTimestampMs(timestamp)
-      .setShowContinueButtonAnimation(!isContinueButtonAnimationSeen && isCurrentStateInitial())
+      .setShowContinueButtonAnimation(false)
       .build()
     currentDialogInteractions.clear()
     pendingTopState = state

--- a/domain/src/main/java/org/oppia/android/domain/state/StateDeck.kt
+++ b/domain/src/main/java/org/oppia/android/domain/state/StateDeck.kt
@@ -149,7 +149,7 @@ class StateDeck constructor(
       .setHasPreviousState(!isCurrentStateInitial())
       .setCompletedState(CompletedState.newBuilder().addAllAnswer(currentDialogInteractions))
       .setContinueButtonAnimationTimestampMs(timestamp)
-      .setShowContinueButtonAnimation(false)
+      .setShowContinueButtonAnimation(!isContinueButtonAnimationSeen)
       .build()
     currentDialogInteractions.clear()
     pendingTopState = state

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
@@ -265,6 +265,24 @@ class ExplorationProgressControllerTest {
   }
 
   @Test
+  fun testEphemeralState_submitNonInitialStateAnswer_shouldIndicateButtonAnimation() {
+    oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
+    startPlayingNewExploration(
+      TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, TEST_EXPLORATION_ID_2
+    )
+    waitForGetCurrentStateSuccessfulLoad()
+    navigateToPrototypeMultipleChoiceState()
+
+    val currentTime = oppiaClock.getCurrentTimeMs()
+    val ephemeralState = submitPrototypeState3Answer()
+
+    assertThat(ephemeralState.stateTypeCase).isEqualTo(COMPLETED_STATE)
+    assertThat(ephemeralState.showContinueButtonAnimation).isTrue()
+    assertThat(ephemeralState.continueButtonAnimationTimestampMs)
+      .isEqualTo(currentTime + TimeUnit.SECONDS.toMillis(45))
+  }
+
+  @Test
   fun testEphemeralState_profile1ClicksContinue_switchToProfile2_shouldIndicateButtonAnimation() {
     oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
     val profileId2 = LegacyProfileId.newBuilder().setInternalId(1).build()


### PR DESCRIPTION
## Explanation
Fixes part of #4742

The Continue button animation was incorrectly shown on completed states because `pushState()` set `showContinueButtonAnimation` based on `isCurrentStateInitial()`, which could evaluate true while pushing state 0 as completed. This PR fixes the issue by setting `showContinueButtonAnimation` to false for completed states, since animation should only appear for the first pending state (already handled in `getCurrentPendingState()`). It also removes `@Ignore` from the two related failing tests and removes the unused import.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).