### PR TITLE
Fix part of #5822 : Add support for Spanish language

### DIFF
--- a/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
@@ -101,11 +101,14 @@ class AudioLanguageSelectionViewModel @Inject constructor(
   fun getAudioLanguageFromOppiaLanguage(oppiaLanguage: OppiaLanguage): AudioLanguage {
     return when (oppiaLanguage) {
       OppiaLanguage.UNRECOGNIZED, OppiaLanguage.LANGUAGE_UNSPECIFIED, OppiaLanguage.HINGLISH,
-      OppiaLanguage.PORTUGUESE, OppiaLanguage.SWAHILI -> AudioLanguage.AUDIO_LANGUAGE_UNSPECIFIED
+      OppiaLanguage.PORTUGUESE, OppiaLanguage.SPANISH, OppiaLanguage.SWAHILI ->
+        AudioLanguage.AUDIO_LANGUAGE_UNSPECIFIED
       OppiaLanguage.ARABIC -> AudioLanguage.ARABIC_LANGUAGE
       OppiaLanguage.ENGLISH -> AudioLanguage.ENGLISH_AUDIO_LANGUAGE
       OppiaLanguage.HINDI -> AudioLanguage.HINDI_AUDIO_LANGUAGE
       OppiaLanguage.BRAZILIAN_PORTUGUESE -> AudioLanguage.BRAZILIAN_PORTUGUESE_LANGUAGE
+      OppiaLanguage.LATIN_AMERICAN_SPANISH ->
+        AudioLanguage.LATIN_AMERICAN_SPANISH_LANGUAGE
       OppiaLanguage.NIGERIAN_PIDGIN -> AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE
     }
   }

--- a/app/src/main/java/org/oppia/android/app/player/audio/AudioFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/audio/AudioFragmentPresenter.kt
@@ -168,6 +168,7 @@ class AudioFragmentPresenter @Inject constructor(
       AudioLanguage.BRAZILIAN_PORTUGUESE_LANGUAGE -> "pt"
       AudioLanguage.ARABIC_LANGUAGE -> "ar"
       AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE -> "pcm"
+      AudioLanguage.LATIN_AMERICAN_SPANISH_LANGUAGE -> "es"
       AudioLanguage.NO_AUDIO, AudioLanguage.UNRECOGNIZED, AudioLanguage.AUDIO_LANGUAGE_UNSPECIFIED,
       AudioLanguage.ENGLISH_AUDIO_LANGUAGE -> "en"
     }

--- a/app/src/main/java/org/oppia/android/app/translation/AppLanguageResourceHandler.kt
+++ b/app/src/main/java/org/oppia/android/app/translation/AppLanguageResourceHandler.kt
@@ -156,6 +156,7 @@ class AppLanguageResourceHandler @Inject constructor(
       AudioLanguage.HINDI_AUDIO_LANGUAGE -> getLocalizedDisplayName("hi")
       AudioLanguage.BRAZILIAN_PORTUGUESE_LANGUAGE -> getLocalizedDisplayName("pt", "BR")
       AudioLanguage.ARABIC_LANGUAGE -> getLocalizedDisplayName("ar", "EG")
+      AudioLanguage.LATIN_AMERICAN_SPANISH_LANGUAGE -> getLocalizedDisplayName("es", "419")
       AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE ->
         resources.getString(R.string.nigerian_pidgin_localized_language_name)
       AudioLanguage.NO_AUDIO, AudioLanguage.AUDIO_LANGUAGE_UNSPECIFIED, AudioLanguage.UNRECOGNIZED,
@@ -174,6 +175,9 @@ class AppLanguageResourceHandler @Inject constructor(
       OppiaLanguage.HINDI -> resources.getString(R.string.hindi_localized_language_name)
       OppiaLanguage.PORTUGUESE ->
         resources.getString(R.string.portuguese_localized_language_name)
+      OppiaLanguage.SPANISH -> resources.getString(R.string.spanish_localized_language_name)
+      OppiaLanguage.LATIN_AMERICAN_SPANISH ->
+        resources.getString(R.string.latin_american_spanish_localized_language_name)
       OppiaLanguage.SWAHILI -> resources.getString(R.string.swahili_localized_language_name)
       OppiaLanguage.BRAZILIAN_PORTUGUESE ->
         resources.getString(R.string.brazilian_portuguese_localized_language_name)

--- a/app/src/main/java/org/oppia/android/app/utility/math/MathExpressionAccessibilityUtil.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/math/MathExpressionAccessibilityUtil.kt
@@ -30,7 +30,9 @@ import org.oppia.android.app.model.OppiaLanguage.HINGLISH
 import org.oppia.android.app.model.OppiaLanguage.LANGUAGE_UNSPECIFIED
 import org.oppia.android.app.model.OppiaLanguage.NIGERIAN_PIDGIN
 import org.oppia.android.app.model.OppiaLanguage.PORTUGUESE
+import org.oppia.android.app.model.OppiaLanguage.SPANISH
 import org.oppia.android.app.model.OppiaLanguage.SWAHILI
+import org.oppia.android.app.model.OppiaLanguage.LATIN_AMERICAN_SPANISH
 import org.oppia.android.app.model.OppiaLanguage.UNRECOGNIZED
 import org.oppia.android.app.model.Real.RealTypeCase.INTEGER
 import org.oppia.android.app.model.Real.RealTypeCase.IRRATIONAL
@@ -74,6 +76,7 @@ class MathExpressionAccessibilityUtil @Inject constructor(
     return when (language) {
       ENGLISH -> expression.toHumanReadableEnglishString(divAsFraction)
       ARABIC, HINDI, HINGLISH, PORTUGUESE, BRAZILIAN_PORTUGUESE, SWAHILI, NIGERIAN_PIDGIN,
+      SPANISH, LATIN_AMERICAN_SPANISH,
       LANGUAGE_UNSPECIFIED, UNRECOGNIZED -> null
     }
   }
@@ -93,6 +96,7 @@ class MathExpressionAccessibilityUtil @Inject constructor(
     return when (language) {
       ENGLISH -> equation.toHumanReadableEnglishString(divAsFraction)
       ARABIC, HINDI, HINGLISH, PORTUGUESE, BRAZILIAN_PORTUGUESE, SWAHILI, NIGERIAN_PIDGIN,
+      SPANISH, LATIN_AMERICAN_SPANISH,
       LANGUAGE_UNSPECIFIED, UNRECOGNIZED -> null
     }
   }

--- a/app/src/main/java/org/oppia/android/app/utility/math/MathExpressionAccessibilityUtil.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/math/MathExpressionAccessibilityUtil.kt
@@ -28,11 +28,11 @@ import org.oppia.android.app.model.OppiaLanguage.ENGLISH
 import org.oppia.android.app.model.OppiaLanguage.HINDI
 import org.oppia.android.app.model.OppiaLanguage.HINGLISH
 import org.oppia.android.app.model.OppiaLanguage.LANGUAGE_UNSPECIFIED
+import org.oppia.android.app.model.OppiaLanguage.LATIN_AMERICAN_SPANISH
 import org.oppia.android.app.model.OppiaLanguage.NIGERIAN_PIDGIN
 import org.oppia.android.app.model.OppiaLanguage.PORTUGUESE
 import org.oppia.android.app.model.OppiaLanguage.SPANISH
 import org.oppia.android.app.model.OppiaLanguage.SWAHILI
-import org.oppia.android.app.model.OppiaLanguage.LATIN_AMERICAN_SPANISH
 import org.oppia.android.app.model.OppiaLanguage.UNRECOGNIZED
 import org.oppia.android.app.model.Real.RealTypeCase.INTEGER
 import org.oppia.android.app.model.Real.RealTypeCase.IRRATIONAL

--- a/app/src/main/res/values/untranslated_strings.xml
+++ b/app/src/main/res/values/untranslated_strings.xml
@@ -139,6 +139,8 @@
   <string name="hindi_localized_language_name" translatable="false">हिन्दी</string>
   <string name="portuguese_localized_language_name" translatable="false">Português</string>
   <string name="brazilian_portuguese_localized_language_name" translatable="false">Português</string>
+  <string name="spanish_localized_language_name" translatable="false">Español</string>
+  <string name="latin_american_spanish_localized_language_name" translatable="false">Español</string>
   <string name="swahili_localized_language_name" translatable="false">Kiswahili</string>
   <string name="nigerian_pidgin_localized_language_name" translatable="false">Naijá</string>
 </resources>

--- a/config/src/java/org/oppia/android/config/alllanguages/supported_languages.textproto
+++ b/config/src/java/org/oppia/android/config/alllanguages/supported_languages.textproto
@@ -117,6 +117,39 @@ language_definitions {
   }
 }
 language_definitions {
+  language: SPANISH
+  min_android_sdk_version: 1
+  content_string_id {
+    ietf_bcp47_id {
+      ietf_language_tag: "es"
+    }
+  }
+}
+language_definitions {
+  language: LATIN_AMERICAN_SPANISH
+  fallback_macro_language: SPANISH
+  min_android_sdk_version: 1
+  app_string_id {
+    ietf_bcp47_id {
+      ietf_language_tag: "es-419"
+    }
+    android_resources_language_id {
+      language_code: "es"
+      region_code: "US"
+    }
+  }
+  content_string_id {
+    ietf_bcp47_id {
+      ietf_language_tag: "es"
+    }
+  }
+  audio_translation_id {
+    ietf_bcp47_id {
+      ietf_language_tag: "es-419"
+    }
+  }
+}
+language_definitions {
   language: SWAHILI
   min_android_sdk_version: 1
   app_string_id {

--- a/config/src/java/org/oppia/android/config/alllanguages/supported_regions.textproto
+++ b/config/src/java/org/oppia/android/config/alllanguages/supported_regions.textproto
@@ -37,3 +37,11 @@ region_definitions {
   languages: ENGLISH
   languages: NIGERIAN_PIDGIN
 }
+region_definitions {
+  region: LATIN_AMERICA
+  region_id {
+    ietf_region_tag: "419"
+  }
+  languages: SPANISH
+  languages: LATIN_AMERICAN_SPANISH
+}

--- a/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
@@ -1008,20 +1008,20 @@ class ProfileManagementController @Inject constructor(
 
   private fun updateLastLoggedInAsyncAndNumberOfLogins(profileId: LegacyProfileId):
     Deferred<ProfileActionStatus> {
-    return profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
-      val profile = it.profilesMap[profileId.internalId]
-        ?: return@storeDataWithCustomChannelAsync Pair(it, ProfileActionStatus.PROFILE_NOT_FOUND)
-      val updatedProfile = profile.toBuilder()
-        .setLastLoggedInTimestampMs(oppiaClock.getCurrentTimeMs())
-        .setNumberOfLogins(profile.numberOfLogins + 1)
-        .build()
-      val profileDatabaseBuilder = it.toBuilder().putProfiles(
-        profileId.internalId,
-        updatedProfile
-      )
-      Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
+      return profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
+        val profile = it.profilesMap[profileId.internalId]
+          ?: return@storeDataWithCustomChannelAsync Pair(it, ProfileActionStatus.PROFILE_NOT_FOUND)
+        val updatedProfile = profile.toBuilder()
+          .setLastLoggedInTimestampMs(oppiaClock.getCurrentTimeMs())
+          .setNumberOfLogins(profile.numberOfLogins + 1)
+          .build()
+        val profileDatabaseBuilder = it.toBuilder().putProfiles(
+          profileId.internalId,
+          updatedProfile
+        )
+        Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
+      }
     }
-  }
 
   /**
    * Deletes an existing profile.

--- a/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
@@ -856,11 +856,14 @@ class ProfileManagementController @Inject constructor(
     ).transform(GET_AUDIO_LANGUAGE_PROVIDER_ID) { oppiaLanguage ->
       when (oppiaLanguage) {
         OppiaLanguage.UNRECOGNIZED, OppiaLanguage.LANGUAGE_UNSPECIFIED, OppiaLanguage.HINGLISH,
-        OppiaLanguage.PORTUGUESE, OppiaLanguage.SWAHILI -> AudioLanguage.AUDIO_LANGUAGE_UNSPECIFIED
+        OppiaLanguage.PORTUGUESE, OppiaLanguage.SPANISH,
+        OppiaLanguage.SWAHILI -> AudioLanguage.AUDIO_LANGUAGE_UNSPECIFIED
         OppiaLanguage.ARABIC -> AudioLanguage.ARABIC_LANGUAGE
         OppiaLanguage.ENGLISH -> AudioLanguage.ENGLISH_AUDIO_LANGUAGE
         OppiaLanguage.HINDI -> AudioLanguage.HINDI_AUDIO_LANGUAGE
         OppiaLanguage.BRAZILIAN_PORTUGUESE -> AudioLanguage.BRAZILIAN_PORTUGUESE_LANGUAGE
+        OppiaLanguage.LATIN_AMERICAN_SPANISH ->
+          AudioLanguage.LATIN_AMERICAN_SPANISH_LANGUAGE
         OppiaLanguage.NIGERIAN_PIDGIN -> AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE
       }
     }
@@ -886,6 +889,7 @@ class ProfileManagementController @Inject constructor(
         AudioLanguage.BRAZILIAN_PORTUGUESE_LANGUAGE -> OppiaLanguage.BRAZILIAN_PORTUGUESE
         AudioLanguage.ARABIC_LANGUAGE -> OppiaLanguage.ARABIC
         AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE -> OppiaLanguage.NIGERIAN_PIDGIN
+        AudioLanguage.LATIN_AMERICAN_SPANISH_LANGUAGE -> OppiaLanguage.LATIN_AMERICAN_SPANISH
       }
     }.build()
     // The transformation is needed to reinterpreted the result of the update to 'Any?'.
@@ -1004,20 +1008,20 @@ class ProfileManagementController @Inject constructor(
 
   private fun updateLastLoggedInAsyncAndNumberOfLogins(profileId: LegacyProfileId):
     Deferred<ProfileActionStatus> {
-      return profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
-        val profile = it.profilesMap[profileId.internalId]
-          ?: return@storeDataWithCustomChannelAsync Pair(it, ProfileActionStatus.PROFILE_NOT_FOUND)
-        val updatedProfile = profile.toBuilder()
-          .setLastLoggedInTimestampMs(oppiaClock.getCurrentTimeMs())
-          .setNumberOfLogins(profile.numberOfLogins + 1)
-          .build()
-        val profileDatabaseBuilder = it.toBuilder().putProfiles(
-          profileId.internalId,
-          updatedProfile
-        )
-        Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
-      }
+    return profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
+      val profile = it.profilesMap[profileId.internalId]
+        ?: return@storeDataWithCustomChannelAsync Pair(it, ProfileActionStatus.PROFILE_NOT_FOUND)
+      val updatedProfile = profile.toBuilder()
+        .setLastLoggedInTimestampMs(oppiaClock.getCurrentTimeMs())
+        .setNumberOfLogins(profile.numberOfLogins + 1)
+        .build()
+      val profileDatabaseBuilder = it.toBuilder().putProfiles(
+        profileId.internalId,
+        updatedProfile
+      )
+      Pair(profileDatabaseBuilder.build(), ProfileActionStatus.SUCCESS)
     }
+  }
 
   /**
    * Deletes an existing profile.

--- a/model/src/main/proto/languages.proto
+++ b/model/src/main/proto/languages.proto
@@ -35,6 +35,12 @@ enum OppiaLanguage {
   // IETF BCP 47 language tag: pcm (as of RFC 5646 since pcm was introduced in ISO 639-3). However,
   // since Android doesn't support pcm natively the app uses pcm-NG for app string translations.
   NIGERIAN_PIDGIN = 8;
+
+  // Corresponds to the Spanish (español) macro language. IETF BCP 47 language tag: es.
+  SPANISH = 9;
+
+  // Corresponds to the Latin American Spanish variant. IETF BCP 47 language tag: es-419.
+  LATIN_AMERICAN_SPANISH = 10;
 }
 
 // The list of regions explicitly supported natively by the Android app. Note that the app is not
@@ -66,6 +72,9 @@ enum OppiaRegion {
   // Corresponds to Nigeria (Jamhuriyar Tarayyar Najeriya / Ọ̀hàńjíkọ̀ Ọ̀hànézè Naìjíríyà / Orílẹ̀-èdè
   // Olómìniira Àpapọ̀ Nàìjíríà). IETF BCP 47 region tag: NG (per ISO 3166).
   NIGERIA = 5;
+
+  // Corresponds to Latin America (UN M.49 numeric-3 area code 419). IETF BCP 47 region tag: 419.
+  LATIN_AMERICA = 6;
 }
 
 // Defines the list of supported languages in the app.

--- a/model/src/main/proto/profile.proto
+++ b/model/src/main/proto/profile.proto
@@ -179,6 +179,7 @@ enum AudioLanguage {
   BRAZILIAN_PORTUGUESE_LANGUAGE = 6;
   ARABIC_LANGUAGE = 7;
   NIGERIAN_PIDGIN_LANGUAGE = 8;
+  LATIN_AMERICAN_SPANISH_LANGUAGE = 9;
 }
 
 // Indicates the state of the app with regards to the number and type of existing profiles.

--- a/scripts/src/javatests/org/oppia/android/scripts/build/FilterPerLanguageResourcesTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/build/FilterPerLanguageResourcesTest.kt
@@ -45,11 +45,15 @@ class FilterPerLanguageResourcesTest {
   private val STR_RESOURCE_1_EN_PT = StringResource(mapOf("" to "en str1", "pt-BR" to "pt str1"))
   private val STR_RESOURCE_2_EN_SW_PCM =
     StringResource(mapOf("" to "en str2", "sw" to "sw str2", "pcm" to "pcm str 3"))
+  private val STR_RESOURCE_3_EN_ES419 = StringResource(mapOf("" to "en str3", "es-419" to "es str3"))
   private val COLOR_RESOURCE_0_EN_PT = ColorResource(mapOf("" to "0xDEF", "pt-BR" to "0xABC"))
   private val RESOURCE_TABLE_EN_PT_SW_PCM =
     createResourceTable(
       STR_RESOURCE_0_EN, STR_RESOURCE_1_EN_PT, STR_RESOURCE_2_EN_SW_PCM, COLOR_RESOURCE_0_EN_PT
     )
+
+  private val RESOURCE_TABLE_EN_ES419 =
+    createResourceTable(STR_RESOURCE_0_EN, STR_RESOURCE_3_EN_ES419)
 
   private val ENGLISH =
     createLanguageSupportDefinition(language = OppiaLanguage.ENGLISH, languageCode = "en")
@@ -63,10 +67,15 @@ class FilterPerLanguageResourcesTest {
     createLanguageSupportDefinition(language = OppiaLanguage.ARABIC, languageCode = "ar")
   private val NIGERIAN_PIDGIN =
     createLanguageSupportDefinition(language = OppiaLanguage.NIGERIAN_PIDGIN, languageCode = "pcm")
+  private val LATIN_AMERICAN_SPANISH =
+    createLanguageSupportDefinition(
+      language = OppiaLanguage.LATIN_AMERICAN_SPANISH, languageCode = "es", regionCode = "419"
+    )
   private val SUPPORTED_LANGUAGES_EN = createSupportedLanguages(ENGLISH)
   private val SUPPORTED_LANGUAGES_EN_PT = createSupportedLanguages(ENGLISH, BRAZILIAN_PORTUGUESE)
   private val SUPPORTED_LANGUAGES_EN_PT_SW_PCM =
     createSupportedLanguages(ENGLISH, BRAZILIAN_PORTUGUESE, SWAHILI, NIGERIAN_PIDGIN)
+  private val SUPPORTED_LANGUAGES_EN_ES419 = createSupportedLanguages(ENGLISH, LATIN_AMERICAN_SPANISH)
   private val SUPPORTED_LANGUAGES_EN_AR = createSupportedLanguages(ENGLISH, ARABIC)
 
   @field:[Rule JvmField] val tempFolder = TemporaryFolder()
@@ -184,6 +193,20 @@ class FilterPerLanguageResourcesTest {
     // Only English & Portuguese resources should be kept.
     val presentLanguages = readSupportedResourceLanguagesFromZip(fileName = "output.zip")
     assertThat(presentLanguages).containsExactly("", "pt-BR")
+  }
+
+  @Test
+  fun testUtility_resourceTable_onlySpanishSupported_keepsOnlyEnglishAndSpanish() {
+    createZipWith(
+      fileName = "input.zip",
+      resourceTable = RESOURCE_TABLE_EN_ES419,
+      supportedLanguages = SUPPORTED_LANGUAGES_EN_ES419
+    )
+
+    runScript(tempFolder.getFilePath("input.zip"), tempFolder.getFilePath("output.zip"))
+
+    val presentLanguages = readSupportedResourceLanguagesFromZip(fileName = "output.zip")
+    assertThat(presentLanguages).containsExactly("", "es-419")
   }
 
   @Test

--- a/scripts/src/javatests/org/oppia/android/scripts/build/FilterPerLanguageResourcesTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/build/FilterPerLanguageResourcesTest.kt
@@ -45,7 +45,8 @@ class FilterPerLanguageResourcesTest {
   private val STR_RESOURCE_1_EN_PT = StringResource(mapOf("" to "en str1", "pt-BR" to "pt str1"))
   private val STR_RESOURCE_2_EN_SW_PCM =
     StringResource(mapOf("" to "en str2", "sw" to "sw str2", "pcm" to "pcm str 3"))
-  private val STR_RESOURCE_3_EN_ES419 = StringResource(mapOf("" to "en str3", "es-419" to "es str3"))
+  private val STR_RESOURCE_3_EN_ES419 =
+    StringResource(mapOf("" to "en str3", "es-419" to "es str3"))
   private val COLOR_RESOURCE_0_EN_PT = ColorResource(mapOf("" to "0xDEF", "pt-BR" to "0xABC"))
   private val RESOURCE_TABLE_EN_PT_SW_PCM =
     createResourceTable(
@@ -75,7 +76,8 @@ class FilterPerLanguageResourcesTest {
   private val SUPPORTED_LANGUAGES_EN_PT = createSupportedLanguages(ENGLISH, BRAZILIAN_PORTUGUESE)
   private val SUPPORTED_LANGUAGES_EN_PT_SW_PCM =
     createSupportedLanguages(ENGLISH, BRAZILIAN_PORTUGUESE, SWAHILI, NIGERIAN_PIDGIN)
-  private val SUPPORTED_LANGUAGES_EN_ES419 = createSupportedLanguages(ENGLISH, LATIN_AMERICAN_SPANISH)
+  private val SUPPORTED_LANGUAGES_EN_ES419 =
+    createSupportedLanguages(ENGLISH, LATIN_AMERICAN_SPANISH)
   private val SUPPORTED_LANGUAGES_EN_AR = createSupportedLanguages(ENGLISH, ARABIC)
 
   @field:[Rule JvmField] val tempFolder = TemporaryFolder()

--- a/utility/src/main/java/org/oppia/android/util/logging/EventBundleCreator.kt
+++ b/utility/src/main/java/org/oppia/android/util/logging/EventBundleCreator.kt
@@ -301,25 +301,25 @@ class EventBundleCreator @Inject constructor(
 
   private fun OppiaMetricLog.LoggableMetric.convertToLoggableMetricType():
     PerformanceMetricsLoggableMetricType<*>? {
-    return when (loggableMetricTypeCase) {
-      APK_SIZE_METRIC -> ApkSizeLoggableMetric("apk_size_metric", apkSizeMetric)
-      STORAGE_USAGE_METRIC -> StorageUsageLoggableMetric(
-        "storage_usage_metric",
-        storageUsageMetric
-      )
-      STARTUP_LATENCY_METRIC -> StartupLatencyLoggableMetric(
-        "startup_latency_metric",
-        startupLatencyMetric
-      )
-      MEMORY_USAGE_METRIC -> MemoryUsageLoggableMetric("memory_usage_metric", memoryUsageMetric)
-      NETWORK_USAGE_METRIC -> NetworkUsageLoggableMetric(
-        "network_usage_metric",
-        networkUsageMetric
-      )
-      CPU_USAGE_METRIC -> CpuUsageLoggableMetric("cpu_usage_metric", cpuUsageMetric)
-      LOGGABLEMETRICTYPE_NOT_SET, null -> null // No context to create here.
+      return when (loggableMetricTypeCase) {
+        APK_SIZE_METRIC -> ApkSizeLoggableMetric("apk_size_metric", apkSizeMetric)
+        STORAGE_USAGE_METRIC -> StorageUsageLoggableMetric(
+          "storage_usage_metric",
+          storageUsageMetric
+        )
+        STARTUP_LATENCY_METRIC -> StartupLatencyLoggableMetric(
+          "startup_latency_metric",
+          startupLatencyMetric
+        )
+        MEMORY_USAGE_METRIC -> MemoryUsageLoggableMetric("memory_usage_metric", memoryUsageMetric)
+        NETWORK_USAGE_METRIC -> NetworkUsageLoggableMetric(
+          "network_usage_metric",
+          networkUsageMetric
+        )
+        CPU_USAGE_METRIC -> CpuUsageLoggableMetric("cpu_usage_metric", cpuUsageMetric)
+        LOGGABLEMETRICTYPE_NOT_SET, null -> null // No context to create here.
+      }
     }
-  }
 
   /**
    * Utility for storing properties within a [Bundle] (indicated by [bundle]), omitting those which

--- a/utility/src/main/java/org/oppia/android/util/logging/EventBundleCreator.kt
+++ b/utility/src/main/java/org/oppia/android/util/logging/EventBundleCreator.kt
@@ -301,25 +301,25 @@ class EventBundleCreator @Inject constructor(
 
   private fun OppiaMetricLog.LoggableMetric.convertToLoggableMetricType():
     PerformanceMetricsLoggableMetricType<*>? {
-      return when (loggableMetricTypeCase) {
-        APK_SIZE_METRIC -> ApkSizeLoggableMetric("apk_size_metric", apkSizeMetric)
-        STORAGE_USAGE_METRIC -> StorageUsageLoggableMetric(
-          "storage_usage_metric",
-          storageUsageMetric
-        )
-        STARTUP_LATENCY_METRIC -> StartupLatencyLoggableMetric(
-          "startup_latency_metric",
-          startupLatencyMetric
-        )
-        MEMORY_USAGE_METRIC -> MemoryUsageLoggableMetric("memory_usage_metric", memoryUsageMetric)
-        NETWORK_USAGE_METRIC -> NetworkUsageLoggableMetric(
-          "network_usage_metric",
-          networkUsageMetric
-        )
-        CPU_USAGE_METRIC -> CpuUsageLoggableMetric("cpu_usage_metric", cpuUsageMetric)
-        LOGGABLEMETRICTYPE_NOT_SET, null -> null // No context to create here.
-      }
+    return when (loggableMetricTypeCase) {
+      APK_SIZE_METRIC -> ApkSizeLoggableMetric("apk_size_metric", apkSizeMetric)
+      STORAGE_USAGE_METRIC -> StorageUsageLoggableMetric(
+        "storage_usage_metric",
+        storageUsageMetric
+      )
+      STARTUP_LATENCY_METRIC -> StartupLatencyLoggableMetric(
+        "startup_latency_metric",
+        startupLatencyMetric
+      )
+      MEMORY_USAGE_METRIC -> MemoryUsageLoggableMetric("memory_usage_metric", memoryUsageMetric)
+      NETWORK_USAGE_METRIC -> NetworkUsageLoggableMetric(
+        "network_usage_metric",
+        networkUsageMetric
+      )
+      CPU_USAGE_METRIC -> CpuUsageLoggableMetric("cpu_usage_metric", cpuUsageMetric)
+      LOGGABLEMETRICTYPE_NOT_SET, null -> null // No context to create here.
     }
+  }
 
   /**
    * Utility for storing properties within a [Bundle] (indicated by [bundle]), omitting those which
@@ -951,6 +951,8 @@ class EventBundleCreator @Inject constructor(
       OppiaLanguage.HINGLISH -> "Hinglish"
       OppiaLanguage.PORTUGUESE -> "Portuguese"
       OppiaLanguage.BRAZILIAN_PORTUGUESE -> "Brazilian Portuguese"
+      OppiaLanguage.SPANISH -> "Spanish"
+      OppiaLanguage.LATIN_AMERICAN_SPANISH -> "Latin American Spanish"
       OppiaLanguage.SWAHILI -> "Swahili"
       OppiaLanguage.NIGERIAN_PIDGIN -> "Nigerian Pidgin"
       OppiaLanguage.UNRECOGNIZED -> "unrecognized_language"


### PR DESCRIPTION

## Explanation
  - "Fixes part of  #5822
  - when this PR is merged spanish language support is enabled for the users.
  

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
