### PR TITLE
Fixes #6146 rendering of bold in Authorize to add profiles screen

### DIFF
--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.text.HtmlCompat
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
 import org.oppia.android.app.activity.ActivityScope
@@ -20,6 +19,7 @@ import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.getProtoExtra
+import org.oppia.android.util.parser.html.HtmlParser
 import javax.inject.Inject
 
 /** The presenter for [AdminPinActivity]. */
@@ -29,7 +29,8 @@ class AdminPinActivityPresenter @Inject constructor(
   private val activity: AppCompatActivity,
   private val profileManagementController: ProfileManagementController,
   private val adminViewModel: AdminPinViewModel,
-  private val resourceHandler: AppLanguageResourceHandler
+  private val resourceHandler: AppLanguageResourceHandler,
+  private val htmlParserFactory: HtmlParser.Factory
 ) {
 
   private var inputtedPin = false
@@ -59,9 +60,11 @@ class AdminPinActivityPresenter @Inject constructor(
 
     binding.adminPinToolbar.title = resourceHandler
       .getStringInLocale(R.string.admin_auth_activity_add_profiles_title)
-    binding.adminPinWarningText.text = HtmlCompat.fromHtml(
+    binding.adminPinWarningText.text = htmlParserFactory.create(
+      displayLocale = resourceHandler.getDisplayLocale()
+    ).parseOppiaHtml(
       resourceHandler.getStringInLocale(R.string.admin_pin_pin_description),
-      HtmlCompat.FROM_HTML_MODE_LEGACY
+      binding.adminPinWarningText
     )
     // [onTextChanged] is a extension function defined at [TextInputEditTextHelper]
     binding.adminPinInputPinEditText.onTextChanged { pin ->

--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.text.HtmlCompat
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
 import org.oppia.android.app.activity.ActivityScope
@@ -58,6 +59,10 @@ class AdminPinActivityPresenter @Inject constructor(
 
     binding.adminPinToolbar.title = resourceHandler
       .getStringInLocale(R.string.admin_auth_activity_add_profiles_title)
+    binding.adminPinWarningText.text = HtmlCompat.fromHtml(
+      resourceHandler.getStringInLocale(R.string.admin_pin_pin_description),
+      HtmlCompat.FROM_HTML_MODE_LEGACY
+    )
     // [onTextChanged] is a extension function defined at [TextInputEditTextHelper]
     binding.adminPinInputPinEditText.onTextChanged { pin ->
       pin?.let {

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
@@ -2,9 +2,12 @@ package org.oppia.android.app.profile
 
 import android.app.Application
 import android.content.Context
+import android.text.Spanned
+import android.text.style.StyleSpan
 import android.view.View
 import android.view.ViewParent
 import android.widget.FrameLayout
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.NestedScrollView
 import androidx.test.core.app.ActivityScenario.launch
@@ -176,6 +179,27 @@ class AdminPinActivityTest {
         // Verify that the activity label is correct as a proxy to verify TalkBack will announce the
         // correct string when it's read out.
         assertThat(title).isEqualTo(context.getString(R.string.admin_pin_activity_title))
+      }
+    }
+  }
+
+  @Test
+  fun testAdminPinActivity_warningText_isBoldFormatted() {
+    launch<AdminPinActivity>(
+      AdminPinActivity.createAdminPinActivityIntent(
+        context = context,
+        profileId = 0,
+        colorRgb = -10710042,
+        adminPinEnum = 0
+      )
+    ).use { scenario ->
+      scenario.onActivity { activity ->
+        val warningText = activity.findViewById<TextView>(R.id.admin_pin_warning_text).text
+
+        assertThat(warningText).isInstanceOf(Spanned::class.java)
+        val boldSpans =
+          (warningText as Spanned).getSpans(0, warningText.length, StyleSpan::class.java)
+        assertThat(boldSpans).isNotEmpty()
       }
     }
   }

--- a/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/profile/AdminPinActivityTest.kt
@@ -2,6 +2,7 @@ package org.oppia.android.app.profile
 
 import android.app.Application
 import android.content.Context
+import android.graphics.Typeface
 import android.text.Spanned
 import android.text.style.StyleSpan
 import android.view.View
@@ -200,6 +201,9 @@ class AdminPinActivityTest {
         val boldSpans =
           (warningText as Spanned).getSpans(0, warningText.length, StyleSpan::class.java)
         assertThat(boldSpans).isNotEmpty()
+        val hasBoldStyle =
+          boldSpans.any { it.style == Typeface.BOLD || it.style == Typeface.BOLD_ITALIC }
+        assertThat(hasBoldStyle).isTrue()
       }
     }
   }


### PR DESCRIPTION

## Explanation
Fixes #6146 
- when this PR is merged it fixes rendering of bold in "Authorize to add profiles" screen
- The admin PIN warning now converts that escaped HTML string into styled text in AdminPinActivityPresenter, so not renders bold without changing the resource format.
- Also added a regression test in AdminPinActivityTest that verifies the warning text contains a bold span.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<img width="717" height="1600" alt="WhatsApp Image 2026-04-26 at 10 17 27 PM" src="https://github.com/user-attachments/assets/a1a62dc9-a6b5-4ffc-a4e0-68c237014d74" />
<img width="717" height="1600" alt="WhatsApp Image 2026-04-26 at 10 17 28 PM" src="https://github.com/user-attachments/assets/d41d756c-c5b7-4b27-8bf3-22849c1e1878" />

<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
