### PR TITLE
Fix part of #6010: Update Android lint script to support optional per-layer manifests with top-level fallback

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/lint/LintCommon.kt
+++ b/scripts/src/java/org/oppia/android/scripts/lint/LintCommon.kt
@@ -42,7 +42,7 @@ data class LayerConfig(
   val srcFiles: List<String>,
   val testFiles: List<String>,
   val resourceDirs: List<String>,
-  val manifestFile: String,
+  val manifestFile: String?,
   val dependencies: List<String>,
   val aarFiles: List<AarFileInfo>,
   val jarFiles: List<String>,

--- a/scripts/src/java/org/oppia/android/scripts/lint/LintProjectDescription.kt
+++ b/scripts/src/java/org/oppia/android/scripts/lint/LintProjectDescription.kt
@@ -302,7 +302,6 @@ class LintProjectDescription(
 
     appendLine("""    desugar="full">""")
 
-    // CHANGE 1: manifestFile nullable hai, sirf tab output karo jab exist kare
     config.manifestFile?.let { manifest ->
       appendLine("""    <manifest file="$manifest"/>""")
     }
@@ -383,7 +382,6 @@ private class LayerConfigurationBuilder(
     )
     private const val ANDROID_MANIFEST_PATH = "src/main/${SdkConstants.FN_ANDROID_MANIFEST_XML}"
 
-    // CHANGE 2: Top-level fallback manifest path add kiya
     private const val TOP_LEVEL_MANIFEST_PATH = SdkConstants.FN_ANDROID_MANIFEST_XML
   }
 
@@ -465,7 +463,6 @@ private class LayerConfigurationBuilder(
     }
   }
 
-  // CHANGE 3: Crash nahi hoga — layer manifest nahi mila toh top-level try karo, warna null
   private fun findManifestFile(layer: LayerName): String? {
     val layerManifest = File(repoRoot, "${layer.layerName}/$ANDROID_MANIFEST_PATH")
     if (layerManifest.exists()) return layerManifest.absolutePath

--- a/scripts/src/java/org/oppia/android/scripts/lint/LintProjectDescription.kt
+++ b/scripts/src/java/org/oppia/android/scripts/lint/LintProjectDescription.kt
@@ -381,7 +381,6 @@ private class LayerConfigurationBuilder(
       LayerName.DATA to listOf(LayerName.UTILITY)
     )
     private const val ANDROID_MANIFEST_PATH = "src/main/${SdkConstants.FN_ANDROID_MANIFEST_XML}"
-
     private const val TOP_LEVEL_MANIFEST_PATH = SdkConstants.FN_ANDROID_MANIFEST_XML
   }
 

--- a/scripts/src/java/org/oppia/android/scripts/lint/LintProjectDescription.kt
+++ b/scripts/src/java/org/oppia/android/scripts/lint/LintProjectDescription.kt
@@ -302,7 +302,10 @@ class LintProjectDescription(
 
     appendLine("""    desugar="full">""")
 
-    appendLine("""    <manifest file="${config.manifestFile}"/>""")
+    // CHANGE 1: manifestFile nullable hai, sirf tab output karo jab exist kare
+    config.manifestFile?.let { manifest ->
+      appendLine("""    <manifest file="$manifest"/>""")
+    }
 
     config.srcFiles.forEach { srcFile ->
       appendLine("""    <src file="$srcFile"/>""")
@@ -379,6 +382,9 @@ private class LayerConfigurationBuilder(
       LayerName.DATA to listOf(LayerName.UTILITY)
     )
     private const val ANDROID_MANIFEST_PATH = "src/main/${SdkConstants.FN_ANDROID_MANIFEST_XML}"
+
+    // CHANGE 2: Top-level fallback manifest path add kiya
+    private const val TOP_LEVEL_MANIFEST_PATH = SdkConstants.FN_ANDROID_MANIFEST_XML
   }
 
   private val dependencyResolver = DependencyResolver(
@@ -459,12 +465,15 @@ private class LayerConfigurationBuilder(
     }
   }
 
-  private fun findManifestFile(layer: LayerName): String {
-    val manifestPath = File(repoRoot, "${layer.layerName}/$ANDROID_MANIFEST_PATH")
-    require(manifestPath.exists()) {
-      "Manifest file not found for layer: ${layer.layerName} at ${manifestPath.absolutePath}"
-    }
-    return manifestPath.absolutePath
+  // CHANGE 3: Crash nahi hoga — layer manifest nahi mila toh top-level try karo, warna null
+  private fun findManifestFile(layer: LayerName): String? {
+    val layerManifest = File(repoRoot, "${layer.layerName}/$ANDROID_MANIFEST_PATH")
+    if (layerManifest.exists()) return layerManifest.absolutePath
+
+    val topLevelManifest = File(repoRoot, TOP_LEVEL_MANIFEST_PATH)
+    if (topLevelManifest.exists()) return topLevelManifest.absolutePath
+
+    return null
   }
 }
 

--- a/scripts/src/javatests/org/oppia/android/scripts/lint/LintProjectDescriptionTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/lint/LintProjectDescriptionTest.kt
@@ -179,16 +179,16 @@ class LintProjectDescriptionTest {
   }
 
   @Test
-  fun testGenerateProjectDescriptionXml_missingManifest_throwsException() {
+  fun testGenerateProjectDescriptionXml_missingManifest_noManifestTagInXml() {
     val appManifest = File(tempFolder.root, "app/src/main/AndroidManifest.xml")
     appManifest.delete()
     setupFakeCommandExecutor()
 
-    val exception = assertThrows<IllegalArgumentException> {
-      lintProjectDescriptionWithFakeExecutor.generateProjectDescriptionXml()
-    }
+    val result = lintProjectDescriptionWithFakeExecutor.generateProjectDescriptionXml()
+    val xmlContent = result.readText()
 
-    assertThat(exception.message).contains("Manifest file not found")
+    val manifestCount = xmlContent.split("<manifest file=").size - 1
+    assertThat(manifestCount).isEqualTo(4)
   }
 
   @Test


### PR DESCRIPTION
## Explanation

**Problem**
The `findManifestFile()` function in `LayerConfigurationBuilder` used `require()` to assert that a manifest must exist for every layer. This caused the lint tool to crash if any layer's manifest was missing or moved, which blocked efforts like moving the main app `AndroidManifest.xml` to the top level.

**Solution**
This PR introduces a fallback strategy for manifest resolution:
- **Layer-specific manifest** — existing behavior preserved. If a layer has its own `src/main/AndroidManifest.xml`, it is used.
- **Top-level fallback** — if no layer manifest exists, the tool now looks for a single top-level `AndroidManifest.xml` at the repo root.
- **Null safe** — if neither exists, `null` is returned instead of crashing. The XML generation skips the `<manifest>` tag gracefully.

## Changes Made

1. `LintCommon.kt` — Changed `manifestFile: String` to `manifestFile: String?` in `LayerConfig` to allow layers without a manifest file.

2. `LintProjectDescription.kt` — Added `TOP_LEVEL_MANIFEST_PATH` constant as the fallback manifest path. Updated `findManifestFile()` to return `String?` with fallback logic instead of crashing via `require()`. Updated `generateModuleXml()` to use `?.let {}` so the `<manifest>` XML tag is only emitted when a manifest is available.

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to scripts/assets files have their rationale included in the PR explanation.
- [x] The PR follows the style guide.
- [x] The PR does not contain any unnecessary code changes from Android Studio.
- [x] The PR is made from a branch that's not called "develop" and is up-to-date with "develop".
- [x] The PR is assigned to the appropriate reviewers.

Fixes part of #6010