### PR TITLE
Fix #6186: Flaky proguard in CI

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -18,12 +18,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_oppia_aab:
-    name: Build Oppia AAB (${{ matrix.flavor }} flavor)
+  build_oppia_dev_aab:
+    name: Build Oppia AAB (dev flavor)
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        flavor: [dev, alpha, beta, ga]
     env:
       CACHE_DIRECTORY: ~/.bazel_cache
     steps:
@@ -91,17 +88,118 @@ jobs:
         run: bazel info
 
       - name: Build Oppia dev AAB
-        if: matrix.flavor == 'dev'
         run: bazel build -- //:oppia_dev
 
-      - name: Build Oppia ${{ matrix.flavor }} deployable AAB
-        if: matrix.flavor != 'dev'
-        run: bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}_deployable
+  # This job pre-builds the deployable (pre-Proguard-map) AABs for all Proguard-enabled flavors in
+  # one shot. Building them together is more memory-efficient since Bazel shares intermediate
+  # artifacts across flavors. The resulting Bazel disk cache is uploaded as a workflow artifact so
+  # that the finalize jobs can skip all heavy compilation & Proguard work.
+  build_proguarded_bases:
+    name: Build Proguarded base AABs (alpha, beta, ga)
+    runs-on: ubuntu-24.04
+    env:
+      CACHE_DIRECTORY: ~/.bazel_cache
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
-      - name: Shutdown Bazel to free memory
-        if: matrix.flavor != 'dev'
-        run: bazel shutdown
+      - name: Set up Bazel
+        uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: 6.5.0
+
+      - name: Set up build environment
+        uses: ./.github/actions/set-up-android-bazel-build-environment
+
+      - uses: actions/cache@v5
+        id: cache
+        with:
+          path: ${{ env.CACHE_DIRECTORY }}
+          key: ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-
+            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-tests-
+            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-
+
+      - name: Ensure cache size
+        env:
+          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
+        run: |
+          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
+          CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_PATH | grep total | cut -f1)
+          echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
+          if [[ "$CACHE_SIZE_MB" -gt 4500 ]]; then
+            echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
+            rm -rf $EXPANDED_BAZEL_CACHE_PATH
+          fi
+
+      - name: Configure Bazel to use a local cache
+        env:
+          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
+        run: |
+          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
+          echo "Using $EXPANDED_BAZEL_CACHE_PATH as Bazel's cache path"
+          echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
+        shell: bash
+
+      - name: Check Bazel environment
+        run: bazel info
+
+      - name: Build all deployable AABs
+        run: >-
+          bazel build --compilation_mode=opt --
+          //:oppia_alpha_deployable
+          //:oppia_beta_deployable
+          //:oppia_ga_deployable
+
+      - name: Upload Bazel cache for finalize jobs
+        uses: actions/upload-artifact@v7
+        with:
+          name: bazel-cache-proguarded
+          path: ~/.bazel_cache
+          retention-days: 1
+
+  # Each finalize job downloads the Bazel cache produced by build_proguarded_bases and runs only the
+  # lightweight final packaging step (bundling the Proguard map into the already-built deployable
+  # AAB). This starts with a fresh JVM so there is no accumulated memory pressure from the heavy
+  # compilation + Proguard work, which avoids OOM crashes (error code 14).
+  finalize_proguarded_aab:
+    name: Finalize Oppia AAB (${{ matrix.flavor }} flavor)
+    needs: build_proguarded_bases
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        flavor: [alpha, beta, ga]
+    env:
+      CACHE_DIRECTORY: ~/.bazel_cache
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Bazel
+        uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: 6.5.0
+
+      - name: Set up build environment
+        uses: ./.github/actions/set-up-android-bazel-build-environment
+
+      - name: Download Bazel cache from base build
+        uses: actions/download-artifact@v8
+        with:
+          name: bazel-cache-proguarded
+          path: ~/.bazel_cache
+
+      - name: Configure Bazel to use the downloaded cache
+        run: |
+          echo "Using $HOME/.bazel_cache as Bazel's cache path"
+          echo "build --disk_cache=$HOME/.bazel_cache" >> $HOME/.bazelrc
+        shell: bash
+
+      - name: Check Bazel environment
+        run: bazel info
 
       - name: Build Oppia ${{ matrix.flavor }} final AAB
-        if: matrix.flavor != 'dev'
         run: bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -90,10 +90,18 @@ jobs:
       - name: Check Bazel environment
         run: bazel info
 
-      - name: Build Oppia ${{ matrix.flavor }} AAB
-        run: |
-          if [[ "${{ matrix.flavor }}" == "dev" ]]; then
-            bazel build -- //:oppia_${{ matrix.flavor }}
-          else
-            bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}
-          fi
+      - name: Build Oppia dev AAB
+        if: matrix.flavor == 'dev'
+        run: bazel build -- //:oppia_dev
+
+      - name: Build Oppia ${{ matrix.flavor }} deployable AAB
+        if: matrix.flavor != 'dev'
+        run: bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}_deployable
+
+      - name: Shutdown Bazel to free memory
+        if: matrix.flavor != 'dev'
+        run: bazel shutdown
+
+      - name: Build Oppia ${{ matrix.flavor }} final AAB
+        if: matrix.flavor != 'dev'
+        run: bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -97,7 +97,7 @@ jobs:
           else
             # Build the deployable (pre-Proguard-map) AAB first, then shutdown Bazel to release
             # JVM memory accumulated during the heavy Proguard step. This avoids OOM crashes
-            # (error code 14) when building the final AAB that packages the Proguard map.
+            # error code 14 when building the final AAB that packages the Proguard map.
             bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}_deployable
             bazel shutdown
             bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -147,11 +147,13 @@ jobs:
         run: bazel info
 
       - name: Build all deployable AABs
-        run: >-
-          bazel build --compilation_mode=opt --
-          //:oppia_alpha_deployable
-          //:oppia_beta_deployable
-          //:oppia_ga_deployable
+        run: |
+          for flavor in alpha beta ga; do
+            echo "=== Building //:oppia_${flavor}_deployable ==="
+            bazel build --compilation_mode=opt -- //:oppia_${flavor}_deployable
+            echo "=== Shutting down Bazel to free memory ==="
+            bazel shutdown
+          done
 
       - name: Upload Bazel cache for finalize jobs
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -187,7 +187,7 @@ jobs:
         uses: ./.github/actions/set-up-android-bazel-build-environment
 
       - name: Download Bazel cache from base build
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: bazel-cache-proguarded-${{ matrix.flavor }}
           path: ${{ env.CACHE_DIRECTORY }}

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -18,11 +18,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_oppia_dev_aab:
-    name: Build Oppia AAB (dev flavor)
+  build_oppia_aab:
+    name: Build Oppia AAB (${{ matrix.flavor }} flavor)
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        flavor: [dev, alpha, beta, ga]
     env:
