### PR TITLE
Fixes part of #5440: Profile id migration utility update

### DIFF
--- a/utility/src/main/java/org/oppia/android/util/profile/CurrentUserProfileIdIntentDecorator.kt
+++ b/utility/src/main/java/org/oppia/android/util/profile/CurrentUserProfileIdIntentDecorator.kt
@@ -21,7 +21,7 @@ object CurrentUserProfileIdIntentDecorator {
    * [extractCurrentUserProfileId] should be used for retrieving the [LegacyProfileId] later.
    */
   fun Intent.decorateWithUserProfileId(profileId: LegacyProfileId) {
-    putProtoExtra(PROFILE_ID_INTENT_DECORATOR, profileId.toProfileId())
+    putProtoExtra(PROFILE_ID_INTENT_DECORATOR, profileId.toProfileIdPreservingZero())
   }
 
   /**
@@ -40,7 +40,7 @@ object CurrentUserProfileIdIntentDecorator {
    * [extractCurrentUserProfileId] should be used for retrieving the [LegacyProfileId] later.
    */
   fun Bundle.decorateWithUserProfileId(profileId: LegacyProfileId) {
-    putProto(PROFILE_ID_BUNDLE_DECORATOR, profileId.toProfileId())
+    putProto(PROFILE_ID_BUNDLE_DECORATOR, profileId.toProfileIdPreservingZero())
   }
 
   /**

--- a/utility/src/main/java/org/oppia/android/util/profile/ProfileIdMigrationUtil.kt
+++ b/utility/src/main/java/org/oppia/android/util/profile/ProfileIdMigrationUtil.kt
@@ -3,8 +3,20 @@ package org.oppia.android.util.profile
 import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.ProfileId
 
-/** Migrates [LegacyProfileId] to the new [ProfileId] proto structure. */
-fun LegacyProfileId.toProfileId(): ProfileId =
+/**
+ * Migrates [LegacyProfileId] to [ProfileId], preserving zero as a valid internal ID.
+ *
+ * Use this for admin profiles where internal_id = 0 is a legitimate value.
+ */
+fun LegacyProfileId.toProfileIdPreservingZero(): ProfileId =
+  ProfileId.newBuilder().setInternalId(this.internalId).build()
+
+/**
+ * Migrates [LegacyProfileId] to [ProfileId], treating zero internal ID as unset.
+ *
+ * Use this for non-admin profiles where internal_id = 0 means no profile is selected.
+ */
+fun LegacyProfileId.toProfileIdUnsetIfZero(): ProfileId =
   ProfileId.newBuilder().mergeFrom(this.toByteString()).build()
 
 /** Converts [ProfileId] back to [LegacyProfileId] for compatibility during migration. */

--- a/utility/src/test/java/org/oppia/android/util/profile/ProfileIdMigrationUtilTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/profile/ProfileIdMigrationUtilTest.kt
@@ -13,17 +13,33 @@ import org.robolectric.annotation.LooperMode
 class ProfileIdMigrationUtilTest {
 
   @Test
-  fun testMigrate_legacyProfileIdWithValidId_migratesCorrectly() {
+  fun testPreservingZero_legacyProfileIdWithValidId_migratesCorrectly() {
     val legacyProfileId = LegacyProfileId.newBuilder().setInternalId(5).build()
-    val profileId = legacyProfileId.toProfileId()
+    val profileId = legacyProfileId.toProfileIdPreservingZero()
     assertThat(profileId.hasInternalId()).isTrue()
     assertThat(profileId.internalId).isEqualTo(5)
   }
 
   @Test
-  fun testMigrate_legacyProfileIdWithZeroId_convertsToNull() {
+  fun testPreservingZero_legacyProfileIdWithZeroId_preservesZero() {
     val legacyProfileId = LegacyProfileId.newBuilder().setInternalId(0).build()
-    val profileId = legacyProfileId.toProfileId()
+    val profileId = legacyProfileId.toProfileIdPreservingZero()
+    assertThat(profileId.hasInternalId()).isTrue()
+    assertThat(profileId.internalId).isEqualTo(0)
+  }
+
+  @Test
+  fun testUnsetIfZero_legacyProfileIdWithValidId_migratesCorrectly() {
+    val legacyProfileId = LegacyProfileId.newBuilder().setInternalId(5).build()
+    val profileId = legacyProfileId.toProfileIdUnsetIfZero()
+    assertThat(profileId.hasInternalId()).isTrue()
+    assertThat(profileId.internalId).isEqualTo(5)
+  }
+
+  @Test
+  fun testUnsetIfZero_legacyProfileIdWithZeroId_convertsToUnset() {
+    val legacyProfileId = LegacyProfileId.newBuilder().setInternalId(0).build()
+    val profileId = legacyProfileId.toProfileIdUnsetIfZero()
     assertThat(profileId.hasInternalId()).isFalse()
   }
 


### PR DESCRIPTION
## Explanation
Fixes part of #5440 
 - Update migration utilities to handle zeroes more freely.
 - Update utility layer accordingly.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).