### PR TITLE
Fix part of #6203: Migrate exploration and progress controllers to use ProfileId

### DIFF
--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/administratorcontrolsitemviewmodel/AdministratorControlsDownloadPermissionsViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/administratorcontrolsitemviewmodel/AdministratorControlsDownloadPermissionsViewModel.kt
@@ -9,6 +9,7 @@ import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 
 /** [ViewModel] for the recycler view in [AdministratorControlsFragment]. */
 class AdministratorControlsDownloadPermissionsViewModel(
@@ -30,7 +31,7 @@ class AdministratorControlsDownloadPermissionsViewModel(
   /** Called when topic wifi update permission changes. */
   fun onTopicWifiUpdatePermissionChanged() {
     profileManagementController.updateWifiPermissionDeviceSettings(
-      userProfileId,
+      userProfileId.toProfileIdPreservingZero(),
       !isTopicWifiUpdatePermission.get()!!
     ).toLiveData()
       .observe(
@@ -50,7 +51,7 @@ class AdministratorControlsDownloadPermissionsViewModel(
   /** Called when topic auto update permission changes. */
   fun onTopicAutoUpdatePermissionChanged() {
     profileManagementController.updateTopicAutomaticallyPermissionDeviceSettings(
-      userProfileId,
+      userProfileId.toProfileIdPreservingZero(),
       !isTopicAutoUpdatePermission.get()!!
     ).toLiveData().observe(
       fragment,

--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
@@ -72,6 +72,7 @@ import org.oppia.android.util.parser.html.TopicHtmlParserEntityType
 import org.oppia.android.util.platformparameter.EnableOnboardingFlowV2
 import org.oppia.android.util.platformparameter.PlatformParameterValue
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** Test tag for the classroom list screen. */
@@ -166,7 +167,9 @@ class ClassroomListFragmentPresenter @Inject constructor(
       }
     )
 
-    profileManagementController.getProfile(profileId).toLiveData().observe(fragment) {
+    profileManagementController.getProfile(
+      profileId.toProfileIdPreservingZero()
+    ).toLiveData().observe(fragment) {
       processProfileResult(it)
     }
 
@@ -186,7 +189,9 @@ class ClassroomListFragmentPresenter @Inject constructor(
   /** Triggers the view model to update the topic list. */
   fun onClassroomSummaryClicked(classroomSummary: ClassroomSummary) {
     val classroomId = classroomSummary.classroomId
-    profileManagementController.updateLastSelectedClassroomId(profileId, classroomId)
+    profileManagementController.updateLastSelectedClassroomId(
+      profileId.toProfileIdPreservingZero(), classroomId
+    )
     classroomListViewModel.fetchAndUpdateTopicList(classroomId)
   }
 
@@ -287,14 +292,18 @@ class ClassroomListFragmentPresenter @Inject constructor(
               // These asynchronous API calls do not block or wait for their results. They execute
               // in the background and have minimal chances of interfering with the synchronous
               // `handleBackPress` call below.
-              profileManagementController.markProfileOnboardingEnded(profileId)
+              profileManagementController.markProfileOnboardingEnded(
+                profileId.toProfileIdPreservingZero()
+              )
               appStartupStateController.markOnboardingFlowCompleted(profileId)
             }
             profileType == ProfileType.ADDITIONAL_LEARNER &&
               !profile.completedProfileOnboarding -> {
               // Additional learners complete only profile onboarding, since they will never be the
               // first profile in the app.
-              profileManagementController.markProfileOnboardingEnded(profileId)
+              profileManagementController.markProfileOnboardingEnded(
+                profileId.toProfileIdPreservingZero()
+              )
             }
           }
         }

--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
@@ -73,6 +73,7 @@ import org.oppia.android.util.platformparameter.EnableOnboardingFlowV2
 import org.oppia.android.util.platformparameter.PlatformParameterValue
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
 import org.oppia.android.util.profile.toProfileIdPreservingZero
+import org.oppia.android.util.profile.toProfileIdUnsetIfZero
 import javax.inject.Inject
 
 /** Test tag for the classroom list screen. */
@@ -293,7 +294,7 @@ class ClassroomListFragmentPresenter @Inject constructor(
               // in the background and have minimal chances of interfering with the synchronous
               // `handleBackPress` call below.
               profileManagementController.markProfileOnboardingEnded(
-                profileId.toProfileIdPreservingZero()
+                profileId.toProfileIdUnsetIfZero()
               )
               appStartupStateController.markOnboardingFlowCompleted(profileId)
             }
@@ -302,7 +303,7 @@ class ClassroomListFragmentPresenter @Inject constructor(
               // Additional learners complete only profile onboarding, since they will never be the
               // first profile in the app.
               profileManagementController.markProfileOnboardingEnded(
-                profileId.toProfileIdPreservingZero()
+                profileId.toProfileIdUnsetIfZero()
               )
             }
           }

--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListFragmentPresenter.kt
@@ -294,7 +294,7 @@ class ClassroomListFragmentPresenter @Inject constructor(
               // in the background and have minimal chances of interfering with the synchronous
               // `handleBackPress` call below.
               profileManagementController.markProfileOnboardingEnded(
-                profileId.toProfileIdUnsetIfZero()
+                profileId.toProfileIdPreservingZero()
               )
               appStartupStateController.markOnboardingFlowCompleted(profileId)
             }

--- a/app/src/main/java/org/oppia/android/app/classroom/ClassroomListViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/classroom/ClassroomListViewModel.kt
@@ -40,6 +40,7 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders.Companion.combineWith
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 
 private const val PROFILE_AND_PROMOTED_ACTIVITY_COMBINED_PROVIDER_ID =
   "profile+promotedActivityList"
@@ -74,7 +75,7 @@ class ClassroomListViewModel(
   val selectedClassroomId = ObservableField("")
 
   private val profileDataProvider: DataProvider<Profile> by lazy {
-    profileManagementController.getProfile(profileId)
+    profileManagementController.getProfile(profileId.toProfileIdPreservingZero())
   }
 
   private val promotedActivityListSummaryDataProvider: DataProvider<PromotedActivityList> by lazy {
@@ -304,7 +305,9 @@ class ClassroomListViewModel(
   fun fetchAndUpdateTopicList(classroomId: String = "") {
     if (classroomId.isBlank()) {
       // Retrieve the last selected classroom ID if no specific classroom ID is provided.
-      profileManagementController.retrieveLastSelectedClassroomId(profileId)
+      profileManagementController.retrieveLastSelectedClassroomId(
+        profileId.toProfileIdPreservingZero()
+      )
         .toLiveData().observe(fragment) { lastSelectedClassroomIdResult ->
           when (lastSelectedClassroomIdResult) {
             is AsyncResult.Success -> {

--- a/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/drawer/NavigationDrawerFragmentPresenter.kt
@@ -41,6 +41,7 @@ import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.platformparameter.EnableMultipleClassrooms
 import org.oppia.android.util.platformparameter.PlatformParameterValue
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.statusbar.StatusBarColor
 import javax.inject.Inject
 
@@ -122,7 +123,7 @@ class NavigationDrawerFragmentPresenter @Inject constructor(
 
   private fun getProfileData(): LiveData<Profile> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId).toLiveData(),
+      profileManagementController.getProfile(profileId.toProfileIdPreservingZero()).toLiveData(),
       ::processGetProfileResult
     )
   }

--- a/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
@@ -39,6 +39,7 @@ import org.oppia.android.util.parser.html.TopicHtmlParserEntityType
 import org.oppia.android.util.platformparameter.EnableOnboardingFlowV2
 import org.oppia.android.util.platformparameter.PlatformParameterValue
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [HomeFragment]. */
@@ -112,7 +113,9 @@ class HomeFragmentPresenter @Inject constructor(
       it.viewModel = homeViewModel
     }
 
-    profileManagementController.getProfile(profileId).toLiveData().observe(fragment) {
+    profileManagementController.getProfile(
+      profileId.toProfileIdPreservingZero()
+    ).toLiveData().observe(fragment) {
       processProfileResult(it)
     }
 
@@ -137,14 +140,18 @@ class HomeFragmentPresenter @Inject constructor(
               // These asynchronous API calls do not block or wait for their results. They execute
               // in the background and have minimal chances of interfering with the synchronous
               // `handleBackPress` call below.
-              profileManagementController.markProfileOnboardingEnded(profileId)
+              profileManagementController.markProfileOnboardingEnded(
+                profileId.toProfileIdPreservingZero()
+              )
               appStartupStateController.markOnboardingFlowCompleted(profileId)
             }
             profileType == ProfileType.ADDITIONAL_LEARNER &&
               !profile.completedProfileOnboarding -> {
               // Additional learners only end profile onboarding, since they will never be the first
               // profile in the app.
-              profileManagementController.markProfileOnboardingEnded(profileId)
+              profileManagementController.markProfileOnboardingEnded(
+                profileId.toProfileIdPreservingZero()
+              )
             }
           }
         }

--- a/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
@@ -40,6 +40,7 @@ import org.oppia.android.util.platformparameter.EnableOnboardingFlowV2
 import org.oppia.android.util.platformparameter.PlatformParameterValue
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
 import org.oppia.android.util.profile.toProfileIdPreservingZero
+import org.oppia.android.util.profile.toProfileIdUnsetIfZero
 import javax.inject.Inject
 
 /** The presenter for [HomeFragment]. */
@@ -141,7 +142,7 @@ class HomeFragmentPresenter @Inject constructor(
               // in the background and have minimal chances of interfering with the synchronous
               // `handleBackPress` call below.
               profileManagementController.markProfileOnboardingEnded(
-                profileId.toProfileIdPreservingZero()
+                profileId.toProfileIdUnsetIfZero()
               )
               appStartupStateController.markOnboardingFlowCompleted(profileId)
             }
@@ -150,7 +151,7 @@ class HomeFragmentPresenter @Inject constructor(
               // Additional learners only end profile onboarding, since they will never be the first
               // profile in the app.
               profileManagementController.markProfileOnboardingEnded(
-                profileId.toProfileIdPreservingZero()
+                profileId.toProfileIdUnsetIfZero()
               )
             }
           }

--- a/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeFragmentPresenter.kt
@@ -142,7 +142,7 @@ class HomeFragmentPresenter @Inject constructor(
               // in the background and have minimal chances of interfering with the synchronous
               // `handleBackPress` call below.
               profileManagementController.markProfileOnboardingEnded(
-                profileId.toProfileIdUnsetIfZero()
+                profileId.toProfileIdPreservingZero()
               )
               appStartupStateController.markOnboardingFlowCompleted(profileId)
             }

--- a/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/home/HomeViewModel.kt
@@ -33,6 +33,7 @@ import org.oppia.android.util.data.DataProviders.Companion.combineWith
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.parser.html.StoryHtmlParserEntityType
 import org.oppia.android.util.parser.html.TopicHtmlParserEntityType
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 
 private const val PROFILE_AND_PROMOTED_ACTIVITY_COMBINED_PROVIDER_ID =
   "profile+promotedActivityList"
@@ -70,7 +71,7 @@ class HomeViewModel(
   val isProgressBarVisible = ObservableField(true)
 
   private val profileDataProvider: DataProvider<Profile> by lazy {
-    profileManagementController.getProfile(profileId)
+    profileManagementController.getProfile(profileId.toProfileIdPreservingZero())
   }
 
   private val promotedActivityListSummaryDataProvider: DataProvider<PromotedActivityList> by lazy {

--- a/app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedFragmentPresenter.kt
@@ -26,6 +26,7 @@ import org.oppia.android.domain.exploration.lightweightcheckpointing.Exploration
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [RecentlyPlayedFragment]. */
@@ -178,13 +179,13 @@ class RecentlyPlayedFragmentPresenter @Inject constructor(
       // cases, lessons played from this fragment are known to be in progress, and that progress
       // can't be resumed here (hence the restart).
       explorationDataController.restartExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
       )
     } else {
       // The only lessons that can't have their progress saved are those that were already
       // completed.
       explorationDataController.replayExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
       )
     }
     startPlayingProvider.toLiveData().observe(fragment) { result ->

--- a/app/src/main/java/org/oppia/android/app/onboarding/AdminIntroFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/AdminIntroFragmentPresenter.kt
@@ -54,6 +54,7 @@ import org.oppia.android.app.ui.R
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.extensions.putProtoExtra
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.decorateWithUserProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** Argument key for [ProfileChooserActivity] intent parameters. */
@@ -87,7 +88,7 @@ class AdminIntroFragmentPresenter @Inject constructor(
 
     createComposeView()
 
-    profileManagementController.markProfileOnboardingStarted(profileId)
+    profileManagementController.markProfileOnboardingStarted(profileId.toProfileIdPreservingZero())
 
     return binding.root
   }

--- a/app/src/main/java/org/oppia/android/app/onboarding/AudioLanguageFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/AudioLanguageFragmentPresenter.kt
@@ -34,6 +34,7 @@ import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.extensions.putProto
 import org.oppia.android.util.platformparameter.EnableMultipleClassrooms
 import org.oppia.android.util.platformparameter.PlatformParameterValue
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [AudioLanguageFragment]. */
@@ -173,7 +174,9 @@ class AudioLanguageFragmentPresenter @Inject constructor(
   ) {
     val audioLanguageSelection =
       AudioTranslationLanguageSelection.newBuilder().setSelectedLanguage(selectedLanguage).build()
-    translationController.updateAudioTranslationContentLanguage(profileId, audioLanguageSelection)
+    translationController.updateAudioTranslationContentLanguage(
+      profileId.toProfileIdPreservingZero(), audioLanguageSelection
+    )
       .toLiveData().observe(fragment) { result ->
         when (result) {
           is AsyncResult.Success -> {
@@ -214,7 +217,9 @@ class AudioLanguageFragmentPresenter @Inject constructor(
   }
 
   private fun logInToProfile(profileId: LegacyProfileId) {
-    profileManagementController.loginToProfile(profileId).toLiveData().observe(
+    profileManagementController.loginToProfile(
+      profileId.toProfileIdPreservingZero()
+    ).toLiveData().observe(
       fragment,
       { result ->
         if (result is AsyncResult.Success) {

--- a/app/src/main/java/org/oppia/android/app/onboarding/CreateProfileFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/CreateProfileFragmentPresenter.kt
@@ -28,6 +28,7 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.parser.image.ImageLoader
 import org.oppia.android.util.parser.image.ImageViewTarget
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** Presenter for [CreateProfileFragment]. */
@@ -152,7 +153,7 @@ class CreateProfileFragmentPresenter @Inject constructor(
 
   private fun updateProfileDetails(profileName: String) {
     profileManagementController.updateNewProfileDetails(
-      profileId = profileId,
+      profileId = profileId.toProfileIdPreservingZero(),
       profileType = profileType,
       avatarImagePath = selectedImageUri,
       colorRgb = selectUniqueRandomColor(),

--- a/app/src/main/java/org/oppia/android/app/onboarding/IntroFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/IntroFragmentPresenter.kt
@@ -15,6 +15,7 @@ import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.ui.R
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.decorateWithUserProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [IntroFragment]. */
@@ -44,7 +45,7 @@ class IntroFragmentPresenter @Inject constructor(
 
     setLearnerName(profileNickname)
 
-    profileManagementController.markProfileOnboardingStarted(profileId)
+    profileManagementController.markProfileOnboardingStarted(profileId.toProfileIdPreservingZero())
 
     if (parentScreen != IntroActivityParams.ParentScreen.CREATE_PROFILE_SCREEN) {
       binding.onboardingStepsCount?.visibility = View.GONE

--- a/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/onboarding/OnboardingFragmentPresenter.kt
@@ -29,6 +29,7 @@ import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.extensions.putProto
 import org.oppia.android.util.locale.OppiaLocale
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.decorateWithUserProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 private const val ONBOARDING_FRAGMENT_SAVED_STATE_KEY = "OnboardingFragment.saved_state"
@@ -151,7 +152,9 @@ class OnboardingFragmentPresenter @Inject constructor(
 
   private fun updateSelectedLanguage(selectedLanguage: OppiaLanguage) {
     val selection = AppLanguageSelection.newBuilder().setSelectedLanguage(selectedLanguage).build()
-    translationController.updateAppLanguage(profileId, selection).toLiveData()
+    translationController.updateAppLanguage(
+      profileId.toProfileIdPreservingZero(), selection
+    ).toLiveData()
       .observe(
         fragment,
         { result ->

--- a/app/src/main/java/org/oppia/android/app/options/AppLanguageFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AppLanguageFragmentPresenter.kt
@@ -24,6 +24,7 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.extensions.putProto
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [AppLanguageFragment]. */
@@ -148,7 +149,7 @@ class AppLanguageFragmentPresenter @Inject constructor(
 
   private fun updateSelectedLanguage(selectedLanguage: OppiaLanguage) {
     val selection = AppLanguageSelection.newBuilder().setSelectedLanguage(selectedLanguage).build()
-    translationController.updateAppLanguage(profileId, selection)
+    translationController.updateAppLanguage(profileId.toProfileIdPreservingZero(), selection)
   }
 
   private fun updateAppLanguage(appLanguage: OppiaLanguage) {

--- a/app/src/main/java/org/oppia/android/app/options/AppLanguageFragmentPresenterV1.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AppLanguageFragmentPresenterV1.kt
@@ -14,6 +14,7 @@ import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.translation.TranslationController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [AppLanguageFragment]. */
@@ -88,7 +89,9 @@ class AppLanguageFragmentPresenterV1 @Inject constructor(
       selectedLanguage = oppiaLanguage
     }.build()
 
-    translationController.updateAppLanguage(profileId, selection).toLiveData().observe(fragment) {
+    translationController.updateAppLanguage(
+      profileId.toProfileIdPreservingZero(), selection
+    ).toLiveData().observe(fragment) {
       when (it) {
         is AsyncResult.Success -> appLanguage = oppiaLanguage
         is AsyncResult.Failure -> {

--- a/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
@@ -16,6 +16,7 @@ import org.oppia.android.domain.translation.TranslationController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** ViewModel for managing language selection in [AudioLanguageFragment]. */
@@ -89,7 +90,7 @@ class AudioLanguageSelectionViewModel @Inject constructor(
     }
 
   private val languagePreselectionProvider: DataProvider<OppiaLanguage> by lazy {
-    translationController.getAudioLanguagePreselection(profileId)
+    translationController.getAudioLanguagePreselection(profileId.toProfileIdPreservingZero())
   }
 
   /** Receives and sets the current profileId in this viewModel. */

--- a/app/src/main/java/org/oppia/android/app/options/OptionControlsViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/OptionControlsViewModel.kt
@@ -18,6 +18,7 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders.Companion.combineWith
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 private const val OPTIONS_ITEM_VIEW_MODEL_APP_AUDIO_LANGUAGE_PROVIDER_ID =
@@ -69,11 +70,13 @@ class OptionControlsViewModel @Inject constructor(
 
   private fun createOptionsItemViewModelProvider(): DataProvider<List<OptionsItemViewModel>> {
     val appAudioLangProvider =
-      translationController.getAppLanguage(profileId).combineWith(
-        profileManagementController.getAudioLanguage(profileId),
+      translationController.getAppLanguage(profileId.toProfileIdPreservingZero()).combineWith(
+        profileManagementController.getAudioLanguage(profileId.toProfileIdPreservingZero()),
         OPTIONS_ITEM_VIEW_MODEL_APP_AUDIO_LANGUAGE_PROVIDER_ID
       ) { appLanguage, audioLanguage -> appLanguage to audioLanguage }
-    return profileManagementController.getProfile(profileId).combineWith(
+    return profileManagementController.getProfile(
+      profileId.toProfileIdPreservingZero()
+    ).combineWith(
       appAudioLangProvider, OPTIONS_ITEM_VIEW_MODEL_LIST_PROVIDER_ID
     ) { profile, (appLang, audioLang) -> processViewModelList(profile, appLang, audioLang) }
   }

--- a/app/src/main/java/org/oppia/android/app/options/OptionsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/options/OptionsFragmentPresenter.kt
@@ -23,6 +23,7 @@ import org.oppia.android.domain.translation.TranslationController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import java.security.InvalidParameterException
 import javax.inject.Inject
 
@@ -199,7 +200,9 @@ class OptionsFragmentPresenter @Inject constructor(
    * @param textSize new textSize to be set as current
    */
   fun updateReadingTextSize(textSize: ReadingTextSize) {
-    val sizeUpdateResult = profileManagementController.updateReadingTextSize(profileId, textSize)
+    val sizeUpdateResult = profileManagementController.updateReadingTextSize(
+      profileId.toProfileIdPreservingZero(), textSize
+    )
     sizeUpdateResult.toLiveData().observe(fragment) {
       when (it) {
         is AsyncResult.Failure -> {
@@ -225,7 +228,9 @@ class OptionsFragmentPresenter @Inject constructor(
       selectedLanguageValue = oppiaLanguage.number
     }.build()
 
-    translationController.updateAppLanguage(profileId, selection).toLiveData().observe(fragment) {
+    translationController.updateAppLanguage(
+      profileId.toProfileIdPreservingZero(), selection
+    ).toLiveData().observe(fragment) {
       when (it) {
         is AsyncResult.Success -> appLanguage = oppiaLanguage
         is AsyncResult.Failure ->
@@ -245,7 +250,9 @@ class OptionsFragmentPresenter @Inject constructor(
    */
   fun updateAudioLanguage(audioLanguage: AudioLanguage) {
     val updateLanguageResult =
-      profileManagementController.updateAudioLanguage(profileId, audioLanguage)
+      profileManagementController.updateAudioLanguage(
+        profileId.toProfileIdPreservingZero(), audioLanguage
+      )
     updateLanguageResult.toLiveData().observe(fragment) {
       when (it) {
         is AsyncResult.Success -> this.audioLanguage = audioLanguage

--- a/app/src/main/java/org/oppia/android/app/player/audio/AudioFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/audio/AudioFragmentPresenter.kt
@@ -32,6 +32,7 @@ import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.networking.NetworkConnectionUtil
 import org.oppia.android.util.platformparameter.EnableSpotlightUi
 import org.oppia.android.util.platformparameter.PlatformParameterValue
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 const val TAG_LANGUAGE_DIALOG = "LANGUAGE_DIALOG"
@@ -146,7 +147,9 @@ class AudioFragmentPresenter @Inject constructor(
 
   private fun retrieveAudioLanguageCode(): LiveData<String> {
     return Transformations.map(
-      profileManagementController.getAudioLanguage(profileId).toLiveData(),
+      profileManagementController.getAudioLanguage(
+        profileId.toProfileIdPreservingZero()
+      ).toLiveData(),
       ::processAudioLanguageResult
     )
   }

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
@@ -42,6 +42,7 @@ import org.oppia.android.domain.translation.TranslationController
 import org.oppia.android.util.accessibility.AccessibilityService
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 private const val TAG_UNSAVED_EXPLORATION_DIALOG = "UNSAVED_EXPLORATION_DIALOG"
@@ -276,7 +277,9 @@ class ExplorationActivityPresenter @Inject constructor(
 
   /** Deletes the saved progress for the current exploration and then stops the exploration. */
   fun deleteCurrentProgressAndStopExploration(isCompletion: Boolean) {
-    explorationDataController.deleteExplorationProgressById(profileId, explorationId)
+    explorationDataController.deleteExplorationProgressById(
+      profileId.toProfileIdPreservingZero(), explorationId
+    )
     stopExploration(isCompletion)
   }
 
@@ -287,7 +290,7 @@ class ExplorationActivityPresenter @Inject constructor(
     // without deleting any checkpoints.
     if (::oldestCheckpointExplorationId.isInitialized) {
       explorationDataController.deleteExplorationProgressById(
-        profileId,
+        profileId.toProfileIdPreservingZero(),
         oldestCheckpointExplorationId
       )
     }
@@ -504,7 +507,7 @@ class ExplorationActivityPresenter @Inject constructor(
    */
   private fun subscribeToOldestSavedExplorationDetails() {
     explorationDataController.getOldestExplorationDetailsDataProvider(
-      profileId
+      profileId.toProfileIdPreservingZero()
     ).toLiveData().observe(activity) {
       when (it) {
         is AsyncResult.Success -> {

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationFragmentPresenter.kt
@@ -28,6 +28,7 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.extensions.putProto
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [ExplorationFragment]. */
@@ -70,7 +71,9 @@ class ExplorationFragmentPresenter @Inject constructor(
 
   /** Handles the [Fragment.onViewCreated] portion of [ExplorationFragment]'s lifecycle. */
   fun handleViewCreated() {
-    val profileDataProvider = profileManagementController.getProfile(retrieveArguments().profileId)
+    val profileDataProvider = profileManagementController.getProfile(
+      retrieveArguments().profileId.toProfileIdPreservingZero()
+    )
     profileDataProvider.toLiveData().observe(
       fragment
     ) { result ->

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationManagerFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationManagerFragmentPresenter.kt
@@ -12,6 +12,7 @@ import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [ExplorationManagerFragment]. */
@@ -36,7 +37,7 @@ class ExplorationManagerFragmentPresenter @Inject constructor(
 
   private fun retrieveReadingTextSize(): LiveData<ReadingTextSize> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId).toLiveData(),
+      profileManagementController.getProfile(profileId.toProfileIdPreservingZero()).toLiveData(),
       ::processReadingTextSizeResult
     )
   }

--- a/app/src/main/java/org/oppia/android/app/player/state/StateViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateViewModel.kt
@@ -29,6 +29,7 @@ import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.locale.OppiaLocale
 import org.oppia.android.util.platformparameter.EnableFastLanguageSwitchingInLesson
 import org.oppia.android.util.platformparameter.PlatformParameterValue
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** [ViewModel] for state-fragment. */
@@ -63,14 +64,16 @@ class StateViewModel @Inject constructor(
   }
   val hasEnabledSwahiliTranslations: LiveData<Boolean> by lazy {
     Transformations.map(
-      translationController.getWrittenTranslationContentLanguage(profileId).toLiveData(),
+      translationController.getWrittenTranslationContentLanguage(
+        profileId.toProfileIdPreservingZero()
+      ).toLiveData(),
       ::processIsCurrentLanguageSwahili
     )
   }
 
   val allowInLessonQuickLanguageSwitching: LiveData<Boolean> by lazy {
     Transformations.map(
-      profileManagementController.getProfile(profileId).toLiveData(),
+      profileManagementController.getProfile(profileId.toProfileIdPreservingZero()).toLiveData(),
       ::processAllowInLessonQuickLanguageSwitching
     )
   }

--- a/app/src/main/java/org/oppia/android/app/player/state/StateViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateViewModel.kt
@@ -131,7 +131,7 @@ class StateViewModel @Inject constructor(
     }.build()
     val updateResultProvider =
       explorationProgressController.updateWrittenTranslationContentLanguageMidLesson(
-        profileId, languageSelection
+        profileId.toProfileIdPreservingZero(), languageSelection
       )
     val updateResultLiveData = updateResultProvider.toLiveData()
     updateResultLiveData.observe(

--- a/app/src/main/java/org/oppia/android/app/player/state/testing/StateFragmentTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/testing/StateFragmentTestActivityPresenter.kt
@@ -5,7 +5,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import org.oppia.android.app.activity.ActivityScope
 import org.oppia.android.app.databinding.databinding.StateFragmentTestActivityBinding
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.StateFragmentTestActivityParams
 import org.oppia.android.app.player.exploration.HintsAndSolutionExplorationManagerFragment
 import org.oppia.android.app.player.exploration.TAG_HINTS_AND_SOLUTION_EXPLORATION_MANAGER
@@ -87,7 +87,7 @@ class StateFragmentTestActivityPresenter @Inject constructor(
 
   fun deleteCurrentProgressAndStopExploration(isCompletion: Boolean) {
     explorationDataController.deleteExplorationProgressById(
-      LegacyProfileId.newBuilder().setInternalId(profileId).build(),
+      ProfileId.newBuilder().setInternalId(profileId).build(),
       explorationId
     )
     stopExploration(isCompletion)
@@ -106,11 +106,13 @@ class StateFragmentTestActivityPresenter @Inject constructor(
     explorationDataController.stopPlayingExploration(isCompletion = false)
     val startPlayingProvider = if (shouldSavePartialProgress) {
       explorationDataController.startPlayingNewExploration(
-        profileId, classroomId, topicId, storyId, explorationId
+        ProfileId.newBuilder().setInternalId(profileId).build(),
+        classroomId, topicId, storyId, explorationId
       )
     } else {
       explorationDataController.replayExploration(
-        profileId, classroomId, topicId, storyId, explorationId
+        ProfileId.newBuilder().setInternalId(profileId).build(),
+        classroomId, topicId, storyId, explorationId
       )
     }
     startPlayingProvider.toLiveData().observe(

--- a/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminAuthActivityPresenter.kt
@@ -18,6 +18,7 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.getProtoExtra
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [AdminAuthActivity]. */
@@ -89,7 +90,9 @@ class AdminAuthActivityPresenter @Inject constructor(
       if (inputPin == adminPin) {
         when (args?.adminPinEnum ?: 0) {
           AdminAuthEnum.PROFILE_ADMIN_CONTROLS.value -> {
-            profileManagementController.loginToProfile(profileId).toLiveData().observe(activity) {
+            profileManagementController.loginToProfile(
+              profileId.toProfileIdPreservingZero()
+            ).toLiveData().observe(activity) {
               if (it is AsyncResult.Success) {
                 activity.startActivity(
                   AdministratorControlsActivity.createAdministratorControlsActivityIntent(
@@ -101,7 +104,9 @@ class AdminAuthActivityPresenter @Inject constructor(
             }
           }
           AdminAuthEnum.PROFILE_ADD_PROFILE.value -> {
-            profileManagementController.loginToProfile(profileId).toLiveData().observe(activity) {
+            profileManagementController.loginToProfile(
+              profileId.toProfileIdPreservingZero()
+            ).toLiveData().observe(activity) {
               if (it is AsyncResult.Success) {
                 activity.startActivity(
                   AddProfileActivity.createAddProfileActivityIntent(

--- a/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/AdminPinActivityPresenter.kt
@@ -20,6 +20,7 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.getProtoExtra
 import org.oppia.android.util.parser.html.HtmlParser
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [AdminPinActivity]. */
@@ -121,7 +122,9 @@ class AdminPinActivityPresenter @Inject constructor(
           .setInternalId(args?.internalProfileId ?: -1)
           .build()
 
-      profileManagementController.updatePin(profileId, inputPin).toLiveData().observe(
+      profileManagementController.updatePin(
+        profileId.toProfileIdPreservingZero(), inputPin
+      ).toLiveData().observe(
         activity,
         Observer {
           if (it is AsyncResult.Success) {

--- a/app/src/main/java/org/oppia/android/app/profile/PinPasswordActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/PinPasswordActivityPresenter.kt
@@ -27,6 +27,7 @@ import org.oppia.android.util.extensions.getProtoExtra
 import org.oppia.android.util.platformparameter.EnableMultipleClassrooms
 import org.oppia.android.util.platformparameter.EnableOnboardingFlowV2
 import org.oppia.android.util.platformparameter.PlatformParameterValue
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 import kotlin.system.exitProcess
 
@@ -108,7 +109,7 @@ class PinPasswordActivityPresenter @Inject constructor(
         ) {
           if (inputtedPin == pinViewModel.correctPin.get()) {
             profileManagementController
-              .loginToProfile(profileId).toLiveData().observe(
+              .loginToProfile(profileId.toProfileIdPreservingZero()).toLiveData().observe(
                 activity,
                 Observer
                 {

--- a/app/src/main/java/org/oppia/android/app/profile/PinPasswordViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/PinPasswordViewModel.kt
@@ -13,6 +13,7 @@ import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 // TODO(#5817): Remove along with PinPasswordActivity when v2 onboarding flow has stabilized.
@@ -34,7 +35,7 @@ class PinPasswordViewModel @Inject constructor(
 
   val profile: LiveData<Profile> by lazy {
     Transformations.map(
-      profileManagementController.getProfile(profileId).toLiveData(),
+      profileManagementController.getProfile(profileId.toProfileIdPreservingZero()).toLiveData(),
       ::processGetProfileResult
     )
   }

--- a/app/src/main/java/org/oppia/android/app/profile/ProfileChooserFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/ProfileChooserFragmentPresenter.kt
@@ -36,6 +36,7 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.platformparameter.EnableMultipleClassrooms
 import org.oppia.android.util.platformparameter.PlatformParameterValue
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.statusbar.StatusBarColor
 import javax.inject.Inject
 
@@ -100,7 +101,9 @@ class ProfileChooserFragmentPresenter @Inject constructor(
     if (parentScreen == ParentScreen.ADMIN_INTRO_SCREEN) {
       // The admin onboarding ends here in order to prevent the admin from seeing the onboarding
       // flow again if they exit the app at this point.
-      profileManagementController.markProfileOnboardingEnded(adminProfileId)
+      profileManagementController.markProfileOnboardingEnded(
+        adminProfileId.toProfileIdPreservingZero()
+      )
     }
 
     binding =
@@ -292,7 +295,7 @@ class ProfileChooserFragmentPresenter @Inject constructor(
   private fun updateLearnerIdIfAbsent(profile: Profile) {
     if (profile.learnerId.isNullOrEmpty()) {
       // TODO(#4345): Block on the following data provider before allowing the user to log in.
-      profileManagementController.initializeLearnerId(profile.id)
+      profileManagementController.initializeLearnerId(profile.id.toProfileIdPreservingZero())
     }
   }
 
@@ -331,7 +334,9 @@ class ProfileChooserFragmentPresenter @Inject constructor(
   }
 
   private fun launchHomeScreen(profileId: LegacyProfileId) {
-    profileManagementController.loginToProfile(profileId).toLiveData().observe(fragment) {
+    profileManagementController.loginToProfile(
+      profileId.toProfileIdPreservingZero()
+    ).toLiveData().observe(fragment) {
       if (it is AsyncResult.Success) {
         if (enableMultipleClassrooms.value) {
           activity.startActivity(

--- a/app/src/main/java/org/oppia/android/app/profile/ProfileChooserFragmentPresenterV1.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/ProfileChooserFragmentPresenterV1.kt
@@ -30,6 +30,7 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.platformparameter.EnableMultipleClassrooms
 import org.oppia.android.util.platformparameter.PlatformParameterValue
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.statusbar.StatusBarColor
 import javax.inject.Inject
 
@@ -236,13 +237,15 @@ class ProfileChooserFragmentPresenterV1 @Inject constructor(
   private fun updateLearnerIdIfAbsent(profile: Profile) {
     if (profile.learnerId.isNullOrEmpty()) {
       // TODO(#4345): Block on the following data provider before allowing the user to log in.
-      profileManagementController.initializeLearnerId(profile.id)
+      profileManagementController.initializeLearnerId(profile.id.toProfileIdPreservingZero())
     }
   }
 
   private fun loginToProfile(profile: Profile) {
     if (profile.pin.isNullOrBlank()) {
-      profileManagementController.loginToProfile(profile.id).toLiveData().observe(fragment) {
+      profileManagementController.loginToProfile(
+        profile.id.toProfileIdPreservingZero()
+      ).toLiveData().observe(fragment) {
         if (it is AsyncResult.Success) {
           if (enableMultipleClassrooms.value) {
             activity.startActivity(

--- a/app/src/main/java/org/oppia/android/app/profile/ProfileLoginFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/ProfileLoginFragmentPresenter.kt
@@ -70,6 +70,7 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.platformparameter.EnableMultipleClassrooms
 import org.oppia.android.util.platformparameter.PlatformParameterValue
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /**
@@ -114,7 +115,11 @@ class ProfileLoginFragmentPresenter @Inject constructor(
     binding = ProfileLoginFragmentBinding.inflate(inflater, container, /* attachToRoot= */ false)
 
     profileLiveData =
-      getProfileResult(profileManagementController.getProfile(profileId).toLiveData())
+      getProfileResult(
+        profileManagementController.getProfile(
+          profileId.toProfileIdPreservingZero()
+        ).toLiveData()
+      )
 
     getAdminPin()
 
@@ -127,7 +132,11 @@ class ProfileLoginFragmentPresenter @Inject constructor(
     val adminProfileId = LegacyProfileId.newBuilder().setInternalId(0).build()
 
     adminProfileLiveData =
-      getProfileResult(profileManagementController.getProfile(adminProfileId).toLiveData())
+      getProfileResult(
+        profileManagementController.getProfile(
+          adminProfileId.toProfileIdPreservingZero()
+        ).toLiveData()
+      )
   }
 
   private fun createComposeView() {
@@ -226,7 +235,7 @@ class ProfileLoginFragmentPresenter @Inject constructor(
   }
 
   private fun loginToProfile(profileId: LegacyProfileId) {
-    profileManagementController.loginToProfile(profileId).toLiveData()
+    profileManagementController.loginToProfile(profileId.toProfileIdPreservingZero()).toLiveData()
       .observe(fragment) {
         if (it is AsyncResult.Success) {
           activity.startActivity(

--- a/app/src/main/java/org/oppia/android/app/profile/ResetPinDialogFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profile/ResetPinDialogFragmentPresenter.kt
@@ -17,6 +17,7 @@ import org.oppia.android.app.utility.TextInputEditTextHelper.Companion.onTextCha
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [ResetPinDialogFragment]. */
@@ -92,7 +93,7 @@ class ResetPinDialogFragmentPresenter @Inject constructor(
         if (input.length == 3) {
           val legacyProfileId = LegacyProfileId.newBuilder().setInternalId(profileId).build()
           profileManagementController
-            .updatePin(legacyProfileId, input).toLiveData()
+            .updatePin(legacyProfileId.toProfileIdPreservingZero(), input).toLiveData()
             .observe(
               fragment,
               Observer {

--- a/app/src/main/java/org/oppia/android/app/profileprogress/ProfilePictureActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profileprogress/ProfilePictureActivityPresenter.kt
@@ -17,6 +17,7 @@ import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.statusbar.StatusBarColor
 import javax.inject.Inject
 
@@ -67,7 +68,7 @@ class ProfilePictureActivityPresenter @Inject constructor(
 
   private fun getProfileData(): LiveData<Profile> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId).toLiveData(),
+      profileManagementController.getProfile(profileId.toProfileIdPreservingZero()).toLiveData(),
       ::processGetProfileResult
     )
   }

--- a/app/src/main/java/org/oppia/android/app/profileprogress/ProfileProgressActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/profileprogress/ProfileProgressActivityPresenter.kt
@@ -8,6 +8,7 @@ import org.oppia.android.app.activity.ActivityScope
 import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.ui.R
 import org.oppia.android.domain.profile.ProfileManagementController
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [ProfileProgressActivity]. */
@@ -51,7 +52,7 @@ class ProfileProgressActivityPresenter @Inject constructor(
 
   fun updateProfileAvatar(intent: Intent?) {
     profileManagementController.updateProfileAvatar(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       intent?.data,
       /* colorRgb= */ 10710042
     )

--- a/app/src/main/java/org/oppia/android/app/profileprogress/ProfileProgressViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/profileprogress/ProfileProgressViewModel.kt
@@ -24,6 +24,7 @@ import org.oppia.android.domain.translation.TranslationController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.parser.html.StoryHtmlParserEntityType
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The [ObservableViewModel] for [ProfileProgressFragment]. */
@@ -62,7 +63,10 @@ class ProfileProgressViewModel @Inject constructor(
 
   private fun getProfileData(): LiveData<Profile> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId).toLiveData(), ::processGetProfileResult
+      profileManagementController.getProfile(
+        profileId.toProfileIdPreservingZero()
+      ).toLiveData(),
+      ::processGetProfileResult
     )
   }
 

--- a/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonActivityPresenter.kt
@@ -18,6 +18,7 @@ import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 private const val RESUME_LESSON_TAG = "ResumeLesson"
@@ -102,7 +103,7 @@ class ResumeLessonActivityPresenter @Inject constructor(
 
   private fun retrieveReadingTextSize(): LiveData<ReadingTextSize> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId).toLiveData(),
+      profileManagementController.getProfile(profileId.toProfileIdPreservingZero()).toLiveData(),
       ::processReadingTextSizeResult
     )
   }

--- a/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonFragmentPresenter.kt
@@ -26,6 +26,7 @@ import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.gcsresource.DefaultResourceBucketName
 import org.oppia.android.util.parser.html.HtmlParser
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [ResumeLessonFragment]. */
@@ -198,11 +199,16 @@ class ResumeLessonFragmentPresenter @Inject constructor(
   ) {
     val startPlayingProvider = if (checkpoint == ExplorationCheckpoint.getDefaultInstance()) {
       explorationDataController.restartExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
       )
     } else {
       explorationDataController.resumeExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId, checkpoint
+        profileId.toProfileIdPreservingZero(),
+        classroomId,
+        topicId,
+        storyId,
+        explorationId,
+        checkpoint
       )
     }
     startPlayingProvider.toLiveData().observe(fragment) { result ->

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditFragmentPresenter.kt
@@ -12,10 +12,12 @@ import org.oppia.android.app.databinding.databinding.ProfileEditFragmentBinding
 import org.oppia.android.app.devoptions.markchapterscompleted.MarkChaptersCompletedActivity
 import org.oppia.android.app.fragment.FragmentScope
 import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** Argument key for profile deletion dialog in [ProfileEditFragment]. */
@@ -99,7 +101,7 @@ class ProfileEditFragmentPresenter @Inject constructor(
       val enableDownloads = !binding.profileEditAllowDownloadSwitch.isChecked
       binding.profileEditAllowDownloadSwitch.isChecked = enableDownloads
       profileManagementController.updateAllowDownloadAccess(
-        LegacyProfileId.newBuilder().setInternalId(internalProfileId).build(),
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         enableDownloads
       ).toLiveData().observe(activity) {
         if (it is AsyncResult.Failure) {
@@ -113,7 +115,7 @@ class ProfileEditFragmentPresenter @Inject constructor(
       val enableLangSwitching = !binding.profileEditEnableInLessonLanguageSwitchingSwitch.isChecked
       binding.profileEditEnableInLessonLanguageSwitchingSwitch.isChecked = enableLangSwitching
       profileManagementController.updateEnableInLessonQuickLanguageSwitching(
-        LegacyProfileId.newBuilder().setInternalId(internalProfileId).build(),
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         enableLangSwitching
       ).toLiveData().observe(activity) {
         if (it is AsyncResult.Failure) {
@@ -145,7 +147,7 @@ class ProfileEditFragmentPresenter @Inject constructor(
   fun deleteProfile(internalProfileId: Int) {
     val legacyProfileId = LegacyProfileId.newBuilder().setInternalId(internalProfileId).build()
     profileManagementController
-      .deleteProfile(legacyProfileId).toLiveData()
+      .deleteProfile(legacyProfileId.toProfileIdPreservingZero()).toLiveData()
       .observe(
         fragment,
         Observer {

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditFragmentPresenter.kt
@@ -12,7 +12,6 @@ import org.oppia.android.app.databinding.databinding.ProfileEditFragmentBinding
 import org.oppia.android.app.devoptions.markchapterscompleted.MarkChaptersCompletedActivity
 import org.oppia.android.app.fragment.FragmentScope
 import org.oppia.android.app.model.LegacyProfileId
-import org.oppia.android.app.model.ProfileId
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
@@ -101,7 +100,8 @@ class ProfileEditFragmentPresenter @Inject constructor(
       val enableDownloads = !binding.profileEditAllowDownloadSwitch.isChecked
       binding.profileEditAllowDownloadSwitch.isChecked = enableDownloads
       profileManagementController.updateAllowDownloadAccess(
-        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
+        LegacyProfileId.newBuilder().setInternalId(internalProfileId)
+          .build().toProfileIdPreservingZero(),
         enableDownloads
       ).toLiveData().observe(activity) {
         if (it is AsyncResult.Failure) {
@@ -115,7 +115,8 @@ class ProfileEditFragmentPresenter @Inject constructor(
       val enableLangSwitching = !binding.profileEditEnableInLessonLanguageSwitchingSwitch.isChecked
       binding.profileEditEnableInLessonLanguageSwitchingSwitch.isChecked = enableLangSwitching
       profileManagementController.updateEnableInLessonQuickLanguageSwitching(
-        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
+        LegacyProfileId.newBuilder().setInternalId(internalProfileId)
+          .build().toProfileIdPreservingZero(),
         enableLangSwitching
       ).toLiveData().observe(activity) {
         if (it is AsyncResult.Failure) {

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditViewModel.kt
@@ -14,6 +14,7 @@ import org.oppia.android.util.platformparameter.EnableDownloadsSupport
 import org.oppia.android.util.platformparameter.EnableFastLanguageSwitchingInLesson
 import org.oppia.android.util.platformparameter.EnableLearnerStudyAnalytics
 import org.oppia.android.util.platformparameter.PlatformParameterValue
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The ViewModel for [ProfileEditActivity]. */
@@ -38,7 +39,7 @@ class ProfileEditViewModel @Inject constructor(
   /** List of all the current profiles registered in the app [ProfileListFragment]. */
   val profile: LiveData<Profile> by lazy {
     Transformations.map(
-      profileManagementController.getProfile(profileId).toLiveData(),
+      profileManagementController.getProfile(profileId.toProfileIdPreservingZero()).toLiveData(),
       ::processGetProfileResult
     )
   }

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileRenameFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileRenameFragmentPresenter.kt
@@ -10,7 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import org.oppia.android.app.databinding.databinding.ProfileRenameFragmentBinding
 import org.oppia.android.app.fragment.FragmentScope
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.ui.R
 import org.oppia.android.app.utility.TextInputEditTextHelper.Companion.onTextChanged
@@ -59,7 +59,7 @@ class ProfileRenameFragmentPresenter @Inject constructor(
       }
       profileManagementController
         .updateName(
-          LegacyProfileId.newBuilder().setInternalId(profileId).build(),
+          ProfileId.newBuilder().setInternalId(profileId).build(),
           binding.profileRenameInputEditText.text.toString()
         ).toLiveData()
         .observe(

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileRenameFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileRenameFragmentPresenter.kt
@@ -10,13 +10,14 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import org.oppia.android.app.databinding.databinding.ProfileRenameFragmentBinding
 import org.oppia.android.app.fragment.FragmentScope
-import org.oppia.android.app.model.ProfileId
+import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.ui.R
 import org.oppia.android.app.utility.TextInputEditTextHelper.Companion.onTextChanged
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [ProfileRenameFragment]. */
@@ -59,7 +60,7 @@ class ProfileRenameFragmentPresenter @Inject constructor(
       }
       profileManagementController
         .updateName(
-          ProfileId.newBuilder().setInternalId(profileId).build(),
+          LegacyProfileId.newBuilder().setInternalId(profileId).build().toProfileIdPreservingZero(),
           binding.profileRenameInputEditText.text.toString()
         ).toLiveData()
         .observe(

--- a/app/src/main/java/org/oppia/android/app/settings/profile/ProfileResetPinFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/settings/profile/ProfileResetPinFragmentPresenter.kt
@@ -17,6 +17,7 @@ import org.oppia.android.app.utility.TextInputEditTextHelper.Companion.onTextCha
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [ProfileResetPinFragment]. */
@@ -125,8 +126,11 @@ class ProfileResetPinFragmentPresenter @Inject constructor(
       if (failed) {
         return@setOnClickListener
       }
+      val profileIdToUpdate =
+        LegacyProfileId.newBuilder().setInternalId(profileId).build()
+          .toProfileIdPreservingZero()
       profileManagementController
-        .updatePin(LegacyProfileId.newBuilder().setInternalId(profileId).build(), pin).toLiveData()
+        .updatePin(profileIdToUpdate, pin).toLiveData()
         .observe(
           activity,
           Observer {

--- a/app/src/main/java/org/oppia/android/app/splash/SplashActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/splash/SplashActivityPresenter.kt
@@ -56,6 +56,7 @@ import org.oppia.android.util.platformparameter.EnableMultipleClassrooms
 import org.oppia.android.util.platformparameter.EnableOnboardingFlowV2
 import org.oppia.android.util.platformparameter.PlatformParameterValue
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.decorateWithUserProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -511,7 +512,7 @@ class SplashActivityPresenter @Inject constructor(
     }
 
     private fun logInToProfile(profileId: LegacyProfileId) {
-      profileManagementController.loginToProfile(profileId)
+      profileManagementController.loginToProfile(profileId.toProfileIdPreservingZero())
         .toLiveData()
         .observe(activity) { result ->
           if (result is AsyncResult.Success && !activity.isFinishing) {

--- a/app/src/main/java/org/oppia/android/app/story/StoryFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/story/StoryFragmentPresenter.kt
@@ -272,7 +272,7 @@ class StoryFragmentPresenter @Inject constructor(
     // one.
     val startPlayingProvider = if (canHavePartialProgressSaved) {
       explorationDataController.startPlayingNewExploration(
-        profileId.internalId,
+        profileId.toProfileIdPreservingZero(),
         classroomId,
         topicId,
         storyId,
@@ -280,7 +280,7 @@ class StoryFragmentPresenter @Inject constructor(
       )
     } else {
       explorationDataController.replayExploration(
-        profileId.internalId,
+        profileId.toProfileIdPreservingZero(),
         classroomId,
         topicId,
         storyId,

--- a/app/src/main/java/org/oppia/android/app/survey/SurveyWelcomeDialogFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/survey/SurveyWelcomeDialogFragmentPresenter.kt
@@ -15,6 +15,7 @@ import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.domain.survey.SurveyController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 const val TAG_SURVEY_WELCOME_DIALOG = "SURVEY_WELCOME_DIALOG"
@@ -55,7 +56,9 @@ class SurveyWelcomeDialogFragmentPresenter @Inject constructor(
       dismissSurveyListener.dismissSurvey()
     }
 
-    profileManagementController.updateSurveyLastShownTimestamp(profileId)
+    profileManagementController.updateSurveyLastShownTimestamp(
+      profileId.toProfileIdPreservingZero()
+    )
 
     logSurveyPopUpShownEvent(explorationId, topicId, profileId)
 

--- a/app/src/main/java/org/oppia/android/app/testing/ExplorationTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/ExplorationTestActivityPresenter.kt
@@ -10,6 +10,7 @@ import org.oppia.android.app.fragment.InjectableFragment
 import org.oppia.android.app.home.RouteToExplorationListener
 import org.oppia.android.app.model.ExplorationActivityParams
 import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.ui.R
 import org.oppia.android.app.utility.SplitScreenManager
 import org.oppia.android.domain.classroom.TEST_CLASSROOM_ID_0
@@ -53,7 +54,7 @@ class ExplorationTestActivityPresenter @Inject constructor(
   private fun playExplorationButton() {
     explorationDataController.stopPlayingExploration(isCompletion = false)
     explorationDataController.replayExploration(
-      INTERNAL_PROFILE_ID,
+      ProfileId.newBuilder().setInternalId(INTERNAL_PROFILE_ID).build(),
       CLASSROOM_ID,
       TOPIC_ID,
       STORY_ID,

--- a/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
@@ -31,6 +31,7 @@ import org.oppia.android.util.accessibility.AccessibilityService
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.enumfilter.filterByEnumCondition
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [TopicLessonsFragment]. */
@@ -369,21 +370,21 @@ class TopicLessonsFragmentPresenter @Inject constructor(
       !canHavePartialProgressSaved -> {
         // Only explorations that have been completed can't be saved, so replay the lesson.
         explorationDataController.replayExploration(
-          profileId.internalId, classroomId, topicId, storyId, explorationId
+          profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
         )
       }
       hadProgress -> {
         // If there was progress, either the checkpoint was never saved, failed to save, or failed
         // to be retrieved. In all cases, this is a restart.
         explorationDataController.restartExploration(
-          profileId.internalId, classroomId, topicId, storyId, explorationId
+          profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
         )
       }
       else -> {
         // If there's no progress and it was never completed, then it's a new play through (or the
         // user is very low on device memory).
         explorationDataController.startPlayingNewExploration(
-          profileId.internalId, classroomId, topicId, storyId, explorationId
+          profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
         )
       }
     }

--- a/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityPresenter.kt
@@ -27,6 +27,7 @@ import org.oppia.android.domain.question.QuestionTrainingController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.getProtoExtra
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 const val TAG_QUESTION_PLAYER_FRAGMENT = "TAG_QUESTION_PLAYER_FRAGMENT"
@@ -101,7 +102,7 @@ class QuestionPlayerActivityPresenter @Inject constructor(
 
   private fun retrieveReadingTextSize(): LiveData<ReadingTextSize> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId).toLiveData(),
+      profileManagementController.getProfile(profileId.toProfileIdPreservingZero()).toLiveData(),
       ::processReadingTextSizeResult
     )
   }

--- a/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityPresenter.kt
@@ -27,6 +27,7 @@ import org.oppia.android.domain.translation.TranslationController
 import org.oppia.android.util.accessibility.AccessibilityService
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [RevisionCardActivity]. */
@@ -101,7 +102,7 @@ class RevisionCardActivityPresenter @Inject constructor(
 
   private fun retrieveReadingTextSize(): LiveData<ReadingTextSize> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId).toLiveData(),
+      profileManagementController.getProfile(profileId.toProfileIdPreservingZero()).toLiveData(),
       ::processReadingTextSizeResult
     )
   }

--- a/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentPresenter.kt
@@ -24,6 +24,7 @@ import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.gcsresource.DefaultResourceBucketName
 import org.oppia.android.util.parser.html.HtmlParser
 import org.oppia.android.util.parser.html.TopicHtmlParserEntityType
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** Presenter for [RevisionCardFragment], sets up bindings from ViewModel. */
@@ -97,7 +98,7 @@ class RevisionCardFragmentPresenter @Inject constructor(
       )
     }
 
-    profileManagementController.getProfile(profileId)
+    profileManagementController.getProfile(profileId.toProfileIdPreservingZero())
       .toLiveData().observe(
         fragment
       ) { result ->

--- a/app/src/main/java/org/oppia/android/app/walkthrough/welcome/WalkthroughWelcomeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/walkthrough/welcome/WalkthroughWelcomeFragmentPresenter.kt
@@ -22,6 +22,7 @@ import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [WalkthroughWelcomeFragment]. */
@@ -67,7 +68,7 @@ class WalkthroughWelcomeFragmentPresenter @Inject constructor(
 
   private fun getProfileData(): LiveData<Profile> {
     return Transformations.map(
-      profileManagementController.getProfile(profileId).toLiveData(),
+      profileManagementController.getProfile(profileId.toProfileIdPreservingZero()).toLiveData(),
       ::processGetProfileResult
     )
   }

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
@@ -59,7 +59,7 @@ import org.oppia.android.app.model.AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE
 import org.oppia.android.app.model.AudioLanguageActivityParams
 import org.oppia.android.app.model.AudioLanguageActivityParams.ParentScreen.LEARNER_INTRO_SCREEN
 import org.oppia.android.app.model.AudioLanguageActivityParams.ParentScreen.OPTIONS_SCREEN
-import org.oppia.android.app.model.ProfileId
+import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.options.AudioLanguageFragment.Companion.retrieveLanguageFromArguments
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
@@ -125,6 +125,7 @@ import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -702,7 +703,7 @@ class AudioLanguageFragmentTest {
   fun testFragment_withHindiLanguagePreviouslySet_defaultsBackToEnglish() {
     initializeTestApplicationComponent(enableOnboardingFlowV2 = false)
 
-    val profileId = ProfileId.newBuilder().setInternalId(0).build()
+    val profileId = LegacyProfileId.newBuilder().setInternalId(0).build().toProfileIdPreservingZero()
     val updateProvider = profileManagementController.updateAudioLanguage(
       profileId,
       HINDI_AUDIO_LANGUAGE

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
@@ -59,7 +59,7 @@ import org.oppia.android.app.model.AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE
 import org.oppia.android.app.model.AudioLanguageActivityParams
 import org.oppia.android.app.model.AudioLanguageActivityParams.ParentScreen.LEARNER_INTRO_SCREEN
 import org.oppia.android.app.model.AudioLanguageActivityParams.ParentScreen.OPTIONS_SCREEN
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.options.AudioLanguageFragment.Companion.retrieveLanguageFromArguments
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
@@ -702,7 +702,7 @@ class AudioLanguageFragmentTest {
   fun testFragment_withHindiLanguagePreviouslySet_defaultsBackToEnglish() {
     initializeTestApplicationComponent(enableOnboardingFlowV2 = false)
 
-    val profileId = LegacyProfileId.newBuilder().setInternalId(0).build()
+    val profileId = ProfileId.newBuilder().setInternalId(0).build()
     val updateProvider = profileManagementController.updateAudioLanguage(
       profileId,
       HINDI_AUDIO_LANGUAGE

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AudioLanguageFragmentTest.kt
@@ -703,7 +703,8 @@ class AudioLanguageFragmentTest {
   fun testFragment_withHindiLanguagePreviouslySet_defaultsBackToEnglish() {
     initializeTestApplicationComponent(enableOnboardingFlowV2 = false)
 
-    val profileId = LegacyProfileId.newBuilder().setInternalId(0).build().toProfileIdPreservingZero()
+    val profileId =
+      LegacyProfileId.newBuilder().setInternalId(0).build().toProfileIdPreservingZero()
     val updateProvider = profileManagementController.updateAudioLanguage(
       profileId,
       HINDI_AUDIO_LANGUAGE

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -174,6 +174,7 @@ import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.io.IOException
@@ -2461,7 +2462,7 @@ class ExplorationActivityTest {
 
   private fun updateContentLanguage(profileId: LegacyProfileId, language: OppiaLanguage) {
     val updateProvider = translationController.updateWrittenTranslationContentLanguage(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       WrittenTranslationLanguageSelection.newBuilder().apply {
         selectedLanguage = language
       }.build()

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -71,6 +71,7 @@ import org.oppia.android.app.model.HelpActivityParams
 import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.model.OptionsActivityParams
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.ScreenName
 import org.oppia.android.app.model.Spotlight
 import org.oppia.android.app.model.WrittenTranslationLanguageSelection
@@ -1540,7 +1541,7 @@ class ExplorationActivityTest {
       shouldSavePartialProgress = false
     ) {
       explorationDataController.replayExploration(
-        internalProfileId,
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         TEST_CLASSROOM_ID_1,
         FRACTIONS_TOPIC_ID,
         FRACTIONS_STORY_ID_0,
@@ -1570,7 +1571,7 @@ class ExplorationActivityTest {
       shouldSavePartialProgress = false
     ) {
       explorationDataController.replayExploration(
-        internalProfileId,
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         TEST_CLASSROOM_ID_1,
         FRACTIONS_TOPIC_ID,
         FRACTIONS_STORY_ID_0,
@@ -2309,7 +2310,8 @@ class ExplorationActivityTest {
       classroomId, topicId, storyId, explorationId, shouldSavePartialProgress
     ) {
       explorationDataController.startPlayingNewExploration(
-        internalProfileId, classroomId, topicId, storyId, explorationId
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
+        classroomId, topicId, storyId, explorationId
       )
       testCoroutineDispatchers.runCurrent()
       testBlock()

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -197,6 +197,7 @@ import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.ImageParsingModule
 import org.oppia.android.util.parser.image.TestGlideImageLoader
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.threading.BackgroundDispatcher
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -5335,7 +5336,9 @@ class StateFragmentTest {
 
       // Update the SurveyLastShownTimestamp to trigger an update in the data provider and notify
       // subscribers of an update.
-      profileManagementController.updateSurveyLastShownTimestamp(profileId)
+      profileManagementController.updateSurveyLastShownTimestamp(
+        profileId.toProfileIdPreservingZero()
+      )
       testCoroutineDispatchers.runCurrent()
 
       onView(withText(R.string.survey_onboarding_title_text))
@@ -6810,7 +6813,7 @@ class StateFragmentTest {
 
   private fun updateContentLanguage(profileId: LegacyProfileId, language: OppiaLanguage) {
     val updateProvider = translationController.updateWrittenTranslationContentLanguage(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       WrittenTranslationLanguageSelection.newBuilder().apply {
         selectedLanguage = language
       }.build()

--- a/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/state/StateFragmentTest.kt
@@ -6823,7 +6823,7 @@ class StateFragmentTest {
 
   private fun enableInLessonLanguageSwitching() {
     val updateProvider = profileManagementController.updateEnableInLessonQuickLanguageSwitching(
-      profileId, allowInLessonQuickLanguageSwitching = true
+      profileId.toProfileIdPreservingZero(), allowInLessonQuickLanguageSwitching = true
     )
     monitorFactory.ensureDataProviderExecutes(updateProvider)
   }

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditFragmentTest.kt
@@ -43,10 +43,10 @@ import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.devoptions.markchapterscompleted.MarkChaptersCompletedActivity
 import org.oppia.android.app.devoptions.markchapterscompleted.MarkChaptersCompletedActivity.Companion.MARK_CHAPTERS_COMPLETED_ACTIVITY_PARAMS
+import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.MarkChaptersCompletedActivityParams
 import org.oppia.android.app.model.ProfileEditActivityParams
 import org.oppia.android.app.model.ProfileEditFragmentArguments
-import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.test.R
@@ -114,6 +114,7 @@ import org.oppia.android.util.networking.NetworkConnectionDebugUtilModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.ImageParsingModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -478,7 +479,8 @@ class ProfileEditFragmentTest {
 
     val updateLangProvider =
       profileManagementController.updateEnableInLessonQuickLanguageSwitching(
-        profileId = ProfileId.newBuilder().apply { internalId = 0 }.build(),
+        profileId = LegacyProfileId.newBuilder().apply { internalId = 0 }.build()
+          .toProfileIdPreservingZero(),
         allowInLessonQuickLanguageSwitching = true,
       )
     monitorFactory.waitForNextSuccessfulResult(updateLangProvider)
@@ -500,7 +502,7 @@ class ProfileEditFragmentTest {
     // The user should not have permission to switch languages (since the switch wasn't toggled).
     val profileProvider =
       profileManagementController.getProfile(
-        ProfileId.newBuilder().apply { internalId = 0 }.build(),
+        LegacyProfileId.newBuilder().apply { internalId = 0 }.build().toProfileIdPreservingZero(),
       )
     val profile = monitorFactory.waitForNextSuccessfulResult(profileProvider)
 
@@ -521,7 +523,7 @@ class ProfileEditFragmentTest {
     // The user should have permission to switch languages (since the switch was toggled).
     val profileProvider =
       profileManagementController.getProfile(
-        ProfileId.newBuilder().apply { internalId = 0 }.build(),
+        LegacyProfileId.newBuilder().apply { internalId = 0 }.build().toProfileIdPreservingZero(),
       )
     val profile = monitorFactory.waitForNextSuccessfulResult(profileProvider)
     assertThat(profile.allowInLessonQuickLanguageSwitching).isTrue()

--- a/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/settings/profile/ProfileEditFragmentTest.kt
@@ -43,10 +43,10 @@ import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.devoptions.markchapterscompleted.MarkChaptersCompletedActivity
 import org.oppia.android.app.devoptions.markchapterscompleted.MarkChaptersCompletedActivity.Companion.MARK_CHAPTERS_COMPLETED_ACTIVITY_PARAMS
-import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.MarkChaptersCompletedActivityParams
 import org.oppia.android.app.model.ProfileEditActivityParams
 import org.oppia.android.app.model.ProfileEditFragmentArguments
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.test.R
@@ -478,7 +478,7 @@ class ProfileEditFragmentTest {
 
     val updateLangProvider =
       profileManagementController.updateEnableInLessonQuickLanguageSwitching(
-        profileId = LegacyProfileId.newBuilder().apply { internalId = 0 }.build(),
+        profileId = ProfileId.newBuilder().apply { internalId = 0 }.build(),
         allowInLessonQuickLanguageSwitching = true,
       )
     monitorFactory.waitForNextSuccessfulResult(updateLangProvider)
@@ -500,7 +500,7 @@ class ProfileEditFragmentTest {
     // The user should not have permission to switch languages (since the switch wasn't toggled).
     val profileProvider =
       profileManagementController.getProfile(
-        LegacyProfileId.newBuilder().apply { internalId = 0 }.build(),
+        ProfileId.newBuilder().apply { internalId = 0 }.build(),
       )
     val profile = monitorFactory.waitForNextSuccessfulResult(profileProvider)
 
@@ -521,7 +521,7 @@ class ProfileEditFragmentTest {
     // The user should have permission to switch languages (since the switch was toggled).
     val profileProvider =
       profileManagementController.getProfile(
-        LegacyProfileId.newBuilder().apply { internalId = 0 }.build(),
+        ProfileId.newBuilder().apply { internalId = 0 }.build(),
       )
     val profile = monitorFactory.waitForNextSuccessfulResult(profileProvider)
     assertThat(profile.allowInLessonQuickLanguageSwitching).isTrue()

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentTest.kt
@@ -128,6 +128,7 @@ import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -535,7 +536,7 @@ class ConceptCardFragmentTest {
 
   private fun updateContentLanguage(profileId: LegacyProfileId, language: OppiaLanguage) {
     val updateProvider = translationController.updateWrittenTranslationContentLanguage(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       WrittenTranslationLanguageSelection.newBuilder().apply {
         selectedLanguage = language
       }.build()

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/questionplayer/QuestionPlayerActivityTest.kt
@@ -152,6 +152,7 @@ import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.threading.BackgroundDispatcher
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -669,7 +670,7 @@ class QuestionPlayerActivityTest {
 
   private fun updateContentLanguage(profileId: LegacyProfileId, language: OppiaLanguage) {
     val updateProvider = translationController.updateWrittenTranslationContentLanguage(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       WrittenTranslationLanguageSelection.newBuilder().apply {
         selectedLanguage = language
       }.build()

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardActivityTest.kt
@@ -106,6 +106,7 @@ import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -445,7 +446,7 @@ class RevisionCardActivityTest {
 
   private fun updateContentLanguage(profileId: LegacyProfileId, language: OppiaLanguage) {
     val updateProvider = translationController.updateWrittenTranslationContentLanguage(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       WrittenTranslationLanguageSelection.newBuilder().apply {
         selectedLanguage = language
       }.build()

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/revisioncard/RevisionCardFragmentTest.kt
@@ -135,6 +135,7 @@ import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -894,7 +895,7 @@ class RevisionCardFragmentTest {
 
   private fun updateContentLanguage(profileId: LegacyProfileId, language: OppiaLanguage) {
     val updateProvider = translationController.updateWrittenTranslationContentLanguage(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       WrittenTranslationLanguageSelection.newBuilder().apply {
         selectedLanguage = language
       }.build()

--- a/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
@@ -40,6 +40,7 @@ import org.oppia.android.app.model.EventLog
 import org.oppia.android.app.model.EventLog.Context.ActivityContextCase.OPEN_EXPLORATION_ACTIVITY
 import org.oppia.android.app.model.ExplorationActivityParams
 import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.Spotlight
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.IntentFactoryShimModule
@@ -339,7 +340,7 @@ class ExplorationActivityLocalTest {
       // Update the SurveyLastShownTimestamp to trigger an update in the data provider and notify
       // subscribers of an update.
       profileManagementController.updateSurveyLastShownTimestamp(
-        LegacyProfileId.newBuilder().setInternalId(internalProfileId).build()
+        ProfileId.newBuilder().setInternalId(internalProfileId).build()
       )
 
       onView(withText(R.string.survey_onboarding_title_text))

--- a/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
@@ -340,7 +340,8 @@ class ExplorationActivityLocalTest {
       // Update the SurveyLastShownTimestamp to trigger an update in the data provider and notify
       // subscribers of an update.
       profileManagementController.updateSurveyLastShownTimestamp(
-        LegacyProfileId.newBuilder().setInternalId(internalProfileId).build().toProfileIdPreservingZero()
+        LegacyProfileId.newBuilder().setInternalId(internalProfileId).build()
+          .toProfileIdPreservingZero()
       )
 
       onView(withText(R.string.survey_onboarding_title_text))

--- a/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
@@ -40,6 +40,7 @@ import org.oppia.android.app.model.EventLog
 import org.oppia.android.app.model.EventLog.Context.ActivityContextCase.OPEN_EXPLORATION_ACTIVITY
 import org.oppia.android.app.model.ExplorationActivityParams
 import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.Spotlight
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.IntentFactoryShimModule
@@ -213,7 +214,7 @@ class ExplorationActivityLocalTest {
       )
     ).use {
       explorationDataController.startPlayingNewExploration(
-        internalProfileId,
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -267,7 +268,7 @@ class ExplorationActivityLocalTest {
       )
     ).use {
       explorationDataController.startPlayingNewExploration(
-        internalProfileId,
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -312,7 +313,7 @@ class ExplorationActivityLocalTest {
       )
     ).use {
       explorationDataController.startPlayingNewExploration(
-        internalProfileId,
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -378,7 +379,7 @@ class ExplorationActivityLocalTest {
       )
     ).use { scenario ->
       explorationDataController.startPlayingNewExploration(
-        internalProfileId,
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -496,7 +497,7 @@ class ExplorationActivityLocalTest {
         networkConnectionUtil = activity.networkConnectionUtil
         explorationDataController = activity.explorationDataController
         explorationDataController.startPlayingNewExploration(
-          internalProfileId,
+          ProfileId.newBuilder().setInternalId(internalProfileId).build(),
           classroomId,
           topicId,
           storyId,

--- a/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
@@ -40,7 +40,6 @@ import org.oppia.android.app.model.EventLog
 import org.oppia.android.app.model.EventLog.Context.ActivityContextCase.OPEN_EXPLORATION_ACTIVITY
 import org.oppia.android.app.model.ExplorationActivityParams
 import org.oppia.android.app.model.LegacyProfileId
-import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.Spotlight
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.IntentFactoryShimModule
@@ -111,6 +110,7 @@ import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -340,7 +340,7 @@ class ExplorationActivityLocalTest {
       // Update the SurveyLastShownTimestamp to trigger an update in the data provider and notify
       // subscribers of an update.
       profileManagementController.updateSurveyLastShownTimestamp(
-        ProfileId.newBuilder().setInternalId(internalProfileId).build()
+        LegacyProfileId.newBuilder().setInternalId(internalProfileId).build().toProfileIdPreservingZero()
       )
 
       onView(withText(R.string.survey_onboarding_title_text))

--- a/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/state/StateFragmentLocalTest.kt
@@ -168,6 +168,7 @@ import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.ImageParsingModule
 import org.oppia.android.util.parser.image.TestGlideImageLoader
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.threading.BackgroundDispatcher
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -2888,7 +2889,7 @@ class StateFragmentLocalTest {
 
   private fun updateContentLanguage(profileId: LegacyProfileId, language: OppiaLanguage) {
     val updateProvider = translationController.updateWrittenTranslationContentLanguage(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       WrittenTranslationLanguageSelection.newBuilder().apply {
         selectedLanguage = language
       }.build()

--- a/app/src/test/java/org/oppia/android/app/translation/ActivityLanguageLocaleHandlerTest.kt
+++ b/app/src/test/java/org/oppia/android/app/translation/ActivityLanguageLocaleHandlerTest.kt
@@ -30,12 +30,12 @@ import org.oppia.android.app.application.testing.TestingBuildFlavorModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.model.AppLanguageSelection
+import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.model.OppiaLanguage.BRAZILIAN_PORTUGUESE
 import org.oppia.android.app.model.OppiaLanguage.ENGLISH
 import org.oppia.android.app.model.OppiaLanguage.SWAHILI
 import org.oppia.android.app.model.OppiaRegion
-import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.testing.activity.TestActivity
@@ -296,7 +296,9 @@ class ActivityLanguageLocaleHandlerTest {
    */
   private fun retrieveAppLanguageLocale(): OppiaLocale.DisplayLocale {
     val localeProvider =
-      translationController.getAppLanguageLocale(LegacyProfileId.getDefaultInstance().toProfileIdPreservingZero())
+      translationController.getAppLanguageLocale(
+        LegacyProfileId.getDefaultInstance().toProfileIdPreservingZero()
+      )
     return monitorFactory.waitForNextSuccessfulResult(localeProvider)
   }
 

--- a/app/src/test/java/org/oppia/android/app/translation/ActivityLanguageLocaleHandlerTest.kt
+++ b/app/src/test/java/org/oppia/android/app/translation/ActivityLanguageLocaleHandlerTest.kt
@@ -30,12 +30,12 @@ import org.oppia.android.app.application.testing.TestingBuildFlavorModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.model.AppLanguageSelection
-import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.model.OppiaLanguage.BRAZILIAN_PORTUGUESE
 import org.oppia.android.app.model.OppiaLanguage.ENGLISH
 import org.oppia.android.app.model.OppiaLanguage.SWAHILI
 import org.oppia.android.app.model.OppiaRegion
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.testing.activity.TestActivity
@@ -280,7 +280,7 @@ class ActivityLanguageLocaleHandlerTest {
   private fun setAppLanguage(language: OppiaLanguage) {
     val updateProvider =
       translationController.updateAppLanguage(
-        LegacyProfileId.getDefaultInstance(),
+        ProfileId.getDefaultInstance(),
         AppLanguageSelection.newBuilder().apply {
           selectedLanguage = language
         }.build()
@@ -295,7 +295,7 @@ class ActivityLanguageLocaleHandlerTest {
    */
   private fun retrieveAppLanguageLocale(): OppiaLocale.DisplayLocale {
     val localeProvider =
-      translationController.getAppLanguageLocale(LegacyProfileId.getDefaultInstance())
+      translationController.getAppLanguageLocale(ProfileId.getDefaultInstance())
     return monitorFactory.waitForNextSuccessfulResult(localeProvider)
   }
 

--- a/app/src/test/java/org/oppia/android/app/translation/ActivityLanguageLocaleHandlerTest.kt
+++ b/app/src/test/java/org/oppia/android/app/translation/ActivityLanguageLocaleHandlerTest.kt
@@ -35,7 +35,7 @@ import org.oppia.android.app.model.OppiaLanguage.BRAZILIAN_PORTUGUESE
 import org.oppia.android.app.model.OppiaLanguage.ENGLISH
 import org.oppia.android.app.model.OppiaLanguage.SWAHILI
 import org.oppia.android.app.model.OppiaRegion
-import org.oppia.android.app.model.ProfileId
+import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.testing.activity.TestActivity
@@ -96,6 +96,7 @@ import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.util.Locale
@@ -280,7 +281,7 @@ class ActivityLanguageLocaleHandlerTest {
   private fun setAppLanguage(language: OppiaLanguage) {
     val updateProvider =
       translationController.updateAppLanguage(
-        ProfileId.getDefaultInstance(),
+        LegacyProfileId.getDefaultInstance().toProfileIdPreservingZero(),
         AppLanguageSelection.newBuilder().apply {
           selectedLanguage = language
         }.build()
@@ -295,7 +296,7 @@ class ActivityLanguageLocaleHandlerTest {
    */
   private fun retrieveAppLanguageLocale(): OppiaLocale.DisplayLocale {
     val localeProvider =
-      translationController.getAppLanguageLocale(ProfileId.getDefaultInstance())
+      translationController.getAppLanguageLocale(LegacyProfileId.getDefaultInstance().toProfileIdPreservingZero())
     return monitorFactory.waitForNextSuccessfulResult(localeProvider)
   }
 

--- a/app/src/test/java/org/oppia/android/app/translation/AppLanguageLocaleHandlerTest.kt
+++ b/app/src/test/java/org/oppia/android/app/translation/AppLanguageLocaleHandlerTest.kt
@@ -15,10 +15,10 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.app.model.AppLanguageSelection
-import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.model.OppiaLanguage.BRAZILIAN_PORTUGUESE
 import org.oppia.android.app.model.OppiaLanguage.ENGLISH
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.domain.oppialogger.LogStorageModule
 import org.oppia.android.domain.oppialogger.LoggingIdentifierModule
 import org.oppia.android.domain.oppialogger.analytics.ApplicationLifecycleModule
@@ -286,7 +286,7 @@ class AppLanguageLocaleHandlerTest {
   private fun setAppLanguage(language: OppiaLanguage) {
     val updateProvider =
       translationController.updateAppLanguage(
-        LegacyProfileId.getDefaultInstance(),
+        ProfileId.getDefaultInstance(),
         AppLanguageSelection.newBuilder().apply {
           selectedLanguage = language
         }.build()
@@ -301,7 +301,7 @@ class AppLanguageLocaleHandlerTest {
    */
   private fun retrieveAppLanguageLocale(): OppiaLocale.DisplayLocale {
     val localeProvider =
-      translationController.getAppLanguageLocale(LegacyProfileId.getDefaultInstance())
+      translationController.getAppLanguageLocale(ProfileId.getDefaultInstance())
     return monitorFactory.waitForNextSuccessfulResult(localeProvider)
   }
 

--- a/app/src/test/java/org/oppia/android/app/translation/AppLanguageResourceHandlerTest.kt
+++ b/app/src/test/java/org/oppia/android/app/translation/AppLanguageResourceHandlerTest.kt
@@ -27,8 +27,8 @@ import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.model.AppLanguageSelection
 import org.oppia.android.app.model.AudioLanguage
-import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.OppiaLanguage
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.testing.activity.TestActivity
@@ -703,7 +703,7 @@ class AppLanguageResourceHandlerTest {
 
   private fun updateAndSetAppLanguage(appLanguageSelection: AppLanguageSelection) {
     // First, update the app language in the controller.
-    val defaultProfileId = LegacyProfileId.getDefaultInstance()
+    val defaultProfileId = ProfileId.getDefaultInstance()
     val updateProvider =
       translationController.updateAppLanguage(defaultProfileId, appLanguageSelection)
     monitorFactory.waitForNextSuccessfulResult(updateProvider)

--- a/app/src/test/java/org/oppia/android/app/translation/AppLanguageWatcherMixinTest.kt
+++ b/app/src/test/java/org/oppia/android/app/translation/AppLanguageWatcherMixinTest.kt
@@ -28,11 +28,11 @@ import org.oppia.android.app.application.testing.TestingBuildFlavorModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.model.AppLanguageSelection
-import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.model.OppiaLanguage.BRAZILIAN_PORTUGUESE
 import org.oppia.android.app.model.OppiaLanguage.ENGLISH
 import org.oppia.android.app.model.OppiaRegion
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.ViewBindingShimModule
 import org.oppia.android.app.testing.activity.TestActivity
@@ -251,7 +251,7 @@ class AppLanguageWatcherMixinTest {
     }.build()
     val updateProvider =
       translationController.updateAppLanguage(
-        LegacyProfileId.getDefaultInstance(), updateLanguageSelection
+        ProfileId.getDefaultInstance(), updateLanguageSelection
       )
     monitorFactory.waitForNextSuccessfulResult(updateProvider)
   }

--- a/app/src/test/java/org/oppia/android/app/translation/AppLanguageWatcherMixinTest.kt
+++ b/app/src/test/java/org/oppia/android/app/translation/AppLanguageWatcherMixinTest.kt
@@ -251,7 +251,7 @@ class AppLanguageWatcherMixinTest {
     }.build()
     val updateProvider =
       translationController.updateAppLanguage(
-        ProfileId.getDefaultInstance(), updateLanguageSelection
+        ProfileId.newBuilder().setInternalId(0).build(), updateLanguageSelection
       )
     monitorFactory.waitForNextSuccessfulResult(updateProvider)
   }

--- a/domain/BUILD.bazel
+++ b/domain/BUILD.bazel
@@ -160,6 +160,7 @@ kt_android_library(
         "//utility/src/main/java/org/oppia/android/util/parser/html:exploration_html_parser_entity_type",
         "//utility/src/main/java/org/oppia/android/util/parser/image:image_parsing_annonations",
         "//utility/src/main/java/org/oppia/android/util/profile:directory_management_util",
+        "//utility/src/main/java/org/oppia/android/util/profile:profile_id_migration_util",
     ],
 )
 

--- a/domain/src/main/java/org/oppia/android/domain/classroom/ClassroomController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/classroom/ClassroomController.kt
@@ -28,6 +28,7 @@ import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders.Companion.transform
 import org.oppia.android.util.extensions.safeForEach
 import org.oppia.android.util.locale.OppiaLocale
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -66,7 +67,9 @@ class ClassroomController @Inject constructor(
   /** Returns the list of [ClassroomSummary]s currently tracked by the app. */
   fun getClassroomList(profileId: LegacyProfileId): DataProvider<ClassroomList> {
     val translationLocaleProvider =
-      translationController.getWrittenTranslationContentLocale(profileId)
+      translationController.getWrittenTranslationContentLocale(
+        profileId.toProfileIdPreservingZero()
+      )
     return translationLocaleProvider.transform(
       GET_CLASSROOM_LIST_PROVIDER_ID,
       ::createClassroomList
@@ -105,7 +108,9 @@ class ClassroomController @Inject constructor(
    */
   fun getTopicList(profileId: LegacyProfileId, classroomId: String): DataProvider<TopicList> {
     val translationLocaleProvider =
-      translationController.getWrittenTranslationContentLocale(profileId)
+      translationController.getWrittenTranslationContentLocale(
+        profileId.toProfileIdPreservingZero()
+      )
     return translationLocaleProvider.transform(GET_TOPIC_LIST_PROVIDER_ID) { contentLocale ->
       createTopicList(classroomId, contentLocale)
     }

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationActiveTimeController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationActiveTimeController.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.TopicLearningTime
 import org.oppia.android.app.model.TopicLearningTimeDatabase
 import org.oppia.android.data.persistence.PersistentCacheStore
@@ -82,9 +82,9 @@ class ExplorationActiveTimeController @Inject constructor(
   }
 
   private val cacheStoreMap =
-    mutableMapOf<LegacyProfileId, PersistentCacheStore<TopicLearningTimeDatabase>>()
+    mutableMapOf<ProfileId, PersistentCacheStore<TopicLearningTimeDatabase>>()
 
-  override fun onExplorationStarted(profileId: LegacyProfileId, topicId: String) {
+  override fun onExplorationStarted(profileId: ProfileId, topicId: String) {
     this.explorationStarted = true
     if (enableNpsSurvey.value) {
       startSessionTimer(
@@ -133,7 +133,7 @@ class ExplorationActiveTimeController @Inject constructor(
   private fun startSessionTimer(
     isAppInForeground: Boolean,
     explorationStarted: Boolean,
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String
   ): DataProvider<Any?> {
     val sessionId = UUID.randomUUID().toString().also {
@@ -286,7 +286,7 @@ class ExplorationActiveTimeController @Inject constructor(
     beginTimerResultFlow: MutableStateFlow<AsyncResult<Any?>>,
     isAppInForeground: Boolean,
     isExplorationStarted: Boolean,
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
   ) {
     tryOperation(beginTimerResultFlow) {
@@ -394,7 +394,7 @@ class ExplorationActiveTimeController @Inject constructor(
     data class InitializeController(
       val isAppInForeground: Boolean,
       val isExplorationStarted: Boolean,
-      val profileId: LegacyProfileId,
+      val profileId: ProfileId,
       val topicId: String,
       override val sessionId: String,
       override val callbackFlow: MutableStateFlow<AsyncResult<Any?>>
@@ -473,7 +473,7 @@ class ExplorationActiveTimeController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this record operation
    */
   private fun recordAggregateTopicLearningTime(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     sessionDuration: Long
   ): DataProvider<Any?> {
@@ -510,7 +510,7 @@ class ExplorationActiveTimeController @Inject constructor(
 
   /** Returns the [TopicLearningTime] [DataProvider] for a specific topicId, per-profile basis. */
   fun retrieveAggregateTopicLearningTimeDataProvider(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String
   ): DataProvider<TopicLearningTime> {
     return retrieveCacheStore(profileId)
@@ -529,7 +529,7 @@ class ExplorationActiveTimeController @Inject constructor(
   }
 
   private fun retrieveCacheStore(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): PersistentCacheStore<TopicLearningTimeDatabase> {
     return cacheStoreMap.getOrPut(profileId) {
       cacheStoreFactory.createPerProfile(

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
@@ -12,6 +12,7 @@ import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders
 import org.oppia.android.util.data.DataProviders.Companion.combineWith
 import org.oppia.android.util.locale.OppiaLocale
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 private const val GET_EXPLORATION_BY_ID_PROVIDER_ID = "get_exploration_by_id_provider_id"
@@ -40,7 +41,9 @@ class ExplorationDataController @Inject constructor(
     id: String
   ): DataProvider<EphemeralExploration> {
     val translationLocaleProvider =
-      translationController.getWrittenTranslationContentLocale(profileId)
+      translationController.getWrittenTranslationContentLocale(
+        profileId.toProfileIdPreservingZero()
+      )
     val explorationProvider = dataProviders.createInMemoryDataProviderAsync(
       GET_EXPLORATION_BY_ID_PROVIDER_ID
     ) { retrieveExplorationById(id) }

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
@@ -3,7 +3,7 @@ package org.oppia.android.domain.exploration
 import org.oppia.android.app.model.EphemeralExploration
 import org.oppia.android.app.model.Exploration
 import org.oppia.android.app.model.ExplorationCheckpoint
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.domain.exploration.lightweightcheckpointing.ExplorationCheckpointController
 import org.oppia.android.domain.oppialogger.exceptions.ExceptionsController
 import org.oppia.android.domain.translation.TranslationController
@@ -12,7 +12,6 @@ import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders
 import org.oppia.android.util.data.DataProviders.Companion.combineWith
 import org.oppia.android.util.locale.OppiaLocale
-import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 private const val GET_EXPLORATION_BY_ID_PROVIDER_ID = "get_exploration_by_id_provider_id"
@@ -37,13 +36,11 @@ class ExplorationDataController @Inject constructor(
 ) {
   /** Returns an [EphemeralExploration] given an ID. */
   fun getExplorationById(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     id: String
   ): DataProvider<EphemeralExploration> {
     val translationLocaleProvider =
-      translationController.getWrittenTranslationContentLocale(
-        profileId.toProfileIdPreservingZero()
-      )
+      translationController.getWrittenTranslationContentLocale(profileId)
     val explorationProvider = dataProviders.createInMemoryDataProviderAsync(
       GET_EXPLORATION_BY_ID_PROVIDER_ID
     ) { retrieveExplorationById(id) }
@@ -78,14 +75,14 @@ class ExplorationDataController @Inject constructor(
    * @return a [DataProvider] to observe whether initiating the play request succeeded
    */
   fun startPlayingNewExploration(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
     explorationId: String
   ): DataProvider<Any?> {
     return startPlayingExploration(
-      internalProfileId,
+      profileId,
       classroomId,
       topicId,
       storyId,
@@ -110,7 +107,7 @@ class ExplorationDataController @Inject constructor(
    * used).
    */
   fun resumeExploration(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
@@ -118,7 +115,7 @@ class ExplorationDataController @Inject constructor(
     explorationCheckpoint: ExplorationCheckpoint
   ): DataProvider<Any?> {
     return startPlayingExploration(
-      internalProfileId,
+      profileId,
       classroomId,
       topicId,
       storyId,
@@ -142,14 +139,14 @@ class ExplorationDataController @Inject constructor(
    * lesson (otherwise [resumeExploration] should be used to resume the lesson).
    */
   fun restartExploration(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
     explorationId: String
   ): DataProvider<Any?> {
     return startPlayingExploration(
-      internalProfileId,
+      profileId,
       classroomId,
       topicId,
       storyId,
@@ -176,14 +173,14 @@ class ExplorationDataController @Inject constructor(
    * instead, depending on the specific situation.
    */
   fun replayExploration(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
     explorationId: String
   ): DataProvider<Any?> {
     return startPlayingExploration(
-      internalProfileId,
+      profileId,
       classroomId,
       topicId,
       storyId,
@@ -224,7 +221,7 @@ class ExplorationDataController @Inject constructor(
    *     requests, succeeded
    */
   private fun startPlayingExploration(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
@@ -235,7 +232,7 @@ class ExplorationDataController @Inject constructor(
     isReplay: Boolean
   ): DataProvider<Any?> {
     return explorationProgressController.beginExplorationAsync(
-      LegacyProfileId.newBuilder().apply { internalId = internalProfileId }.build(),
+      profileId,
       classroomId,
       topicId,
       storyId,
@@ -270,7 +267,7 @@ class ExplorationDataController @Inject constructor(
    *     has to be retrieved
    * @return a [DataProvider] that indicates the success or failure of the retrieve operation
    */
-  fun getOldestExplorationDetailsDataProvider(profileId: LegacyProfileId) =
+  fun getOldestExplorationDetailsDataProvider(profileId: ProfileId) =
     explorationCheckpointController.retrieveOldestSavedExplorationCheckpointDetails(profileId)
 
   /**
@@ -281,7 +278,7 @@ class ExplorationDataController @Inject constructor(
    *     has to be retrieved
    * @param explorationId the ID of the exploration whose checkpoint has to be deleted
    */
-  fun deleteExplorationProgressById(profileId: LegacyProfileId, explorationId: String) {
+  fun deleteExplorationProgressById(profileId: ProfileId, explorationId: String) {
     explorationCheckpointController.deleteSavedExplorationCheckpoint(
       profileId,
       explorationId

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgress.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgress.kt
@@ -4,7 +4,7 @@ import org.oppia.android.app.model.CheckpointState
 import org.oppia.android.app.model.EphemeralState
 import org.oppia.android.app.model.Exploration
 import org.oppia.android.app.model.ExplorationCheckpoint
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.State
 import org.oppia.android.domain.state.StateDeck
 import org.oppia.android.domain.state.StateGraph
@@ -18,7 +18,7 @@ private const val TERMINAL_INTERACTION_ID = "EndExploration"
  * instances, but calling code is responsible for ensuring it is properly reset.
  */
 internal class ExplorationProgress {
-  internal lateinit var currentProfileId: LegacyProfileId
+  internal lateinit var currentProfileId: ProfileId
   internal lateinit var currentClassroomId: String
   internal lateinit var currentTopicId: String
   internal lateinit var currentStoryId: String

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
@@ -49,6 +49,7 @@ import org.oppia.android.util.data.DataProviders.Companion.combineWith
 import org.oppia.android.util.data.DataProviders.Companion.transform
 import org.oppia.android.util.platformparameter.EnableFlashbackSupport
 import org.oppia.android.util.platformparameter.PlatformParameterValue
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.system.OppiaClock
 import org.oppia.android.util.threading.BackgroundDispatcher
 import java.util.UUID
@@ -439,7 +440,9 @@ class ExplorationProgressController @Inject constructor(
    */
   fun getCurrentState(): DataProvider<EphemeralState> {
     val writtenTranslationContentLocale =
-      translationController.getWrittenTranslationContentLocale(profileId)
+      translationController.getWrittenTranslationContentLocale(
+        profileId.toProfileIdPreservingZero()
+      )
     val ephemeralStateDataProvider =
       mostRecentEphemeralStateFlow.convertToSessionProvider(CURRENT_STATE_PROVIDER_ID)
     return writtenTranslationContentLocale.combineWith(
@@ -473,7 +476,7 @@ class ExplorationProgressController @Inject constructor(
     selection: WrittenTranslationLanguageSelection
   ): DataProvider<Any> {
     return translationController.updateWrittenTranslationContentLanguage(
-      profileId, selection
+      profileId.toProfileIdPreservingZero(), selection
     ).transform(UPDATE_WRITTEN_TRANSLATION_CONTENT_PROVIDER_ID) { previousSelection ->
       val explorationLogger = learnerAnalyticsLogger.explorationAnalyticsLogger.value
       val stateLogger = explorationLogger?.stateAnalyticsLogger?.value
@@ -500,11 +503,13 @@ class ExplorationProgressController @Inject constructor(
           val unused = when (message) {
             is ControllerMessage.InitializeController -> {
               // Synchronously fetch the learner & installation IDs (these may result in file I/O).
-              val learnerId = profileManagementController.fetchLearnerId(message.profileId)
+              val learnerId = profileManagementController.fetchLearnerId(
+                message.profileId.toProfileIdPreservingZero()
+              )
               val installationId = loggingIdentifierController.fetchInstallationId()
               val isContinueButtonAnimationSeen =
                 profileManagementController.fetchContinueAnimationSeenStatus(
-                  message.profileId
+                  message.profileId.toProfileIdPreservingZero()
                 ) ?: false
 
               // Ensure the state is completely recreated for each session to avoid leaking state
@@ -872,7 +877,9 @@ class ExplorationProgressController @Inject constructor(
       }
 
       if (!isContinueButtonAnimationSeen) {
-        profileManagementController.markContinueButtonAnimationSeen(profileId)
+        profileManagementController.markContinueButtonAnimationSeen(
+          profileId.toProfileIdPreservingZero()
+        )
       }
       isContinueButtonAnimationSeen = true
     }

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
@@ -24,7 +24,6 @@ import org.oppia.android.app.model.HelpIndex.IndexTypeCase.INDEXTYPE_NOT_SET
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.LATEST_REVEALED_HINT_INDEX
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.NEXT_AVAILABLE_HINT_INDEX
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.SHOW_SOLUTION
-import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.UserAnswer
 import org.oppia.android.app.model.WrittenTranslationLanguageSelection
 import org.oppia.android.domain.classify.AnswerClassificationController
@@ -49,7 +48,7 @@ import org.oppia.android.util.data.DataProviders.Companion.combineWith
 import org.oppia.android.util.data.DataProviders.Companion.transform
 import org.oppia.android.util.platformparameter.EnableFlashbackSupport
 import org.oppia.android.util.platformparameter.PlatformParameterValue
-import org.oppia.android.util.profile.toProfileIdPreservingZero
+import org.oppia.android.util.profile.toLegacyProfileId
 import org.oppia.android.util.system.OppiaClock
 import org.oppia.android.util.threading.BackgroundDispatcher
 import java.util.UUID
@@ -136,7 +135,7 @@ class ExplorationProgressController @Inject constructor(
 
   // TODO(#606): Replace this with a profile scope to avoid this hacky workaround (which is needed
   //  for getCurrentState).
-  private lateinit var profileId: LegacyProfileId
+  private lateinit var profileId: ProfileId
 
   private var mostRecentSessionId = MutableStateFlow<String?>(null)
   private val activeSessionId: String
@@ -160,7 +159,7 @@ class ExplorationProgressController @Inject constructor(
    * [submitAnswer].
    */
   internal fun beginExplorationAsync(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
@@ -440,9 +439,7 @@ class ExplorationProgressController @Inject constructor(
    */
   fun getCurrentState(): DataProvider<EphemeralState> {
     val writtenTranslationContentLocale =
-      translationController.getWrittenTranslationContentLocale(
-        profileId.toProfileIdPreservingZero()
-      )
+      translationController.getWrittenTranslationContentLocale(profileId)
     val ephemeralStateDataProvider =
       mostRecentEphemeralStateFlow.convertToSessionProvider(CURRENT_STATE_PROVIDER_ID)
     return writtenTranslationContentLocale.combineWith(
@@ -472,11 +469,11 @@ class ExplorationProgressController @Inject constructor(
    *     language
    */
   fun updateWrittenTranslationContentLanguageMidLesson(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     selection: WrittenTranslationLanguageSelection
   ): DataProvider<Any> {
     return translationController.updateWrittenTranslationContentLanguage(
-      profileId.toProfileIdPreservingZero(), selection
+      profileId, selection
     ).transform(UPDATE_WRITTEN_TRANSLATION_CONTENT_PROVIDER_ID) { previousSelection ->
       val explorationLogger = learnerAnalyticsLogger.explorationAnalyticsLogger.value
       val stateLogger = explorationLogger?.stateAnalyticsLogger?.value
@@ -504,12 +501,12 @@ class ExplorationProgressController @Inject constructor(
             is ControllerMessage.InitializeController -> {
               // Synchronously fetch the learner & installation IDs (these may result in file I/O).
               val learnerId = profileManagementController.fetchLearnerId(
-                message.profileId.toProfileIdPreservingZero()
+                message.profileId
               )
               val installationId = loggingIdentifierController.fetchInstallationId()
               val isContinueButtonAnimationSeen =
                 profileManagementController.fetchContinueAnimationSeenStatus(
-                  message.profileId.toProfileIdPreservingZero()
+                  message.profileId
                 ) ?: false
 
               // Ensure the state is completely recreated for each session to avoid leaking state
@@ -632,7 +629,7 @@ class ExplorationProgressController @Inject constructor(
 
   private suspend fun ControllerState.beginExplorationImpl(
     beginExplorationResultFlow: MutableStateFlow<AsyncResult<Any?>>,
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
@@ -877,9 +874,7 @@ class ExplorationProgressController @Inject constructor(
       }
 
       if (!isContinueButtonAnimationSeen) {
-        profileManagementController.markContinueButtonAnimationSeen(
-          profileId.toProfileIdPreservingZero()
-        )
+        profileManagementController.markContinueButtonAnimationSeen(profileId)
       }
       isContinueButtonAnimationSeen = true
     }
@@ -1174,7 +1169,7 @@ class ExplorationProgressController @Inject constructor(
     // Do not save checkpoints if shouldSavePartialProgress is false. This is expected to happen
     // when the current exploration has been already completed previously.
     if (!explorationProgress.shouldSavePartialProgress) return
-    val profileId: LegacyProfileId = explorationProgress.currentProfileId
+    val profileId: ProfileId = explorationProgress.currentProfileId
     val topicId: String = explorationProgress.currentTopicId
     val storyId: String = explorationProgress.currentStoryId
     val explorationId: String = explorationProgress.currentExplorationId
@@ -1240,7 +1235,7 @@ class ExplorationProgressController @Inject constructor(
    *     unsuccessfully
    */
   private suspend fun ControllerState.processSaveCheckpointResult(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String,
@@ -1301,7 +1296,7 @@ class ExplorationProgressController @Inject constructor(
     interactionId == "Continue"
 
   private fun markExplorationAsInProgressSaved(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String,
@@ -1317,7 +1312,7 @@ class ExplorationProgressController @Inject constructor(
   }
 
   private fun markExplorationAsInProgressNotSaved(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String,
@@ -1362,7 +1357,7 @@ class ExplorationProgressController @Inject constructor(
     val ephemeralStateFlow: MutableStateFlow<AsyncResult<EphemeralState>>,
     val commandQueue: SendChannel<ControllerMessage<*>>,
     private val installationId: String?,
-    private val profileId: LegacyProfileId,
+    private val profileId: ProfileId,
     private val learnerId: String?,
     private val learnerAnalyticsLogger: LearnerAnalyticsLogger,
     val startSessionTimeMs: Long,
@@ -1401,7 +1396,7 @@ class ExplorationProgressController @Inject constructor(
     fun initializeEventLogger(exploration: Exploration) {
       explorationAnalyticsLogger = learnerAnalyticsLogger.beginExploration(
         installationId,
-        profileId,
+        profileId.toLegacyProfileId(),
         learnerId,
         exploration,
         explorationProgress.currentClassroomId,
@@ -1514,7 +1509,7 @@ class ExplorationProgressController @Inject constructor(
 
     /** [ControllerMessage] for initializing a new play session. */
     data class InitializeController(
-      val profileId: LegacyProfileId,
+      val profileId: ProfileId,
       val classroomId: String,
       val topicId: String,
       val storyId: String,
@@ -1640,7 +1635,7 @@ class ExplorationProgressController @Inject constructor(
      * the app (e.g. that an exploration is considered 'in-progress' in such circumstances).
      */
     data class ProcessSavedCheckpointResult(
-      val profileId: LegacyProfileId,
+      val profileId: ProfileId,
       val topicId: String,
       val storyId: String,
       val explorationId: String,

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressListener.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressListener.kt
@@ -1,6 +1,6 @@
 package org.oppia.android.domain.exploration
 
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 
 /**
  * Listener for when an exploration has started or ended.
@@ -12,7 +12,7 @@ import org.oppia.android.app.model.LegacyProfileId
  */
 interface ExplorationProgressListener {
   /** Called when an exploration has started. */
-  fun onExplorationStarted(profileId: LegacyProfileId, topicId: String)
+  fun onExplorationStarted(profileId: ProfileId, topicId: String)
 
   /** Called when an exploration has ended. */
   fun onExplorationEnded()

--- a/domain/src/main/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointController.kt
@@ -9,7 +9,7 @@ import org.oppia.android.app.model.Exploration
 import org.oppia.android.app.model.ExplorationCheckpoint
 import org.oppia.android.app.model.ExplorationCheckpointDatabase
 import org.oppia.android.app.model.ExplorationCheckpointDetails
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.State
 import org.oppia.android.data.persistence.PersistentCacheStore
 import org.oppia.android.data.persistence.PersistentCacheStore.PublishMode
@@ -68,7 +68,7 @@ class ExplorationCheckpointController @Inject constructor(
   }
 
   private val cacheStoreMap =
-    mutableMapOf<LegacyProfileId, PersistentCacheStore<ExplorationCheckpointDatabase>>()
+    mutableMapOf<ProfileId, PersistentCacheStore<ExplorationCheckpointDatabase>>()
 
   /**
    * Records an exploration checkpoint for the specified profile.
@@ -82,7 +82,7 @@ class ExplorationCheckpointController @Inject constructor(
    *     completion of deferred.
    */
   internal fun recordExplorationCheckpointAsync(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     explorationId: String,
     explorationCheckpoint: ExplorationCheckpoint
   ): Deferred<CheckpointState> {
@@ -129,7 +129,7 @@ class ExplorationCheckpointController @Inject constructor(
    * Returns a [DataProvider] for the [Deferred] returned from [recordExplorationCheckpointAsync].
    */
   fun recordExplorationCheckpoint(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     explorationId: String,
     explorationCheckpoint: ExplorationCheckpoint
   ): DataProvider<Any?> {
@@ -147,7 +147,7 @@ class ExplorationCheckpointController @Inject constructor(
 
   /** Returns the saved checkpoint for a specified explorationId and profileId. */
   fun retrieveExplorationCheckpoint(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     explorationId: String
   ): DataProvider<ExplorationCheckpoint> {
     return retrieveCacheStore(profileId)
@@ -178,7 +178,7 @@ class ExplorationCheckpointController @Inject constructor(
             AsyncResult.Failure(
               ExplorationCheckpointNotFoundException(
                 "Checkpoint with the explorationId $explorationId was not found " +
-                  "for profileId ${profileId.internalId}."
+                  "for profileId $profileId."
               )
             )
           }
@@ -193,7 +193,7 @@ class ExplorationCheckpointController @Inject constructor(
    *      and explorationVersion of the oldest saved checkpoint for the specified profile.
    */
   fun retrieveOldestSavedExplorationCheckpointDetails(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): DataProvider<ExplorationCheckpointDetails> {
     return retrieveCacheStore(profileId)
       .transform(
@@ -214,7 +214,7 @@ class ExplorationCheckpointController @Inject constructor(
 
   /** Deletes the saved checkpoint for a specified explorationId and profileId. */
   fun deleteSavedExplorationCheckpoint(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     explorationId: String
   ): DataProvider<Any?> {
     val deferred = retrieveCacheStore(profileId).storeDataWithCustomChannelAsync(
@@ -252,14 +252,14 @@ class ExplorationCheckpointController @Inject constructor(
   private suspend fun getDeferredResult(
     deferred: Deferred<ExplorationCheckpointActionStatus>,
     explorationId: String?,
-    profileId: LegacyProfileId?,
+    profileId: ProfileId?,
   ): AsyncResult<Any?> {
     return when (deferred.await()) {
       ExplorationCheckpointActionStatus.CHECKPOINT_NOT_FOUND ->
         AsyncResult.Failure(
           ExplorationCheckpointNotFoundException(
             "No saved checkpoint with explorationId ${explorationId!!} found for " +
-              "the profileId ${profileId!!.internalId}."
+              "the profileId ${profileId!!}."
           )
         )
       ExplorationCheckpointActionStatus.SUCCESS -> AsyncResult.Success(null)
@@ -267,7 +267,7 @@ class ExplorationCheckpointController @Inject constructor(
   }
 
   private fun retrieveCacheStore(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): PersistentCacheStore<ExplorationCheckpointDatabase> {
     val cacheStore = if (profileId in cacheStoreMap) {
       cacheStoreMap[profileId]!!

--- a/domain/src/main/java/org/oppia/android/domain/oppialogger/analytics/AnalyticsController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/oppialogger/analytics/AnalyticsController.kt
@@ -36,6 +36,7 @@ import org.oppia.android.util.networking.NetworkConnectionUtil
 import org.oppia.android.util.networking.NetworkConnectionUtil.ProdConnectionStatus.NONE
 import org.oppia.android.util.platformparameter.EnableLearnerStudyAnalytics
 import org.oppia.android.util.platformparameter.PlatformParameterValue
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.system.OppiaClock
 import org.oppia.android.util.threading.BackgroundDispatcher
 import org.oppia.android.util.threading.BlockingDispatcher
@@ -157,14 +158,25 @@ class AnalyticsController @Inject constructor(
       this.context = context
       profileId?.let { this.profileId = it }
       resolveProfileOperation(
-        profileId, translationController::getAppLanguageSelection
-      )?.let { this.appLanguageSelection = it }
+        profileId
+      ) { translationController.getAppLanguageSelection(it.toProfileIdPreservingZero()) }
+        ?.let { this.appLanguageSelection = it }
       resolveProfileOperation(
-        profileId, translationController::getWrittenTranslationContentLanguageSelection
-      )?.let { this.writtenTranslationLanguageSelection = it }
+        profileId
+      ) {
+        translationController.getWrittenTranslationContentLanguageSelection(
+          it.toProfileIdPreservingZero()
+        )
+      }
+        ?.let { this.writtenTranslationLanguageSelection = it }
       resolveProfileOperation(
-        profileId, translationController::getAudioTranslationContentLanguageSelection
-      )?.let { this.audioTranslationLanguageSelection = it }
+        profileId
+      ) {
+        translationController.getAudioTranslationContentLanguageSelection(
+          it.toProfileIdPreservingZero()
+        )
+      }
+        ?.let { this.audioTranslationLanguageSelection = it }
     }.build()
   }
 

--- a/domain/src/main/java/org/oppia/android/domain/oppialogger/analytics/AnalyticsController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/oppialogger/analytics/AnalyticsController.kt
@@ -18,6 +18,7 @@ import org.oppia.android.app.model.EventLog
 import org.oppia.android.app.model.EventLog.Priority
 import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.OppiaEventLogs
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.data.backends.gae.NetworkLoggingInterceptor
 import org.oppia.android.data.persistence.PersistentCacheStore
 import org.oppia.android.data.persistence.PersistentCacheStore.PublishMode.PUBLISH_TO_IN_MEMORY_CACHE
@@ -157,25 +158,18 @@ class AnalyticsController @Inject constructor(
       this.priority = priority
       this.context = context
       profileId?.let { this.profileId = it }
+      val profileIdNew = profileId?.toProfileIdPreservingZero()
       resolveProfileOperation(
-        profileId
-      ) { translationController.getAppLanguageSelection(it.toProfileIdPreservingZero()) }
+        profileIdNew
+      ) { translationController.getAppLanguageSelection(it) }
         ?.let { this.appLanguageSelection = it }
       resolveProfileOperation(
-        profileId
-      ) {
-        translationController.getWrittenTranslationContentLanguageSelection(
-          it.toProfileIdPreservingZero()
-        )
-      }
+        profileIdNew
+      ) { translationController.getWrittenTranslationContentLanguageSelection(it) }
         ?.let { this.writtenTranslationLanguageSelection = it }
       resolveProfileOperation(
-        profileId
-      ) {
-        translationController.getAudioTranslationContentLanguageSelection(
-          it.toProfileIdPreservingZero()
-        )
-      }
+        profileIdNew
+      ) { translationController.getAudioTranslationContentLanguageSelection(it) }
         ?.let { this.audioTranslationLanguageSelection = it }
     }.build()
   }
@@ -414,8 +408,8 @@ class AnalyticsController @Inject constructor(
 
   private companion object {
     private suspend fun <T> resolveProfileOperation(
-      profileId: LegacyProfileId?,
-      createProvider: (LegacyProfileId) -> DataProvider<T>
+      profileId: ProfileId?,
+      createProvider: (ProfileId) -> DataProvider<T>
     ): T? = profileId?.let { (createProvider(it).retrieveData() as? AsyncResult.Success<T>)?.value }
   }
 }

--- a/domain/src/main/java/org/oppia/android/domain/oppialogger/analytics/AnalyticsController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/oppialogger/analytics/AnalyticsController.kt
@@ -158,19 +158,18 @@ class AnalyticsController @Inject constructor(
       this.priority = priority
       this.context = context
       profileId?.let { this.profileId = it }
-      val profileIdNew = profileId?.toProfileIdPreservingZero()
       resolveProfileOperation(
-        profileIdNew
-      ) { translationController.getAppLanguageSelection(it) }
-        ?.let { this.appLanguageSelection = it }
+        profileId?.toProfileIdPreservingZero(),
+        translationController::getAppLanguageSelection
+      )?.let { this.appLanguageSelection = it }
       resolveProfileOperation(
-        profileIdNew
-      ) { translationController.getWrittenTranslationContentLanguageSelection(it) }
-        ?.let { this.writtenTranslationLanguageSelection = it }
+        profileId?.toProfileIdPreservingZero(),
+        translationController::getWrittenTranslationContentLanguageSelection
+      )?.let { this.writtenTranslationLanguageSelection = it }
       resolveProfileOperation(
-        profileIdNew
-      ) { translationController.getAudioTranslationContentLanguageSelection(it) }
-        ?.let { this.audioTranslationLanguageSelection = it }
+        profileId?.toProfileIdPreservingZero(),
+        translationController::getAudioTranslationContentLanguageSelection
+      )?.let { this.audioTranslationLanguageSelection = it }
     }.build()
   }
 

--- a/domain/src/main/java/org/oppia/android/domain/oppialogger/analytics/ApplicationLifecycleObserver.kt
+++ b/domain/src/main/java/org/oppia/android/domain/oppialogger/analytics/ApplicationLifecycleObserver.kt
@@ -23,6 +23,7 @@ import org.oppia.android.util.logging.performancemetrics.PerformanceMetricsAsses
 import org.oppia.android.util.logging.performancemetrics.PerformanceMetricsAssessor.AppIconification.APP_IN_FOREGROUND
 import org.oppia.android.util.platformparameter.EnablePerformanceMetricsCollection
 import org.oppia.android.util.platformparameter.PlatformParameterValue
+import org.oppia.android.util.profile.toLegacyProfileId
 import org.oppia.android.util.system.OppiaClock
 import org.oppia.android.util.threading.BackgroundDispatcher
 import javax.inject.Inject
@@ -149,7 +150,7 @@ class ApplicationLifecycleObserver @Inject constructor(
       val installationId = loggingIdentifierController.fetchInstallationId()
       val profileId = profileManagementController.getCurrentProfileId()
       val learnerId = profileManagementController.fetchCurrentLearnerId()
-      logMethod(installationId, profileId, learnerId)
+      logMethod(installationId, profileId?.toLegacyProfileId(), learnerId)
     }.invokeOnCompletion { failure ->
       if (failure != null) {
         oppiaLogger.e(

--- a/domain/src/main/java/org/oppia/android/domain/oppialogger/analytics/BUILD.bazel
+++ b/domain/src/main/java/org/oppia/android/domain/oppialogger/analytics/BUILD.bazel
@@ -35,6 +35,7 @@ kt_android_library(
         "//utility/src/main/java/org/oppia/android/util/logging:exception_logger",
         "//utility/src/main/java/org/oppia/android/util/logging:sync_status_manager",
         "//utility/src/main/java/org/oppia/android/util/networking:network_connection_util",
+        "//utility/src/main/java/org/oppia/android/util/profile:profile_id_migration_util",
     ],
 )
 
@@ -132,6 +133,7 @@ kt_android_library(
         "//model/src/main/proto:screens_java_proto_lite",
         "//third_party:androidx_lifecycle_lifecycle-extensions",
         "//utility/src/main/java/org/oppia/android/util/logging:current_app_screen_name_intent_decorator",
+        "//utility/src/main/java/org/oppia/android/util/profile:profile_id_migration_util",
         "//utility/src/main/java/org/oppia/android/util/system:oppia_clock",
     ],
 )

--- a/domain/src/main/java/org/oppia/android/domain/profile/BUILD.bazel
+++ b/domain/src/main/java/org/oppia/android/domain/profile/BUILD.bazel
@@ -24,6 +24,7 @@ kt_android_library(
         "//utility/src/main/java/org/oppia/android/util/data:data_providers",
         "//utility/src/main/java/org/oppia/android/util/locale:oppia_locale",
         "//utility/src/main/java/org/oppia/android/util/profile:directory_management_util",
+        "//utility/src/main/java/org/oppia/android/util/profile:profile_id_migration_util",
         "//utility/src/main/java/org/oppia/android/util/profile:profile_name_validator",
         "//utility/src/main/java/org/oppia/android/util/system:oppia_clock",
     ],

--- a/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt
@@ -16,6 +16,7 @@ import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.model.Profile
 import org.oppia.android.app.model.ProfileAvatar
 import org.oppia.android.app.model.ProfileDatabase
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.ProfileOnboardingMode
 import org.oppia.android.app.model.ProfileType
 import org.oppia.android.app.model.ReadingTextSize
@@ -40,6 +41,7 @@ import org.oppia.android.util.platformparameter.EnableOnboardingFlowV2
 import org.oppia.android.util.platformparameter.PlatformParameterValue
 import org.oppia.android.util.profile.DirectoryManagementUtil
 import org.oppia.android.util.profile.ProfileNameValidator
+import org.oppia.android.util.profile.toLegacyProfileId
 import org.oppia.android.util.system.OppiaClock
 import java.io.File
 import java.io.FileOutputStream
@@ -221,7 +223,7 @@ class ProfileManagementController @Inject constructor(
   }
 
   /** Returns a single profile, specified by profiledId. */
-  fun getProfile(profileId: LegacyProfileId): DataProvider<Profile> {
+  fun getProfile(profileId: ProfileId): DataProvider<Profile> {
     return profileDataStore.transformAsync(GET_PROFILE_PROVIDER_ID) {
       val profile = it.profilesMap[profileId.internalId]
       if (profile != null) {
@@ -403,7 +405,7 @@ class ProfileManagementController @Inject constructor(
    * @param profileId The ID of the profile to update.
    * @return A [DataProvider] that represents the result of the update operation.
    */
-  fun markProfileOnboardingStarted(profileId: LegacyProfileId): DataProvider<Any?> {
+  fun markProfileOnboardingStarted(profileId: ProfileId): DataProvider<Any?> {
     val deferred = profileDataStore.storeDataWithCustomChannelAsync(
       updateInMemoryCache = true
     ) {
@@ -415,7 +417,7 @@ class ProfileManagementController @Inject constructor(
       val updatedProfileBuilder = profile.toBuilder()
       if (!profile.startedProfileOnboarding) {
         updatedProfileBuilder.startedProfileOnboarding = true
-        analyticsController.logProfileOnboardingStartedContext(profileId)
+        analyticsController.logProfileOnboardingStartedContext(profileId.toLegacyProfileId())
       }
       val profileDatabaseBuilder = it.toBuilder().putProfiles(
         profileId.internalId,
@@ -435,7 +437,7 @@ class ProfileManagementController @Inject constructor(
    * @param profileId the ID of the profile to update
    * @return a [DataProvider] that represents the result of the update operation
    */
-  fun markProfileOnboardingEnded(profileId: LegacyProfileId): DataProvider<Any?> {
+  fun markProfileOnboardingEnded(profileId: ProfileId): DataProvider<Any?> {
     val deferred = profileDataStore.storeDataWithCustomChannelAsync(
       updateInMemoryCache = true
     ) {
@@ -447,7 +449,7 @@ class ProfileManagementController @Inject constructor(
       val updatedProfileBuilder = profile.toBuilder()
       if (!profile.completedProfileOnboarding) {
         updatedProfileBuilder.completedProfileOnboarding = true
-        analyticsController.logProfileOnboardingEndedContext(profileId)
+        analyticsController.logProfileOnboardingEndedContext(profileId.toLegacyProfileId())
       }
       val profileDatabaseBuilder = it.toBuilder().putProfiles(
         profileId.internalId,
@@ -492,7 +494,7 @@ class ProfileManagementController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this update operation.
    */
   fun updateProfileAvatar(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     avatarImagePath: Uri?,
     colorRgb: Int
   ): DataProvider<Any?> {
@@ -539,7 +541,7 @@ class ProfileManagementController @Inject constructor(
    * @param newName new name for the profile being updated.
    * @return a [DataProvider] that indicates the success/failure of this update operation.
    */
-  fun updateName(profileId: LegacyProfileId, newName: String): DataProvider<Any?> {
+  fun updateName(profileId: ProfileId, newName: String): DataProvider<Any?> {
     val deferred = profileDataStore.storeDataWithCustomChannelAsync(
       updateInMemoryCache = true
     ) {
@@ -573,7 +575,7 @@ class ProfileManagementController @Inject constructor(
    * @return a [DataProvider] that represents the result of the update operation
    */
   fun updateProfileType(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     profileType: ProfileType
   ): DataProvider<Any?> {
     val deferred = profileDataStore.storeDataWithCustomChannelAsync(
@@ -614,7 +616,7 @@ class ProfileManagementController @Inject constructor(
    * @param newPin New pin for the profile being updated.
    * @return a [DataProvider] that indicates the success/failure of this update operation.
    */
-  fun updatePin(profileId: LegacyProfileId, newPin: String): DataProvider<Any?> {
+  fun updatePin(profileId: ProfileId, newPin: String): DataProvider<Any?> {
     val deferred = profileDataStore.storeDataWithCustomChannelAsync(
       updateInMemoryCache = true
     ) {
@@ -643,7 +645,7 @@ class ProfileManagementController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this update operation.
    */
   fun updateWifiPermissionDeviceSettings(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     downloadAndUpdateOnWifiOnly: Boolean
   ): DataProvider<Any?> {
     val deferred = profileDataStore.storeDataWithCustomChannelAsync(
@@ -679,7 +681,7 @@ class ProfileManagementController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this update operation.
    */
   fun updateTopicAutomaticallyPermissionDeviceSettings(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     automaticallyUpdateTopics: Boolean
   ): DataProvider<Any?> {
     val deferred = profileDataStore.storeDataWithCustomChannelAsync(
@@ -715,7 +717,7 @@ class ProfileManagementController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this update operation.
    */
   fun updateAllowDownloadAccess(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     allowDownloadAccess: Boolean
   ): DataProvider<Any?> {
     val deferred = profileDataStore.storeDataWithCustomChannelAsync(
@@ -750,7 +752,7 @@ class ProfileManagementController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this update operation
    */
   fun updateEnableInLessonQuickLanguageSwitching(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     allowInLessonQuickLanguageSwitching: Boolean
   ): DataProvider<Any?> {
     val deferred = profileDataStore.storeDataWithCustomChannelAsync(
@@ -784,7 +786,7 @@ class ProfileManagementController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this update operation.
    */
   fun updateReadingTextSize(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     readingTextSize: ReadingTextSize
   ): DataProvider<Any?> {
     val deferred = profileDataStore.storeDataWithCustomChannelAsync(
@@ -813,7 +815,7 @@ class ProfileManagementController @Inject constructor(
    *
    * @param profileId the ID corresponding to the profile being updated
    */
-  fun initializeLearnerId(profileId: LegacyProfileId): DataProvider<Any?> {
+  fun initializeLearnerId(profileId: ProfileId): DataProvider<Any?> {
     val deferred = profileDataStore.storeDataWithCustomChannelAsync(
       updateInMemoryCache = true
     ) {
@@ -850,7 +852,7 @@ class ProfileManagementController @Inject constructor(
    * The return [DataProvider] will automatically update for subsequent calls to
    * [updateAudioLanguage] for this [profileId].
    */
-  fun getAudioLanguage(profileId: LegacyProfileId): DataProvider<AudioLanguage> {
+  fun getAudioLanguage(profileId: ProfileId): DataProvider<AudioLanguage> {
     return translationController.getAudioTranslationContentLanguage(
       profileId
     ).transform(GET_AUDIO_LANGUAGE_PROVIDER_ID) { oppiaLanguage ->
@@ -874,7 +876,7 @@ class ProfileManagementController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this update operation
    */
   fun updateAudioLanguage(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     audioLanguage: AudioLanguage
   ): DataProvider<Any?> {
     val audioSelection = AudioTranslationLanguageSelection.newBuilder().apply {
@@ -905,7 +907,7 @@ class ProfileManagementController @Inject constructor(
    * @return [DataProvider] that represents the result of the update operation
    */
   fun updateNewProfileDetails(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     profileType: ProfileType,
     avatarImagePath: Uri?,
     colorRgb: Int,
@@ -971,7 +973,7 @@ class ProfileManagementController @Inject constructor(
    * @param profileId the ID corresponding to the profile being logged into.
    * @return a [DataProvider] that indicates the success/failure of this login operation.
    */
-  fun loginToProfile(profileId: LegacyProfileId): DataProvider<Any?> {
+  fun loginToProfile(profileId: ProfileId): DataProvider<Any?> {
     return setCurrentProfileId(profileId).transformAsync(LOGIN_TO_PROFILE_PROVIDER_ID) {
       return@transformAsync getDeferredResult(
         profileId,
@@ -986,7 +988,7 @@ class ProfileManagementController @Inject constructor(
     }
   }
 
-  private fun setCurrentProfileId(profileId: LegacyProfileId): DataProvider<Any?> {
+  private fun setCurrentProfileId(profileId: ProfileId): DataProvider<Any?> {
     return dataProviders.createInMemoryDataProviderAsync(SET_CURRENT_PROFILE_ID_PROVIDER_ID) {
       val profileDatabase = profileDataStore.readDataAsync().await()
       if (profileDatabase.profilesMap.containsKey(profileId.internalId)) {
@@ -1002,7 +1004,7 @@ class ProfileManagementController @Inject constructor(
     }
   }
 
-  private fun updateLastLoggedInAsyncAndNumberOfLogins(profileId: LegacyProfileId):
+  private fun updateLastLoggedInAsyncAndNumberOfLogins(profileId: ProfileId):
     Deferred<ProfileActionStatus> {
       return profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
         val profile = it.profilesMap[profileId.internalId]
@@ -1025,7 +1027,7 @@ class ProfileManagementController @Inject constructor(
    * @param profileId the ID corresponding to the profile being deleted.
    * @return a [DataProvider] that indicates the success/failure of this delete operation.
    */
-  fun deleteProfile(profileId: LegacyProfileId): DataProvider<Any?> {
+  fun deleteProfile(profileId: ProfileId): DataProvider<Any?> {
     val deferred = profileDataStore.storeDataWithCustomChannelAsync(updateInMemoryCache = true) {
       if (!it.profilesMap.containsKey(profileId.internalId)) {
         return@storeDataWithCustomChannelAsync Pair(it, ProfileActionStatus.PROFILE_NOT_FOUND)
@@ -1068,10 +1070,10 @@ class ProfileManagementController @Inject constructor(
     }
   }
 
-  /** Returns the [Profile ID] of the current profile, or null if one hasn't yet been logged into. */
-  fun getCurrentProfileId(): LegacyProfileId? {
+  /** Returns the [ProfileId] of the current profile, or null if one hasn't yet been logged into. */
+  fun getCurrentProfileId(): ProfileId? {
     return currentProfileId.takeIf { it != DEFAULT_LOGGED_OUT_INTERNAL_PROFILE_ID }?.let {
-      LegacyProfileId.newBuilder().setInternalId(it).build()
+      ProfileId.newBuilder().setInternalId(it).build()
     }
   }
 
@@ -1096,7 +1098,7 @@ class ProfileManagementController @Inject constructor(
    * 3. This method is meant to only be called by background coroutines and should never be used
    *    from UI code.
    */
-  suspend fun fetchLearnerId(profileId: LegacyProfileId): String? {
+  suspend fun fetchLearnerId(profileId: ProfileId): String? {
     val profileDatabase = profileDataStore.readDataAsync().await()
     return profileDatabase.profilesMap[profileId.internalId]?.learnerId
   }
@@ -1105,13 +1107,13 @@ class ProfileManagementController @Inject constructor(
    * Returns whether the exploration continue button animation has shown (or been disabled) for the
    * specified [profileId], or null if the profile doesn't exist.
    */
-  suspend fun fetchContinueAnimationSeenStatus(profileId: LegacyProfileId): Boolean? {
+  suspend fun fetchContinueAnimationSeenStatus(profileId: ProfileId): Boolean? {
     val profileDatabase = profileDataStore.readDataAsync().await()
     return profileDatabase.profilesMap[profileId.internalId]?.isContinueButtonAnimationSeen
   }
 
   /** Marks that the continue button animation has been seen for the specified profile. */
-  suspend fun markContinueButtonAnimationSeen(profileId: LegacyProfileId) {
+  suspend fun markContinueButtonAnimationSeen(profileId: ProfileId) {
     val updateDatabaseDeferred = profileDataStore.storeDataAsync(true) {
       val profile = it.profilesMap[profileId.internalId]
       if (profile != null) {
@@ -1130,7 +1132,7 @@ class ProfileManagementController @Inject constructor(
    * Sets the timestamp when a nps survey was last shown for the specified profile.
    * Returns a [DataProvider] indicating whether the save was a success.
    */
-  fun updateSurveyLastShownTimestamp(profileId: LegacyProfileId): DataProvider<Any?> {
+  fun updateSurveyLastShownTimestamp(profileId: ProfileId): DataProvider<Any?> {
     val deferred = profileDataStore.storeDataWithCustomChannelAsync(
       updateInMemoryCache = true
     ) { profileDatabase ->
@@ -1153,7 +1155,7 @@ class ProfileManagementController @Inject constructor(
 
   /** Returns the timestamp at which the nps survey was last shown. */
   fun retrieveSurveyLastShownTimestamp(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): DataProvider<Long> {
     return profileDataStore.transformAsync(RETRIEVE_SURVEY_LAST_SHOWN_TIMESTAMP_PROVIDER_ID) {
       val surveyLastShownTimestampMs =
@@ -1167,7 +1169,7 @@ class ProfileManagementController @Inject constructor(
    * indicating whether the save was a success.
    */
   fun updateLastSelectedClassroomId(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     classroomId: String
   ): DataProvider<Any?> {
     val deferred = profileDataStore.storeDataWithCustomChannelAsync(
@@ -1195,7 +1197,7 @@ class ProfileManagementController @Inject constructor(
    * [profileId].
    */
   fun retrieveLastSelectedClassroomId(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): DataProvider<String?> {
     return profileDataStore.transformAsync(RETRIEVE_LAST_SELECTED_CLASSROOM_ID_PROVIDER_ID) {
       val lastSelectedClassroomId = it.profilesMap[profileId.internalId]?.lastSelectedClassroomId
@@ -1204,7 +1206,7 @@ class ProfileManagementController @Inject constructor(
   }
 
   private suspend fun getDeferredResult(
-    profileId: LegacyProfileId?,
+    profileId: ProfileId?,
     name: String?,
     deferred: Deferred<ProfileActionStatus>
   ): AsyncResult<Any?> {

--- a/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/question/QuestionAssessmentProgressController.kt
@@ -32,6 +32,7 @@ import org.oppia.android.util.data.DataProviders.Companion.combineWith
 import org.oppia.android.util.data.DataProviders.Companion.transformNested
 import org.oppia.android.util.data.DataProviders.NestedTransformedDataProvider
 import org.oppia.android.util.locale.OppiaLocale
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.system.OppiaClock
 import org.oppia.android.util.threading.BackgroundDispatcher
 import java.util.UUID
@@ -321,7 +322,9 @@ class QuestionAssessmentProgressController @Inject constructor(
    */
   fun getCurrentQuestion(): DataProvider<EphemeralQuestion> {
     val writtenTranslationContentLocale =
-      translationController.getWrittenTranslationContentLocale(profileId)
+      translationController.getWrittenTranslationContentLocale(
+        profileId.toProfileIdPreservingZero()
+      )
     val ephemeralQuestionDataProvider =
       mostRecentEphemeralQuestionFlow.convertToSessionProvider(CURRENT_QUESTION_PROVIDER_ID)
 

--- a/domain/src/main/java/org/oppia/android/domain/survey/BUILD.bazel
+++ b/domain/src/main/java/org/oppia/android/domain/survey/BUILD.bazel
@@ -15,6 +15,7 @@ kt_android_library(
         "//domain/src/main/java/org/oppia/android/domain/profile:profile_management_controller",
         "//third_party:javax_inject_javax_inject",
         "//utility/src/main/java/org/oppia/android/util/locale:oppia_locale",
+        "//utility/src/main/java/org/oppia/android/util/profile:profile_id_migration_util",
         "//utility/src/main/java/org/oppia/android/util/system:oppia_clock",
     ],
 )

--- a/domain/src/main/java/org/oppia/android/domain/survey/SurveyGatingController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/survey/SurveyGatingController.kt
@@ -11,6 +11,7 @@ import org.oppia.android.util.locale.OppiaLocale
 import org.oppia.android.util.platformparameter.NpsSurveyGracePeriodInDays
 import org.oppia.android.util.platformparameter.NpsSurveyMinimumAggregateLearningTimeInATopicInMinutes
 import org.oppia.android.util.platformparameter.PlatformParameterValue
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.system.OppiaClock
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -70,7 +71,9 @@ class SurveyGatingController @Inject constructor(
   }
 
   private fun retrieveSurveyLastShownDate(profileId: LegacyProfileId) =
-    profileManagementController.retrieveSurveyLastShownTimestamp(profileId)
+    profileManagementController.retrieveSurveyLastShownTimestamp(
+      profileId.toProfileIdPreservingZero()
+    )
 
   private fun hasReachedMinimumTopicLearningThreshold(topicLearningTimeMs: Long): Boolean {
     return topicLearningTimeMs >= minimumLearningTimeForGatingMillis

--- a/domain/src/main/java/org/oppia/android/domain/topic/StoryProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/StoryProgressController.kt
@@ -3,7 +3,7 @@ package org.oppia.android.domain.topic
 import kotlinx.coroutines.Deferred
 import org.oppia.android.app.model.ChapterPlayState
 import org.oppia.android.app.model.ChapterProgress
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.StoryProgress
 import org.oppia.android.app.model.TopicProgress
 import org.oppia.android.app.model.TopicProgressDatabase
@@ -70,7 +70,7 @@ class StoryProgressController @Inject constructor(
   }
 
   private val cacheStoreMap =
-    mutableMapOf<LegacyProfileId, PersistentCacheStore<TopicProgressDatabase>>()
+    mutableMapOf<ProfileId, PersistentCacheStore<TopicProgressDatabase>>()
 
   /**
    * Records the specified chapter completed within the context of the specified exploration, story,
@@ -85,7 +85,7 @@ class StoryProgressController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this record progress operation
    */
   fun recordCompletedChapter(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String,
@@ -148,7 +148,7 @@ class StoryProgressController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this record progress operation
    */
   fun recordChapterAsInProgressSaved(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String,
@@ -231,7 +231,7 @@ class StoryProgressController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this record progress operation
    */
   fun recordChapterAsInProgressNotSaved(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String,
@@ -302,7 +302,7 @@ class StoryProgressController @Inject constructor(
 
   /** Returns the [ChapterPlayState] [DataProvider] for a particular explorationId and profile. */
   fun retrieveChapterPlayStateByExplorationId(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String
@@ -320,7 +320,7 @@ class StoryProgressController @Inject constructor(
 
   /** Returns list of [TopicProgress] [DataProvider] for a particular profile. */
   internal fun retrieveTopicProgressListDataProvider(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): DataProvider<List<TopicProgress>> {
     return retrieveCacheStore(profileId)
       .transformAsync(RETRIEVE_TOPIC_PROGRESS_LIST_DATA_PROVIDER_ID) { topicProgressDatabase ->
@@ -332,7 +332,7 @@ class StoryProgressController @Inject constructor(
 
   /** Returns a [TopicProgress] [DataProvider] for a specific topicId, per-profile basis. */
   private fun retrieveTopicProgressDataProvider(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String
   ): DataProvider<TopicProgress> {
     return retrieveTopicsProgressDataProvider(profileId, listOf(topicId))
@@ -346,7 +346,7 @@ class StoryProgressController @Inject constructor(
    * The provider defaults the progress for any IDs that don't have progress corresponding to them.
    */
   internal fun retrieveTopicsProgressDataProvider(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicIds: List<String>
   ): DataProvider<List<TopicProgress>> {
     return retrieveCacheStore(profileId)
@@ -359,7 +359,7 @@ class StoryProgressController @Inject constructor(
 
   /** Returns a [StoryProgress] [DataProvider] for a specific storyId, per-profile basis. */
   internal fun retrieveStoryProgressDataProvider(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String
   ): DataProvider<StoryProgress> {
@@ -378,7 +378,7 @@ class StoryProgressController @Inject constructor(
   }
 
   private fun retrieveCacheStore(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): PersistentCacheStore<TopicProgressDatabase> {
     val cacheStore = if (profileId in cacheStoreMap) {
       cacheStoreMap[profileId]!!

--- a/domain/src/main/java/org/oppia/android/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/TopicController.kt
@@ -45,6 +45,7 @@ import org.oppia.android.util.data.DataProviders.Companion.transform
 import org.oppia.android.util.data.DataProviders.Companion.transformAsync
 import org.oppia.android.util.extensions.safeForEach
 import org.oppia.android.util.locale.OppiaLocale
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -159,7 +160,9 @@ class TopicController @Inject constructor(
       ::combineTopicsAndTopicsProgress
     )
     val translationLocaleProvider =
-      translationController.getWrittenTranslationContentLocale(profileId)
+      translationController.getWrittenTranslationContentLocale(
+        profileId.toProfileIdPreservingZero()
+      )
     return topicsCombinedProvider.combineWith(
       translationLocaleProvider, GET_LOCALIZABLE_TOPICS_PROVIDER_ID
     ) { topics, locale ->
@@ -193,7 +196,9 @@ class TopicController @Inject constructor(
       ::combineStorySummaryAndStoryProgress
     )
     val translationLocaleProvider =
-      translationController.getWrittenTranslationContentLocale(profileId)
+      translationController.getWrittenTranslationContentLocale(
+        profileId.toProfileIdPreservingZero()
+      )
     return storyCombinedProvider.combineWith(
       translationLocaleProvider, GET_LOCALIZABLE_STORY_PROVIDER_ID
     ) { storySummary, locale -> storySummary.toEphemeral(locale) }
@@ -231,7 +236,9 @@ class TopicController @Inject constructor(
     }
 
     val translationLocaleProvider =
-      translationController.getWrittenTranslationContentLocale(profileId)
+      translationController.getWrittenTranslationContentLocale(
+        profileId.toProfileIdPreservingZero()
+      )
     return chapterCombinedProvider.combineWith(
       translationLocaleProvider, GET_LOCALIZABLE_CHAPTER_PROVIDER_ID
     ) { chapterSummary, locale -> chapterSummary.toEphemeral(locale) }
@@ -246,7 +253,7 @@ class TopicController @Inject constructor(
     skillId: String
   ): DataProvider<EphemeralConceptCard> {
     return translationController.getWrittenTranslationContentLocale(
-      profileId
+      profileId.toProfileIdPreservingZero()
     ).transform(GET_CONCEPT_CARD_PROVIDER_ID) { contentLocale ->
       EphemeralConceptCard.newBuilder().apply {
         conceptCard = conceptCardRetriever.loadConceptCard(skillId)
@@ -268,7 +275,7 @@ class TopicController @Inject constructor(
     subtopicId: Int
   ): DataProvider<EphemeralRevisionCard> {
     return translationController.getWrittenTranslationContentLocale(
-      profileId
+      profileId.toProfileIdPreservingZero()
     ).transform(GET_REVISION_CARD_PROVIDER_ID) { contentLocale ->
       EphemeralRevisionCard.newBuilder().apply {
         revisionCard = retrieveReviewCard(topicId, subtopicId)
@@ -288,7 +295,9 @@ class TopicController @Inject constructor(
     val retrieveTopicProgressListProvider =
       storyProgressController.retrieveTopicProgressListDataProvider(profileId)
     val translationLocaleProvider =
-      translationController.getWrittenTranslationContentLocale(profileId)
+      translationController.getWrittenTranslationContentLocale(
+        profileId.toProfileIdPreservingZero()
+      )
     return retrieveTopicProgressListProvider.combineWith(
       translationLocaleProvider, GET_COMPLETED_STORY_LIST_PROVIDER_ID
     ) { progressList, contentLocale ->
@@ -313,7 +322,9 @@ class TopicController @Inject constructor(
     val retrieveTopicProgressListProvider =
       storyProgressController.retrieveTopicProgressListDataProvider(profileId)
     val translationLocaleProvider =
-      translationController.getWrittenTranslationContentLocale(profileId)
+      translationController.getWrittenTranslationContentLocale(
+        profileId.toProfileIdPreservingZero()
+      )
     return retrieveTopicProgressListProvider.combineWith(
       translationLocaleProvider,
       GET_ONGOING_TOPIC_LIST_PROVIDER_ID,

--- a/domain/src/main/java/org/oppia/android/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/TopicListController.kt
@@ -37,6 +37,7 @@ import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders.Companion.combineWith
 import org.oppia.android.util.data.DataProviders.Companion.transform
 import org.oppia.android.util.locale.OppiaLocale
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.system.OppiaClock
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -109,7 +110,9 @@ class TopicListController @Inject constructor(
    */
   fun getTopicList(profileId: LegacyProfileId): DataProvider<TopicList> {
     val translationLocaleProvider =
-      translationController.getWrittenTranslationContentLocale(profileId)
+      translationController.getWrittenTranslationContentLocale(
+        profileId.toProfileIdPreservingZero()
+      )
     return translationLocaleProvider.transform(GET_TOPIC_LIST_PROVIDER_ID, ::createTopicList)
   }
 
@@ -126,7 +129,9 @@ class TopicListController @Inject constructor(
     val retrieveTopicProgressListProvider =
       storyProgressController.retrieveTopicProgressListDataProvider(profileId)
     val translationLocaleProvider =
-      translationController.getWrittenTranslationContentLocale(profileId)
+      translationController.getWrittenTranslationContentLocale(
+        profileId.toProfileIdPreservingZero()
+      )
     return retrieveTopicProgressListProvider.combineWith(
       translationLocaleProvider,
       GET_PROMOTED_ACTIVITY_LIST_PROVIDER_ID,

--- a/domain/src/main/java/org/oppia/android/domain/translation/BUILD.bazel
+++ b/domain/src/main/java/org/oppia/android/domain/translation/BUILD.bazel
@@ -23,5 +23,6 @@ kt_android_library(
         "//utility/src/main/java/org/oppia/android/util/data:data_provider",
         "//utility/src/main/java/org/oppia/android/util/data:data_providers",
         "//utility/src/main/java/org/oppia/android/util/locale:oppia_locale",
+        "//utility/src/main/java/org/oppia/android/util/profile:profile_id_migration_util",
     ],
 )

--- a/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
@@ -8,8 +8,8 @@ import org.oppia.android.app.model.LanguageSupportDefinition
 import org.oppia.android.app.model.LanguageSupportDefinition.LanguageId.LanguageTypeCase.IETF_BCP47_ID
 import org.oppia.android.app.model.LanguageSupportDefinition.LanguageId.LanguageTypeCase.LANGUAGETYPE_NOT_SET
 import org.oppia.android.app.model.LanguageSupportDefinition.LanguageId.LanguageTypeCase.MACARONIC_ID
-import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.OppiaLanguage
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.SubtitledHtml
 import org.oppia.android.app.model.SubtitledUnicode
 import org.oppia.android.app.model.TranslatableSetOfNormalizedString
@@ -29,6 +29,7 @@ import org.oppia.android.util.data.DataProviders.Companion.combineWithAsync
 import org.oppia.android.util.data.DataProviders.Companion.transform
 import org.oppia.android.util.data.DataProviders.Companion.transformAsync
 import org.oppia.android.util.locale.OppiaLocale
+import org.oppia.android.util.profile.toLegacyProfileId
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -82,11 +83,11 @@ class TranslationController @Inject constructor(
   private val oppiaLogger: OppiaLogger,
 ) {
   private val appLanguageCacheStoreMap =
-    mutableMapOf<LegacyProfileId, PersistentCacheStore<AppLanguageSelection>>()
+    mutableMapOf<ProfileId, PersistentCacheStore<AppLanguageSelection>>()
   private val writtenTranslationLanguageCacheStoreMap =
-    mutableMapOf<LegacyProfileId, PersistentCacheStore<WrittenTranslationLanguageSelection>>()
+    mutableMapOf<ProfileId, PersistentCacheStore<WrittenTranslationLanguageSelection>>()
   private val audioTranslationLanguageCacheStoreMap =
-    mutableMapOf<LegacyProfileId, PersistentCacheStore<AudioTranslationLanguageSelection>>()
+    mutableMapOf<ProfileId, PersistentCacheStore<AudioTranslationLanguageSelection>>()
 
   /**
    * Returns a data provider for an app string [OppiaLocale.DisplayLocale] corresponding to the
@@ -104,7 +105,7 @@ class TranslationController @Inject constructor(
    *
    * This language can be updated via [updateAppLanguage].
    */
-  fun getAppLanguage(profileId: LegacyProfileId): DataProvider<OppiaLanguage> {
+  fun getAppLanguage(profileId: ProfileId): DataProvider<OppiaLanguage> {
     return getAppLanguageLocale(profileId).transform(APP_LANGUAGE_DATA_PROVIDER_ID) { locale ->
       locale.getCurrentLanguage()
     }
@@ -125,7 +126,7 @@ class TranslationController @Inject constructor(
    * Returns a data provider for a [OppiaLocale.DisplayLocale] corresponding to the user's selected
    * language for app strings (see [getAppLanguage]).
    */
-  fun getAppLanguageLocale(profileId: LegacyProfileId): DataProvider<OppiaLocale.DisplayLocale> {
+  fun getAppLanguageLocale(profileId: ProfileId): DataProvider<OppiaLocale.DisplayLocale> {
     val providerId = APP_LANGUAGE_LOCALE_DATA_PROVIDER_ID
     return getSystemLanguage().combineWithAsync(
       getAppLanguageSelection(profileId), providerId
@@ -143,7 +144,7 @@ class TranslationController @Inject constructor(
    * Note that providing the returned selection to [updateAppLanguage] should result in no change to
    * the underlying configured selection.
    */
-  fun getAppLanguageSelection(profileId: LegacyProfileId): DataProvider<AppLanguageSelection> =
+  fun getAppLanguageSelection(profileId: ProfileId): DataProvider<AppLanguageSelection> =
     retrieveAppLanguageContentCacheStore(profileId)
 
   /**
@@ -159,7 +160,7 @@ class TranslationController @Inject constructor(
    *     payload of the data provider is the *previous* selection state.
    */
   fun updateAppLanguage(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     selection: AppLanguageSelection
   ): DataProvider<AppLanguageSelection> {
     val cacheStore = retrieveAppLanguageContentCacheStore(profileId)
@@ -177,7 +178,7 @@ class TranslationController @Inject constructor(
    * This language can be updated via [updateWrittenTranslationContentLanguage].
    */
   fun getWrittenTranslationContentLanguage(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): DataProvider<OppiaLanguage> {
     val providerId = WRITTEN_TRANSLATION_CONTENT_DATA_PROVIDER_ID
     return getWrittenTranslationContentLocale(profileId).transform(providerId) { locale ->
@@ -190,7 +191,7 @@ class TranslationController @Inject constructor(
    * language for written content strings (see [getWrittenTranslationContentLanguage]).
    */
   fun getWrittenTranslationContentLocale(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): DataProvider<OppiaLocale.ContentLocale> {
     val resolvedLanguageProvider =
       getWrittenTranslationContentLanguageSelection(profileId).combineWith(
@@ -216,7 +217,7 @@ class TranslationController @Inject constructor(
    * result in no change to the underlying configured selection.
    */
   fun getWrittenTranslationContentLanguageSelection(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): DataProvider<WrittenTranslationLanguageSelection> =
     retrieveWrittenTranslationLanguageContentCacheStore(profileId)
 
@@ -234,7 +235,7 @@ class TranslationController @Inject constructor(
    *     state.
    */
   fun updateWrittenTranslationContentLanguage(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     selection: WrittenTranslationLanguageSelection
   ): DataProvider<WrittenTranslationLanguageSelection> {
     val cacheStore = retrieveWrittenTranslationLanguageContentCacheStore(profileId)
@@ -260,7 +261,7 @@ class TranslationController @Inject constructor(
    * This ensures that user preferences take priority over application defaults, which in turn
    * take priority over the device's system language.
    */
-  fun getAudioLanguagePreselection(profileId: LegacyProfileId): DataProvider<OppiaLanguage> {
+  fun getAudioLanguagePreselection(profileId: ProfileId): DataProvider<OppiaLanguage> {
     return getAudioTranslationContentLanguage(profileId).combineWith(
       getAppLanguageSelection(profileId), PROFILE_AUDIO_LANGUAGE_PROVIDER_ID
     ) { profileAudioLanguageSelection, appLanguageSelection ->
@@ -285,7 +286,7 @@ class TranslationController @Inject constructor(
    *
    * This language can be updated via [updateAudioTranslationContentLanguage].
    */
-  fun getAudioTranslationContentLanguage(profileId: LegacyProfileId): DataProvider<OppiaLanguage> {
+  fun getAudioTranslationContentLanguage(profileId: ProfileId): DataProvider<OppiaLanguage> {
     val providerId = AUDIO_TRANSLATION_CONTENT_DATA_PROVIDER_ID
     return getAudioTranslationContentLocale(profileId).transform(providerId) { locale ->
       locale.getCurrentLanguage()
@@ -297,7 +298,7 @@ class TranslationController @Inject constructor(
    * language for audio voiceovers (see [getAudioTranslationContentLanguage]).
    */
   fun getAudioTranslationContentLocale(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): DataProvider<OppiaLocale.ContentLocale> {
     // TODO(#6020): Replace getSupportedAppLanguages with an audio languages specific API.
     val resolvedLanguageProvider =
@@ -339,7 +340,7 @@ class TranslationController @Inject constructor(
    * result in no change to the underlying configured selection.
    */
   fun getAudioTranslationContentLanguageSelection(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): DataProvider<AudioTranslationLanguageSelection> =
     retrieveAudioTranslationLanguageContentCacheStore(profileId)
 
@@ -357,7 +358,7 @@ class TranslationController @Inject constructor(
    *     state.
    */
   fun updateAudioTranslationContentLanguage(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     selection: AudioTranslationLanguageSelection
   ): DataProvider<AudioTranslationLanguageSelection> {
     val cacheStore = retrieveAudioTranslationLanguageContentCacheStore(profileId)
@@ -464,7 +465,7 @@ class TranslationController @Inject constructor(
   }
 
   private fun retrieveAppLanguageContentCacheStore(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): PersistentCacheStore<AppLanguageSelection> {
     return retrieveContentCacheStore(
       profileId,
@@ -475,7 +476,7 @@ class TranslationController @Inject constructor(
   }
 
   private fun retrieveWrittenTranslationLanguageContentCacheStore(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): PersistentCacheStore<WrittenTranslationLanguageSelection> {
     return retrieveContentCacheStore(
       profileId,
@@ -486,7 +487,7 @@ class TranslationController @Inject constructor(
   }
 
   private fun retrieveAudioTranslationLanguageContentCacheStore(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): PersistentCacheStore<AudioTranslationLanguageSelection> {
     return retrieveContentCacheStore(
       profileId,
@@ -497,14 +498,14 @@ class TranslationController @Inject constructor(
   }
 
   private fun <T : MessageLite> retrieveContentCacheStore(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     databaseName: String,
     defaultCacheValue: T,
-    cacheMap: MutableMap<LegacyProfileId, PersistentCacheStore<T>>
+    cacheMap: MutableMap<ProfileId, PersistentCacheStore<T>>
   ): PersistentCacheStore<T> {
     return cacheMap.getOrPut(profileId) {
       cacheStoreFactory.createPerProfile(
-        databaseName, defaultCacheValue, profileId
+        databaseName, defaultCacheValue, profileId.toLegacyProfileId()
       ).also<PersistentCacheStore<T>> {
         it.primeInMemoryAndDiskCacheAsync(
           updateMode = PersistentCacheStore.UpdateMode.UPDATE_IF_NEW_CACHE,

--- a/domain/src/test/java/org/oppia/android/domain/audio/AudioPlayerControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/audio/AudioPlayerControllerTest.kt
@@ -76,6 +76,7 @@ import org.oppia.android.util.locale.LocaleProdModule
 import org.oppia.android.util.logging.LoggerModule
 import org.oppia.android.util.logging.SyncStatusModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
@@ -937,7 +938,7 @@ class AudioPlayerControllerTest {
     )
     monitorFactory.waitForNextSuccessfulResult(addProfileProvider)
     monitorFactory.waitForNextSuccessfulResult(
-      profileManagementController.loginToProfile(rootProfileId)
+      profileManagementController.loginToProfile(rootProfileId.toProfileIdPreservingZero())
     )
   }
 

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationActiveTimeControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationActiveTimeControllerTest.kt
@@ -13,7 +13,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.domain.classify.InteractionsModule
 import org.oppia.android.domain.classify.rules.algebraicexpressioninput.AlgebraicExpressionInputModule
 import org.oppia.android.domain.classify.rules.continueinteraction.ContinueModule
@@ -95,8 +95,8 @@ class ExplorationActiveTimeControllerTest {
   @Inject
   lateinit var explorationDataController: ExplorationDataController
 
-  private val firstTestProfile = LegacyProfileId.newBuilder().setInternalId(0).build()
-  private val secondTestProfile = LegacyProfileId.newBuilder().setInternalId(1).build()
+  private val firstTestProfile = ProfileId.newBuilder().setInternalId(0).build()
+  private val secondTestProfile = ProfileId.newBuilder().setInternalId(1).build()
 
   @Before
   fun setUp() {
@@ -493,7 +493,7 @@ class ExplorationActiveTimeControllerTest {
     topicId: String,
     storyId: String,
     explorationId: String,
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ) {
     val startPlayingProvider =
       explorationDataController.startPlayingNewExploration(

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationDataControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationDataControllerTest.kt
@@ -13,7 +13,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.app.model.ExplorationCheckpoint
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.domain.classify.InteractionsModule
 import org.oppia.android.domain.classify.rules.algebraicexpressioninput.AlgebraicExpressionInputModule
 import org.oppia.android.domain.classify.rules.continueinteraction.ContinueModule
@@ -91,7 +91,7 @@ class ExplorationDataControllerTest {
   @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
   @Inject lateinit var explorationCheckpointController: ExplorationCheckpointController
 
-  private val profileId = LegacyProfileId.newBuilder().setInternalId(0).build()
+  private val profileId = ProfileId.newBuilder().setInternalId(0).build()
 
   @Before
   fun setUp() {
@@ -190,7 +190,7 @@ class ExplorationDataControllerTest {
   fun testStartPlayingNewExploration_returnsSuccess() {
     val startProvider =
       explorationDataController.startPlayingNewExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -266,7 +266,7 @@ class ExplorationDataControllerTest {
 
     val secondStartProvider =
       explorationDataController.startPlayingNewExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0, TEST_STORY_ID_0,
         TEST_EXPLORATION_ID_2
@@ -288,7 +288,7 @@ class ExplorationDataControllerTest {
     val checkpoint = retrieveExplorationCheckpoint(TEST_EXPLORATION_ID_2)
     val secondStartProvider =
       explorationDataController.resumeExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -303,7 +303,7 @@ class ExplorationDataControllerTest {
   fun testRestartExploration_returnsSuccess() {
     val startProvider =
       explorationDataController.restartExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -325,7 +325,7 @@ class ExplorationDataControllerTest {
 
     val secondStartProvider =
       explorationDataController.restartExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -339,7 +339,7 @@ class ExplorationDataControllerTest {
   fun testReplayExploration_returnsSuccess() {
     val startProvider =
       explorationDataController.replayExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -361,7 +361,7 @@ class ExplorationDataControllerTest {
 
     val secondStartProvider =
       explorationDataController.replayExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -382,7 +382,7 @@ class ExplorationDataControllerTest {
 
     val dataProvider =
       explorationDataController.replayExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_1,
         TEST_STORY_ID_2,
@@ -442,7 +442,7 @@ class ExplorationDataControllerTest {
   ) {
     val startPlayingProvider =
       explorationDataController.startPlayingNewExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId, classroomId, topicId, storyId, explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }
@@ -455,7 +455,7 @@ class ExplorationDataControllerTest {
   ) {
     val startPlayingProvider =
       explorationDataController.restartExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId, classroomId, topicId, storyId, explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }
@@ -468,7 +468,7 @@ class ExplorationDataControllerTest {
   ) {
     val startPlayingProvider =
       explorationDataController.replayExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId, classroomId, topicId, storyId, explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }
@@ -495,7 +495,7 @@ class ExplorationDataControllerTest {
     val checkpoint = retrieveExplorationCheckpoint(explorationId)
     val resumeProvider =
       explorationDataController.resumeExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId, checkpoint
+        profileId, classroomId, topicId, storyId, explorationId, checkpoint
       )
     monitorFactory.waitForNextSuccessfulResult(resumeProvider)
   }

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
@@ -116,6 +116,7 @@ import org.oppia.android.util.logging.GlobalLogLevel
 import org.oppia.android.util.logging.LogLevel
 import org.oppia.android.util.logging.SyncStatusModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.util.Locale
@@ -3153,7 +3154,10 @@ class ExplorationProgressControllerTest {
     monitorFactory.waitForNextSuccessfulResult(updateProv)
 
     // Verify that the learner's profile-wide content language has changed.
-    val contentLangProvider = translationController.getWrittenTranslationContentLanguage(profileId)
+    val contentLangProvider =
+      translationController.getWrittenTranslationContentLanguage(
+        profileId.toProfileIdPreservingZero()
+      )
     val contentLanguage = monitorFactory.waitForNextSuccessfulResult(contentLangProvider)
     assertThat(contentLanguage).isEqualTo(OppiaLanguage.SWAHILI)
   }
@@ -3209,7 +3213,9 @@ class ExplorationProgressControllerTest {
 
     // Verify that the other learner's profile-wide content language hasn't changed.
     val contentLangProvider =
-      translationController.getWrittenTranslationContentLanguage(arabicProfileId)
+      translationController.getWrittenTranslationContentLanguage(
+        arabicProfileId.toProfileIdPreservingZero()
+      )
     val contentLanguage = monitorFactory.waitForNextSuccessfulResult(contentLangProvider)
     assertThat(contentLanguage).isEqualTo(OppiaLanguage.ARABIC)
   }
@@ -3232,7 +3238,10 @@ class ExplorationProgressControllerTest {
     monitorFactory.waitForNextSuccessfulResult(updateProv)
 
     // Verify that the learner's profile-wide content language has changed.
-    val contentLangProvider = translationController.getWrittenTranslationContentLanguage(profileId)
+    val contentLangProvider =
+      translationController.getWrittenTranslationContentLanguage(
+        profileId.toProfileIdPreservingZero()
+      )
     val contentLanguage = monitorFactory.waitForNextSuccessfulResult(contentLangProvider)
     assertThat(contentLanguage).isEqualTo(OppiaLanguage.ENGLISH)
   }
@@ -4144,7 +4153,7 @@ class ExplorationProgressControllerTest {
 
   private fun updateContentLanguage(profileId: LegacyProfileId, language: OppiaLanguage) {
     val updateProvider = translationController.updateWrittenTranslationContentLanguage(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       WrittenTranslationLanguageSelection.newBuilder().apply {
         selectedLanguage = language
       }.build()
@@ -4215,7 +4224,7 @@ class ExplorationProgressControllerTest {
     )
     monitorFactory.waitForNextSuccessfulResult(addProfileProvider)
     monitorFactory.waitForNextSuccessfulResult(
-      profileManagementController.loginToProfile(rootProfileId)
+      profileManagementController.loginToProfile(rootProfileId.toProfileIdPreservingZero())
     )
   }
 

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
@@ -41,10 +41,10 @@ import org.oppia.android.app.model.HelpIndex.IndexTypeCase.NEXT_AVAILABLE_HINT_I
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.SHOW_SOLUTION
 import org.oppia.android.app.model.InteractionObject
 import org.oppia.android.app.model.ItemSelectionAnswerState
-import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.ListOfSetsOfTranslatableHtmlContentIds
 import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.model.Point2d
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.RatioExpression
 import org.oppia.android.app.model.SetOfTranslatableHtmlContentIds
 import org.oppia.android.app.model.TranslatableHtmlContentId
@@ -116,7 +116,6 @@ import org.oppia.android.util.logging.GlobalLogLevel
 import org.oppia.android.util.logging.LogLevel
 import org.oppia.android.util.logging.SyncStatusModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
-import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.util.Locale
@@ -163,7 +162,7 @@ class ExplorationProgressControllerTest {
   @Inject lateinit var profileManagementController: ProfileManagementController
   @Inject lateinit var explorationActiveTimeController: ExplorationActiveTimeController
 
-  private val profileId = LegacyProfileId.newBuilder().setInternalId(0).build()
+  private val profileId = ProfileId.newBuilder().setInternalId(0).build()
 
   @Before
   fun setUp() {
@@ -192,7 +191,7 @@ class ExplorationProgressControllerTest {
   fun testPlayExploration_invalid_returnsSuccess() {
     val resultDataProvider =
       explorationDataController.replayExploration(
-        profileId.internalId,
+        profileId,
         INVALID_CLASSROOM_ID,
         INVALID_TOPIC_ID,
         INVALID_STORY_ID,
@@ -219,7 +218,7 @@ class ExplorationProgressControllerTest {
   fun testPlayExploration_valid_returnsSuccess() {
     val resultDataProvider =
       explorationDataController.replayExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -268,7 +267,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testEphemeralState_profile1ClicksContinue_switchToProfile2_shouldIndicateButtonAnimation() {
     oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
-    val profileId2 = LegacyProfileId.newBuilder().setInternalId(1).build()
+    val profileId2 = ProfileId.newBuilder().setInternalId(1).build()
     startPlayingNewExploration(
       TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, TEST_EXPLORATION_ID_2
     )
@@ -358,7 +357,7 @@ class ExplorationProgressControllerTest {
     // Try playing another exploration without finishing the previous one.
     val resultDataProvider =
       explorationDataController.replayExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -2179,7 +2178,7 @@ class ExplorationProgressControllerTest {
 
   @Test
   fun testGetCurrentState_englishLangProfile_includesTranslationContextForEnglish() {
-    val englishProfileId = LegacyProfileId.newBuilder().apply { internalId = 1 }.build()
+    val englishProfileId = ProfileId.newBuilder().apply { internalId = 1 }.build()
     updateContentLanguage(englishProfileId, OppiaLanguage.ENGLISH)
     startPlayingNewExploration(
       TEST_CLASSROOM_ID_0,
@@ -2200,7 +2199,7 @@ class ExplorationProgressControllerTest {
 
   @Test
   fun testGetCurrentState_englishLangProfile_switchToArabic_includesTranslationContextForArabic() {
-    val englishProfileId = LegacyProfileId.newBuilder().apply { internalId = 1 }.build()
+    val englishProfileId = ProfileId.newBuilder().apply { internalId = 1 }.build()
     updateContentLanguage(englishProfileId, OppiaLanguage.ENGLISH)
     startPlayingNewExploration(
       TEST_CLASSROOM_ID_0,
@@ -2223,8 +2222,8 @@ class ExplorationProgressControllerTest {
 
   @Test
   fun testGetCurrentState_arabicLangProfile_includesTranslationContextForArabic() {
-    val englishProfileId = LegacyProfileId.newBuilder().apply { internalId = 1 }.build()
-    val arabicProfileId = LegacyProfileId.newBuilder().apply { internalId = 2 }.build()
+    val englishProfileId = ProfileId.newBuilder().apply { internalId = 1 }.build()
+    val arabicProfileId = ProfileId.newBuilder().apply { internalId = 2 }.build()
     updateContentLanguage(englishProfileId, OppiaLanguage.ENGLISH)
     updateContentLanguage(arabicProfileId, OppiaLanguage.ARABIC)
     startPlayingNewExploration(
@@ -3156,7 +3155,7 @@ class ExplorationProgressControllerTest {
     // Verify that the learner's profile-wide content language has changed.
     val contentLangProvider =
       translationController.getWrittenTranslationContentLanguage(
-        profileId.toProfileIdPreservingZero()
+        profileId
       )
     val contentLanguage = monitorFactory.waitForNextSuccessfulResult(contentLangProvider)
     assertThat(contentLanguage).isEqualTo(OppiaLanguage.SWAHILI)
@@ -3190,8 +3189,8 @@ class ExplorationProgressControllerTest {
 
   @Test
   fun testUpdateLanguageMidLesson_englishToSwahili_diffProfile_doesNotChangeOtherProfilesLang() {
-    val englishProfileId = LegacyProfileId.newBuilder().apply { internalId = 1 }.build()
-    val arabicProfileId = LegacyProfileId.newBuilder().apply { internalId = 2 }.build()
+    val englishProfileId = ProfileId.newBuilder().apply { internalId = 1 }.build()
+    val arabicProfileId = ProfileId.newBuilder().apply { internalId = 2 }.build()
     updateContentLanguage(englishProfileId, OppiaLanguage.ENGLISH)
     updateContentLanguage(arabicProfileId, OppiaLanguage.ARABIC)
     startPlayingNewExploration(
@@ -3214,7 +3213,7 @@ class ExplorationProgressControllerTest {
     // Verify that the other learner's profile-wide content language hasn't changed.
     val contentLangProvider =
       translationController.getWrittenTranslationContentLanguage(
-        arabicProfileId.toProfileIdPreservingZero()
+        arabicProfileId
       )
     val contentLanguage = monitorFactory.waitForNextSuccessfulResult(contentLangProvider)
     assertThat(contentLanguage).isEqualTo(OppiaLanguage.ARABIC)
@@ -3240,7 +3239,7 @@ class ExplorationProgressControllerTest {
     // Verify that the learner's profile-wide content language has changed.
     val contentLangProvider =
       translationController.getWrittenTranslationContentLanguage(
-        profileId.toProfileIdPreservingZero()
+        profileId
       )
     val contentLanguage = monitorFactory.waitForNextSuccessfulResult(contentLangProvider)
     assertThat(contentLanguage).isEqualTo(OppiaLanguage.ENGLISH)
@@ -3696,11 +3695,11 @@ class ExplorationProgressControllerTest {
     topicId: String,
     storyId: String,
     explorationId: String,
-    profileId: LegacyProfileId = this.profileId
+    profileId: ProfileId = this.profileId
   ) {
     val startPlayingProvider =
       explorationDataController.startPlayingNewExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId, classroomId, topicId, storyId, explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }
@@ -3711,11 +3710,11 @@ class ExplorationProgressControllerTest {
     storyId: String,
     explorationId: String,
     explorationCheckpoint: ExplorationCheckpoint,
-    profileId: LegacyProfileId = this.profileId
+    profileId: ProfileId = this.profileId
   ) {
     val startPlayingProvider =
       explorationDataController.resumeExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId, explorationCheckpoint
+        profileId, classroomId, topicId, storyId, explorationId, explorationCheckpoint
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }
@@ -3725,11 +3724,11 @@ class ExplorationProgressControllerTest {
     topicId: String,
     storyId: String,
     explorationId: String,
-    profileId: LegacyProfileId = this.profileId
+    profileId: ProfileId = this.profileId
   ) {
     val startPlayingProvider =
       explorationDataController.restartExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId, classroomId, topicId, storyId, explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }
@@ -3739,18 +3738,18 @@ class ExplorationProgressControllerTest {
     topicId: String,
     storyId: String,
     explorationId: String,
-    profileId: LegacyProfileId = this.profileId
+    profileId: ProfileId = this.profileId
   ) {
     val startPlayingProvider =
       explorationDataController.replayExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId, classroomId, topicId, storyId, explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }
 
   private fun retrieveExplorationCheckpoint(
     explorationId: String,
-    profileId: LegacyProfileId = this.profileId
+    profileId: ProfileId = this.profileId
   ): ExplorationCheckpoint {
     return monitorFactory.waitForNextSuccessfulResult(
       explorationCheckpointController.retrieveExplorationCheckpoint(profileId, explorationId)
@@ -4151,9 +4150,9 @@ class ExplorationProgressControllerTest {
     Locale.setDefault(locale)
   }
 
-  private fun updateContentLanguage(profileId: LegacyProfileId, language: OppiaLanguage) {
+  private fun updateContentLanguage(profileId: ProfileId, language: OppiaLanguage) {
     val updateProvider = translationController.updateWrittenTranslationContentLanguage(
-      profileId.toProfileIdPreservingZero(),
+      profileId,
       WrittenTranslationLanguageSelection.newBuilder().apply {
         selectedLanguage = language
       }.build()
@@ -4213,7 +4212,7 @@ class ExplorationProgressControllerTest {
   }
 
   private fun logIntoAnalyticsReadyAdminProfile() {
-    val rootProfileId = LegacyProfileId.getDefaultInstance()
+    val rootProfileId = ProfileId.getDefaultInstance()
     val addProfileProvider = profileManagementController.addProfile(
       name = "Admin",
       pin = "",
@@ -4224,7 +4223,7 @@ class ExplorationProgressControllerTest {
     )
     monitorFactory.waitForNextSuccessfulResult(addProfileProvider)
     monitorFactory.waitForNextSuccessfulResult(
-      profileManagementController.loginToProfile(rootProfileId.toProfileIdPreservingZero())
+      profileManagementController.loginToProfile(rootProfileId)
     )
   }
 

--- a/domain/src/test/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointControllerTest.kt
@@ -17,7 +17,7 @@ import org.oppia.android.app.model.CheckpointState
 import org.oppia.android.app.model.ExplorationCheckpoint
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.NEXT_AVAILABLE_HINT_INDEX
 import org.oppia.android.app.model.InteractionObject
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.UserAnswer
 import org.oppia.android.domain.classify.InteractionsModule
 import org.oppia.android.domain.classify.rules.algebraicexpressioninput.AlgebraicExpressionInputModule
@@ -74,6 +74,7 @@ import org.oppia.android.util.logging.GlobalLogLevel
 import org.oppia.android.util.logging.LogLevel
 import org.oppia.android.util.logging.SyncStatusModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
+import org.oppia.android.util.profile.toLegacyProfileId
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -117,8 +118,8 @@ class ExplorationCheckpointControllerTest {
   @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
   @Inject lateinit var fakeExplorationRetriever: FakeExplorationRetriever
 
-  private val firstTestProfile = LegacyProfileId.newBuilder().setInternalId(0).build()
-  private val secondTestProfile = LegacyProfileId.newBuilder().setInternalId(1).build()
+  private val firstTestProfile = ProfileId.newBuilder().setInternalId(0).build()
+  private val secondTestProfile = ProfileId.newBuilder().setInternalId(1).build()
 
   @Before
   fun setUp() {
@@ -154,7 +155,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoint_retrieveSavedCheckpoint_isSuccessful() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -170,7 +171,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoint_retrieveUnsavedCheckpoint_isFailure() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -187,7 +188,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoint_retrieveCheckpointWithDifferentProfileId_isFailure() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -204,11 +205,11 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoint_updateSavedCheckpoint_checkUpdatedCheckpointIsRetrieved() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
     explorationCheckpointTestHelper.updateCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -226,11 +227,11 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoints_retrieveOldestCheckpointDetails_correctCheckpointRetrieved() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration1(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_1_CURRENT_VERSION
     )
 
@@ -258,7 +259,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testCheckpointController_saveCheckpoint_deleteSavedCheckpoint_isSuccessful() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -274,7 +275,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testCheckpointController_saveCheckpoint_deleteSavedCheckpoint_checkpointWasDeleted() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
     val deleteCheckpointProvider =
@@ -329,7 +330,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCompatibleCheckpoint_retrieveCheckpoint_isSuccessful() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -826,7 +827,7 @@ class ExplorationCheckpointControllerTest {
     }
   }
 
-  private fun saveCheckpoint(profileId: LegacyProfileId, index: Int): Any? {
+  private fun saveCheckpoint(profileId: ProfileId, index: Int): Any? {
     val recordProvider = explorationCheckpointController.recordExplorationCheckpoint(
       profileId = profileId,
       explorationId = createExplorationIdForIndex(index),
@@ -835,7 +836,7 @@ class ExplorationCheckpointControllerTest {
     return monitorFactory.waitForNextSuccessfulResult(recordProvider)
   }
 
-  private fun saveMultipleCheckpoints(profileId: LegacyProfileId, numberOfCheckpoints: Int) {
+  private fun saveMultipleCheckpoints(profileId: ProfileId, numberOfCheckpoints: Int) {
     for (index in 0 until numberOfCheckpoints) {
       saveCheckpoint(profileId, index)
     }
@@ -879,7 +880,7 @@ class ExplorationCheckpointControllerTest {
       .build()
 
   private fun retrieveExplorationCheckpointWithOverride(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     expIdToLoadInstead: String
   ): DataProvider<ExplorationCheckpoint> {
     fakeExplorationRetriever.setExplorationProxy(
@@ -892,7 +893,7 @@ class ExplorationCheckpointControllerTest {
   }
 
   private fun createCheckpointForTestExploration(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     playRoutine: () -> Unit
   ) {
     fakeExplorationRetriever.setExplorationProxy(

--- a/domain/src/test/java/org/oppia/android/domain/oppialogger/analytics/AnalyticsControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/oppialogger/analytics/AnalyticsControllerTest.kt
@@ -68,6 +68,7 @@ import org.oppia.android.util.networking.NetworkConnectionDebugUtil
 import org.oppia.android.util.networking.NetworkConnectionUtil.ProdConnectionStatus.LOCAL
 import org.oppia.android.util.networking.NetworkConnectionUtil.ProdConnectionStatus.NONE
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.system.OppiaClock
 import org.oppia.android.util.threading.BackgroundDispatcher
 import org.robolectric.annotation.Config
@@ -1273,7 +1274,8 @@ class AnalyticsControllerTest {
     monitorFactory.ensureDataProviderExecutes(addProfileProvider)
 
     return LegacyProfileId.newBuilder().apply { internalId = 0 }.build().also { expectedProfileId ->
-      val logInProvider = profileManagementController.loginToProfile(expectedProfileId)
+      val logInProvider =
+        profileManagementController.loginToProfile(expectedProfileId.toProfileIdPreservingZero())
       monitorFactory.waitForNextSuccessfulResult(logInProvider) // Ensure that the login succeeds.
     }
   }
@@ -1281,7 +1283,8 @@ class AnalyticsControllerTest {
   private fun ensureAppLanguageIsUpdatedTo(profileId: LegacyProfileId, language: OppiaLanguage) {
     val resultProvider =
       translationController.updateAppLanguage(
-        profileId, AppLanguageSelection.newBuilder().apply { selectedLanguage = language }.build()
+        profileId.toProfileIdPreservingZero(),
+        AppLanguageSelection.newBuilder().apply { selectedLanguage = language }.build()
       )
     monitorFactory.waitForNextSuccessfulResult(resultProvider)
   }
@@ -1292,7 +1295,7 @@ class AnalyticsControllerTest {
   ) {
     val resultProvider =
       translationController.updateWrittenTranslationContentLanguage(
-        profileId,
+        profileId.toProfileIdPreservingZero(),
         WrittenTranslationLanguageSelection.newBuilder().apply {
           selectedLanguage = language
         }.build()
@@ -1306,7 +1309,7 @@ class AnalyticsControllerTest {
   ) {
     val resultProvider =
       translationController.updateAudioTranslationContentLanguage(
-        profileId,
+        profileId.toProfileIdPreservingZero(),
         AudioTranslationLanguageSelection.newBuilder().apply {
           selectedLanguage = language
         }.build()

--- a/domain/src/test/java/org/oppia/android/domain/oppialogger/analytics/ApplicationLifecycleObserverTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/oppialogger/analytics/ApplicationLifecycleObserverTest.kt
@@ -106,6 +106,7 @@ import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.ImageParsingModule
 import org.oppia.android.util.platformparameter.EnableDownloadsSupport
 import org.oppia.android.util.platformparameter.PlatformParameterValue
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import retrofit2.Retrofit
@@ -590,7 +591,7 @@ class ApplicationLifecycleObserverTest {
     )
     monitorFactory.waitForNextSuccessfulResult(addProfileProvider)
     monitorFactory.waitForNextSuccessfulResult(
-      profileManagementController.loginToProfile(rootProfileId)
+      profileManagementController.loginToProfile(rootProfileId.toProfileIdPreservingZero())
     )
   }
 

--- a/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/profile/ProfileManagementControllerTest.kt
@@ -28,6 +28,7 @@ import org.oppia.android.app.model.AudioLanguage.NIGERIAN_PIDGIN_LANGUAGE
 import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.Profile
 import org.oppia.android.app.model.ProfileDatabase
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.ProfileOnboardingMode
 import org.oppia.android.app.model.ProfileType
 import org.oppia.android.app.model.ReadingTextSize.MEDIUM_TEXT_SIZE
@@ -100,13 +101,13 @@ class ProfileManagementControllerTest {
       Profile.newBuilder().setName("Veena").setPin("567").setAllowDownloadAccess(true).build()
     )
 
-    private val ADMIN_PROFILE_ID_0 = LegacyProfileId.newBuilder().setInternalId(0).build()
-    private val PROFILE_ID_0 = LegacyProfileId.newBuilder().setInternalId(0).build()
-    private val PROFILE_ID_1 = LegacyProfileId.newBuilder().setInternalId(1).build()
-    private val PROFILE_ID_2 = LegacyProfileId.newBuilder().setInternalId(2).build()
-    private val PROFILE_ID_3 = LegacyProfileId.newBuilder().setInternalId(3).build()
-    private val PROFILE_ID_4 = LegacyProfileId.newBuilder().setInternalId(4).build()
-    private val PROFILE_ID_6 = LegacyProfileId.newBuilder().setInternalId(6).build()
+    private val ADMIN_PROFILE_ID_0 = ProfileId.newBuilder().setInternalId(0).build()
+    private val PROFILE_ID_0 = ProfileId.newBuilder().setInternalId(0).build()
+    private val PROFILE_ID_1 = ProfileId.newBuilder().setInternalId(1).build()
+    private val PROFILE_ID_2 = ProfileId.newBuilder().setInternalId(2).build()
+    private val PROFILE_ID_3 = ProfileId.newBuilder().setInternalId(3).build()
+    private val PROFILE_ID_4 = ProfileId.newBuilder().setInternalId(4).build()
+    private val PROFILE_ID_6 = ProfileId.newBuilder().setInternalId(6).build()
 
     private const val DEFAULT_PIN = "12345"
     private const val DEFAULT_ALLOW_DOWNLOAD_ACCESS = true
@@ -408,7 +409,7 @@ class ProfileManagementControllerTest {
     addTestProfiles()
     testCoroutineDispatchers.runCurrent()
 
-    val profileId = LegacyProfileId.newBuilder().setInternalId(2).build()
+    val profileId = ProfileId.newBuilder().setInternalId(2).build()
     val updateProvider = profileManagementController.initializeLearnerId(profileId)
     monitorFactory.ensureDataProviderExecutes(updateProvider)
     val profileProvider = profileManagementController.getProfile(profileId)
@@ -424,7 +425,7 @@ class ProfileManagementControllerTest {
     addTestProfiles()
     testCoroutineDispatchers.runCurrent()
 
-    val profileId = LegacyProfileId.newBuilder().setInternalId(2).build()
+    val profileId = ProfileId.newBuilder().setInternalId(2).build()
     val updateProvider = profileManagementController.initializeLearnerId(profileId)
     monitorFactory.ensureDataProviderExecutes(updateProvider)
     val profileProvider = profileManagementController.getProfile(profileId)
@@ -2000,7 +2001,7 @@ class ProfileManagementControllerTest {
     monitorFactory.ensureDataProviderExecutes(onboardingProvider)
     val event = fakeAnalyticsEventLogger.getMostRecentEvent()
     assertThat(event).hasStartProfileOnboardingContextThat {
-      hasProfileIdThat().isEqualTo(PROFILE_ID_0)
+      hasProfileIdThat().isEqualTo(LegacyProfileId.newBuilder().setInternalId(0).build())
     }
   }
 
@@ -2012,7 +2013,7 @@ class ProfileManagementControllerTest {
     monitorFactory.ensureDataProviderExecutes(onboardingProvider)
     val event = fakeAnalyticsEventLogger.getMostRecentEvent()
     assertThat(event).hasEndProfileOnboardingContextThat {
-      hasProfileIdThat().isEqualTo(PROFILE_ID_0)
+      hasProfileIdThat().isEqualTo(LegacyProfileId.newBuilder().setInternalId(0).build())
     }
   }
 
@@ -2040,7 +2041,7 @@ class ProfileManagementControllerTest {
     )
   }
 
-  private fun retrieveProfile(profileId: LegacyProfileId) =
+  private fun retrieveProfile(profileId: ProfileId) =
     monitorFactory.waitForNextSuccessfulResult(profileManagementController.getProfile(profileId))
 
   private fun retrieveCurrentSessionId() =
@@ -2127,8 +2128,8 @@ class ProfileManagementControllerTest {
     CoroutineScope(backgroundDispatcher).async { block() }.waitForSuccessfulResult()
 
   private fun <T> fetchSuccessfulAsyncValue(
-    block: suspend (profileId: LegacyProfileId) -> T,
-    profileId: LegacyProfileId
+    block: suspend (profileId: ProfileId) -> T,
+    profileId: ProfileId
   ) = CoroutineScope(backgroundDispatcher).async { block(profileId) }.waitForSuccessfulResult()
 
   private fun <T> Deferred<T>.waitForSuccessfulResult(): T {

--- a/domain/src/test/java/org/oppia/android/domain/question/QuestionAssessmentProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/question/QuestionAssessmentProgressControllerTest.kt
@@ -74,6 +74,7 @@ import org.oppia.android.util.logging.GlobalLogLevel
 import org.oppia.android.util.logging.LogLevel
 import org.oppia.android.util.logging.SyncStatusModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.util.Locale
@@ -1551,7 +1552,7 @@ class QuestionAssessmentProgressControllerTest {
 
   private fun updateContentLanguage(profileId: LegacyProfileId, language: OppiaLanguage) {
     val updateProvider = translationController.updateWrittenTranslationContentLanguage(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       WrittenTranslationLanguageSelection.newBuilder().apply {
         selectedLanguage = language
       }.build()

--- a/domain/src/test/java/org/oppia/android/domain/survey/SurveyGatingControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/survey/SurveyGatingControllerTest.kt
@@ -100,9 +100,7 @@ class SurveyGatingControllerTest {
     oppiaClock.setCurrentTimeMs(LATE_NIGHT_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
       profileManagementController.updateSurveyLastShownTimestamp(
-
         PROFILE_ID_0.toProfileIdPreservingZero()
-
       )
     )
     startAndEndExplorationSession(SESSION_LENGTH_SHORT, PROFILE_ID_0, TEST_TOPIC_ID_0)
@@ -168,9 +166,7 @@ class SurveyGatingControllerTest {
     oppiaClock.setCurrentTimeMs(EARLY_MORNING_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
       profileManagementController.updateSurveyLastShownTimestamp(
-
         PROFILE_ID_0.toProfileIdPreservingZero()
-
       )
     )
     startAndEndExplorationSession(SESSION_LENGTH_SHORT, PROFILE_ID_0, TEST_TOPIC_ID_0)
@@ -236,9 +232,7 @@ class SurveyGatingControllerTest {
     oppiaClock.setCurrentTimeMs(MID_MORNING_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
       profileManagementController.updateSurveyLastShownTimestamp(
-
         PROFILE_ID_0.toProfileIdPreservingZero()
-
       )
     )
     startAndEndExplorationSession(SESSION_LENGTH_SHORT, PROFILE_ID_0, TEST_TOPIC_ID_0)
@@ -256,9 +250,7 @@ class SurveyGatingControllerTest {
     oppiaClock.setCurrentTimeMs(MID_MORNING_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
       profileManagementController.updateSurveyLastShownTimestamp(
-
         PROFILE_ID_0.toProfileIdPreservingZero()
-
       )
     )
     startAndEndExplorationSession(SESSION_LENGTH_MINIMUM, PROFILE_ID_0, TEST_TOPIC_ID_0)
@@ -276,9 +268,7 @@ class SurveyGatingControllerTest {
     oppiaClock.setCurrentTimeMs(MID_MORNING_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
       profileManagementController.updateSurveyLastShownTimestamp(
-
         PROFILE_ID_0.toProfileIdPreservingZero()
-
       )
     )
     startAndEndExplorationSession(SESSION_LENGTH_LONG, PROFILE_ID_0, TEST_TOPIC_ID_0)
@@ -350,9 +340,7 @@ class SurveyGatingControllerTest {
     oppiaClock.setCurrentTimeMs(AFTERNOON_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
       profileManagementController.updateSurveyLastShownTimestamp(
-
         PROFILE_ID_0.toProfileIdPreservingZero()
-
       )
     )
     startAndEndExplorationSession(SESSION_LENGTH_SHORT, PROFILE_ID_0, TEST_TOPIC_ID_0)
@@ -370,9 +358,7 @@ class SurveyGatingControllerTest {
     oppiaClock.setCurrentTimeMs(AFTERNOON_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
       profileManagementController.updateSurveyLastShownTimestamp(
-
         PROFILE_ID_0.toProfileIdPreservingZero()
-
       )
     )
     startAndEndExplorationSession(SESSION_LENGTH_MINIMUM, PROFILE_ID_0, TEST_TOPIC_ID_0)
@@ -390,9 +376,7 @@ class SurveyGatingControllerTest {
     oppiaClock.setCurrentTimeMs(AFTERNOON_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
       profileManagementController.updateSurveyLastShownTimestamp(
-
         PROFILE_ID_0.toProfileIdPreservingZero()
-
       )
     )
     startAndEndExplorationSession(SESSION_LENGTH_LONG, PROFILE_ID_0, TEST_TOPIC_ID_0)
@@ -466,9 +450,7 @@ class SurveyGatingControllerTest {
     oppiaClock.setCurrentTimeMs(EVENING_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
       profileManagementController.updateSurveyLastShownTimestamp(
-
         PROFILE_ID_0.toProfileIdPreservingZero()
-
       )
     )
     startAndEndExplorationSession(SESSION_LENGTH_SHORT, PROFILE_ID_0, TEST_TOPIC_ID_0)
@@ -486,9 +468,7 @@ class SurveyGatingControllerTest {
     oppiaClock.setCurrentTimeMs(EVENING_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
       profileManagementController.updateSurveyLastShownTimestamp(
-
         PROFILE_ID_0.toProfileIdPreservingZero()
-
       )
     )
     startAndEndExplorationSession(SESSION_LENGTH_MINIMUM, PROFILE_ID_0, TEST_TOPIC_ID_0)
@@ -506,9 +486,7 @@ class SurveyGatingControllerTest {
     oppiaClock.setCurrentTimeMs(EVENING_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
       profileManagementController.updateSurveyLastShownTimestamp(
-
         PROFILE_ID_0.toProfileIdPreservingZero()
-
       )
     )
     startAndEndExplorationSession(SESSION_LENGTH_LONG, PROFILE_ID_0, TEST_TOPIC_ID_0)
@@ -630,9 +608,7 @@ class SurveyGatingControllerTest {
     // The surveyLastShownTimestamp is updated every time a survey is shown
     monitorFactory.ensureDataProviderExecutes(
       profileManagementController.updateSurveyLastShownTimestamp(
-
         PROFILE_ID_0.toProfileIdPreservingZero()
-
       )
     )
 

--- a/domain/src/test/java/org/oppia/android/domain/survey/SurveyGatingControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/survey/SurveyGatingControllerTest.kt
@@ -43,6 +43,7 @@ import org.oppia.android.util.logging.LogLevel
 import org.oppia.android.util.logging.SyncStatusModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.platformparameter.LEARNER_STUDY_ANALYTICS_DEFAULT_VALUE
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -98,7 +99,11 @@ class SurveyGatingControllerTest {
     oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
     oppiaClock.setCurrentTimeMs(LATE_NIGHT_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.updateSurveyLastShownTimestamp(PROFILE_ID_0)
+      profileManagementController.updateSurveyLastShownTimestamp(
+
+        PROFILE_ID_0.toProfileIdPreservingZero()
+
+      )
     )
     startAndEndExplorationSession(SESSION_LENGTH_SHORT, PROFILE_ID_0, TEST_TOPIC_ID_0)
 
@@ -162,7 +167,11 @@ class SurveyGatingControllerTest {
     oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
     oppiaClock.setCurrentTimeMs(EARLY_MORNING_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.updateSurveyLastShownTimestamp(PROFILE_ID_0)
+      profileManagementController.updateSurveyLastShownTimestamp(
+
+        PROFILE_ID_0.toProfileIdPreservingZero()
+
+      )
     )
     startAndEndExplorationSession(SESSION_LENGTH_SHORT, PROFILE_ID_0, TEST_TOPIC_ID_0)
 
@@ -226,7 +235,11 @@ class SurveyGatingControllerTest {
     oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
     oppiaClock.setCurrentTimeMs(MID_MORNING_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.updateSurveyLastShownTimestamp(PROFILE_ID_0)
+      profileManagementController.updateSurveyLastShownTimestamp(
+
+        PROFILE_ID_0.toProfileIdPreservingZero()
+
+      )
     )
     startAndEndExplorationSession(SESSION_LENGTH_SHORT, PROFILE_ID_0, TEST_TOPIC_ID_0)
 
@@ -242,7 +255,11 @@ class SurveyGatingControllerTest {
     oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
     oppiaClock.setCurrentTimeMs(MID_MORNING_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.updateSurveyLastShownTimestamp(PROFILE_ID_0)
+      profileManagementController.updateSurveyLastShownTimestamp(
+
+        PROFILE_ID_0.toProfileIdPreservingZero()
+
+      )
     )
     startAndEndExplorationSession(SESSION_LENGTH_MINIMUM, PROFILE_ID_0, TEST_TOPIC_ID_0)
 
@@ -258,7 +275,11 @@ class SurveyGatingControllerTest {
     oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
     oppiaClock.setCurrentTimeMs(MID_MORNING_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.updateSurveyLastShownTimestamp(PROFILE_ID_0)
+      profileManagementController.updateSurveyLastShownTimestamp(
+
+        PROFILE_ID_0.toProfileIdPreservingZero()
+
+      )
     )
     startAndEndExplorationSession(SESSION_LENGTH_LONG, PROFILE_ID_0, TEST_TOPIC_ID_0)
 
@@ -328,7 +349,11 @@ class SurveyGatingControllerTest {
     oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
     oppiaClock.setCurrentTimeMs(AFTERNOON_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.updateSurveyLastShownTimestamp(PROFILE_ID_0)
+      profileManagementController.updateSurveyLastShownTimestamp(
+
+        PROFILE_ID_0.toProfileIdPreservingZero()
+
+      )
     )
     startAndEndExplorationSession(SESSION_LENGTH_SHORT, PROFILE_ID_0, TEST_TOPIC_ID_0)
 
@@ -344,7 +369,11 @@ class SurveyGatingControllerTest {
     oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
     oppiaClock.setCurrentTimeMs(AFTERNOON_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.updateSurveyLastShownTimestamp(PROFILE_ID_0)
+      profileManagementController.updateSurveyLastShownTimestamp(
+
+        PROFILE_ID_0.toProfileIdPreservingZero()
+
+      )
     )
     startAndEndExplorationSession(SESSION_LENGTH_MINIMUM, PROFILE_ID_0, TEST_TOPIC_ID_0)
 
@@ -360,7 +389,11 @@ class SurveyGatingControllerTest {
     oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
     oppiaClock.setCurrentTimeMs(AFTERNOON_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.updateSurveyLastShownTimestamp(PROFILE_ID_0)
+      profileManagementController.updateSurveyLastShownTimestamp(
+
+        PROFILE_ID_0.toProfileIdPreservingZero()
+
+      )
     )
     startAndEndExplorationSession(SESSION_LENGTH_LONG, PROFILE_ID_0, TEST_TOPIC_ID_0)
 
@@ -432,7 +465,11 @@ class SurveyGatingControllerTest {
     oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
     oppiaClock.setCurrentTimeMs(EVENING_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.updateSurveyLastShownTimestamp(PROFILE_ID_0)
+      profileManagementController.updateSurveyLastShownTimestamp(
+
+        PROFILE_ID_0.toProfileIdPreservingZero()
+
+      )
     )
     startAndEndExplorationSession(SESSION_LENGTH_SHORT, PROFILE_ID_0, TEST_TOPIC_ID_0)
 
@@ -448,7 +485,11 @@ class SurveyGatingControllerTest {
     oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
     oppiaClock.setCurrentTimeMs(EVENING_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.updateSurveyLastShownTimestamp(PROFILE_ID_0)
+      profileManagementController.updateSurveyLastShownTimestamp(
+
+        PROFILE_ID_0.toProfileIdPreservingZero()
+
+      )
     )
     startAndEndExplorationSession(SESSION_LENGTH_MINIMUM, PROFILE_ID_0, TEST_TOPIC_ID_0)
 
@@ -464,7 +505,11 @@ class SurveyGatingControllerTest {
     oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
     oppiaClock.setCurrentTimeMs(EVENING_UTC_TIMESTAMP_MILLIS)
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.updateSurveyLastShownTimestamp(PROFILE_ID_0)
+      profileManagementController.updateSurveyLastShownTimestamp(
+
+        PROFILE_ID_0.toProfileIdPreservingZero()
+
+      )
     )
     startAndEndExplorationSession(SESSION_LENGTH_LONG, PROFILE_ID_0, TEST_TOPIC_ID_0)
 
@@ -537,7 +582,7 @@ class SurveyGatingControllerTest {
     oppiaClock.setCurrentTimeMs(EVENING_UTC_TIMESTAMP_MILLIS)
 
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.loginToProfile(PROFILE_ID_0)
+      profileManagementController.loginToProfile(PROFILE_ID_0.toProfileIdPreservingZero())
     )
 
     // The default surveyLastShownTimestamp is set to the beginning of epoch which will always be
@@ -547,7 +592,7 @@ class SurveyGatingControllerTest {
     startAndEndExplorationSession(SESSION_LENGTH_LONG, PROFILE_ID_0, TEST_TOPIC_ID_0)
 
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.loginToProfile(PROFILE_ID_1)
+      profileManagementController.loginToProfile(PROFILE_ID_1.toProfileIdPreservingZero())
     )
 
     val gatingProvider = surveyGatingController.maybeShowSurvey(PROFILE_ID_1, TEST_TOPIC_ID_0)
@@ -579,16 +624,20 @@ class SurveyGatingControllerTest {
   @Test
   fun testGating_criteriaMetOnProfileTwo_afterSurveyShownOnProfileOne_triggersSurveyProfileTwo() {
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.loginToProfile(PROFILE_ID_0)
+      profileManagementController.loginToProfile(PROFILE_ID_0.toProfileIdPreservingZero())
     )
 
     // The surveyLastShownTimestamp is updated every time a survey is shown
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.updateSurveyLastShownTimestamp(PROFILE_ID_0)
+      profileManagementController.updateSurveyLastShownTimestamp(
+
+        PROFILE_ID_0.toProfileIdPreservingZero()
+
+      )
     )
 
     monitorFactory.ensureDataProviderExecutes(
-      profileManagementController.loginToProfile(PROFILE_ID_1)
+      profileManagementController.loginToProfile(PROFILE_ID_1.toProfileIdPreservingZero())
     )
 
     // The default surveyLastShownTimestamp is set to the beginning of epoch which will always be

--- a/domain/src/test/java/org/oppia/android/domain/topic/StoryProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/topic/StoryProgressControllerTest.kt
@@ -13,7 +13,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.app.model.ChapterPlayState
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.domain.oppialogger.LogStorageModule
 import org.oppia.android.domain.oppialogger.LoggingIdentifierModule
 import org.oppia.android.domain.oppialogger.analytics.ApplicationLifecycleModule
@@ -55,11 +55,11 @@ class StoryProgressControllerTest {
   @Inject lateinit var fakeOppiaClock: FakeOppiaClock
   @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
 
-  private lateinit var profileId: LegacyProfileId
+  private lateinit var profileId: ProfileId
 
   @Before
   fun setUp() {
-    profileId = LegacyProfileId.newBuilder().setInternalId(0).build()
+    profileId = ProfileId.newBuilder().setInternalId(0).build()
     setUpTestApplicationComponent()
   }
 
@@ -281,7 +281,7 @@ class StoryProgressControllerTest {
   }
 
   private fun retrieveChapterPlayState(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String

--- a/domain/src/test/java/org/oppia/android/domain/topic/TopicControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/topic/TopicControllerTest.kt
@@ -55,6 +55,7 @@ import org.oppia.android.util.logging.GlobalLogLevel
 import org.oppia.android.util.logging.LogLevel
 import org.oppia.android.util.logging.SyncStatusModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.util.Locale
@@ -1164,7 +1165,7 @@ class TopicControllerTest {
 
   private fun updateContentLanguage(profileId: LegacyProfileId, language: OppiaLanguage) {
     val updateProvider = translationController.updateWrittenTranslationContentLanguage(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       WrittenTranslationLanguageSelection.newBuilder().apply {
         selectedLanguage = language
       }.build()

--- a/domain/src/test/java/org/oppia/android/domain/translation/TranslationControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/translation/TranslationControllerTest.kt
@@ -20,7 +20,6 @@ import org.oppia.android.app.model.AudioTranslationLanguageSelection
 import org.oppia.android.app.model.HtmlTranslationList
 import org.oppia.android.app.model.LanguageSupportDefinition.LanguageId.LanguageTypeCase.IETF_BCP47_ID
 import org.oppia.android.app.model.LanguageSupportDefinition.LanguageId.LanguageTypeCase.LANGUAGETYPE_NOT_SET
-import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.model.OppiaLanguage.ARABIC
 import org.oppia.android.app.model.OppiaLanguage.BRAZILIAN_PORTUGUESE
@@ -39,6 +38,7 @@ import org.oppia.android.app.model.OppiaRegion.BRAZIL
 import org.oppia.android.app.model.OppiaRegion.INDIA
 import org.oppia.android.app.model.OppiaRegion.REGION_UNSPECIFIED
 import org.oppia.android.app.model.OppiaRegion.UNITED_STATES
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.SubtitledHtml
 import org.oppia.android.app.model.SubtitledUnicode
 import org.oppia.android.app.model.TranslatableSetOfNormalizedString
@@ -2023,13 +2023,13 @@ class TranslationControllerTest {
     return monitorFactory.waitForNextSuccessfulResult(localeProvider)
   }
 
-  private fun ensureAppLanguageIsUpdatedToUseSystem(profileId: LegacyProfileId) {
+  private fun ensureAppLanguageIsUpdatedToUseSystem(profileId: ProfileId) {
     val resultProvider =
       translationController.updateAppLanguage(profileId, APP_LANGUAGE_SELECTION_SYSTEM)
     monitorFactory.waitForNextSuccessfulResult(resultProvider)
   }
 
-  private fun ensureAppLanguageIsUpdatedTo(profileId: LegacyProfileId, language: OppiaLanguage) {
+  private fun ensureAppLanguageIsUpdatedTo(profileId: ProfileId, language: OppiaLanguage) {
     val resultProvider =
       translationController.updateAppLanguage(profileId, createAppLanguageSelection(language))
     monitorFactory.waitForNextSuccessfulResult(resultProvider)
@@ -2042,7 +2042,7 @@ class TranslationControllerTest {
   }
 
   private fun ensureWrittenTranslationsLanguageIsUpdatedTo(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     language: OppiaLanguage
   ) {
     val resultProvider =
@@ -2052,7 +2052,7 @@ class TranslationControllerTest {
     monitorFactory.waitForNextSuccessfulResult(resultProvider)
   }
 
-  private fun ensureWrittenTranslationsLanguageIsUpdatedToUseApp(profileId: LegacyProfileId) {
+  private fun ensureWrittenTranslationsLanguageIsUpdatedToUseApp(profileId: ProfileId) {
     val resultProvider =
       translationController.updateWrittenTranslationContentLanguage(
         profileId, WRITTEN_TRANSLATION_LANGUAGE_SELECTION_APP_LANGUAGE
@@ -2069,7 +2069,7 @@ class TranslationControllerTest {
   }
 
   private fun ensureAudioTranslationsLanguageIsUpdatedTo(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     language: OppiaLanguage
   ) {
     val resultProvider =
@@ -2079,7 +2079,7 @@ class TranslationControllerTest {
     monitorFactory.waitForNextSuccessfulResult(resultProvider)
   }
 
-  private fun ensureAudioTranslationsLanguageIsUpdatedToUseApp(profileId: LegacyProfileId) {
+  private fun ensureAudioTranslationsLanguageIsUpdatedToUseApp(profileId: ProfileId) {
     val resultProvider =
       translationController.updateAudioTranslationContentLanguage(
         profileId, AUDIO_TRANSLATION_LANGUAGE_SELECTION_APP_LANGUAGE
@@ -2158,11 +2158,11 @@ class TranslationControllerTest {
     private val INDIA_HINDI_LOCALE = Locale("hi", "IN")
     private val KENYA_KISWAHILI_LOCALE = Locale("sw", "KE")
 
-    private val PROFILE_ID_0 = LegacyProfileId.newBuilder().apply {
+    private val PROFILE_ID_0 = ProfileId.newBuilder().apply {
       internalId = 0
     }.build()
 
-    private val PROFILE_ID_1 = LegacyProfileId.newBuilder().apply {
+    private val PROFILE_ID_1 = ProfileId.newBuilder().apply {
       internalId = 1
     }.build()
 

--- a/testing/src/main/java/org/oppia/android/testing/profile/ProfileTestHelper.kt
+++ b/testing/src/main/java/org/oppia/android/testing/profile/ProfileTestHelper.kt
@@ -6,6 +6,7 @@ import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.testing.data.DataProviderTestMonitor
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProvider
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** This helper allows tests to easily create new profiles and switch between them. */
@@ -107,28 +108,35 @@ class ProfileTestHelper @Inject constructor(
   private fun logIntoProfile(internalProfileId: Int): DataProvider<Any?> {
     return profileManagementController.loginToProfile(
       LegacyProfileId.newBuilder().setInternalId(internalProfileId).build()
+        .toProfileIdPreservingZero()
     )
   }
 
   /** Marks a profile as having finished the onboarding flow. */
   fun markProfileOnboardingEnded(profileId: LegacyProfileId): DataProvider<Any?> {
-    return profileManagementController.markProfileOnboardingEnded(profileId)
+    return profileManagementController.markProfileOnboardingEnded(
+      profileId.toProfileIdPreservingZero()
+    )
   }
 
   /** Marks a profile as having started the onboarding flow. */
   fun markProfileOnboardingStarted(profileId: LegacyProfileId): DataProvider<Any?> {
-    return profileManagementController.markProfileOnboardingStarted(profileId)
+    return profileManagementController.markProfileOnboardingStarted(
+      profileId.toProfileIdPreservingZero()
+    )
   }
 
   /** Updates the [ProfileType] of an existing profile. */
   fun updateProfileType(profileId: LegacyProfileId, profileType: ProfileType): DataProvider<Any?> {
-    return profileManagementController.updateProfileType(profileId, profileType)
+    return profileManagementController.updateProfileType(
+      profileId.toProfileIdPreservingZero(), profileType
+    )
   }
 
   /** Returns the continue button animation seen for profile. */
   fun getContinueButtonAnimationSeenStatus(profileId: LegacyProfileId): Boolean {
     return monitorFactory.waitForNextSuccessfulResult(
-      profileManagementController.getProfile(profileId)
+      profileManagementController.getProfile(profileId.toProfileIdPreservingZero())
     ).isContinueButtonAnimationSeen
   }
 

--- a/testing/src/main/java/org/oppia/android/testing/profile/ProfileTestHelper.kt
+++ b/testing/src/main/java/org/oppia/android/testing/profile/ProfileTestHelper.kt
@@ -1,6 +1,7 @@
 package org.oppia.android.testing.profile
 
 import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.ProfileType
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.testing.data.DataProviderTestMonitor
@@ -119,6 +120,11 @@ class ProfileTestHelper @Inject constructor(
     )
   }
 
+  /** Marks a profile as having finished the onboarding flow. */
+  fun markProfileOnboardingEnded(profileId: ProfileId): DataProvider<Any?> {
+    return profileManagementController.markProfileOnboardingEnded(profileId)
+  }
+
   /** Marks a profile as having started the onboarding flow. */
   fun markProfileOnboardingStarted(profileId: LegacyProfileId): DataProvider<Any?> {
     return profileManagementController.markProfileOnboardingStarted(
@@ -126,11 +132,21 @@ class ProfileTestHelper @Inject constructor(
     )
   }
 
+  /** Marks a profile as having started the onboarding flow. */
+  fun markProfileOnboardingStarted(profileId: ProfileId): DataProvider<Any?> {
+    return profileManagementController.markProfileOnboardingStarted(profileId)
+  }
+
   /** Updates the [ProfileType] of an existing profile. */
   fun updateProfileType(profileId: LegacyProfileId, profileType: ProfileType): DataProvider<Any?> {
     return profileManagementController.updateProfileType(
       profileId.toProfileIdPreservingZero(), profileType
     )
+  }
+
+  /** Updates the [ProfileType] of an existing profile. */
+  fun updateProfileType(profileId: ProfileId, profileType: ProfileType): DataProvider<Any?> {
+    return profileManagementController.updateProfileType(profileId, profileType)
   }
 
   /** Returns the continue button animation seen for profile. */


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixes part of #6203: This PR completes the migration for the domain-layer exploration and progress controllers. It migrates these controllers from using `LegacyProfileId` (and raw `Int` internal IDs) to the new `ProfileId` schema.

Here is a detailed breakdown of the architectural changes made:

**1. Domain Layer Controllers Migrated to ProfileId:**
*   `ExplorationProgressController.kt` & `ExplorationDataController.kt`: Updated all internal state maps, data classes, and method signatures to utilize `ProfileId` instead of legacy types. 
*   `StoryProgressController.kt`, `ExplorationCheckpointController.kt`, and `ExplorationActiveTimeController.kt`: Signatures and internal progress tracking methods were migrated to `ProfileId`.
*   *Note on Analytics:* The explicit boundary at `LearnerAnalyticsLogger.beginExploration` is maintained intentionally using `.toLegacyProfileId()` since the logging infrastructure is not yet fully migrated.

**2. Domain Layer Tests Fully Migrated:**
*   `ExplorationDataControllerTest.kt`, `ExplorationProgressControllerTest.kt`, `ExplorationActiveTimeControllerTest.kt`, `ExplorationCheckpointControllerTest.kt`, and `StoryProgressControllerTest.kt`: Removed all instances of `.internalId` and legacy types. Updated all test helpers and mocking setups to instantiate and pass `ProfileId` objects natively.

**3. App-Layer Boundary Isolation (Temporary Compatibility):**
Because the App Layer is slated for migration in a future task, strict type-safe boundaries were introduced at the presenter call-sites to prevent polluting the domain layer with legacy types:
*   `TopicLessonsFragmentPresenter.kt`, `RecentlyPlayedFragmentPresenter.kt`, `StoryFragmentPresenter.kt`, and `ResumeLessonFragmentPresenter.kt`: Added `toProfileIdPreservingZero()` to calls accessing `ExplorationDataController`.
*   `ExplorationActivityPresenter.kt` & `StateViewModel.kt`: Refactored `deleteExplorationProgressById`, `getOldestExplorationDetailsDataProvider`, and `updateWrittenTranslationContentLanguageMidLesson` to convert the internally held `LegacyProfileId` at the boundary.
*   `StateFragmentTestActivityPresenter.kt` & `ExplorationTestActivityPresenter.kt`: Wrapped raw `Int` profile values in `ProfileId.newBuilder().setInternalId(..).build()` when triggering `replayExploration` and `startPlayingNewExploration`.
*   **App Tests** (`ExplorationActivityTest.kt`, `ExplorationActivityLocalTest.kt`): Safely wrapped injected test properties (`internalProfileId`) in `ProfileId` prior to domain controller interaction.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