-      CACHE_DIRECTORY: /home/runner/.bazel_cache
+      CACHE_DIRECTORY: ~/.bazel_cache
     steps:
       - uses: actions/checkout@v6
         with:
@@ -62,7 +65,8 @@ jobs:
           BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
         run: |
           # See https://stackoverflow.com/a/27485157 for reference.
-          CACHE_SIZE_MB=$(du -smc $BAZEL_CACHE_DIR | grep total | cut -f1)
+          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
+          CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_PATH | grep total | cut -f1)
           echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
           # Use a 4.5GB threshold since actions/cache compresses the results, and Bazel caches seem
           # to only increase by a few hundred megabytes across changes for unrelated branches. This
@@ -71,142 +75,30 @@ jobs:
           # compressed cache).
           if [[ "$CACHE_SIZE_MB" -gt 4500 ]]; then
             echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
-            rm -rf $BAZEL_CACHE_DIR
+            rm -rf $EXPANDED_BAZEL_CACHE_PATH
           fi
 
       - name: Configure Bazel to use a local cache
         env:
           BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
         run: |
-          echo "Using $BAZEL_CACHE_DIR as Bazel's cache path"
-          echo "build --disk_cache=$BAZEL_CACHE_DIR" >> $HOME/.bazelrc
-          echo "build --local_ram_resources=HOST_RAM*.5" >> $HOME/.bazelrc
+          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
+          echo "Using $EXPANDED_BAZEL_CACHE_PATH as Bazel's cache path"
+          echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
         shell: bash
 
       - name: Check Bazel environment
         run: bazel info
 
-      - name: Build Oppia dev AAB
-        run: bazel build -- //:oppia_dev
-
-  # Each of these jobs pre-builds the deployable (pre-Proguard-map) AAB for a single
-  # Proguard-enabled flavor on its own fresh runner. Building each flavor on a separate runner
-  # avoids OOM crashes that occur when all three are built sequentially on a single VM (even with
-  # bazel shutdown between them, memory accumulates across builds). The resulting Bazel disk cache
-  # is uploaded as a flavor-specific workflow artifact so that the corresponding finalize job can
-  # skip the heavy compilation & Proguard work.
-  build_proguarded_base:
-    name: Build Proguarded base AAB (${{ matrix.flavor }})
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [alpha, beta, ga]
-    env:
-      CACHE_DIRECTORY: /home/runner/.bazel_cache
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
-        with:
-          version: 6.5.0
-
-      - name: Set up build environment
-        uses: ./.github/actions/set-up-android-bazel-build-environment
-
-      - uses: actions/cache@v5
-        id: cache
-        with:
-          path: ${{ env.CACHE_DIRECTORY }}
-          key: ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-${{ matrix.flavor }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-${{ matrix.flavor }}-
-            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-
-            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-tests-
-            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-
-
-      - name: Ensure cache size
-        env:
-          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
+      - name: Build Oppia ${{ matrix.flavor }} AAB
         run: |
-          CACHE_SIZE_MB=$(du -smc $BAZEL_CACHE_DIR | grep total | cut -f1)
-          echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
-          if [[ "$CACHE_SIZE_MB" -gt 4500 ]]; then
-            echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
-            rm -rf $BAZEL_CACHE_DIR
+          if [[ "${{ matrix.flavor }}" == "dev" ]]; then
+            bazel build -- //:oppia_${{ matrix.flavor }}
+          else
+            # Build the deployable (pre-Proguard-map) AAB first, then shutdown Bazel to release
+            # JVM memory accumulated during the heavy Proguard step. This avoids OOM crashes
+            # (error code 14) when building the final AAB that packages the Proguard map.
+            bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}_deployable
+            bazel shutdown
+            bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}
           fi
-
-      - name: Configure Bazel to use a local cache
-        env:
-          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
-        run: |
-          echo "Using $BAZEL_CACHE_DIR as Bazel's cache path"
-          echo "build --disk_cache=$BAZEL_CACHE_DIR" >> $HOME/.bazelrc
-          echo "build --local_ram_resources=HOST_RAM*.5" >> $HOME/.bazelrc
-        shell: bash
-
-      - name: Check Bazel environment
-        run: bazel info
-
-      - name: Build deployable AAB (${{ matrix.flavor }})
-        run: bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}_deployable
-
-      - name: Upload Bazel cache for finalize job
-        uses: actions/upload-artifact@v7
-        with:
-          name: bazel-cache-proguarded-${{ matrix.flavor }}
-          path: ${{ env.CACHE_DIRECTORY }}
-          include-hidden-files: true
-          retention-days: 1
-
-  # Each finalize job downloads the Bazel cache produced by the matching build_proguarded_base
-  # matrix job and runs only the lightweight final packaging step (bundling the Proguard map into
-  # the already-built deployable AAB). This starts with a fresh JVM so there is no accumulated
-  # memory pressure from the heavy compilation + Proguard work, which avoids OOM crashes
-  # (error code 14).
-  finalize_proguarded_aab:
-    name: Finalize Oppia AAB (${{ matrix.flavor }} flavor)
-    needs: build_proguarded_base
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [alpha, beta, ga]
-    env:
-      CACHE_DIRECTORY: /home/runner/.bazel_cache
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
-        with:
-          version: 6.5.0
-
-      - name: Set up build environment
-        uses: ./.github/actions/set-up-android-bazel-build-environment
-
-      - name: Download Bazel cache from base build
-        uses: actions/download-artifact@v7
-        with:
-          name: bazel-cache-proguarded-${{ matrix.flavor }}
-          path: ${{ env.CACHE_DIRECTORY }}
-
-      - name: Configure Bazel to use the downloaded cache
-        env:
-          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
-        run: |
-          echo "Using $BAZEL_CACHE_DIR as Bazel's cache path"
-          echo "build --disk_cache=$BAZEL_CACHE_DIR" >> $HOME/.bazelrc
-          echo "build --local_ram_resources=HOST_RAM*.5" >> $HOME/.bazelrc
-        shell: bash
-
-      - name: Check Bazel environment
-        run: bazel info
-
-      - name: Build Oppia ${{ matrix.flavor }} final AAB
-        run: bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -159,6 +159,7 @@ jobs:
         with:
           name: bazel-cache-proguarded-${{ matrix.flavor }}
           path: ${{ env.CACHE_DIRECTORY }}
+          include-hidden-files: true
           retention-days: 1
 
   # Each finalize job downloads the Bazel cache produced by the matching build_proguarded_base

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -90,13 +90,19 @@ jobs:
       - name: Build Oppia dev AAB
         run: bazel build -- //:oppia_dev
 
