### PR TITLE
Fixes part of #5035: Add missing reading text size tests

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/options/ReadingTextSizeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/ReadingTextSizeActivityTest.kt
@@ -24,6 +24,7 @@ import org.oppia.android.app.application.ApplicationStartupListenerModule
 import org.oppia.android.app.application.testing.TestingBuildFlavorModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
+import org.oppia.android.app.model.ReadingTextSize
 import org.oppia.android.app.model.ReadingTextSize.LARGE_TEXT_SIZE
 import org.oppia.android.app.model.ReadingTextSize.MEDIUM_TEXT_SIZE
 import org.oppia.android.app.model.ReadingTextSize.SMALL_TEXT_SIZE
@@ -136,49 +137,39 @@ class ReadingTextSizeActivityTest {
 
   @Test
   fun testReadingTextSizeActivity_initialTextSize_backNavigation_returnsCorrectResult() {
-    val intent =
-      ReadingTextSizeActivity.createReadingTextSizeActivityIntent(context, MEDIUM_TEXT_SIZE)
-    val scenario = ActivityScenario.launch<ReadingTextSizeActivity>(intent)
-    testCoroutineDispatchers.runCurrent()
+    runWithLaunchedActivity {
+      // Trigger back press — the activity calls setResult(RESULT_OK, ...) then finish().
+      onActivity { it.onBackPressedDispatcher.onBackPressed() }
+      testCoroutineDispatchers.runCurrent()
 
-    // Trigger back press — the activity calls setResult(RESULT_OK, ...) then finish().
-    scenario.onActivity { it.onBackPressedDispatcher.onBackPressed() }
-    testCoroutineDispatchers.runCurrent()
-
-    val result = scenario.result
-    assertThat(result.resultCode).isEqualTo(Activity.RESULT_OK)
-    val resultBundle = result.resultData.getProtoExtra(
-      MESSAGE_READING_TEXT_SIZE_RESULTS_KEY,
-      ReadingTextSizeActivityResultBundle.getDefaultInstance()
-    )
-    assertThat(resultBundle.selectedReadingTextSize).isEqualTo(MEDIUM_TEXT_SIZE)
+      val result = this.result
+      assertThat(result.resultCode).isEqualTo(Activity.RESULT_OK)
+      val resultBundle = result.resultData.getProtoExtra(
+        MESSAGE_READING_TEXT_SIZE_RESULTS_KEY,
+        ReadingTextSizeActivityResultBundle.getDefaultInstance()
+      )
+      assertThat(resultBundle.selectedReadingTextSize).isEqualTo(MEDIUM_TEXT_SIZE)
+    }
   }
 
   @Test
   fun testReadingTextSizeActivity_newTextSizeSelected_backNavigation_returnsUpdatedResult() {
-    val intent =
-      ReadingTextSizeActivity.createReadingTextSizeActivityIntent(context, SMALL_TEXT_SIZE)
-    val scenario = ActivityScenario.launch<ReadingTextSizeActivity>(intent)
-    testCoroutineDispatchers.runCurrent()
+    runWithLaunchedActivity(initialSize = SMALL_TEXT_SIZE) {
+      // Change selection before pressing back.
+      selectTextSize(LARGE_TEXT_SIZE)
 
-    // Change selection before pressing back.
-    scenario.onActivity { activity ->
-      val fragment = activity.supportFragmentManager
-        .findFragmentById(R.id.reading_text_size_container) as ReadingTextSizeFragment
-      fragment.readingTextSizeFragmentPresenter.onTextSizeSelected(LARGE_TEXT_SIZE)
+      // Trigger back press — result should report the updated selection.
+      onActivity { it.onBackPressedDispatcher.onBackPressed() }
+      testCoroutineDispatchers.runCurrent()
+
+      val result = this.result
+      assertThat(result.resultCode).isEqualTo(Activity.RESULT_OK)
+      val resultBundle = result.resultData.getProtoExtra(
+        MESSAGE_READING_TEXT_SIZE_RESULTS_KEY,
+        ReadingTextSizeActivityResultBundle.getDefaultInstance()
+      )
+      assertThat(resultBundle.selectedReadingTextSize).isEqualTo(LARGE_TEXT_SIZE)
     }
-
-    // Trigger back press — result should report the updated selection.
-    scenario.onActivity { it.onBackPressedDispatcher.onBackPressed() }
-    testCoroutineDispatchers.runCurrent()
-
-    val result = scenario.result
-    assertThat(result.resultCode).isEqualTo(Activity.RESULT_OK)
-    val resultBundle = result.resultData.getProtoExtra(
-      MESSAGE_READING_TEXT_SIZE_RESULTS_KEY,
-      ReadingTextSizeActivityResultBundle.getDefaultInstance()
-    )
-    assertThat(resultBundle.selectedReadingTextSize).isEqualTo(LARGE_TEXT_SIZE)
   }
 
   private fun setUpTestApplicationComponent() {
@@ -186,13 +177,24 @@ class ReadingTextSizeActivityTest {
   }
 
   private fun runWithLaunchedActivity(
+    initialSize: ReadingTextSize = MEDIUM_TEXT_SIZE,
     testBlock: ActivityScenario<ReadingTextSizeActivity>.() -> Unit
   ) {
     val intent =
-      ReadingTextSizeActivity.createReadingTextSizeActivityIntent(context, MEDIUM_TEXT_SIZE)
+      ReadingTextSizeActivity.createReadingTextSizeActivityIntent(context, initialSize)
     ActivityScenario.launch<ReadingTextSizeActivity>(intent).use { scenario ->
       testCoroutineDispatchers.runCurrent()
       scenario.testBlock()
+    }
+  }
+
+  private fun ActivityScenario<ReadingTextSizeActivity>.selectTextSize(
+    textSize: ReadingTextSize
+  ) {
+    onActivity { activity ->
+      val fragment = activity.supportFragmentManager
+        .findFragmentById(R.id.reading_text_size_container) as ReadingTextSizeFragment
+      fragment.readingTextSizeFragmentPresenter.onTextSizeSelected(textSize)
     }
   }
 

--- a/app/src/sharedTest/java/org/oppia/android/app/options/ReadingTextSizeActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/ReadingTextSizeActivityTest.kt
@@ -1,5 +1,6 @@
 package org.oppia.android.app.options
 
+import android.app.Activity
 import android.app.Application
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
@@ -23,7 +24,10 @@ import org.oppia.android.app.application.ApplicationStartupListenerModule
 import org.oppia.android.app.application.testing.TestingBuildFlavorModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
+import org.oppia.android.app.model.ReadingTextSize.LARGE_TEXT_SIZE
 import org.oppia.android.app.model.ReadingTextSize.MEDIUM_TEXT_SIZE
+import org.oppia.android.app.model.ReadingTextSize.SMALL_TEXT_SIZE
+import org.oppia.android.app.model.ReadingTextSizeActivityResultBundle
 import org.oppia.android.app.model.ScreenName
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
@@ -72,6 +76,7 @@ import org.oppia.android.testing.time.FakeOppiaClockModule
 import org.oppia.android.util.accessibility.AccessibilityTestModule
 import org.oppia.android.util.caching.AssetModule
 import org.oppia.android.util.caching.testing.CachingTestModule
+import org.oppia.android.util.extensions.getProtoExtra
 import org.oppia.android.util.gcsresource.GcsResourceModule
 import org.oppia.android.util.locale.LocaleProdModule
 import org.oppia.android.util.logging.CurrentAppScreenNameIntentDecorator.extractCurrentAppScreenName
@@ -127,6 +132,53 @@ class ReadingTextSizeActivityTest {
         assertThat(title).isEqualTo(context.getString(R.string.reading_text_size_activity_title))
       }
     }
+  }
+
+  @Test
+  fun testReadingTextSizeActivity_initialTextSize_backNavigation_returnsCorrectResult() {
+    val intent =
+      ReadingTextSizeActivity.createReadingTextSizeActivityIntent(context, MEDIUM_TEXT_SIZE)
+    val scenario = ActivityScenario.launch<ReadingTextSizeActivity>(intent)
+    testCoroutineDispatchers.runCurrent()
+
+    // Trigger back press — the activity calls setResult(RESULT_OK, ...) then finish().
+    scenario.onActivity { it.onBackPressedDispatcher.onBackPressed() }
+    testCoroutineDispatchers.runCurrent()
+
+    val result = scenario.result
+    assertThat(result.resultCode).isEqualTo(Activity.RESULT_OK)
+    val resultBundle = result.resultData.getProtoExtra(
+      MESSAGE_READING_TEXT_SIZE_RESULTS_KEY,
+      ReadingTextSizeActivityResultBundle.getDefaultInstance()
+    )
+    assertThat(resultBundle.selectedReadingTextSize).isEqualTo(MEDIUM_TEXT_SIZE)
+  }
+
+  @Test
+  fun testReadingTextSizeActivity_newTextSizeSelected_backNavigation_returnsUpdatedResult() {
+    val intent =
+      ReadingTextSizeActivity.createReadingTextSizeActivityIntent(context, SMALL_TEXT_SIZE)
+    val scenario = ActivityScenario.launch<ReadingTextSizeActivity>(intent)
+    testCoroutineDispatchers.runCurrent()
+
+    // Change selection before pressing back.
+    scenario.onActivity { activity ->
+      val fragment = activity.supportFragmentManager
+        .findFragmentById(R.id.reading_text_size_container) as ReadingTextSizeFragment
+      fragment.readingTextSizeFragmentPresenter.onTextSizeSelected(LARGE_TEXT_SIZE)
+    }
+
+    // Trigger back press — result should report the updated selection.
+    scenario.onActivity { it.onBackPressedDispatcher.onBackPressed() }
+    testCoroutineDispatchers.runCurrent()
+
+    val result = scenario.result
+    assertThat(result.resultCode).isEqualTo(Activity.RESULT_OK)
+    val resultBundle = result.resultData.getProtoExtra(
+      MESSAGE_READING_TEXT_SIZE_RESULTS_KEY,
+      ReadingTextSizeActivityResultBundle.getDefaultInstance()
+    )
+    assertThat(resultBundle.selectedReadingTextSize).isEqualTo(LARGE_TEXT_SIZE)
   }
 
   private fun setUpTestApplicationComponent() {

--- a/app/src/sharedTest/java/org/oppia/android/app/testing/TestFontScaleConfigurationUtilActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/testing/TestFontScaleConfigurationUtilActivityTest.kt
@@ -184,6 +184,70 @@ class TestFontScaleConfigurationUtilActivityTest {
     }
   }
 
+  @Test
+  fun testFontScaleConfigurationUtil_smallTextSize_afterRecreate_hasCorrectDimension() {
+    launch<TestFontScaleConfigurationUtilActivity>(
+      createFontScaleTestActivityIntent(ReadingTextSize.SMALL_TEXT_SIZE)
+    ).use { scenario ->
+      scenario.recreate()
+      onView(withId(R.id.font_scale_content_text_view)).check(
+        matches(
+          withFontSize(
+            context.resources.getDimension(R.dimen.font_scale_content_small_text_view_size)
+          )
+        )
+      )
+    }
+  }
+
+  @Test
+  fun testFontScaleConfigurationUtil_mediumTextSize_afterRecreate_hasCorrectDimension() {
+    launch<TestFontScaleConfigurationUtilActivity>(
+      createFontScaleTestActivityIntent(ReadingTextSize.MEDIUM_TEXT_SIZE)
+    ).use { scenario ->
+      scenario.recreate()
+      onView(withId(R.id.font_scale_content_text_view)).check(
+        matches(
+          withFontSize(
+            context.resources.getDimension(R.dimen.font_scale_content_text_size)
+          )
+        )
+      )
+    }
+  }
+
+  @Test
+  fun testFontScaleConfigurationUtil_largeTextSize_afterRecreate_hasCorrectDimension() {
+    launch<TestFontScaleConfigurationUtilActivity>(
+      createFontScaleTestActivityIntent(ReadingTextSize.LARGE_TEXT_SIZE)
+    ).use { scenario ->
+      scenario.recreate()
+      onView(withId(R.id.font_scale_content_text_view)).check(
+        matches(
+          withFontSize(
+            context.resources.getDimension(R.dimen.font_scale_content_large_text_view_size)
+          )
+        )
+      )
+    }
+  }
+
+  @Test
+  fun testFontScaleConfigurationUtil_extraLargeTextSize_afterRecreate_hasCorrectDimension() {
+    launch<TestFontScaleConfigurationUtilActivity>(
+      createFontScaleTestActivityIntent(ReadingTextSize.EXTRA_LARGE_TEXT_SIZE)
+    ).use { scenario ->
+      scenario.recreate()
+      onView(withId(R.id.font_scale_content_text_view)).check(
+        matches(
+          withFontSize(
+            context.resources.getDimension(R.dimen.font_scale_content_extra_large_text_view_size)
+          )
+        )
+      )
+    }
+  }
+
   // TODO(#59): Figure out a way to reuse modules instead of needing to re-declare them.
   @Singleton
   @Component(


### PR DESCRIPTION
## Explanation

Fixes part of #5035

Adds the remaining missing tests for PR #4411 

- `TestFontScaleConfigurationUtilActivityTest`: 4 new tests verifying that the correct font scale dimension is applied after `scenario.recreate()`, covering all four `ReadingTextSize` values (small, medium, large, extra-large). These directly test the recreation-based font scale fix introduced in #4411.

- `ReadingTextSizeActivityTest`: 2 new tests verifying that pressing back returns a `ReadingTextSizeActivityResultBundle` proto with the correct `selectedReadingTextSize`; once when the initial selection is unchanged, and once when the user changes the selection before navigating away.

**Note**: This PR covers the `FontScaleConfigurationUtil` & Recreation Behavior and Intent Extras & Result Handling sections of #4411. The remaining sections require additional tests.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
