### PR TITLE
Fixes  #6147: Keep Save enabled by default on Authorize to add profiles screen

### DIFF
--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
@@ -30,10 +30,6 @@ class AdminPinActivityPresenter @Inject constructor(
   private val adminViewModel: AdminPinViewModel,
   private val resourceHandler: AppLanguageResourceHandler
 ) {
-
-  private var inputtedPin = false
-  private var inputtedConfirmPin = false
-
   private val args by lazy {
     activity.intent.getProtoExtra(
       ADMIN_PIN_ACTIVITY_PARAMS_KEY,
@@ -65,12 +61,9 @@ class AdminPinActivityPresenter @Inject constructor(
           adminViewModel.savedPin.get() == it
         ) {
           adminViewModel.savedPin.set(it)
-          inputtedPin = pin.isNotEmpty()
         } else {
           adminViewModel.pinErrorMsg.set("")
           adminViewModel.savedPin.set(it)
-          inputtedPin = pin.isNotEmpty()
-          setValidPin()
         }
       }
     }
@@ -82,12 +75,9 @@ class AdminPinActivityPresenter @Inject constructor(
           adminViewModel.savedConfirmPin.get() == it
         ) {
           adminViewModel.savedConfirmPin.set(it)
-          inputtedConfirmPin = confirmPin.isNotEmpty()
         } else {
           adminViewModel.confirmPinErrorMsg.set("")
           adminViewModel.savedConfirmPin.set(it)
-          inputtedConfirmPin = confirmPin.isNotEmpty()
-          setValidPin()
         }
       }
     }
@@ -167,7 +157,4 @@ class AdminPinActivityPresenter @Inject constructor(
     }
   }
 
-  private fun setValidPin() {
-    adminViewModel.isButtonActive.set(inputtedPin && inputtedConfirmPin)
-  }
 }

--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
@@ -96,7 +96,7 @@ class AdminPinActivityPresenter @Inject constructor(
         )
         failed = true
       }
-      if (inputPin != confirmPin) {
+      if (!failed && inputPin != confirmPin) {
         adminViewModel.confirmPinErrorMsg.set(
           resourceHandler.getStringInLocale(
             R.string.admin_pin_error_pin_confirm_wrong

--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
@@ -156,5 +156,4 @@ class AdminPinActivityPresenter @Inject constructor(
       false
     }
   }
-
 }

--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
@@ -65,6 +65,7 @@ class AdminPinActivityPresenter @Inject constructor(
           adminViewModel.pinErrorMsg.set("")
           adminViewModel.savedPin.set(it)
         }
+        updateSubmitButtonState()
       }
     }
 
@@ -79,6 +80,7 @@ class AdminPinActivityPresenter @Inject constructor(
           adminViewModel.confirmPinErrorMsg.set("")
           adminViewModel.savedConfirmPin.set(it)
         }
+        updateSubmitButtonState()
       }
     }
 
@@ -103,6 +105,7 @@ class AdminPinActivityPresenter @Inject constructor(
         failed = true
       }
       if (failed) {
+        updateSubmitButtonState()
         return@setOnClickListener
       }
       val profileId =
@@ -155,5 +158,13 @@ class AdminPinActivityPresenter @Inject constructor(
       }
       false
     }
+
+    updateSubmitButtonState()
+  }
+
+  private fun updateSubmitButtonState() {
+    val hasPinError = !adminViewModel.pinErrorMsg.get().isNullOrEmpty()
+    val hasConfirmPinError = !adminViewModel.confirmPinErrorMsg.get().isNullOrEmpty()
+    adminViewModel.isButtonActive.set(!hasPinError && !hasConfirmPinError)
   }
 }

--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
@@ -22,6 +22,7 @@ import org.oppia.android.util.extensions.getProtoExtra
 import javax.inject.Inject
 
 /** The presenter for [AdminPinActivity]. */
+// Manages the state and interactions for Admin PIN entry and validation.
 @ActivityScope
 class AdminPinActivityPresenter @Inject constructor(
   private val context: Context,

--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
@@ -22,7 +22,6 @@ import org.oppia.android.util.extensions.getProtoExtra
 import javax.inject.Inject
 
 /** The presenter for [AdminPinActivity]. */
-// Manages the state and interactions for Admin PIN entry and validation.
 @ActivityScope
 class AdminPinActivityPresenter @Inject constructor(
   private val context: Context,

--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinViewModel.kt
@@ -12,5 +12,5 @@ class AdminPinViewModel @Inject constructor() : ObservableViewModel() {
   val confirmPinErrorMsg = ObservableField("")
   val savedPin = ObservableField("")
   val savedConfirmPin = ObservableField("")
-  val isButtonActive = ObservableField(false)
+  val isButtonActive = ObservableField(true)
 }

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
@@ -366,6 +366,7 @@ class AdminPinActivityTest {
           )
         )
       )
+      onView(withId(R.id.submit_button)).check(matches(not(isClickable())))
     }
   }
 
@@ -400,6 +401,7 @@ class AdminPinActivityTest {
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
         .check(matches(hasNoErrorText()))
+      onView(withId(R.id.submit_button)).check(matches(isClickable()))
     }
   }
 
@@ -445,6 +447,7 @@ class AdminPinActivityTest {
             )
           )
         )
+      onView(withId(R.id.submit_button)).check(matches(not(isClickable())))
     }
   }
 