-  # This job pre-builds the deployable (pre-Proguard-map) AABs for all Proguard-enabled flavors in
-  # one shot. Building them together is more memory-efficient since Bazel shares intermediate
-  # artifacts across flavors. The resulting Bazel disk cache is uploaded as a workflow artifact so
-  # that the finalize jobs can skip all heavy compilation & Proguard work.
-  build_proguarded_bases:
-    name: Build Proguarded base AABs (alpha, beta, ga)
+  # Each of these jobs pre-builds the deployable (pre-Proguard-map) AAB for a single
+  # Proguard-enabled flavor on its own fresh runner. Building each flavor on a separate runner
+  # avoids OOM crashes that occur when all three are built sequentially on a single VM (even with
+  # bazel shutdown between them, memory accumulates across builds). The resulting Bazel disk cache
+  # is uploaded as a flavor-specific workflow artifact so that the corresponding finalize job can
+  # skip the heavy compilation & Proguard work.
+  build_proguarded_base:
+    name: Build Proguarded base AAB (${{ matrix.flavor }})
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [alpha, beta, ga]
     env:
       CACHE_DIRECTORY: ~/.bazel_cache
     steps:
@@ -146,31 +152,27 @@ jobs:
       - name: Check Bazel environment
         run: bazel info
 
-      - name: Build all deployable AABs
-        run: |
-          for flavor in alpha beta ga; do
-            echo "=== Building //:oppia_${flavor}_deployable ==="
-            bazel build --compilation_mode=opt -- //:oppia_${flavor}_deployable
-            echo "=== Shutting down Bazel to free memory ==="
-            bazel shutdown
-          done
+      - name: Build deployable AAB (${{ matrix.flavor }})
+        run: bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}_deployable
 
-      - name: Upload Bazel cache for finalize jobs
+      - name: Upload Bazel cache for finalize job
         uses: actions/upload-artifact@v7
         with:
-          name: bazel-cache-proguarded
+          name: bazel-cache-proguarded-${{ matrix.flavor }}
           path: ${{ env.CACHE_DIRECTORY }}
           retention-days: 1
 
-  # Each finalize job downloads the Bazel cache produced by build_proguarded_bases and runs only the
-  # lightweight final packaging step (bundling the Proguard map into the already-built deployable
-  # AAB). This starts with a fresh JVM so there is no accumulated memory pressure from the heavy
-  # compilation + Proguard work, which avoids OOM crashes (error code 14).
+  # Each finalize job downloads the Bazel cache produced by the matching build_proguarded_base
+  # matrix job and runs only the lightweight final packaging step (bundling the Proguard map into
+  # the already-built deployable AAB). This starts with a fresh JVM so there is no accumulated
+  # memory pressure from the heavy compilation + Proguard work, which avoids OOM crashes
+  # (error code 14).
   finalize_proguarded_aab:
     name: Finalize Oppia AAB (${{ matrix.flavor }} flavor)
-    needs: build_proguarded_bases
+    needs: build_proguarded_base
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         flavor: [alpha, beta, ga]
     env:
@@ -191,7 +193,7 @@ jobs:
       - name: Download Bazel cache from base build
         uses: actions/download-artifact@v8
         with:
-          name: bazel-cache-proguarded
+          name: bazel-cache-proguarded-${{ matrix.flavor }}
           path: ${{ env.CACHE_DIRECTORY }}
 
       - name: Configure Bazel to use the downloaded cache

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -159,7 +159,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: bazel-cache-proguarded
-          path: ~/.bazel_cache
+          path: ${{ env.CACHE_DIRECTORY }}
           retention-days: 1
 
   # Each finalize job downloads the Bazel cache produced by build_proguarded_bases and runs only the
@@ -192,12 +192,15 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: bazel-cache-proguarded
-          path: ~/.bazel_cache
+          path: ${{ env.CACHE_DIRECTORY }}
 
       - name: Configure Bazel to use the downloaded cache
+        env:
+          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
         run: |
-          echo "Using $HOME/.bazel_cache as Bazel's cache path"
-          echo "build --disk_cache=$HOME/.bazel_cache" >> $HOME/.bazelrc
+          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
+          echo "Using $EXPANDED_BAZEL_CACHE_PATH as Bazel's cache path"
+          echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
         shell: bash
 
       - name: Check Bazel environment

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -80,6 +80,7 @@ jobs:
         run: |
           echo "Using $BAZEL_CACHE_DIR as Bazel's cache path"
           echo "build --disk_cache=$BAZEL_CACHE_DIR" >> $HOME/.bazelrc
+          echo "build --local_ram_resources=HOST_RAM*.5" >> $HOME/.bazelrc
         shell: bash
 
       - name: Check Bazel environment
@@ -120,8 +121,9 @@ jobs:
         id: cache
         with:
           path: ${{ env.CACHE_DIRECTORY }}
-          key: ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-${{ github.sha }}
+          key: ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-${{ matrix.flavor }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-${{ matrix.flavor }}-
             ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-
             ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-tests-
             ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-
@@ -143,6 +145,7 @@ jobs:
         run: |
           echo "Using $BAZEL_CACHE_DIR as Bazel's cache path"
           echo "build --disk_cache=$BAZEL_CACHE_DIR" >> $HOME/.bazelrc
+          echo "build --local_ram_resources=HOST_RAM*.5" >> $HOME/.bazelrc
         shell: bash
 
       - name: Check Bazel environment
@@ -198,6 +201,7 @@ jobs:
         run: |
           echo "Using $BAZEL_CACHE_DIR as Bazel's cache path"
           echo "build --disk_cache=$BAZEL_CACHE_DIR" >> $HOME/.bazelrc
+          echo "build --local_ram_resources=HOST_RAM*.5" >> $HOME/.bazelrc
         shell: bash
 
       - name: Check Bazel environment

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build Oppia AAB (dev flavor)
     runs-on: ubuntu-24.04
     env:
-      CACHE_DIRECTORY: ~/.bazel_cache
+      CACHE_DIRECTORY: /home/runner/.bazel_cache
     steps:
       - uses: actions/checkout@v6
         with:
@@ -62,8 +62,7 @@ jobs:
           BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
         run: |
           # See https://stackoverflow.com/a/27485157 for reference.
-          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
-          CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_PATH | grep total | cut -f1)
+          CACHE_SIZE_MB=$(du -smc $BAZEL_CACHE_DIR | grep total | cut -f1)
           echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
           # Use a 4.5GB threshold since actions/cache compresses the results, and Bazel caches seem
           # to only increase by a few hundred megabytes across changes for unrelated branches. This
@@ -72,16 +71,15 @@ jobs:
           # compressed cache).
           if [[ "$CACHE_SIZE_MB" -gt 4500 ]]; then
             echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
-            rm -rf $EXPANDED_BAZEL_CACHE_PATH
+            rm -rf $BAZEL_CACHE_DIR
           fi
 
       - name: Configure Bazel to use a local cache
         env:
           BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
         run: |
-          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
-          echo "Using $EXPANDED_BAZEL_CACHE_PATH as Bazel's cache path"
-          echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
+          echo "Using $BAZEL_CACHE_DIR as Bazel's cache path"
+          echo "build --disk_cache=$BAZEL_CACHE_DIR" >> $HOME/.bazelrc
         shell: bash
 
       - name: Check Bazel environment
