### PR TITLE
Fix part of #6106: Implement DeriveVersionNameForCommit.kt with unit tests

### DIFF
--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -347,3 +347,12 @@ kt_jvm_binary(
     main_class = "org.oppia.android.scripts.binary.BinaryFileCheckKt",
     runtime_deps = ["//scripts/src/java/org/oppia/android/scripts/binary:binary_file_check_lib"],
 )
+
+kt_jvm_binary(
+    name = "derive_version_name_for_commit",
+    testonly = True,
+    main_class = "org.oppia.android.scripts.release.DeriveVersionNameForCommitKt",
+    runtime_deps = [
+        "//scripts/src/java/org/oppia/android/scripts/release:derive_version_name_for_commit_lib",
+    ],
+)

--- a/scripts/src/java/org/oppia/android/scripts/release/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/release/BUILD.bazel
@@ -1,0 +1,18 @@
+"""
+Libraries for Oppia Android release automation scripts.
+"""
+
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "derive_version_name_for_commit_lib",
+    testonly = True,
+    srcs = [
+        "DeriveVersionNameForCommit.kt",
+    ],
+    visibility = ["//scripts:oppia_script_binary_visibility"],
+    deps = [
+        "//scripts/src/java/org/oppia/android/scripts/common:command_executor",
+        "//scripts/src/java/org/oppia/android/scripts/common:script_background_coroutine_dispatcher",
+    ],
+)

--- a/scripts/src/java/org/oppia/android/scripts/release/DeriveVersionNameForCommit.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/DeriveVersionNameForCommit.kt
@@ -1,0 +1,116 @@
+package org.oppia.android.scripts.release
+
+import org.oppia.android.scripts.common.CommandExecutor
+import org.oppia.android.scripts.common.CommandExecutorImpl
+import org.oppia.android.scripts.common.ScriptBackgroundCoroutineDispatcher
+import java.io.File
+
+/**
+ * The main entrypoint for deriving the fully qualified release binary archive name for a given
+ * commit.
+ *
+ * Reads version.bzl from the specified commit using git show and constructs the archive name
+ * following the pattern: oppia-android-<major>.<minor>-rc<nn>-<flavor>-<short_sha>.aab, where
+ * <short_sha> is the first 10 characters of the commit SHA.
+ *
+ * Fails with a non-zero exit code if:
+ * - The commit does not exist (exits with an InvalidCommitException message).
+ * - version.bzl is missing at the given commit (exits with a VersionParseException message).
+ * - version.bzl cannot be parsed for MAJOR_VERSION or MINOR_VERSION (exits with a
+ *     VersionParseException message).
+ *
+ * Usage:
+ *   bazel run //scripts:derive_version_name_for_commit -- \\
+ *     <path_to_directory_root> <commit_ref> <flavor> <rc_number>
+ *
+ * Arguments:
+ * - path_to_directory_root: directory path to the root of the Oppia Android repository.
+ * - commit_ref: the commit SHA or branch name to derive the version from (e.g. release-0.17).
+ * - flavor: the build flavor to include in the name (alpha, beta, or ga).
+ * - rc_number: the release candidate number as a string (e.g. "01", "02").
+ *
+ * Example:
+ *   bazel run //scripts:derive_version_name_for_commit -- \\
+ *     $(pwd) release-0.17 beta 01
+ */
+fun main(vararg args: String) {
+  require(args.size == 4) {
+    "Usage: bazel run //scripts:derive_version_name_for_commit --" +
+      " <path_to_directory_root> <commit_ref> <flavor> <rc_number>"
+  }
+  val repoRoot = args[0]
+  val commitRef = args[1]
+  val flavor = args[2]
+  val rcNumber = args[3]
+  ScriptBackgroundCoroutineDispatcher().use { scriptBgDispatcher ->
+    val deriver = DeriveVersionNameForCommit(repoRoot, scriptBgDispatcher)
+    println(deriver.computeBinaryName(commitRef, flavor, rcNumber))
+  }
+}
+
+/**
+ * Computes the fully qualified release binary archive name for a given commit, flavor, and RC
+ * number.
+ *
+ * The archive name follows the format:
+ *   oppia-android-<major>.<minor>-rc<nn>-<flavor>-<short_sha>.aab
+ */
+class DeriveVersionNameForCommit(
+  private val repoRoot: String,
+  scriptBgDispatcher: ScriptBackgroundCoroutineDispatcher,
+  private val commandExecutor: CommandExecutor = CommandExecutorImpl(scriptBgDispatcher)
+) {
+  /**
+   * Returns the fully qualified AAB archive name for [commitRef], [flavor], and [rcNumber].
+   *
+   * @param commitRef the commit SHA or branch name to derive the version from
+   * @param flavor the build flavor to include in the name (alpha, beta, or ga)
+   * @param rcNumber the release candidate number as a string (e.g. "01")
+   */
+  fun computeBinaryName(commitRef: String, flavor: String, rcNumber: String): String {
+    verifyCommitExists(commitRef)
+    val versionBzlContent = readVersionBzl(commitRef)
+    val (major, minor) = parseVersion(versionBzlContent, commitRef)
+    val shortSha = resolveShortSha(commitRef)
+    val paddedRc = rcNumber.padStart(2, '0')
+    return "oppia-android-$major.$minor-rc$paddedRc-$flavor-$shortSha.aab"
+  }
+
+  private fun verifyCommitExists(commitRef: String) {
+    val result = commandExecutor.executeCommand(
+      File(repoRoot), "git", "cat-file", "-e", "$commitRef^{commit}",
+      includeErrorOutput = false
+    )
+    check(result.exitCode == 0) {
+      "InvalidCommitException: Commit does not exist: $commitRef"
+    }
+  }
+
+  private fun readVersionBzl(commitRef: String): String {
+    val result = commandExecutor.executeCommand(
+      File(repoRoot), "git", "show", "$commitRef:version.bzl",
+      includeErrorOutput = false
+    )
+    check(result.exitCode == 0) {
+      "VersionParseException: version.bzl does not exist at commit: $commitRef"
+    }
+    return result.output.joinToString("\n")
+  }
+
+  private fun parseVersion(content: String, commitRef: String): Pair<Int, Int> {
+    val majorMatch = Regex("""MAJOR_VERSION\s*=\s*(\d+)""").find(content)
+    val minorMatch = Regex("""MINOR_VERSION\s*=\s*(\d+)""").find(content)
+    check(majorMatch != null && minorMatch != null) {
+      "VersionParseException: Could not parse MAJOR_VERSION or MINOR_VERSION in version.bzl" +
+        " at commit: $commitRef"
+    }
+    return majorMatch.groupValues[1].toInt() to minorMatch.groupValues[1].toInt()
+  }
+
+  private fun resolveShortSha(commitRef: String): String {
+    val result = commandExecutor.executeCommand(
+      File(repoRoot), "git", "rev-parse", "--short=10", commitRef
+    )
+    return result.output.first().trim()
+  }
+}

