### PR TITLE
Add study guide sections to subtopic records

### DIFF
--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package model;
 
 import "subtitled_html.proto";
+import "subtitled_unicode.proto";
 import "thumbnail.proto";
 import "translation.proto";
 import "voiceover.proto";
@@ -769,8 +770,21 @@ message SubtopicRecord {
   // The thumbnail corresponding to this subtopic.
   LessonThumbnail subtopic_thumbnail = 6;
 
+  // The ordered list of sections in this subtopic's study guide. This is stored in addition to the
+  // existing page contents.
+  repeated StudyGuideSection sections = 8;
+
   // The old title corresponding to the subtopic (as a string).
   reserved 1;
+}
+
+// Corresponds to one section in a study guide.
+message StudyGuideSection {
+  // The heading shown above this section's content.
+  SubtitledUnicode heading = 1;
+
+  // The main content displayed in this section.
+  SubtitledHtml content = 2;
 }
 
 // Top-level proto used to store the aggregate learning duration timestamps in a topic,


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixes part of #6105

This PR updates the Android app-side proto model so subtopic/revision card records can store Study Guide sections directly. Each section has a heading and content. The existing `page_contents` field is kept unchanged so the current revision card flow can continue using the legacy single-block content representation.

This is the Android app proto change needed before the download/export pipeline can populate Study Guide sections in a follow-up PR which will be in a different branch and will not be merged in develop like this one.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).