@@ -104,7 +102,7 @@ jobs:
       matrix:
         flavor: [alpha, beta, ga]
     env:
-      CACHE_DIRECTORY: ~/.bazel_cache
+      CACHE_DIRECTORY: /home/runner/.bazel_cache
     steps:
       - uses: actions/checkout@v6
         with:
@@ -132,21 +130,19 @@ jobs:
         env:
           BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
         run: |
-          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
-          CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_PATH | grep total | cut -f1)
+          CACHE_SIZE_MB=$(du -smc $BAZEL_CACHE_DIR | grep total | cut -f1)
           echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
           if [[ "$CACHE_SIZE_MB" -gt 4500 ]]; then
             echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
-            rm -rf $EXPANDED_BAZEL_CACHE_PATH
+            rm -rf $BAZEL_CACHE_DIR
           fi
 
       - name: Configure Bazel to use a local cache
         env:
           BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
         run: |
-          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
-          echo "Using $EXPANDED_BAZEL_CACHE_PATH as Bazel's cache path"
-          echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
+          echo "Using $BAZEL_CACHE_DIR as Bazel's cache path"
+          echo "build --disk_cache=$BAZEL_CACHE_DIR" >> $HOME/.bazelrc
         shell: bash
 
       - name: Check Bazel environment
@@ -176,7 +172,7 @@ jobs:
       matrix:
         flavor: [alpha, beta, ga]
     env:
-      CACHE_DIRECTORY: ~/.bazel_cache
+      CACHE_DIRECTORY: /home/runner/.bazel_cache
     steps:
       - uses: actions/checkout@v6
         with:
@@ -200,9 +196,8 @@ jobs:
         env:
           BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
         run: |
-          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
-          echo "Using $EXPANDED_BAZEL_CACHE_PATH as Bazel's cache path"
-          echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
+          echo "Using $BAZEL_CACHE_DIR as Bazel's cache path"
+          echo "build --disk_cache=$BAZEL_CACHE_DIR" >> $HOME/.bazelrc
         shell: bash
 
       - name: Check Bazel environment

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -29,8 +29,11 @@ jobs:
           CURRENT_OPEN_PR_INFO="$(gh pr list --json number,baseRefName,headRefName,headRepository,headRepositoryOwner | tr -d '[:space:]')"
           echo "matrix={\"prInfo\": $CURRENT_OPEN_PR_INFO}" >> "$GITHUB_OUTPUT"
 
-  build_stats:
-    name: Build Stats
+  # This job builds the deployable (pre-Proguard-map) AABs for both head and base branches, then
+  # uploads the Bazel disk cache so that the finalize job can build finals with a fresh JVM,
+  # avoiding OOM crashes (error code 14).
+  build_stats_deployables:
+    name: Build Stats (deployable AABs)
     needs: find_open_pull_requests
     runs-on: ubuntu-24.04
     # Reduce parallelization due to high build times, and allow individual PRs to fail.
@@ -204,6 +207,163 @@ jobs:
           ref: ${{ env.PR_HEAD_REF_NAME }}
           path: head
 
+      - name: Build deployable AABs (feature branch)
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
+        run: |
+          cd head
+          git log -n 1
+          bazel build -- //:oppia_alpha_deployable //:oppia_beta_deployable //:oppia_ga_deployable
+          bazel shutdown
+
+      - name: Build deployable AABs (base branch)
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
+        run: |
+          cd base
+          git log -n 1
+          bazel build -- //:oppia_alpha_deployable //:oppia_beta_deployable //:oppia_ga_deployable
+          bazel shutdown
+
+      - name: Upload Bazel cache for finalize job
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: bazel-cache-stats-pr-${{ matrix.prInfo.number }}
+          path: ~/.bazel_cache
+          retention-days: 1
+
+  # Each finalize job downloads the Bazel cache produced by build_stats_deployables and runs only
+  # the lightweight final packaging steps (bundling the Proguard map into the already-built
+  # deployable AABs). This starts with a fresh JVM so there is no accumulated memory pressure.
+  finalize_stats_and_report:
+    name: Finalize Stats & Report
+    needs: [find_open_pull_requests, build_stats_deployables]
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix: ${{ fromJson(needs.find_open_pull_requests.outputs.matrix) }}
+    env:
+      ENABLE_CACHING: false
+      CACHE_DIRECTORY: ~/.bazel_cache
+    steps:
+      # Re-check whether this PR has new commits (lightweight GitHub API calls).
+      - name: Find the latest APK & AAB Analysis Comment
+        uses: actions/github-script@v8
+        id: find_latest_apk_aab_comment
+        with:
+           script: |
+             const comments = await github.paginate(github.rest.issues.listComments, {
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               issue_number: ${{ matrix.prInfo.number }},
+             });
+
+             for (let i = comments.length - 1; i >= 0; i--) {
+               if (comments[i].body.includes("# APK & AAB differences analysis")) {
+                 const latestComment = comments[i];
+                 const commentBody = latestComment.body;
+                 const commentDate = latestComment.created_at;
+
+                 require('fs').writeFileSync('latest_aab_comment_body.log', commentBody, 'utf8');
+                 core.setOutput("latest_aab_comment_created_at", commentDate);
+
+                 return
+               }
+             }
+
+      - name: Track Commits following the latest APK & AAB Analysis Comment
+        uses: actions/github-script@v8
+        id: track_commits
+        with:
+           script: |
+             const commits = await github.paginate(github.rest.pulls.listCommits, {
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               pull_number: ${{ matrix.prInfo.number }},
+             });
+
+             const latestCommentDate = "${{ steps.find_latest_apk_aab_comment.outputs.latest_aab_comment_created_at }}";
+             const recentCommits = commits.filter(commit => {
+               const commitDate = new Date(commit.commit.committer.date);
+               return commitDate > new Date("${{ steps.find_latest_apk_aab_comment.outputs.latest_aab_comment_created_at }}");
+             });
+
+             const recentCommitsCount = recentCommits.length;
+             if(recentCommitsCount > 0 || !latestCommentDate) {
+               core.setOutput("new_commits", "true");
+             } else {
+               console.log("No new commits since the last APK & AAB report; Skipping redundant analysis.");
+               core.setOutput("new_commits", "false");
+             }
+
+      - name: Compute PR head owner/repo reference
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
+        env:
+          PR_HEAD_REPO: ${{ matrix.prInfo.headRepository.name }}
+          PR_HEAD_REPO_OWNER: ${{ matrix.prInfo.headRepositoryOwner.login }}
+        run: |
+          echo "PR_HEAD=$PR_HEAD_REPO_OWNER/$PR_HEAD_REPO" >> "$GITHUB_ENV"
+
+      - name: Set up Bazel
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
+        uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: 6.5.0
+
+      - name: Download Bazel cache from deployable build
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: bazel-cache-stats-pr-${{ matrix.prInfo.number }}
+          path: ~/.bazel_cache
+
+      - name: Configure Bazel to use the downloaded cache
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
+        run: |
+          echo "Using $HOME/.bazel_cache as Bazel's cache path"
+          echo "build --disk_cache=$HOME/.bazel_cache" >> $HOME/.bazelrc
+        shell: bash
+
+      # This checks out the actual true develop branch separately to ensure that the stats check is
+      # run from the latest develop rather than the base branch (which might be different for
+      # chained PRs).
+      - name: Check out develop repository
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
+        uses: actions/checkout@v6
+        with:
+          path: develop
+
+      - name: Set up build environment
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
+        uses: ./develop/.github/actions/set-up-android-bazel-build-environment
+
+      - name: Check Bazel environment
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
+        run: |
+          cd develop
+          bazel info
+
+      - name: Check out base repository and branch
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
+        env:
+          PR_BASE_REF_NAME: ${{ matrix.prInfo.baseRefName }}
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ env.PR_BASE_REF_NAME }}
+          path: base
+
+      - name: Check out head repository and branch
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
+        env:
+          PR_HEAD_REF_NAME: ${{ matrix.prInfo.headRefName }}
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          repository: ${{ env.PR_HEAD }}
+          ref: ${{ env.PR_HEAD_REF_NAME }}
+          path: head
+
       # Note that Bazel is shutdown between builds since multiple Bazel servers will otherwise end
       # up being active (due to multiple repositories being used) and this can quickly overwhelm CI
       # worker resources.
