### PR TITLE
Fixes part of #5440: ProfileId migration utility

### DIFF
--- a/utility/src/main/java/org/oppia/android/util/profile/BUILD.bazel
+++ b/utility/src/main/java/org/oppia/android/util/profile/BUILD.bazel
@@ -33,6 +33,7 @@ kt_android_library(
     ],
     visibility = ["//:oppia_api_visibility"],
     deps = [
+        ":profile_id_migration_util",
         "//model/src/main/proto:profile_java_proto_lite",
         "//utility/src/main/java/org/oppia/android/util/extensions:bundle_extensions",
     ],

--- a/utility/src/main/java/org/oppia/android/util/profile/CurrentUserProfileIdIntentDecorator.kt
+++ b/utility/src/main/java/org/oppia/android/util/profile/CurrentUserProfileIdIntentDecorator.kt
@@ -3,6 +3,7 @@ package org.oppia.android.util.profile
 import android.content.Intent
 import android.os.Bundle
 import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.extensions.getProtoExtra
 import org.oppia.android.util.extensions.putProto
@@ -13,14 +14,14 @@ const val PROFILE_ID_INTENT_DECORATOR = "CurrentUserProfileIdIntentDecorator.pro
 private const val PROFILE_ID_BUNDLE_DECORATOR =
   "CurrentUserProfileIdIntentDecorator.profile_id_bundle_key"
 
-/** Decorator that allows an activity to wrap a user's [LegacyProfileId] within its intent. */
+/** Decorator that allows an activity to wrap a user's [ProfileId] within its intent. */
 object CurrentUserProfileIdIntentDecorator {
   /**
    * Packs [this] intent with a [LegacyProfileId] proto object.
    * [extractCurrentUserProfileId] should be used for retrieving the [LegacyProfileId] later.
    */
   fun Intent.decorateWithUserProfileId(profileId: LegacyProfileId) {
-    putProtoExtra(PROFILE_ID_INTENT_DECORATOR, profileId)
+    putProtoExtra(PROFILE_ID_INTENT_DECORATOR, profileId.toProfileId())
   }
 
   /**
@@ -30,8 +31,8 @@ object CurrentUserProfileIdIntentDecorator {
   fun Intent.extractCurrentUserProfileId(): LegacyProfileId {
     return getProtoExtra(
       PROFILE_ID_INTENT_DECORATOR,
-      LegacyProfileId.getDefaultInstance()
-    )
+      ProfileId.getDefaultInstance()
+    ).toLegacyProfileId()
   }
 
   /**
@@ -39,7 +40,7 @@ object CurrentUserProfileIdIntentDecorator {
    * [extractCurrentUserProfileId] should be used for retrieving the [LegacyProfileId] later.
    */
   fun Bundle.decorateWithUserProfileId(profileId: LegacyProfileId) {
-    putProto(PROFILE_ID_BUNDLE_DECORATOR, profileId)
+    putProto(PROFILE_ID_BUNDLE_DECORATOR, profileId.toProfileId())
   }
 
   /**
@@ -49,7 +50,7 @@ object CurrentUserProfileIdIntentDecorator {
   fun Bundle.extractCurrentUserProfileId(): LegacyProfileId {
     return getProto(
       PROFILE_ID_BUNDLE_DECORATOR,
-      LegacyProfileId.getDefaultInstance()
-    )
+      ProfileId.getDefaultInstance()
+    ).toLegacyProfileId()
   }
 }


### PR DESCRIPTION
## Explanation
Fixes part of #5440 
- Adds `profile_id_migration_util` as a dependency for `CurrentUserProfileIdIntentDecorator.kt`.
- Updates utility layer to use ProfileId internally and use `.toLegacyProfileId()` and `.toProfileId()`  at boundaries.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).