### PR TITLE
Fix part of #6106: Implement Deploy to Play Console workflow

### DIFF
--- a/.github/workflows/deploy_to_play_console.yml
+++ b/.github/workflows/deploy_to_play_console.yml
@@ -1,0 +1,149 @@
+# Downloads a signed release AAB from the GCS archive and uploads it to the Google Play Console
+# via the UploadBinaryToPlayConsole Kotlin script. The AAB must have been previously produced by
+# build_and_sign.yml and archived in GCS. Precondition checks (version inversion, pending release,
+# changelog existence) are enforced by the script before any upload is attempted.
+#
+# Authentication uses the same Workload Identity Federation setup as build_and_sign.yml. The WIF
+# service account must have the "Release to production" permission on the target Play Console app.
+
+name: Deploy to Play Console
+
+on:
+  workflow_dispatch:
+    inputs:
+      gcs_aab_path:
+        description: "Full GCS path to the signed AAB from the archive (e.g. gs://oppia-android-alpha-releases/0.17/RC01/oppia-android-0.17-rc01-alpha-abc1234567.aab)"
+        required: true
+        type: string
+      track:
+        description: "Play Console track to deploy to"
+        required: true
+        type: choice
+        options:
+          - alpha
+          - beta
+          - production
+      rollout_fraction:
+        description: "Rollout fraction for staged rollouts, between 0.0 and 1.0 (e.g. 0.1 for 10%). Use 1.0 for a full rollout."
+        required: false
+        type: string
+        default: "1.0"
+
+concurrency:
+  # One Play Console deployment per track at a time to prevent overlapping edit sessions.
+  group: deploy-play-console-${{ github.event.inputs.track }}
+  cancel-in-progress: false
+
+jobs:
+  deploy_to_play_console:
+    name: Deploy to Play Console (${{ github.event.inputs.track }})
+    runs-on: ubuntu-24.04
+    environment: oppia-android-release-env
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CACHE_DIRECTORY: ~/.bazel_cache
+    steps:
+      - uses: actions/checkout@v4
+
+      # Validates inputs and extracts the flavor from the GCS path for downstream steps.
+      - name: Validate inputs and extract flavor
+        run: |
+          GCS_PATH="${{ github.event.inputs.gcs_aab_path }}"
+          ROLLOUT="${{ github.event.inputs.rollout_fraction }}"
+
+          if [[ ! "$GCS_PATH" =~ ^gs://oppia-android-(alpha|beta|ga)-releases/.+\.aab$ ]]; then
+            echo "::error::Invalid gcs_aab_path: '$GCS_PATH'"
+            echo "::error::Must match: gs://oppia-android-{alpha|beta|ga}-releases/<path>.aab"
+            exit 1
+          fi
+
+          if ! [[ "$ROLLOUT" =~ ^(0(\.[0-9]+)?|1(\.0+)?)$ ]]; then
+            echo "::error::Invalid rollout_fraction: '$ROLLOUT'. Must be a decimal between 0.0 and 1.0."
+            exit 1
+          fi
+
+          FLAVOR=$(echo "$GCS_PATH" | grep -oP '(?<=oppia-android-)(alpha|beta|ga)(?=-releases)')
+          AAB_NAME=$(basename "$GCS_PATH")
+
+          echo "FLAVOR=$FLAVOR" >> $GITHUB_ENV
+          echo "AAB_NAME=$AAB_NAME" >> $GITHUB_ENV
+          echo "Inputs validated: flavor=$FLAVOR, track=${{ github.event.inputs.track }}, aab=$AAB_NAME, rollout=$ROLLOUT"
+
+      - name: Authenticate to GCP via Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_RELEASE_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      # Downloads the signed AAB from the GCS archive to a temp path for the upload script.
+      # Uses gsutil instead of gcloud storage due to known bucket-name validation issues.
+      - name: Download signed AAB from GCS
+        run: |
+          gsutil cp "${{ github.event.inputs.gcs_aab_path }}" "/tmp/$AAB_NAME"
+
+          # Verify the download produced a non-empty file.
+          if [[ ! -s "/tmp/$AAB_NAME" ]]; then
+            echo "::error::Downloaded AAB is empty or missing at /tmp/$AAB_NAME"
+            exit 1
+          fi
+
+          echo "AAB_LOCAL_PATH=/tmp/$AAB_NAME" >> $GITHUB_ENV
+          FILE_SIZE=$(stat --printf="%s" "/tmp/$AAB_NAME")
+          echo "Downloaded: $AAB_NAME ($FILE_SIZE bytes)"
+
+      - name: Set up Bazel
+        uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: 6.5.0
+
+      - name: Set up build environment
+        uses: ./.github/actions/set-up-android-bazel-build-environment
+
+      - uses: actions/cache@v4
+        id: cache
+        with:
+          path: ${{ env.CACHE_DIRECTORY }}
+          key: ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-
+            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-tests-
+            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-
+
+      - name: Ensure cache size
+        env:
+          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
+        run: |
+          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
+          CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_PATH | grep total | cut -f1)
+          echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
+          if [[ "$CACHE_SIZE_MB" -gt 4500 ]]; then
+            echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
+            rm -rf $EXPANDED_BAZEL_CACHE_PATH
+          fi
+
+      - name: Configure Bazel to use a local cache
+        env:
+          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
+        run: |
+          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
+          echo "Using $EXPANDED_BAZEL_CACHE_PATH as Bazel's cache path"
+          echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
+        shell: bash
+
+      # Runs the UploadBinaryToPlayConsole Kotlin script which enforces all precondition checks
+      # (pending release, version inversion, changelog existence) before uploading the AAB.
+      - name: Upload AAB to Play Console
+        run: |
+          bazel run //scripts:upload_binary_to_play_console -- \
+            "$(pwd)" \
+            "$AAB_LOCAL_PATH" \
+            "${{ github.event.inputs.track }}" \
+            "${{ secrets.GCP_PROJECT_ID }}" \
+            "${{ github.event.inputs.rollout_fraction }}"
+
+          echo "Successfully uploaded $AAB_NAME to Play Console track: ${{ github.event.inputs.track }}"

--- a/.github/workflows/deploy_to_play_console.yml
+++ b/.github/workflows/deploy_to_play_console.yml
@@ -42,8 +42,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    env:
-      CACHE_DIRECTORY: ~/.bazel_cache
     steps:
       - uses: actions/checkout@v4
 
@@ -80,8 +78,18 @@ jobs:
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Set up Bazel
+        uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: 6.5.0
+
+      - name: Set up build environment
+        uses: ./.github/actions/set-up-android-bazel-build-environment
+
       # Downloads the signed AAB from the GCS archive to a temp path for the upload script.
-      # Uses gsutil instead of gcloud storage due to known bucket-name validation issues.
+      # Uses gsutil instead of gcloud storage: gcloud storage applies DNS-compliant bucket name
+      # validation that rejects bucket names containing hyphens in certain configurations,
+      # whereas gsutil does not apply this validation.
       - name: Download signed AAB from GCS
         run: |
           gsutil cp "${{ github.event.inputs.gcs_aab_path }}" "/tmp/$AAB_NAME"
@@ -96,45 +104,6 @@ jobs:
           FILE_SIZE=$(stat --printf="%s" "/tmp/$AAB_NAME")
           echo "Downloaded: $AAB_NAME ($FILE_SIZE bytes)"
 
-      - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
-        with:
-          version: 6.5.0
-
-      - name: Set up build environment
-        uses: ./.github/actions/set-up-android-bazel-build-environment
-
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: ${{ env.CACHE_DIRECTORY }}
-          key: ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-binary-
-            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-tests-
-            ${{ runner.os }}-${{ env.CACHE_DIRECTORY }}-bazel-
-
-      - name: Ensure cache size
-        env:
-          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
-        run: |
-          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
-          CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_PATH | grep total | cut -f1)
-          echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
-          if [[ "$CACHE_SIZE_MB" -gt 4500 ]]; then
-            echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
-            rm -rf $EXPANDED_BAZEL_CACHE_PATH
-          fi
-
-      - name: Configure Bazel to use a local cache
-        env:
-          BAZEL_CACHE_DIR: ${{ env.CACHE_DIRECTORY }}
-        run: |
-          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
-          echo "Using $EXPANDED_BAZEL_CACHE_PATH as Bazel's cache path"
-          echo "build --disk_cache=$EXPANDED_BAZEL_CACHE_PATH" >> $HOME/.bazelrc
-        shell: bash
-
       # Runs the UploadBinaryToPlayConsole Kotlin script which enforces all precondition checks
       # (pending release, version inversion, changelog existence) before uploading the AAB.
       - name: Upload AAB to Play Console
@@ -145,5 +114,3 @@ jobs:
             "${{ github.event.inputs.track }}" \
             "${{ secrets.GCP_PROJECT_ID }}" \
             "${{ github.event.inputs.rollout_fraction }}"
-
-          echo "Successfully uploaded $AAB_NAME to Play Console track: ${{ github.event.inputs.track }}"


### PR DESCRIPTION
Fixes part of #6106
## Files Created
`.github/workflows/deploy_to_play_console.yml`
## Explanation
Adds a manually triggered GitHub Actions workflow that uploads a signed AAB to the Google Play Console. The AAB is downloaded from GCS (produced by `build_and_sign.yml`) and passed to the `UploadBinaryToPlayConsole` Kotlin script, which runs precondition checks (pending release, version inversion, changelog existence) before uploading.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).