@@ -212,8 +372,6 @@ jobs:
         run: |
           cd head
           git log -n 1
-          bazel build -- //:oppia_alpha_deployable //:oppia_beta_deployable //:oppia_ga_deployable
-          bazel shutdown
           bazel build -- //:oppia_dev //:oppia_alpha //:oppia_beta //:oppia_ga
           cp bazel-bin/oppia_dev.aab ../develop/oppia_dev_with_changes.aab
           cp bazel-bin/oppia_alpha.aab ../develop/oppia_alpha_with_changes.aab
@@ -226,8 +384,6 @@ jobs:
         run: |
           cd base
           git log -n 1
-          bazel build -- //:oppia_alpha_deployable //:oppia_beta_deployable //:oppia_ga_deployable
-          bazel shutdown
           bazel build -- //:oppia_dev //:oppia_alpha //:oppia_beta //:oppia_ga
           cp bazel-bin/oppia_dev.aab ../develop/oppia_dev_without_changes.aab
           cp bazel-bin/oppia_alpha.aab ../develop/oppia_alpha_without_changes.aab

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -212,6 +212,8 @@ jobs:
         run: |
           cd head
           git log -n 1
+          bazel build -- //:oppia_alpha_deployable //:oppia_beta_deployable //:oppia_ga_deployable
+          bazel shutdown
           bazel build -- //:oppia_dev //:oppia_alpha //:oppia_beta //:oppia_ga
           cp bazel-bin/oppia_dev.aab ../develop/oppia_dev_with_changes.aab
           cp bazel-bin/oppia_alpha.aab ../develop/oppia_alpha_with_changes.aab
@@ -224,6 +226,8 @@ jobs:
         run: |
           cd base
           git log -n 1
+          bazel build -- //:oppia_alpha_deployable //:oppia_beta_deployable //:oppia_ga_deployable
+          bazel shutdown
           bazel build -- //:oppia_dev //:oppia_alpha //:oppia_beta //:oppia_ga
           cp bazel-bin/oppia_dev.aab ../develop/oppia_dev_without_changes.aab
           cp bazel-bin/oppia_alpha.aab ../develop/oppia_alpha_without_changes.aab

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -29,15 +29,10 @@ jobs:
           CURRENT_OPEN_PR_INFO="$(gh pr list --json number,baseRefName,headRefName,headRepository,headRepositoryOwner | tr -d '[:space:]')"
           echo "matrix={\"prInfo\": $CURRENT_OPEN_PR_INFO}" >> "$GITHUB_OUTPUT"
 
-  # This job builds the deployable (pre-Proguard-map) AABs for both head and base branches, then
-  # uploads the Bazel disk cache so that the finalize job can build finals with a fresh JVM,
-  # avoiding OOM crashes (error code 14).
-  build_stats_deployables:
-    name: Build Stats (deployable AABs)
+  build_stats:
+    name: Build Stats
     needs: find_open_pull_requests
     runs-on: ubuntu-24.04
-    outputs:
-      new_commits: ${{ steps.track_commits.outputs.new_commits }}
     # Reduce parallelization due to high build times, and allow individual PRs to fail.
     strategy:
       fail-fast: false
@@ -97,6 +92,7 @@ jobs:
              }
 
       - name: Compute PR head owner/repo reference
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
           PR_HEAD_REPO: ${{ matrix.prInfo.headRepository.name }}
           PR_HEAD_REPO_OWNER: ${{ matrix.prInfo.headRepositoryOwner.login }}
@@ -208,162 +204,47 @@ jobs:
           ref: ${{ env.PR_HEAD_REF_NAME }}
           path: head
 
