### PR TITLE
Fixes #6149, Fixes part of #6202: Use bazel-contrib/setup-bazel in workflows to setup bazel

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -32,9 +32,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       - name: Set up build environment
         uses: ./.github/actions/set-up-android-bazel-build-environment

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -44,9 +44,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       - uses: actions/cache@v5
         id: scripts_cache
@@ -142,9 +142,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       - uses: actions/cache@v5
         id: scripts_cache
@@ -288,9 +288,9 @@ jobs:
           echo "${PB_FILES_LIST[@]}" > pb_files.txt
 
       - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       - uses: actions/cache@v5
         id: scripts_cache

--- a/.github/workflows/issue_checks.yml
+++ b/.github/workflows/issue_checks.yml
@@ -17,9 +17,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       - name: Pre-build required scripts
         id: pre-build-scripts

--- a/.github/workflows/lesson_checks.yml
+++ b/.github/workflows/lesson_checks.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       - name: Check out introduce-asset-download-script branch
         uses: actions/checkout@v6

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -105,9 +105,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       - uses: actions/cache@v5
         id: scripts_cache
@@ -232,9 +232,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       - name: Maven Repin Check
         # The expression if: ${{ !cancelled() }} runs a job or step regardless of its success or failure while responding to cancellations,

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -110,9 +110,9 @@ jobs:
 
       - name: Set up Bazel
         if: ${{ steps.track_commits.outputs.new_commits == 'true' }}
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       # For reference on this & the later cache actions, see:
       # https://github.com/actions/cache/issues/239#issuecomment-606950711 &

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -34,9 +34,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       - uses: actions/cache@v5
         id: scripts_cache
@@ -132,9 +132,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       - uses: actions/cache@v5
         id: scripts_cache

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -27,9 +27,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       - name: Check Wiki Table of Contents
         id: checkWikiToc


### PR DESCRIPTION
## Explanation
Fixes #6149
Fixes part of #6202
 - Replace all workflows using unmaintained `abhinavsingh/setup-bazel` with bazel's own `bazel-contrib/setup-bazel`.
 - Enable `bazelisk-cache: true` to enable caching and preventing bazel being downloaded repeatedly.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).