--- a/scripts/src/javatests/org/oppia/android/scripts/release/BUILD.bazel
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/BUILD.bazel
@@ -1,0 +1,17 @@
+"""
+Tests for Oppia Android release automation scripts.
+"""
+
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "DeriveVersionNameForCommitTest",
+    srcs = ["DeriveVersionNameForCommitTest.kt"],
+    deps = [
+        "//scripts/src/java/org/oppia/android/scripts/common:command_executor",
+        "//scripts/src/java/org/oppia/android/scripts/common:script_background_coroutine_dispatcher",
+        "//scripts/src/java/org/oppia/android/scripts/release:derive_version_name_for_commit_lib",
+        "//testing:assertion_helpers",
+        "//third_party:com_google_truth_truth",
+    ],
+)

--- a/scripts/src/javatests/org/oppia/android/scripts/release/DeriveVersionNameForCommitTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/DeriveVersionNameForCommitTest.kt
@@ -1,0 +1,214 @@
+package org.oppia.android.scripts.release
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.oppia.android.scripts.common.CommandExecutorImpl
+import org.oppia.android.scripts.common.ScriptBackgroundCoroutineDispatcher
+import org.oppia.android.testing.assertThrows
+
+/** Tests for [DeriveVersionNameForCommit]. */
+// Function name: test names are conventionally named with underscores.
+@Suppress("FunctionName")
+class DeriveVersionNameForCommitTest {
+  @field:[Rule JvmField]
+  var tempFolder = TemporaryFolder()
+
+  private val scriptBgDispatcher by lazy { ScriptBackgroundCoroutineDispatcher() }
+  private val commandExecutor by lazy { CommandExecutorImpl(scriptBgDispatcher) }
+  private lateinit var deriver: DeriveVersionNameForCommit
+
+  @Before
+  fun setUp() {
+    deriver = DeriveVersionNameForCommit(
+      repoRoot = tempFolder.root.absolutePath,
+      scriptBgDispatcher = scriptBgDispatcher
+    )
+    initGitRepo()
+  }
+
+  @After
+  fun tearDown() {
+    scriptBgDispatcher.close()
+  }
+
+  @Test
+  fun testComputeBinaryName_validCommitBetaFlavor_returnsCorrectName() {
+    val sha = createAndCommitVersionBzl(major = 0, minor = 17)
+    val shortSha = getShortSha(sha)
+
+    val result = deriver.computeBinaryName(sha, "beta", "01")
+
+    assertThat(result).isEqualTo("oppia-android-0.17-rc01-beta-$shortSha.aab")
+  }
+
+  @Test
+  fun testComputeBinaryName_validCommitAlphaFlavor_includesAlphaInName() {
+    val sha = createAndCommitVersionBzl(major = 0, minor = 17)
+    val shortSha = getShortSha(sha)
+
+    val result = deriver.computeBinaryName(sha, "alpha", "01")
+
+    assertThat(result).isEqualTo("oppia-android-0.17-rc01-alpha-$shortSha.aab")
+  }
+
+  @Test
+  fun testComputeBinaryName_validCommitGaFlavor_includesGaInName() {
+    val sha = createAndCommitVersionBzl(major = 0, minor = 17)
+    val shortSha = getShortSha(sha)
+
+    val result = deriver.computeBinaryName(sha, "ga", "01")
+
+    assertThat(result).isEqualTo("oppia-android-0.17-rc01-ga-$shortSha.aab")
+  }
+
+  @Test
+  fun testComputeBinaryName_differentVersion_reflectsCorrectVersion() {
+    val sha = createAndCommitVersionBzl(major = 1, minor = 5)
+    val shortSha = getShortSha(sha)
+
+    val result = deriver.computeBinaryName(sha, "beta", "01")
+
+    assertThat(result).isEqualTo("oppia-android-1.5-rc01-beta-$shortSha.aab")
+  }
+
+  @Test
+  fun testComputeBinaryName_singleDigitRcNumber_isPaddedToTwoDigits() {
+    val sha = createAndCommitVersionBzl(major = 0, minor = 17)
+    val shortSha = getShortSha(sha)
+
+    val result = deriver.computeBinaryName(sha, "beta", "1")
+
+    assertThat(result).isEqualTo("oppia-android-0.17-rc01-beta-$shortSha.aab")
+  }
+
+  @Test
+  fun testComputeBinaryName_twoDigitRcNumber_isNotPadded() {
+    val sha = createAndCommitVersionBzl(major = 0, minor = 17)
+    val shortSha = getShortSha(sha)
+
+    val result = deriver.computeBinaryName(sha, "beta", "10")
+
+    assertThat(result).isEqualTo("oppia-android-0.17-rc10-beta-$shortSha.aab")
+  }
+
+  @Test
+  fun testComputeBinaryName_branchRef_resolvesCorrectly() {
+    createAndCommitVersionBzl(major = 0, minor = 17)
+    runGit("checkout", "-b", "release-0.17")
+    val shortSha = getShortSha("release-0.17")
+
+    val result = deriver.computeBinaryName("release-0.17", "beta", "01")
+
+    assertThat(result).isEqualTo("oppia-android-0.17-rc01-beta-$shortSha.aab")
+  }
+
+  @Test
+  fun testComputeBinaryName_nonExistentCommit_throwsInvalidCommitException() {
+    createAndCommitVersionBzl(major = 0, minor = 17)
+
+    val exception = assertThrows<IllegalStateException> {
+      deriver.computeBinaryName("nonexistentcommitsha123", "beta", "01")
+    }
+
+    assertThat(exception).hasMessageThat().contains("InvalidCommitException")
+    assertThat(exception).hasMessageThat().contains("Commit does not exist")
+  }
+
+  @Test
+  fun testComputeBinaryName_versionBzlMissingAtCommit_throwsVersionParseException() {
+    val readmeFile = tempFolder.newFile("README.md")
+    readmeFile.writeText("test")
+    runGit("add", "README.md")
+    runGit("commit", "-m", "Initial commit without version.bzl")
+    val sha = getHeadSha()
+
+    val exception = assertThrows<IllegalStateException> {
+      deriver.computeBinaryName(sha, "beta", "01")
+    }
+
+    assertThat(exception).hasMessageThat().contains("VersionParseException")
+    assertThat(exception).hasMessageThat().contains("version.bzl does not exist at commit")
+  }
+
+  @Test
+  fun testComputeBinaryName_malformedVersionBzl_throwsVersionParseException() {
+    val versionBzlFile = tempFolder.newFile("version.bzl")
+    versionBzlFile.writeText("NOT_A_VERSION_FILE = 0")
+    runGit("add", "version.bzl")
+    runGit("commit", "-m", "Add malformed version.bzl")
+    val sha = getHeadSha()
+
+    val exception = assertThrows<IllegalStateException> {
+      deriver.computeBinaryName(sha, "beta", "01")
+    }
+
+    assertThat(exception).hasMessageThat().contains("VersionParseException")
+    assertThat(exception).hasMessageThat()
+      .contains("Could not parse MAJOR_VERSION or MINOR_VERSION")
+  }
+
+  @Test
+  fun testComputeBinaryName_missingMinorVersion_throwsVersionParseException() {
+    val versionBzlFile = tempFolder.newFile("version.bzl")
+    versionBzlFile.writeText("MAJOR_VERSION = 0")
+    runGit("add", "version.bzl")
+    runGit("commit", "-m", "Add version.bzl without MINOR_VERSION")
+    val sha = getHeadSha()
+
+    val exception = assertThrows<IllegalStateException> {
+      deriver.computeBinaryName(sha, "beta", "01")
+    }
+
+    assertThat(exception).hasMessageThat().contains("VersionParseException")
+  }
+
+  @Test
+  fun testMain_wrongNumberOfArgs_throwsIllegalArgumentException() {
+    val exception = assertThrows<IllegalArgumentException> {
+      main("only_one_arg")
+    }
+
+    assertThat(exception).hasMessageThat().contains(
+      "Usage: bazel run //scripts:derive_version_name_for_commit"
+    )
+  }
+
+  // region helpers
+
+  private fun initGitRepo() {
+    runGit("init")
+    runGit("config", "user.email", "test@test.com")
+    runGit("config", "user.name", "Test User")
+  }
+
+  private fun createAndCommitVersionBzl(major: Int, minor: Int): String {
+    val versionBzlFile = tempFolder.newFile("version.bzl")
+    versionBzlFile.writeText(
+      """
+      MAJOR_VERSION = $major
+      MINOR_VERSION = $minor
+      """.trimIndent()
+    )
+    runGit("add", "version.bzl")
+    runGit("commit", "-m", "Add version.bzl for $major.$minor")
+    return getHeadSha()
+  }
+
+  private fun getHeadSha(): String =
+    commandExecutor.executeCommand(tempFolder.root, "git", "rev-parse", "HEAD")
+      .output.first().trim()
+
+  private fun getShortSha(ref: String): String =
+    commandExecutor.executeCommand(tempFolder.root, "git", "rev-parse", "--short=10", ref)
+      .output.first().trim()
+
+  private fun runGit(vararg args: String) {
+    commandExecutor.executeCommand(tempFolder.root, "git", *args)
+  }
+
+  // endregion
+}


### PR DESCRIPTION
Fixes part of #6106

## Explanation
Two failure modes are distinguished:
- `InvalidCommitException`: commit ref does not exist
- `VersionParseException`: `version.bzl` is missing at the commit, or `MAJOR_VERSION`/`MINOR_VERSION` cannot be parsed

Also adds:
- `DeriveVersionNameForCommitTest.kt` with 12 unit tests using a real git repo in `TemporaryFolder`
- `kt_jvm_library` and `kt_jvm_test` BUILD targets under a new `release/` package
- `kt_jvm_binary` target `derive_version_name_for_commit` in `scripts/BUILD.bazel`

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).