-      - name: Build deployable AABs (feature branch)
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
-        run: |
-          cd head
-          git log -n 1
-          for flavor in alpha beta ga; do
-            echo "=== Building //:oppia_${flavor}_deployable ==="
-            bazel build -- //:oppia_${flavor}_deployable
-            echo "=== Shutting down Bazel to free memory ==="
-            bazel shutdown
-          done
-
-      - name: Build deployable AABs (base branch)
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
-        run: |
-          cd base
-          git log -n 1
-          for flavor in alpha beta ga; do
-            echo "=== Building //:oppia_${flavor}_deployable ==="
-            bazel build -- //:oppia_${flavor}_deployable
-            echo "=== Shutting down Bazel to free memory ==="
-            bazel shutdown
-          done
-
-      - name: Upload Bazel cache for finalize job
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: bazel-cache-stats-pr-${{ matrix.prInfo.number }}
-          path: ${{ env.CACHE_DIRECTORY }}
-          include-hidden-files: true
-          retention-days: 1
-
-  # Each finalize job downloads the Bazel cache produced by build_stats_deployables and runs only
-  # the lightweight final packaging steps (bundling the Proguard map into the already-built
-  # deployable AABs). This starts with a fresh JVM so there is no accumulated memory pressure.
-  finalize_stats_and_report:
-    name: Finalize Stats & Report
-    needs: [find_open_pull_requests, build_stats_deployables]
-    if: ${{ needs.build_stats_deployables.outputs.new_commits == 'true' }}
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      max-parallel: 5
-      matrix: ${{ fromJson(needs.find_open_pull_requests.outputs.matrix) }}
-    env:
-      ENABLE_CACHING: false
-      CACHE_DIRECTORY: ~/.bazel_cache
-    steps:
-      - name: Compute PR head owner/repo reference
-        env:
-          PR_HEAD_REPO: ${{ matrix.prInfo.headRepository.name }}
-          PR_HEAD_REPO_OWNER: ${{ matrix.prInfo.headRepositoryOwner.login }}
-        run: |
-          echo "PR_HEAD=$PR_HEAD_REPO_OWNER/$PR_HEAD_REPO" >> "$GITHUB_ENV"
-
-      - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
-        with:
-          version: 6.5.0
-
-      - name: Download Bazel cache from deployable build
-        id: download_cache
-        continue-on-error: true
-        uses: actions/download-artifact@v7
-        with:
-          name: bazel-cache-stats-pr-${{ matrix.prInfo.number }}
-          path: ${{ env.CACHE_DIRECTORY }}
-
-      # If the artifact wasn't uploaded (e.g. build_stats_deployables skipped
-      # this PR because new_commits was 'false'), skip all remaining steps.
-      - name: Skip if no artifact available
-        if: ${{ steps.download_cache.outcome != 'success' }}
-        run: |
-          echo "::warning::No Bazel cache artifact found for PR ${{ matrix.prInfo.number }}; skipping finalize."
-          echo "SKIP_FINALIZE=true" >> "$GITHUB_ENV"
-
-      - name: Configure Bazel to use the downloaded cache
-        if: ${{ env.SKIP_FINALIZE != 'true' }}
-        env:
-          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
-        run: |
-          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
-          echo "Using $EXPANDED_BAZEL_CACHE_PATH as Bazel's cache path"
-          echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
-        shell: bash
-
-      # This checks out the actual true develop branch separately to ensure that the stats check is
-      # run from the latest develop rather than the base branch (which might be different for
-      # chained PRs).
-      - name: Check out develop repository
-        if: ${{ env.SKIP_FINALIZE != 'true' }}
-        uses: actions/checkout@v6
-        with:
-          path: develop
-
-      - name: Set up build environment
-        if: ${{ env.SKIP_FINALIZE != 'true' }}
-        uses: ./develop/.github/actions/set-up-android-bazel-build-environment
-
-      - name: Check Bazel environment
-        if: ${{ env.SKIP_FINALIZE != 'true' }}
-        run: |
-          cd develop
-          bazel info
-
-      - name: Check out base repository and branch
-        if: ${{ env.SKIP_FINALIZE != 'true' }}
-        env:
-          PR_BASE_REF_NAME: ${{ matrix.prInfo.baseRefName }}
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          ref: ${{ env.PR_BASE_REF_NAME }}
-          path: base
-
-      - name: Check out head repository and branch
-        if: ${{ env.SKIP_FINALIZE != 'true' }}
-        env:
-          PR_HEAD_REF_NAME: ${{ matrix.prInfo.headRefName }}
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          repository: ${{ env.PR_HEAD }}
-          ref: ${{ env.PR_HEAD_REF_NAME }}
-          path: head
-
       # Note that Bazel is shutdown between builds since multiple Bazel servers will otherwise end
       # up being active (due to multiple repositories being used) and this can quickly overwhelm CI
       # worker resources.
       - name: Build Oppia dev, alpha, beta, and GA (feature branch)
-        if: ${{ env.SKIP_FINALIZE != 'true' }}
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         run: |
           cd head
           git log -n 1
-          bazel build -- //:oppia_dev //:oppia_alpha //:oppia_beta //:oppia_ga
+          # Build dev (no Proguard) and Proguard-enabled deployable targets first.
+          bazel build -- //:oppia_dev //:oppia_alpha_deployable //:oppia_beta_deployable //:oppia_ga_deployable
           cp bazel-bin/oppia_dev.aab ../develop/oppia_dev_with_changes.aab
+          # Shutdown Bazel to release JVM memory accumulated during Proguard, then build the
+          # lightweight final AABs that package the Proguard map. This avoids OOM crashes
+          # (error code 14).
+          bazel shutdown
+          bazel build -- //:oppia_alpha //:oppia_beta //:oppia_ga
           cp bazel-bin/oppia_alpha.aab ../develop/oppia_alpha_with_changes.aab
           cp bazel-bin/oppia_beta.aab ../develop/oppia_beta_with_changes.aab
           cp bazel-bin/oppia_ga.aab ../develop/oppia_ga_with_changes.aab
           bazel shutdown
 
       - name: Build Oppia dev, alpha, beta, and GA (base branch)
-        if: ${{ env.SKIP_FINALIZE != 'true' }}
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         run: |
           cd base
           git log -n 1
-          bazel build -- //:oppia_dev //:oppia_alpha //:oppia_beta //:oppia_ga
+          # Build dev (no Proguard) and Proguard-enabled deployable targets first.
+          bazel build -- //:oppia_dev //:oppia_alpha_deployable //:oppia_beta_deployable //:oppia_ga_deployable
           cp bazel-bin/oppia_dev.aab ../develop/oppia_dev_without_changes.aab
+          # Shutdown Bazel to release JVM memory accumulated during Proguard, then build the
+          # lightweight final AABs that package the Proguard map. This avoids OOM crashes
+          # (error code 14).
+          bazel shutdown
+          bazel build -- //:oppia_alpha //:oppia_beta //:oppia_ga
           cp bazel-bin/oppia_alpha.aab ../develop/oppia_alpha_without_changes.aab
           cp bazel-bin/oppia_beta.aab ../develop/oppia_beta_without_changes.aab
           cp bazel-bin/oppia_ga.aab ../develop/oppia_ga_without_changes.aab
           bazel shutdown
 
       - name: Run stats analysis tool (develop branch)
-        if: ${{ env.SKIP_FINALIZE != 'true' }}
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         run: |
           cd develop
           git log -n 1
@@ -377,7 +258,7 @@ jobs:
       # Reference: https://github.com/peter-evans/create-or-update-comment#setting-the-comment-body-from-a-file.
       # Also, for multi-line env values, see: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings.
       - name: Extract reports for uploading & commenting
-        if: ${{ env.SKIP_FINALIZE != 'true' }}
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
           PR_NUMBER: ${{ matrix.prInfo.number }}
         id: compute-comment-body
@@ -394,7 +275,7 @@ jobs:
           cp "$GITHUB_WORKSPACE/develop/full_build_summary.log" "$FULL_BUILD_SUMMARY_FILE_PATH"
 
       - name: Add build stats summary comment
-        if: ${{ env.SKIP_FINALIZE != 'true' }}
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
           PR_NUMBER: ${{ matrix.prInfo.number }}
         uses: peter-evans/create-or-update-comment@v5
@@ -402,8 +283,8 @@ jobs:
           issue-number: ${{ env.PR_NUMBER }}
           body: ${{ steps.compute-comment-body.outputs.comment_body }}
 
