### PR TITLE
Fix part of #6010: Update Android lint script to support optional per-layer manifests with top-level fallback

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/lint/LintCommon.kt
+++ b/scripts/src/java/org/oppia/android/scripts/lint/LintCommon.kt
@@ -42,7 +42,7 @@ data class LayerConfig(
   val srcFiles: List<String>,
   val testFiles: List<String>,
   val resourceDirs: List<String>,
-  val manifestFile: String,
+  val manifestFile: String?,
   val dependencies: List<String>,
   val aarFiles: List<AarFileInfo>,
   val jarFiles: List<String>,

--- a/scripts/src/java/org/oppia/android/scripts/lint/LintProjectDescription.kt
+++ b/scripts/src/java/org/oppia/android/scripts/lint/LintProjectDescription.kt
@@ -302,7 +302,10 @@ class LintProjectDescription(
 
     appendLine("""    desugar="full">""")
 
-    appendLine("""    <manifest file="${config.manifestFile}"/>""")
+    // CHANGE 1: manifestFile nullable hai, sirf tab output karo jab exist kare
+    config.manifestFile?.let { manifest ->
+      appendLine("""    <manifest file="$manifest"/>""")
+    }
 
     config.srcFiles.forEach { srcFile ->
       appendLine("""    <src file="$srcFile"/>""")
@@ -379,6 +382,9 @@ private class LayerConfigurationBuilder(
       LayerName.DATA to listOf(LayerName.UTILITY)
     )
     private const val ANDROID_MANIFEST_PATH = "src/main/${SdkConstants.FN_ANDROID_MANIFEST_XML}"
+
+    // CHANGE 2: Top-level fallback manifest path add kiya
+    private const val TOP_LEVEL_MANIFEST_PATH = SdkConstants.FN_ANDROID_MANIFEST_XML
   }
 
   private val dependencyResolver = DependencyResolver(
@@ -459,12 +465,15 @@ private class LayerConfigurationBuilder(
     }
   }
 
-  private fun findManifestFile(layer: LayerName): String {
-    val manifestPath = File(repoRoot, "${layer.layerName}/$ANDROID_MANIFEST_PATH")
-    require(manifestPath.exists()) {
-      "Manifest file not found for layer: ${layer.layerName} at ${manifestPath.absolutePath}"
-    }
-    return manifestPath.absolutePath
+  // CHANGE 3: Crash nahi hoga — layer manifest nahi mila toh top-level try karo, warna null
+  private fun findManifestFile(layer: LayerName): String? {
+    val layerManifest = File(repoRoot, "${layer.layerName}/$ANDROID_MANIFEST_PATH")
+    if (layerManifest.exists()) return layerManifest.absolutePath
+
+    val topLevelManifest = File(repoRoot, TOP_LEVEL_MANIFEST_PATH)
+    if (topLevelManifest.exists()) return topLevelManifest.absolutePath
+
+    return null
   }
 }
 


### PR DESCRIPTION
## Overview

This PR addresses part of #6010 by updating the Android lint wrapper 
script to remove the hard requirement that every top-level layer 
directory must contain its own `AndroidManifest.xml` file.

Previously, the lint tool strictly enforced a Gradle-style project 
structure where each layer (app/, domain/, utility/, data/, testing/) 
was required to have its own manifest file. This was a carryover from 
when the project used Gradle, and it unnecessarily restricts how the 
codebase can be organized going forward.

## Problem

The `findManifestFile()` function in `LayerConfigurationBuilder` used 
`require()` to assert that a manifest must exist for every layer:

```kotlin
private fun findManifestFile(layer: LayerName): String {
  val manifestPath = File(repoRoot, "${layer.layerName}/$ANDROID_MANIFEST_PATH")
  require(manifestPath.exists()) {
    "Manifest file not found for layer: ${layer.layerName} at ${manifestPath.absolutePath}"
  }
  return manifestPath.absolutePath
}
```

This caused the lint tool to crash if any layer's manifest was missing 
or moved, which blocked efforts like:
- Moving the main app `AndroidManifest.xml` to the top level (#1640)
- Removing unnecessary library-specific manifests (#1632)

## Solution

This PR introduces a fallback strategy for manifest resolution:

1. **Layer-specific manifest** — existing behavior preserved. If a 
   layer has its own `src/main/AndroidManifest.xml`, it is used.
2. **Top-level fallback** — if no layer manifest exists, the tool now 
   looks for a single top-level `AndroidManifest.xml` at the repo root.
3. **Null safe** — if neither exists, `null` is returned instead of 
   crashing. The XML generation skips the `<manifest>` tag gracefully.

## Files Changed

### `LintCommon.kt`
- Changed `manifestFile: String` to `manifestFile: String?` in 
  `LayerConfig` to allow layers without a manifest file.

### `LintProjectDescription.kt`
- Added `TOP_LEVEL_MANIFEST_PATH` constant as the fallback manifest path.
- Updated `findManifestFile()` to return `String?` with fallback logic 
  instead of crashing via `require()`.
- Updated `generateModuleXml()` to use `?.let {}` so the 
  `<manifest>` XML tag is only emitted when a manifest is available.

## Testing

The existing behavior is fully preserved — all layers that currently 
have their own manifests will continue to use them. The fallback path 
is only triggered when a layer manifest is absent, which does not 
occur in the current codebase but will be needed for follow-up issues 
#1640 and #1632.

## Related Issues
- Fixes part of #6010
- Unblocks #1640
- Unblocks #1632