### PR TITLE
Fix #6209: Add EDGE_TO_EDGE feature flag for edge-to-edge display support

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/featureflags/FeatureFlagsFragmentTest.kt
@@ -167,7 +167,7 @@ class FeatureFlagsFragmentTest {
 
       // Note to developers: if you add/remove a feature flag, please update the expected count.
       onView(withId(R.id.feature_flags_recycler_view))
-        .check(RecyclerViewMatcher.hasItemCount(count = 15))
+        .check(RecyclerViewMatcher.hasItemCount(count = 16))
     }
   }
 

--- a/config/src/java/org/oppia/android/config/platform/feature_flags.textproto
+++ b/config/src/java/org/oppia/android/config/platform/feature_flags.textproto
@@ -73,3 +73,8 @@ feature_flag_definition {
   remote_server_name: "android_enable_topic_practice_tab"
   default_is_enabled: false
 }
+feature_flag_definition {
+  id: EDGE_TO_EDGE
+  remote_server_name: "android_enable_edge_to_edge"
+  default_is_enabled: true
+}

--- a/config/src/java/org/oppia/android/config/platform/feature_flags.textproto
+++ b/config/src/java/org/oppia/android/config/platform/feature_flags.textproto
@@ -76,5 +76,5 @@ feature_flag_definition {
 feature_flag_definition {
   id: EDGE_TO_EDGE
   remote_server_name: "android_enable_edge_to_edge"
-  default_is_enabled: true
+  default_is_enabled: false
 }

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/FeatureFlagBindingModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/FeatureFlagBindingModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import org.oppia.android.app.model.FeatureFlagId
 import org.oppia.android.util.platformparameter.EnableAppAndOsDeprecation
 import org.oppia.android.util.platformparameter.EnableDownloadsSupport
+import org.oppia.android.util.platformparameter.EnableEdgeToEdge
 import org.oppia.android.util.platformparameter.EnableEditAccountsOptionsUi
 import org.oppia.android.util.platformparameter.EnableFastLanguageSwitchingInLesson
 import org.oppia.android.util.platformparameter.EnableFlashbackSupport
@@ -100,6 +101,11 @@ class FeatureFlagBindingModule {
   @EnableTopicPracticeTab
   fun provideEnableTopicPracticeTab(processState: PlatformParameterProcessState) =
     processState.retrieveFeatureFlag(FeatureFlagId.TOPIC_PRACTICE_TAB)
+
+  @Provides
+  @EnableEdgeToEdge
+  fun provideEnableEdgeToEdge(processState: PlatformParameterProcessState) =
+    processState.retrieveFeatureFlag(FeatureFlagId.EDGE_TO_EDGE)
 
   private companion object {
     private fun PlatformParameterProcessState.retrieveFeatureFlag(

--- a/domain/src/main/java/org/oppia/android/domain/platformparameter/FeatureFlagsMapBindingModule.kt
+++ b/domain/src/main/java/org/oppia/android/domain/platformparameter/FeatureFlagsMapBindingModule.kt
@@ -6,6 +6,7 @@ import dagger.multibindings.IntoMap
 import org.oppia.android.app.model.FeatureFlagId
 import org.oppia.android.util.platformparameter.EnableAppAndOsDeprecation
 import org.oppia.android.util.platformparameter.EnableDownloadsSupport
+import org.oppia.android.util.platformparameter.EnableEdgeToEdge
 import org.oppia.android.util.platformparameter.EnableEditAccountsOptionsUi
 import org.oppia.android.util.platformparameter.EnableFastLanguageSwitchingInLesson
 import org.oppia.android.util.platformparameter.EnableFlashbackSupport
@@ -143,5 +144,13 @@ interface FeatureFlagsMapBindingModule {
   @FeatureFlagIdKey(FeatureFlagId.TOPIC_PRACTICE_TAB)
   fun bindTopicPracticeTab(
     @EnableTopicPracticeTab param: PlatformParameterValue<Boolean>
+  ): PlatformParameterValue<Boolean>
+
+  @Binds
+  @IntoMap
+  @FeatureFlags
+  @FeatureFlagIdKey(FeatureFlagId.EDGE_TO_EDGE)
+  fun bindEdgeToEdge(
+    @EnableEdgeToEdge param: PlatformParameterValue<Boolean>
   ): PlatformParameterValue<Boolean>
 }

--- a/domain/src/test/java/org/oppia/android/domain/oppialogger/analytics/FeatureFlagsLoggerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/oppialogger/analytics/FeatureFlagsLoggerTest.kt
@@ -141,7 +141,7 @@ class FeatureFlagsLoggerTest {
 
   @Test
   fun testLogFeatureFlags_correctNumberOfFeatureFlagsIsLogged() {
-    val expectedFeatureFlagCount = 15
+    val expectedFeatureFlagCount = 16
 
     featureFlagsLogger.logAllFeatureFlags(TEST_SESSION_ID)
     testCoroutineDispatchers.runCurrent()
@@ -168,6 +168,7 @@ class FeatureFlagsLoggerTest {
   @Iteration("flashback_support", "index=12", "flagId=FLASHBACK_SUPPORT")
   @Iteration("topic_info_tab", "index=13", "flagId=TOPIC_INFO_TAB")
   @Iteration("topic_practice_tab", "index=14", "flagId=TOPIC_PRACTICE_TAB")
+  @Iteration("edge_to_edge", "index=15", "flagId=EDGE_TO_EDGE")
   fun testLogFeatureFlags_allFeatureFlagIdsAreLogged() {
     featureFlagsLogger.logAllFeatureFlags(TEST_SESSION_ID)
 

--- a/model/src/main/proto/platform_parameter.proto
+++ b/model/src/main/proto/platform_parameter.proto
@@ -149,6 +149,9 @@ enum FeatureFlagId {
 
   // Corresponds to a topic activity feature that enables the practice tab.
   TOPIC_PRACTICE_TAB = 18;
+
+  // Corresponds to a feature enabling edge-to-edge display support for Android 15+ compatibility.
+  EDGE_TO_EDGE = 19;
 }
 
 // Corresponds to a compile-time definition of a platform parameter which is a mechanism by which to

--- a/testing/src/main/java/org/oppia/android/testing/platformparameter/TestPlatformParameterModule.kt
+++ b/testing/src/main/java/org/oppia/android/testing/platformparameter/TestPlatformParameterModule.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import org.oppia.android.app.model.FeatureFlagId.APP_AND_OS_DEPRECATION
 import org.oppia.android.app.model.FeatureFlagId.DOWNLOADS_SUPPORT
+import org.oppia.android.app.model.FeatureFlagId.EDGE_TO_EDGE
 import org.oppia.android.app.model.FeatureFlagId.EDIT_ACCOUNTS_OPTIONS_UI
 import org.oppia.android.app.model.FeatureFlagId.FAST_LANGUAGE_SWITCHING_IN_LESSON
 import org.oppia.android.app.model.FeatureFlagId.FLASHBACK_SUPPORT
@@ -148,6 +149,10 @@ class TestPlatformParameterModule {
 
     fun forceEnableTopicPracticeTab(value: Boolean) {
       TestPlatformParameterConfigRetriever.setFlagOverride(TOPIC_PRACTICE_TAB, value)
+    }
+
+    fun forceEnableEdgeToEdge(value: Boolean) {
+      TestPlatformParameterConfigRetriever.setFlagOverride(EDGE_TO_EDGE, value)
     }
 
     fun reset() {

--- a/utility/src/main/java/org/oppia/android/util/platformparameter/FeatureFlagConstants.kt
+++ b/utility/src/main/java/org/oppia/android/util/platformparameter/FeatureFlagConstants.kt
@@ -201,3 +201,16 @@ const val ENABLE_TOPIC_PRACTICE_TAB = "enable_topic_practice_tab"
 
 /** Default value for the feature flag corresponding to [EnableTopicPracticeTab]. */
 const val ENABLE_TOPIC_PRACTICE_TAB_DEFAULT_VALUE = false
+
+/**
+ * Qualifier for the feature flag that controls whether edge-to-edge display support
+ * is enabled for Android 15+ (API 35+) compatibility.
+ */
+@Qualifier
+annotation class EnableEdgeToEdge
+
+/** Name of the feature flag that controls whether to enable edge-to-edge display support. */
+const val EDGE_TO_EDGE = "android_enable_edge_to_edge"
+
+/** Default value for the feature flag corresponding to [EnableEdgeToEdge]. */
+const val ENABLE_EDGE_TO_EDGE_DEFAULT_VALUE = false

--- a/utility/src/main/java/org/oppia/android/util/platformparameter/FeatureFlagConstants.kt
+++ b/utility/src/main/java/org/oppia/android/util/platformparameter/FeatureFlagConstants.kt
@@ -208,9 +208,3 @@ const val ENABLE_TOPIC_PRACTICE_TAB_DEFAULT_VALUE = false
  */
 @Qualifier
 annotation class EnableEdgeToEdge
-
-/** Name of the feature flag that controls whether to enable edge-to-edge display support. */
-const val EDGE_TO_EDGE = "android_enable_edge_to_edge"
-
-/** Default value for the feature flag corresponding to [EnableEdgeToEdge]. */
-const val ENABLE_EDGE_TO_EDGE_DEFAULT_VALUE = false


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fixes #6209

This PR adds the `EDGE_TO_EDGE` feature flag that will be used to gate all edge-to-edge display changes behind a toggle.
                                                                                                                                                                                              
On Android 15+ (API 35+), edge-to-edge is enforced by default and our app currently opts out using `windowOptOutEdgeToEdgeEnforcement` in `values-v35/themes.xml`. This opt-out is deprecated in SDK 36 and will stop working -- link: https://developer.android.com/about/versions/16/behavior-changes-16#edge-to-edge                                                          
                                                                                                                                                                                              
So we need to properly handle window insets across all screens. This feature flag lets us gate those changes safely so we can roll back if something breaks.                                
  
  ### Changes                                                                                                                                                                                 
  - Added `EDGE_TO_EDGE = 19` to the `FeatureFlagId` proto enum
  - Added feature flag definition in `feature_flags.textproto` with `default_is_enabled: false`                                                                                               
  - Added `@EnableEdgeToEdge` qualifier and default value in `FeatureFlagConstants.kt`                                                                                                        
  - Wired up the provider in `FeatureFlagBindingModule.kt`                                                                                                                                    
  - Wired up the map binding in `FeatureFlagsMapBindingModule.kt`                                                                                                                             
  - Added `forceEnableEdgeToEdge()` in `TestPlatformParameterModule.kt` for tests                                                                                                             
  - Updated feature flag count to 16 in `FeatureFlagsLoggerTest.kt`                                                                                                                           
                                                                                                                                                                                              
  The flag is `false` by default and will be set to `true` once all screens are fixed in #5940 and #6208.                                                                                     
                                                                                                                                                                                              
  Full discussion and approach: https://github.com/oppia/oppia-android/discussions/6196   and #5943                                                                                                     


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