-      - if: ${{ env.SKIP_FINALIZE != 'true' }}
-        uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v7
+        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         with:
           name: ${{ env.FULL_BUILD_SUMMARY_FILE_NAME }}
           path: ${{ env.FULL_BUILD_SUMMARY_FILE_PATH }}

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -271,7 +271,7 @@ jobs:
       - name: Download Bazel cache from deployable build
         id: download_cache
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: bazel-cache-stats-pr-${{ matrix.prInfo.number }}
           path: ${{ env.CACHE_DIRECTORY }}

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -238,6 +238,7 @@ jobs:
         with:
           name: bazel-cache-stats-pr-${{ matrix.prInfo.number }}
           path: ${{ env.CACHE_DIRECTORY }}
+          include-hidden-files: true
           retention-days: 1
 
   # Each finalize job downloads the Bazel cache produced by build_stats_deployables and runs only

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -236,7 +236,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: bazel-cache-stats-pr-${{ matrix.prInfo.number }}
-          path: ~/.bazel_cache
+          path: ${{ env.CACHE_DIRECTORY }}
           retention-days: 1
 
   # Each finalize job downloads the Bazel cache produced by build_stats_deployables and runs only
@@ -323,13 +323,16 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: bazel-cache-stats-pr-${{ matrix.prInfo.number }}
-          path: ~/.bazel_cache
+          path: ${{ env.CACHE_DIRECTORY }}
 
       - name: Configure Bazel to use the downloaded cache
         if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
+        env:
+          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
         run: |
-          echo "Using $HOME/.bazel_cache as Bazel's cache path"
-          echo "build --disk_cache=$HOME/.bazel_cache" >> $HOME/.bazelrc
+          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
+          echo "Using $EXPANDED_BAZEL_CACHE_PATH as Bazel's cache path"
+          echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
         shell: bash
 
       # This checks out the actual true develop branch separately to ensure that the stats check is

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -212,16 +212,24 @@ jobs:
         run: |
           cd head
           git log -n 1
-          bazel build -- //:oppia_alpha_deployable //:oppia_beta_deployable //:oppia_ga_deployable
-          bazel shutdown
+          for flavor in alpha beta ga; do
+            echo "=== Building //:oppia_${flavor}_deployable ==="
+            bazel build -- //:oppia_${flavor}_deployable
+            echo "=== Shutting down Bazel to free memory ==="
+            bazel shutdown
+          done
 
       - name: Build deployable AABs (base branch)
         if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         run: |
           cd base
           git log -n 1
-          bazel build -- //:oppia_alpha_deployable //:oppia_beta_deployable //:oppia_ga_deployable
-          bazel shutdown
+          for flavor in alpha beta ga; do
+            echo "=== Building //:oppia_${flavor}_deployable ==="
+            bazel build -- //:oppia_${flavor}_deployable
+            echo "=== Shutting down Bazel to free memory ==="
+            bazel shutdown
+          done
 
       - name: Upload Bazel cache for finalize job
         if: ${{ steps.track_commits.outputs.new_commits == 'true' }}

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -269,12 +269,23 @@ jobs:
           version: 6.5.0
 
       - name: Download Bazel cache from deployable build
+        id: download_cache
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: bazel-cache-stats-pr-${{ matrix.prInfo.number }}
           path: ${{ env.CACHE_DIRECTORY }}
 
+      # If the artifact wasn't uploaded (e.g. build_stats_deployables skipped
+      # this PR because new_commits was 'false'), skip all remaining steps.
+      - name: Skip if no artifact available
+        if: ${{ steps.download_cache.outcome != 'success' }}
+        run: |
+          echo "::warning::No Bazel cache artifact found for PR ${{ matrix.prInfo.number }}; skipping finalize."
+          echo "SKIP_FINALIZE=true" >> "$GITHUB_ENV"
+
       - name: Configure Bazel to use the downloaded cache
+        if: ${{ env.SKIP_FINALIZE != 'true' }}
         env:
           BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
         run: |
@@ -287,19 +298,23 @@ jobs:
       # run from the latest develop rather than the base branch (which might be different for
       # chained PRs).
       - name: Check out develop repository
+        if: ${{ env.SKIP_FINALIZE != 'true' }}
         uses: actions/checkout@v6
         with:
           path: develop
 
       - name: Set up build environment
+        if: ${{ env.SKIP_FINALIZE != 'true' }}
         uses: ./develop/.github/actions/set-up-android-bazel-build-environment
 
       - name: Check Bazel environment
+        if: ${{ env.SKIP_FINALIZE != 'true' }}
         run: |
           cd develop
           bazel info
 
       - name: Check out base repository and branch
+        if: ${{ env.SKIP_FINALIZE != 'true' }}
         env:
           PR_BASE_REF_NAME: ${{ matrix.prInfo.baseRefName }}
         uses: actions/checkout@v6
@@ -309,6 +324,7 @@ jobs:
           path: base
 
       - name: Check out head repository and branch
+        if: ${{ env.SKIP_FINALIZE != 'true' }}
         env:
           PR_HEAD_REF_NAME: ${{ matrix.prInfo.headRefName }}
         uses: actions/checkout@v6
@@ -322,6 +338,7 @@ jobs:
       # up being active (due to multiple repositories being used) and this can quickly overwhelm CI
       # worker resources.
       - name: Build Oppia dev, alpha, beta, and GA (feature branch)
+        if: ${{ env.SKIP_FINALIZE != 'true' }}
         run: |
           cd head
           git log -n 1
@@ -333,6 +350,7 @@ jobs:
           bazel shutdown
 
       - name: Build Oppia dev, alpha, beta, and GA (base branch)
+        if: ${{ env.SKIP_FINALIZE != 'true' }}
         run: |
           cd base
           git log -n 1
@@ -344,6 +362,7 @@ jobs:
           bazel shutdown
 
       - name: Run stats analysis tool (develop branch)
+        if: ${{ env.SKIP_FINALIZE != 'true' }}
         run: |
           cd develop
           git log -n 1
@@ -357,6 +376,7 @@ jobs:
       # Reference: https://github.com/peter-evans/create-or-update-comment#setting-the-comment-body-from-a-file.
       # Also, for multi-line env values, see: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings.
       - name: Extract reports for uploading & commenting
+        if: ${{ env.SKIP_FINALIZE != 'true' }}
         env:
           PR_NUMBER: ${{ matrix.prInfo.number }}
         id: compute-comment-body
@@ -373,6 +393,7 @@ jobs:
           cp "$GITHUB_WORKSPACE/develop/full_build_summary.log" "$FULL_BUILD_SUMMARY_FILE_PATH"
 
       - name: Add build stats summary comment
+        if: ${{ env.SKIP_FINALIZE != 'true' }}
         env:
           PR_NUMBER: ${{ matrix.prInfo.number }}
         uses: peter-evans/create-or-update-comment@v5
@@ -380,7 +401,8 @@ jobs:
           issue-number: ${{ env.PR_NUMBER }}
           body: ${{ steps.compute-comment-body.outputs.comment_body }}
 