@@ -517,6 +520,7 @@ class AdminPinActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo()).perform(click())
+      onView(withId(R.id.submit_button)).check(matches(not(isClickable())))
       onView(
         allOf(
           withId(R.id.admin_pin_input_confirm_pin_edit_text),
@@ -528,6 +532,7 @@ class AdminPinActivityTest {
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
         .check(matches(hasNoErrorText()))
+      onView(withId(R.id.submit_button)).check(matches(isClickable()))
     }
   }
 
@@ -794,6 +799,7 @@ class AdminPinActivityTest {
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
         .check(matches(hasNoErrorText()))
+      onView(withId(R.id.submit_button)).check(matches(isClickable()))
     }
   }
 
@@ -837,6 +843,7 @@ class AdminPinActivityTest {
           )
         )
       )
+      onView(withId(R.id.submit_button)).check(matches(not(isClickable())))
     }
   }
 
@@ -915,6 +922,7 @@ class AdminPinActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo(), click())
+      onView(withId(R.id.submit_button)).check(matches(not(isClickable())))
       onView(
         allOf(
           withId(R.id.admin_pin_input_confirm_pin_edit_text),
@@ -927,6 +935,7 @@ class AdminPinActivityTest {
       )
       onView(withId(R.id.admin_pin_input_confirm_pin))
         .check(matches(hasNoErrorText()))
+      onView(withId(R.id.submit_button)).check(matches(isClickable()))
     }
   }
 
@@ -1016,6 +1025,7 @@ class AdminPinActivityTest {
           )
         )
       )
+      onView(withId(R.id.submit_button)).check(matches(not(isClickable())))
     }
   }
 
@@ -1057,6 +1067,7 @@ class AdminPinActivityTest {
           )
         )
       )
+      onView(withId(R.id.submit_button)).check(matches(not(isClickable())))
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
@@ -325,7 +325,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_inputShortPin_clickIsDisabled() {
+  fun testAdminPinActivity_inputShortPin_clickIsEnabled() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context = context,
@@ -344,7 +344,28 @@ class AdminPinActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo())
-      onView(withId(R.id.submit_button)).check(matches(not(isClickable())))
+      onView(withId(R.id.submit_button)).check(matches(isClickable()))
+    }
+  }
+
+  @Test
+  fun testAdminPinActivity_emptyPins_submit_showsPinLengthError() {
+    launch<AdminPinActivity>(
+      AdminPinActivity.createAdminPinActivityIntent(
+        context = context,
+        profileId = 0,
+        colorRgb = -10710042,
+        adminPinEnum = 0
+      )
+    ).use {
+      onView(withId(R.id.submit_button)).perform(nestedScrollTo(), click())
+      onView(withId(R.id.admin_pin_input_pin)).check(
+        matches(
+          hasErrorText(
+            context.resources.getString(R.string.admin_pin_error_pin_length)
+          )
+        )
+      )
     }
   }
 
@@ -717,7 +738,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_configChange_inputShortPin_submit_clickIsDisabled() {
+  fun testAdminPinActivity_configChange_inputShortPin_submit_clickIsEnabled() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context = context,
@@ -737,7 +758,7 @@ class AdminPinActivityTest {
         closeSoftKeyboard()
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo())
-      onView(withId(R.id.submit_button)).check(matches(not(isClickable())))
+      onView(withId(R.id.submit_button)).check(matches(isClickable()))
     }
   }
 
@@ -1040,7 +1061,7 @@ class AdminPinActivityTest {
   }
 
   @Test
-  fun testAdminPinActivity_inputShortPin_configChange_clickIsDisabled() {
+  fun testAdminPinActivity_inputShortPin_configChange_clickIsEnabled() {
     launch<AdminPinActivity>(
       AdminPinActivity.createAdminPinActivityIntent(
         context = context,
@@ -1060,7 +1081,7 @@ class AdminPinActivityTest {
       )
       onView(withId(R.id.submit_button)).perform(nestedScrollTo())
       onView(isRoot()).perform(orientationLandscape())
-      onView(withId(R.id.submit_button)).check(matches(not(isClickable())))
+      onView(withId(R.id.submit_button)).check(matches(isClickable()))
     }
   }
 


### PR DESCRIPTION
## Explanation
Fixes #6147

Restore Admin PIN Save button state management.

**Changes:**
- Modified `AdminPinActivityPresenter` to centrally manage submit button enabled/disabled state via a new `updateSubmitButtonState()` method.
- The Save button is disabled whenever a PIN validation error exists, such as a short PIN or mismatched confirmation.
- The Save button automatically re-enables when the user edits the input and clears the error.
- This prevents users from accidentally submitting invalid PIN data.
- Added test coverage in `AdminPinActivityTest` to verify that the button disables on error, re-enables on input correction, and maintains state across configuration changes such as device rotation.

**UI Changes:**
- On the "Authorize to add profiles" screen, the Save button is enabled by default.
- Entering an invalid PIN shows the validation error and disables Save.
- Correcting the PIN clears the error and re-enables Save.

**Demo video:**
Shows Save enabled by default on the "Authorize to add profiles" screen, validation errors for invalid PIN input, and Save re-enabling after correcting the input.
https://drive.google.com/file/d/1xSW9y-VvF_DiJYjymoZ8XWcYOY5E-eSF/view?usp=sharing

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to scripts/assets files have their rationale included in the PR explanation.
- [x] The PR follows the style guide.
- [x] The PR does not contain any unnecessary code changes from Android Studio.
- [x] The PR is made from a branch that's not called "develop" and is up-to-date with "develop".
- [x] The PR is assigned to the appropriate reviewers.