-      - uses: actions/upload-artifact@v7
+      - if: ${{ env.SKIP_FINALIZE != 'true' }}
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.FULL_BUILD_SUMMARY_FILE_NAME }}
           path: ${{ env.FULL_BUILD_SUMMARY_FILE_PATH }}

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -36,6 +36,8 @@ jobs:
     name: Build Stats (deployable AABs)
     needs: find_open_pull_requests
     runs-on: ubuntu-24.04
+    outputs:
+      new_commits: ${{ steps.track_commits.outputs.new_commits }}
     # Reduce parallelization due to high build times, and allow individual PRs to fail.
     strategy:
       fail-fast: false
@@ -95,7 +97,6 @@ jobs:
              }
 
       - name: Compute PR head owner/repo reference
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
           PR_HEAD_REPO: ${{ matrix.prInfo.headRepository.name }}
           PR_HEAD_REPO_OWNER: ${{ matrix.prInfo.headRepositoryOwner.login }}
@@ -245,6 +246,7 @@ jobs:
   finalize_stats_and_report:
     name: Finalize Stats & Report
     needs: [find_open_pull_requests, build_stats_deployables]
+    if: ${{ needs.build_stats_deployables.outputs.new_commits == 'true' }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -254,58 +256,7 @@ jobs:
       ENABLE_CACHING: false
       CACHE_DIRECTORY: ~/.bazel_cache
     steps:
-      # Re-check whether this PR has new commits (lightweight GitHub API calls).
-      - name: Find the latest APK & AAB Analysis Comment
-        uses: actions/github-script@v8
-        id: find_latest_apk_aab_comment
-        with:
-           script: |
-             const comments = await github.paginate(github.rest.issues.listComments, {
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               issue_number: ${{ matrix.prInfo.number }},
-             });
-
-             for (let i = comments.length - 1; i >= 0; i--) {
-               if (comments[i].body.includes("# APK & AAB differences analysis")) {
-                 const latestComment = comments[i];
-                 const commentBody = latestComment.body;
-                 const commentDate = latestComment.created_at;
-
-                 require('fs').writeFileSync('latest_aab_comment_body.log', commentBody, 'utf8');
-                 core.setOutput("latest_aab_comment_created_at", commentDate);
-
-                 return
-               }
-             }
-
-      - name: Track Commits following the latest APK & AAB Analysis Comment
-        uses: actions/github-script@v8
-        id: track_commits
-        with:
-           script: |
-             const commits = await github.paginate(github.rest.pulls.listCommits, {
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               pull_number: ${{ matrix.prInfo.number }},
-             });
-
-             const latestCommentDate = "${{ steps.find_latest_apk_aab_comment.outputs.latest_aab_comment_created_at }}";
-             const recentCommits = commits.filter(commit => {
-               const commitDate = new Date(commit.commit.committer.date);
-               return commitDate > new Date("${{ steps.find_latest_apk_aab_comment.outputs.latest_aab_comment_created_at }}");
-             });
-
-             const recentCommitsCount = recentCommits.length;
-             if(recentCommitsCount > 0 || !latestCommentDate) {
-               core.setOutput("new_commits", "true");
-             } else {
-               console.log("No new commits since the last APK & AAB report; Skipping redundant analysis.");
-               core.setOutput("new_commits", "false");
-             }
-
       - name: Compute PR head owner/repo reference
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
           PR_HEAD_REPO: ${{ matrix.prInfo.headRepository.name }}
           PR_HEAD_REPO_OWNER: ${{ matrix.prInfo.headRepositoryOwner.login }}
@@ -313,20 +264,17 @@ jobs:
           echo "PR_HEAD=$PR_HEAD_REPO_OWNER/$PR_HEAD_REPO" >> "$GITHUB_ENV"
 
       - name: Set up Bazel
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         uses: abhinavsingh/setup-bazel@v3
         with:
           version: 6.5.0
 
       - name: Download Bazel cache from deployable build
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         uses: actions/download-artifact@v8
         with:
           name: bazel-cache-stats-pr-${{ matrix.prInfo.number }}
           path: ${{ env.CACHE_DIRECTORY }}
 
       - name: Configure Bazel to use the downloaded cache
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
           BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
         run: |
@@ -339,23 +287,19 @@ jobs:
       # run from the latest develop rather than the base branch (which might be different for
       # chained PRs).
       - name: Check out develop repository
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         uses: actions/checkout@v6
         with:
           path: develop
 
       - name: Set up build environment
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         uses: ./develop/.github/actions/set-up-android-bazel-build-environment
 
       - name: Check Bazel environment
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         run: |
           cd develop
           bazel info
 
       - name: Check out base repository and branch
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
           PR_BASE_REF_NAME: ${{ matrix.prInfo.baseRefName }}
         uses: actions/checkout@v6
@@ -365,7 +309,6 @@ jobs:
           path: base
 
       - name: Check out head repository and branch
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
           PR_HEAD_REF_NAME: ${{ matrix.prInfo.headRefName }}
         uses: actions/checkout@v6
@@ -379,7 +322,6 @@ jobs:
       # up being active (due to multiple repositories being used) and this can quickly overwhelm CI
       # worker resources.
       - name: Build Oppia dev, alpha, beta, and GA (feature branch)
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         run: |
           cd head
           git log -n 1
@@ -391,7 +333,6 @@ jobs:
           bazel shutdown
 
       - name: Build Oppia dev, alpha, beta, and GA (base branch)
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         run: |
           cd base
           git log -n 1
@@ -403,7 +344,6 @@ jobs:
           bazel shutdown
 
       - name: Run stats analysis tool (develop branch)
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         run: |
           cd develop
           git log -n 1
@@ -417,7 +357,6 @@ jobs:
       # Reference: https://github.com/peter-evans/create-or-update-comment#setting-the-comment-body-from-a-file.
       # Also, for multi-line env values, see: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings.
       - name: Extract reports for uploading & commenting
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
           PR_NUMBER: ${{ matrix.prInfo.number }}
         id: compute-comment-body
@@ -434,7 +373,6 @@ jobs:
           cp "$GITHUB_WORKSPACE/develop/full_build_summary.log" "$FULL_BUILD_SUMMARY_FILE_PATH"
 
       - name: Add build stats summary comment
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         env:
           PR_NUMBER: ${{ matrix.prInfo.number }}
         uses: peter-evans/create-or-update-comment@v5
@@ -443,7 +381,6 @@ jobs:
           body: ${{ steps.compute-comment-body.outputs.comment_body }}
 
       - uses: actions/upload-artifact@v7
-        if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
         with:
           name: ${{ env.FULL_BUILD_SUMMARY_FILE_NAME }}
           path: ${{ env.FULL_BUILD_SUMMARY_FILE_PATH }}


### PR DESCRIPTION
## Explanation
Fixes #6186
 - In `build_tests.yml` & `stats.yml`, splits builds into separate jobs and shares Bazel cache via GH artifacts so final AAB packaging runs on fresh workers, avoiding Proguard OOMs.
## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).