### PR TITLE
Fix part of #6203: Migrate exploration and progress controllers to use ProfileId

### DIFF
--- a/app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedFragmentPresenter.kt
@@ -98,7 +98,7 @@ class RecentlyPlayedFragmentPresenter @Inject constructor(
     if (promotedStory.chapterPlayState == ChapterPlayState.IN_PROGRESS_SAVED) {
       val explorationCheckpointLiveData =
         explorationCheckpointController.retrieveExplorationCheckpoint(
-          profileId, promotedStory.explorationId
+          profileId.toProfileIdPreservingZero(), promotedStory.explorationId
         ).toLiveData()
 
       explorationCheckpointLiveData.observe(

--- a/app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedFragmentPresenter.kt
@@ -26,6 +26,7 @@ import org.oppia.android.domain.exploration.lightweightcheckpointing.Exploration
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [RecentlyPlayedFragment]. */
@@ -178,13 +179,13 @@ class RecentlyPlayedFragmentPresenter @Inject constructor(
       // cases, lessons played from this fragment are known to be in progress, and that progress
       // can't be resumed here (hence the restart).
       explorationDataController.restartExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
       )
     } else {
       // The only lessons that can't have their progress saved are those that were already
       // completed.
       explorationDataController.replayExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
       )
     }
     startPlayingProvider.toLiveData().observe(fragment) { result ->

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivity.kt
@@ -30,6 +30,8 @@ import org.oppia.android.app.topic.conceptcard.ConceptCardListener
 import org.oppia.android.util.extensions.getProtoExtra
 import org.oppia.android.util.extensions.putProtoExtra
 import org.oppia.android.util.logging.CurrentAppScreenNameIntentDecorator.decorateWithScreenName
+import org.oppia.android.util.profile.toLegacyProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 const val TAG_HINTS_AND_SOLUTION_DIALOG = "HINTS_AND_SOLUTION_DIALOG"
@@ -65,7 +67,7 @@ class ExplorationActivity :
     val params = intent.extractParams()
     explorationActivityPresenter.handleOnCreate(
       this,
-      params.profileId,
+      params.profileId.toLegacyProfileId(),
       params.classroomId,
       params.topicId,
       params.storyId,
@@ -102,7 +104,7 @@ class ExplorationActivity :
       isCheckpointingEnabled: Boolean
     ): Intent {
       val params = ExplorationActivityParams.newBuilder().apply {
-        this.profileId = profileId
+        this.profileId = profileId.toProfileIdPreservingZero()
         this.classroomId = classroomId
         this.topicId = topicId
         this.storyId = storyId

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
@@ -354,7 +354,9 @@ class ExplorationActivityPresenter @Inject constructor(
 
   private fun updateToolbarTitle(explorationId: String) {
     subscribeToExploration(
-      explorationDataController.getExplorationById(profileId.toProfileIdPreservingZero(), explorationId).toLiveData()
+      explorationDataController.getExplorationById(
+        profileId.toProfileIdPreservingZero(), explorationId
+      ).toLiveData()
     )
   }
 

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
@@ -354,7 +354,7 @@ class ExplorationActivityPresenter @Inject constructor(
 
   private fun updateToolbarTitle(explorationId: String) {
     subscribeToExploration(
-      explorationDataController.getExplorationById(profileId, explorationId).toLiveData()
+      explorationDataController.getExplorationById(profileId.toProfileIdPreservingZero(), explorationId).toLiveData()
     )
   }
 

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
@@ -42,6 +42,7 @@ import org.oppia.android.domain.translation.TranslationController
 import org.oppia.android.util.accessibility.AccessibilityService
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 private const val TAG_UNSAVED_EXPLORATION_DIALOG = "UNSAVED_EXPLORATION_DIALOG"
@@ -276,7 +277,9 @@ class ExplorationActivityPresenter @Inject constructor(
 
   /** Deletes the saved progress for the current exploration and then stops the exploration. */
   fun deleteCurrentProgressAndStopExploration(isCompletion: Boolean) {
-    explorationDataController.deleteExplorationProgressById(profileId, explorationId)
+    explorationDataController.deleteExplorationProgressById(
+      profileId.toProfileIdPreservingZero(), explorationId
+    )
     stopExploration(isCompletion)
   }
 
@@ -287,7 +290,7 @@ class ExplorationActivityPresenter @Inject constructor(
     // without deleting any checkpoints.
     if (::oldestCheckpointExplorationId.isInitialized) {
       explorationDataController.deleteExplorationProgressById(
-        profileId,
+        profileId.toProfileIdPreservingZero(),
         oldestCheckpointExplorationId
       )
     }
@@ -504,7 +507,7 @@ class ExplorationActivityPresenter @Inject constructor(
    */
   private fun subscribeToOldestSavedExplorationDetails() {
     explorationDataController.getOldestExplorationDetailsDataProvider(
-      profileId
+      profileId.toProfileIdPreservingZero()
     ).toLiveData().observe(activity) {
       when (it) {
         is AsyncResult.Success -> {

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationFragment.kt
@@ -11,6 +11,7 @@ import org.oppia.android.app.model.ExplorationFragmentArguments
 import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.ReadingTextSize
 import org.oppia.android.util.extensions.putProto
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** Fragment that contains displays single exploration. */
@@ -29,7 +30,7 @@ class ExplorationFragment : InjectableFragment() {
       readingTextSize: ReadingTextSize
     ): ExplorationFragment {
       val args = ExplorationFragmentArguments.newBuilder().apply {
-        this.profileId = profileId
+        this.profileId = profileId.toProfileIdPreservingZero()
         this.classroomId = classroomId
         this.topicId = topicId
         this.storyId = storyId

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationFragmentPresenter.kt
@@ -28,7 +28,6 @@ import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.extensions.putProto
-import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [ExplorationFragment]. */
@@ -72,7 +71,7 @@ class ExplorationFragmentPresenter @Inject constructor(
   /** Handles the [Fragment.onViewCreated] portion of [ExplorationFragment]'s lifecycle. */
   fun handleViewCreated() {
     val profileDataProvider = profileManagementController.getProfile(
-      retrieveArguments().profileId.toProfileIdPreservingZero()
+      retrieveArguments().profileId
     )
     profileDataProvider.toLiveData().observe(
       fragment

--- a/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
@@ -55,6 +55,7 @@ import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.gcsresource.DefaultResourceBucketName
 import org.oppia.android.util.parser.html.ExplorationHtmlParserEntityType
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.system.OppiaClock
 import javax.inject.Inject
 
@@ -493,7 +494,7 @@ class StateFragmentPresenter @Inject constructor(
 
   private fun markExplorationCompleted() {
     val markStoryCompletedLivedata = storyProgressController.recordCompletedChapter(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       topicId,
       storyId,
       explorationId,

--- a/app/src/main/java/org/oppia/android/app/player/state/StateViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateViewModel.kt
@@ -131,7 +131,7 @@ class StateViewModel @Inject constructor(
     }.build()
     val updateResultProvider =
       explorationProgressController.updateWrittenTranslationContentLanguageMidLesson(
-        profileId, languageSelection
+        profileId.toProfileIdPreservingZero(), languageSelection
       )
     val updateResultLiveData = updateResultProvider.toLiveData()
     updateResultLiveData.observe(

--- a/app/src/main/java/org/oppia/android/app/player/state/testing/StateFragmentTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/testing/StateFragmentTestActivityPresenter.kt
@@ -34,8 +34,8 @@ class StateFragmentTestActivityPresenter @Inject constructor(
   private val stateFragmentTestViewModel: StateFragmentTestViewModel
 ) {
 
-  private var profileId: Int = 1
-  private val profileIdProto get() = ProfileId.newBuilder().setInternalId(profileId).build()
+  private var internalProfileId: Int = 1
+  private val profileId get() = ProfileId.newBuilder().setInternalId(internalProfileId).build()
   private lateinit var classroomId: String
   private lateinit var topicId: String
   private lateinit var storyId: String
@@ -56,7 +56,7 @@ class StateFragmentTestActivityPresenter @Inject constructor(
       STATE_FRAGMENT_TEST_ACTIVITY_PARAMS_KEY,
       StateFragmentTestActivityParams.getDefaultInstance()
     )
-    profileId = args?.internalProfileId ?: 1
+    internalProfileId = args?.internalProfileId ?: 1
     classroomId = args?.classroomId ?: TEST_CLASSROOM_ID_0
     topicId =
       args?.topicId ?: TEST_TOPIC_ID_0
@@ -68,7 +68,7 @@ class StateFragmentTestActivityPresenter @Inject constructor(
     shouldSavePartialProgress = args?.shouldSavePartialProgress ?: false
     activity.findViewById<Button>(R.id.play_test_exploration_button)?.setOnClickListener {
       startPlayingExploration(
-        profileId,
+        internalProfileId,
         classroomId,
         topicId,
         storyId,
@@ -88,14 +88,14 @@ class StateFragmentTestActivityPresenter @Inject constructor(
 
   fun deleteCurrentProgressAndStopExploration(isCompletion: Boolean) {
     explorationDataController.deleteExplorationProgressById(
-      profileIdProto,
+      profileId,
       explorationId
     )
     stopExploration(isCompletion)
   }
 
   private fun startPlayingExploration(
-    profileId: Int,
+    internalProfileId: Int,
     classroomId: String,
     topicId: String,
     storyId: String,
@@ -107,12 +107,12 @@ class StateFragmentTestActivityPresenter @Inject constructor(
     explorationDataController.stopPlayingExploration(isCompletion = false)
     val startPlayingProvider = if (shouldSavePartialProgress) {
       explorationDataController.startPlayingNewExploration(
-        profileIdProto,
+        this.profileId,
         classroomId, topicId, storyId, explorationId
       )
     } else {
       explorationDataController.replayExploration(
-        profileIdProto,
+        this.profileId,
         classroomId, topicId, storyId, explorationId
       )
     }
@@ -125,7 +125,7 @@ class StateFragmentTestActivityPresenter @Inject constructor(
             oppiaLogger.e(TEST_ACTIVITY_TAG, "Failed to load exploration", result.error)
           is AsyncResult.Success -> {
             oppiaLogger.d(TEST_ACTIVITY_TAG, "Successfully loaded exploration")
-            initializeExploration(profileId, topicId, storyId, explorationId)
+            initializeExploration(internalProfileId, topicId, storyId, explorationId)
           }
         }
       }
@@ -137,14 +137,16 @@ class StateFragmentTestActivityPresenter @Inject constructor(
    * session is fully started).
    */
   private fun initializeExploration(
-    profileId: Int,
+    internalProfileId: Int,
     topicId: String,
     storyId: String,
     explorationId: String
   ) {
     stateFragmentTestViewModel.hasExplorationStarted.set(true)
 
-    val stateFragment = StateFragment.newInstance(profileId, topicId, storyId, explorationId)
+    val stateFragment = StateFragment.newInstance(
+      internalProfileId, topicId, storyId, explorationId
+    )
     activity.supportFragmentManager.beginTransaction().add(
       R.id.state_fragment_placeholder,
       stateFragment

--- a/app/src/main/java/org/oppia/android/app/player/state/testing/StateFragmentTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/testing/StateFragmentTestActivityPresenter.kt
@@ -5,7 +5,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import org.oppia.android.app.activity.ActivityScope
 import org.oppia.android.app.databinding.databinding.StateFragmentTestActivityBinding
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.StateFragmentTestActivityParams
 import org.oppia.android.app.player.exploration.HintsAndSolutionExplorationManagerFragment
 import org.oppia.android.app.player.exploration.TAG_HINTS_AND_SOLUTION_EXPLORATION_MANAGER
@@ -87,7 +87,7 @@ class StateFragmentTestActivityPresenter @Inject constructor(
 
   fun deleteCurrentProgressAndStopExploration(isCompletion: Boolean) {
     explorationDataController.deleteExplorationProgressById(
-      LegacyProfileId.newBuilder().setInternalId(profileId).build(),
+      ProfileId.newBuilder().setInternalId(profileId).build(),
       explorationId
     )
     stopExploration(isCompletion)
@@ -106,11 +106,13 @@ class StateFragmentTestActivityPresenter @Inject constructor(
     explorationDataController.stopPlayingExploration(isCompletion = false)
     val startPlayingProvider = if (shouldSavePartialProgress) {
       explorationDataController.startPlayingNewExploration(
-        profileId, classroomId, topicId, storyId, explorationId
+        ProfileId.newBuilder().setInternalId(profileId).build(),
+        classroomId, topicId, storyId, explorationId
       )
     } else {
       explorationDataController.replayExploration(
-        profileId, classroomId, topicId, storyId, explorationId
+        ProfileId.newBuilder().setInternalId(profileId).build(),
+        classroomId, topicId, storyId, explorationId
       )
     }
     startPlayingProvider.toLiveData().observe(

--- a/app/src/main/java/org/oppia/android/app/player/state/testing/StateFragmentTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/testing/StateFragmentTestActivityPresenter.kt
@@ -35,6 +35,7 @@ class StateFragmentTestActivityPresenter @Inject constructor(
 ) {
 
   private var profileId: Int = 1
+  private val profileIdProto get() = ProfileId.newBuilder().setInternalId(profileId).build()
   private lateinit var classroomId: String
   private lateinit var topicId: String
   private lateinit var storyId: String
@@ -87,7 +88,7 @@ class StateFragmentTestActivityPresenter @Inject constructor(
 
   fun deleteCurrentProgressAndStopExploration(isCompletion: Boolean) {
     explorationDataController.deleteExplorationProgressById(
-      ProfileId.newBuilder().setInternalId(profileId).build(),
+      profileIdProto,
       explorationId
     )
     stopExploration(isCompletion)
@@ -106,12 +107,12 @@ class StateFragmentTestActivityPresenter @Inject constructor(
     explorationDataController.stopPlayingExploration(isCompletion = false)
     val startPlayingProvider = if (shouldSavePartialProgress) {
       explorationDataController.startPlayingNewExploration(
-        ProfileId.newBuilder().setInternalId(profileId).build(),
+        profileIdProto,
         classroomId, topicId, storyId, explorationId
       )
     } else {
       explorationDataController.replayExploration(
-        ProfileId.newBuilder().setInternalId(profileId).build(),
+        profileIdProto,
         classroomId, topicId, storyId, explorationId
       )
     }

--- a/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonActivity.kt
@@ -18,6 +18,8 @@ import org.oppia.android.app.player.exploration.ExplorationActivity
 import org.oppia.android.util.extensions.getProtoExtra
 import org.oppia.android.util.extensions.putProtoExtra
 import org.oppia.android.util.logging.CurrentAppScreenNameIntentDecorator.decorateWithScreenName
+import org.oppia.android.util.profile.toLegacyProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** Activity that allows the user to resume a saved exploration. */
@@ -34,7 +36,7 @@ class ResumeLessonActivity :
 
     val params = intent.getProtoExtra(PARAMS_KEY, ResumeLessonActivityParams.getDefaultInstance())
     resumeLessonActivityPresenter.handleOnCreate(
-      params.profileId,
+      params.profileId.toLegacyProfileId(),
       params.classroomId,
       params.topicId,
       params.storyId,
@@ -72,7 +74,7 @@ class ResumeLessonActivity :
       checkpoint: ExplorationCheckpoint
     ): Intent {
       val params = ResumeLessonActivityParams.newBuilder().apply {
-        this.profileId = profileId
+        this.profileId = profileId.toProfileIdPreservingZero()
         this.classroomId = classroomId
         this.topicId = topicId
         this.storyId = storyId

--- a/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonActivity.kt
@@ -18,8 +18,6 @@ import org.oppia.android.app.player.exploration.ExplorationActivity
 import org.oppia.android.util.extensions.getProtoExtra
 import org.oppia.android.util.extensions.putProtoExtra
 import org.oppia.android.util.logging.CurrentAppScreenNameIntentDecorator.decorateWithScreenName
-import org.oppia.android.util.profile.toLegacyProfileId
-import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** Activity that allows the user to resume a saved exploration. */
@@ -36,7 +34,7 @@ class ResumeLessonActivity :
 
     val params = intent.getProtoExtra(PARAMS_KEY, ResumeLessonActivityParams.getDefaultInstance())
     resumeLessonActivityPresenter.handleOnCreate(
-      params.profileId.toLegacyProfileId(),
+      params.profileId,
       params.classroomId,
       params.topicId,
       params.storyId,
@@ -74,7 +72,7 @@ class ResumeLessonActivity :
       checkpoint: ExplorationCheckpoint
     ): Intent {
       val params = ResumeLessonActivityParams.newBuilder().apply {
-        this.profileId = profileId.toProfileIdPreservingZero()
+        this.profileId = profileId
         this.classroomId = classroomId
         this.topicId = topicId
         this.storyId = storyId

--- a/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonActivityPresenter.kt
@@ -85,7 +85,7 @@ class ResumeLessonActivityPresenter @Inject constructor(
         .remove(getResumeLessonFragment() as Fragment).commitNow()
 
     val resumeLessonFragment = ResumeLessonFragment.newInstance(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       classroomId,
       topicId,
       storyId,

--- a/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonFragment.kt
@@ -9,13 +9,11 @@ import org.oppia.android.app.fragment.FragmentComponentImpl
 import org.oppia.android.app.fragment.InjectableFragment
 import org.oppia.android.app.model.ExplorationActivityParams
 import org.oppia.android.app.model.ExplorationCheckpoint
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.ReadingTextSize
 import org.oppia.android.app.model.ResumeLessonFragmentArguments
 import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.extensions.putProto
-import org.oppia.android.util.profile.toLegacyProfileId
-import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** Fragment that allows the user to resume a saved exploration. */
@@ -27,7 +25,7 @@ class ResumeLessonFragment : InjectableFragment() {
 
     /** Creates new instance of [ResumeLessonFragment] for the provided parameters. */
     fun newInstance(
-      profileId: LegacyProfileId,
+      profileId: ProfileId,
       classroomId: String,
       topicId: String,
       storyId: String,
@@ -37,7 +35,7 @@ class ResumeLessonFragment : InjectableFragment() {
       readingTextSize: ReadingTextSize
     ): ResumeLessonFragment {
       val args = ResumeLessonFragmentArguments.newBuilder().apply {
-        this.profileId = profileId.toProfileIdPreservingZero()
+        this.profileId = profileId
         this.classroomId = classroomId
         this.topicId = topicId
         this.storyId = storyId
@@ -77,7 +75,7 @@ class ResumeLessonFragment : InjectableFragment() {
     return resumeLessonFragmentPresenter.handleOnCreate(
       inflater,
       container,
-      args.profileId.toLegacyProfileId(),
+      args.profileId,
       args.classroomId,
       args.topicId,
       args.storyId,

--- a/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonFragment.kt
@@ -14,6 +14,8 @@ import org.oppia.android.app.model.ReadingTextSize
 import org.oppia.android.app.model.ResumeLessonFragmentArguments
 import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.extensions.putProto
+import org.oppia.android.util.profile.toLegacyProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** Fragment that allows the user to resume a saved exploration. */
@@ -35,7 +37,7 @@ class ResumeLessonFragment : InjectableFragment() {
       readingTextSize: ReadingTextSize
     ): ResumeLessonFragment {
       val args = ResumeLessonFragmentArguments.newBuilder().apply {
-        this.profileId = profileId
+        this.profileId = profileId.toProfileIdPreservingZero()
         this.classroomId = classroomId
         this.topicId = topicId
         this.storyId = storyId
@@ -75,7 +77,7 @@ class ResumeLessonFragment : InjectableFragment() {
     return resumeLessonFragmentPresenter.handleOnCreate(
       inflater,
       container,
-      args.profileId,
+      args.profileId.toLegacyProfileId(),
       args.classroomId,
       args.topicId,
       args.storyId,

--- a/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonFragmentPresenter.kt
@@ -26,6 +26,7 @@ import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.gcsresource.DefaultResourceBucketName
 import org.oppia.android.util.parser.html.HtmlParser
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [ResumeLessonFragment]. */
@@ -198,11 +199,16 @@ class ResumeLessonFragmentPresenter @Inject constructor(
   ) {
     val startPlayingProvider = if (checkpoint == ExplorationCheckpoint.getDefaultInstance()) {
       explorationDataController.restartExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
       )
     } else {
       explorationDataController.resumeExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId, checkpoint
+        profileId.toProfileIdPreservingZero(),
+        classroomId,
+        topicId,
+        storyId,
+        explorationId,
+        checkpoint
       )
     }
     startPlayingProvider.toLiveData().observe(fragment) { result ->

--- a/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/resumelesson/ResumeLessonFragmentPresenter.kt
@@ -13,7 +13,7 @@ import org.oppia.android.app.home.RouteToExplorationListener
 import org.oppia.android.app.model.EphemeralChapterSummary
 import org.oppia.android.app.model.ExplorationActivityParams
 import org.oppia.android.app.model.ExplorationCheckpoint
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.ResumeLessonFragmentArguments
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.utility.FontScaleConfigurationUtil
@@ -26,7 +26,7 @@ import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.extensions.getProto
 import org.oppia.android.util.gcsresource.DefaultResourceBucketName
 import org.oppia.android.util.parser.html.HtmlParser
-import org.oppia.android.util.profile.toProfileIdPreservingZero
+import org.oppia.android.util.profile.toLegacyProfileId
 import javax.inject.Inject
 
 /** The presenter for [ResumeLessonFragment]. */
@@ -47,14 +47,16 @@ class ResumeLessonFragmentPresenter @Inject constructor(
   private val routeToExplorationListener = activity as RouteToExplorationListener
 
   private lateinit var binding: ResumeLessonFragmentBinding
-  private lateinit var profileId: LegacyProfileId
+  private lateinit var profileId: ProfileId
   private lateinit var classroomId: String
   private lateinit var topicId: String
   private lateinit var storyId: String
   private lateinit var explorationId: String
 
   private val chapterSummaryResultLiveData: LiveData<AsyncResult<EphemeralChapterSummary>> by lazy {
-    topicController.retrieveChapter(profileId, topicId, storyId, explorationId).toLiveData()
+    topicController.retrieveChapter(
+      profileId.toLegacyProfileId(), topicId, storyId, explorationId
+    ).toLiveData()
   }
 
   private val chapterSummaryLiveData: LiveData<EphemeralChapterSummary> by lazy {
@@ -70,7 +72,7 @@ class ResumeLessonFragmentPresenter @Inject constructor(
   fun handleOnCreate(
     inflater: LayoutInflater,
     container: ViewGroup?,
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
@@ -189,7 +191,7 @@ class ResumeLessonFragmentPresenter @Inject constructor(
   }
 
   private fun playExploration(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
@@ -199,11 +201,11 @@ class ResumeLessonFragmentPresenter @Inject constructor(
   ) {
     val startPlayingProvider = if (checkpoint == ExplorationCheckpoint.getDefaultInstance()) {
       explorationDataController.restartExploration(
-        profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
+        profileId, classroomId, topicId, storyId, explorationId
       )
     } else {
       explorationDataController.resumeExploration(
-        profileId.toProfileIdPreservingZero(),
+        profileId,
         classroomId,
         topicId,
         storyId,
@@ -219,7 +221,7 @@ class ResumeLessonFragmentPresenter @Inject constructor(
         is AsyncResult.Success -> {
           oppiaLogger.d("ResumeLessonFragment", "Successfully loaded exploration")
           routeToExplorationListener.routeToExploration(
-            profileId,
+            profileId.toLegacyProfileId(),
             classroomId,
             topicId,
             storyId,

--- a/app/src/main/java/org/oppia/android/app/story/StoryFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/story/StoryFragmentPresenter.kt
@@ -41,6 +41,7 @@ import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.gcsresource.DefaultResourceBucketName
 import org.oppia.android.util.parser.html.HtmlParser
 import org.oppia.android.util.parser.html.TopicHtmlParserEntityType
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [StoryFragment]. */

--- a/app/src/main/java/org/oppia/android/app/story/StoryFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/story/StoryFragmentPresenter.kt
@@ -272,7 +272,7 @@ class StoryFragmentPresenter @Inject constructor(
     // one.
     val startPlayingProvider = if (canHavePartialProgressSaved) {
       explorationDataController.startPlayingNewExploration(
-        profileId.internalId,
+        profileId.toProfileIdPreservingZero(),
         classroomId,
         topicId,
         storyId,
@@ -280,7 +280,7 @@ class StoryFragmentPresenter @Inject constructor(
       )
     } else {
       explorationDataController.replayExploration(
-        profileId.internalId,
+        profileId.toProfileIdPreservingZero(),
         classroomId,
         topicId,
         storyId,

--- a/app/src/main/java/org/oppia/android/app/story/storyitemviewmodel/StoryChapterSummaryViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/story/storyitemviewmodel/StoryChapterSummaryViewModel.kt
@@ -15,6 +15,7 @@ import org.oppia.android.domain.exploration.lightweightcheckpointing.Exploration
 import org.oppia.android.domain.translation.TranslationController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 
 /** Chapter summary view model for the recycler view in [StoryFragment]. */
 class StoryChapterSummaryViewModel(
@@ -63,9 +64,7 @@ class StoryChapterSummaryViewModel(
     if (chapterPlayState == ChapterPlayState.IN_PROGRESS_SAVED) {
       val explorationCheckpointLiveData =
         explorationCheckpointController.retrieveExplorationCheckpoint(
-          LegacyProfileId.newBuilder().apply {
-            internalId = internalProfileId
-          }.build(),
+          profileId.toProfileIdPreservingZero(),
           explorationId
         ).toLiveData()
 

--- a/app/src/main/java/org/oppia/android/app/testing/ExplorationTestActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/testing/ExplorationTestActivityPresenter.kt
@@ -10,6 +10,7 @@ import org.oppia.android.app.fragment.InjectableFragment
 import org.oppia.android.app.home.RouteToExplorationListener
 import org.oppia.android.app.model.ExplorationActivityParams
 import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.ui.R
 import org.oppia.android.app.utility.SplitScreenManager
 import org.oppia.android.domain.classroom.TEST_CLASSROOM_ID_0
@@ -53,7 +54,7 @@ class ExplorationTestActivityPresenter @Inject constructor(
   private fun playExplorationButton() {
     explorationDataController.stopPlayingExploration(isCompletion = false)
     explorationDataController.replayExploration(
-      INTERNAL_PROFILE_ID,
+      ProfileId.newBuilder().setInternalId(INTERNAL_PROFILE_ID).build(),
       CLASSROOM_ID,
       TOPIC_ID,
       STORY_ID,

--- a/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
@@ -31,6 +31,7 @@ import org.oppia.android.util.accessibility.AccessibilityService
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
 import org.oppia.android.util.enumfilter.filterByEnumCondition
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 /** The presenter for [TopicLessonsFragment]. */
@@ -369,21 +370,21 @@ class TopicLessonsFragmentPresenter @Inject constructor(
       !canHavePartialProgressSaved -> {
         // Only explorations that have been completed can't be saved, so replay the lesson.
         explorationDataController.replayExploration(
-          profileId.internalId, classroomId, topicId, storyId, explorationId
+          profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
         )
       }
       hadProgress -> {
         // If there was progress, either the checkpoint was never saved, failed to save, or failed
         // to be retrieved. In all cases, this is a restart.
         explorationDataController.restartExploration(
-          profileId.internalId, classroomId, topicId, storyId, explorationId
+          profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
         )
       }
       else -> {
         // If there's no progress and it was never completed, then it's a new play through (or the
         // user is very low on device memory).
         explorationDataController.startPlayingNewExploration(
-          profileId.internalId, classroomId, topicId, storyId, explorationId
+          profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
         )
       }
     }

--- a/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
@@ -299,7 +299,7 @@ class TopicLessonsFragmentPresenter @Inject constructor(
       ChapterPlayState.IN_PROGRESS_SAVED -> {
         val explorationCheckpointLiveData =
           explorationCheckpointController.retrieveExplorationCheckpoint(
-            profileId, explorationId
+            profileId.toProfileIdPreservingZero(), explorationId
           ).toLiveData()
         explorationCheckpointLiveData.observe(
           fragment,

--- a/app/src/sharedTest/java/org/oppia/android/app/devoptions/markchapterscompleted/MarkChaptersCompletedFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/devoptions/markchapterscompleted/MarkChaptersCompletedFragmentTest.kt
@@ -108,6 +108,7 @@ import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.parser.html.HtmlParserEntityTypeModule
 import org.oppia.android.util.parser.image.GlideImageLoaderModule
 import org.oppia.android.util.parser.image.ImageParsingModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -1054,7 +1055,7 @@ class MarkChaptersCompletedFragmentTest {
   ): ChapterPlayState {
     val playStateProvider =
       storyProgressController.retrieveChapterPlayStateByExplorationId(
-        profileId, topicId, storyId, expId
+        profileId.toProfileIdPreservingZero(), topicId, storyId, expId
       )
     return monitorFactory.waitForNextSuccessfulResult(playStateProvider)
   }

--- a/app/src/sharedTest/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedActivityTest.kt
@@ -315,7 +315,7 @@ class RecentlyPlayedActivityTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = ProfileId.newBuilder().apply { internalId = internalProfileId }.build()
+        profileId = LegacyProfileId.newBuilder().setInternalId(internalProfileId).build()
         parentScreen = ExplorationActivityParams.ParentScreen.PARENT_SCREEN_UNSPECIFIED
         checkpoint = ExplorationCheckpoint.newBuilder().apply {
           explorationTitle = "What is a Fraction?"

--- a/app/src/sharedTest/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/home/recentlyplayed/RecentlyPlayedActivityTest.kt
@@ -43,6 +43,7 @@ import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.model.ExplorationActivityParams
 import org.oppia.android.app.model.ExplorationCheckpoint
 import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.RecentlyPlayedActivityParams
 import org.oppia.android.app.model.RecentlyPlayedActivityTitle
 import org.oppia.android.app.model.RecentlyPlayedActivityTitle.RECENTLY_PLAYED_STORIES
@@ -314,7 +315,7 @@ class RecentlyPlayedActivityTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = LegacyProfileId.newBuilder().apply { internalId = internalProfileId }.build()
+        profileId = ProfileId.newBuilder().apply { internalId = internalProfileId }.build()
         parentScreen = ExplorationActivityParams.ParentScreen.PARENT_SCREEN_UNSPECIFIED
         checkpoint = ExplorationCheckpoint.newBuilder().apply {
           explorationTitle = "What is a Fraction?"
@@ -367,7 +368,7 @@ class RecentlyPlayedActivityTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = LegacyProfileId.newBuilder().apply { internalId = internalProfileId }.build()
+        profileId = ProfileId.newBuilder().apply { internalId = internalProfileId }.build()
         isCheckpointingEnabled = true
         parentScreen = ExplorationActivityParams.ParentScreen.PARENT_SCREEN_UNSPECIFIED
       }.build()
@@ -402,7 +403,7 @@ class RecentlyPlayedActivityTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = LegacyProfileId.newBuilder().apply { internalId = internalProfileId }.build()
+        profileId = ProfileId.newBuilder().apply { internalId = internalProfileId }.build()
         isCheckpointingEnabled = true
         parentScreen = ExplorationActivityParams.ParentScreen.PARENT_SCREEN_UNSPECIFIED
       }.build()
@@ -442,7 +443,7 @@ class RecentlyPlayedActivityTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = LegacyProfileId.newBuilder().apply { internalId = internalProfileId }.build()
+        profileId = ProfileId.newBuilder().apply { internalId = internalProfileId }.build()
         isCheckpointingEnabled = true
         parentScreen = ExplorationActivityParams.ParentScreen.PARENT_SCREEN_UNSPECIFIED
       }.build()

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -71,6 +71,7 @@ import org.oppia.android.app.model.HelpActivityParams
 import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.model.OptionsActivityParams
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.ScreenName
 import org.oppia.android.app.model.Spotlight
 import org.oppia.android.app.model.WrittenTranslationLanguageSelection
@@ -1539,7 +1540,7 @@ class ExplorationActivityTest {
       shouldSavePartialProgress = false
     ) {
       explorationDataController.replayExploration(
-        internalProfileId,
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         TEST_CLASSROOM_ID_1,
         FRACTIONS_TOPIC_ID,
         FRACTIONS_STORY_ID_0,
@@ -1569,7 +1570,7 @@ class ExplorationActivityTest {
       shouldSavePartialProgress = false
     ) {
       explorationDataController.replayExploration(
-        internalProfileId,
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         TEST_CLASSROOM_ID_1,
         FRACTIONS_TOPIC_ID,
         FRACTIONS_STORY_ID_0,
@@ -2308,7 +2309,8 @@ class ExplorationActivityTest {
       classroomId, topicId, storyId, explorationId, shouldSavePartialProgress
     ) {
       explorationDataController.startPlayingNewExploration(
-        internalProfileId, classroomId, topicId, storyId, explorationId
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
+        classroomId, topicId, storyId, explorationId
       )
       testCoroutineDispatchers.runCurrent()
       testBlock()

--- a/app/src/sharedTest/java/org/oppia/android/app/resumelesson/ResumeLessonFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/resumelesson/ResumeLessonFragmentTest.kt
@@ -38,6 +38,7 @@ import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.model.ExplorationActivityParams
 import org.oppia.android.app.model.ExplorationCheckpoint
 import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.ReadingTextSize
 import org.oppia.android.app.model.ResumeLessonFragmentArguments
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
@@ -283,7 +284,7 @@ class ResumeLessonFragmentTest {
         val receivedCheckpoint = args.checkpoint
 
         assertThat(receivedProfileId)
-          .isEqualTo(LegacyProfileId.newBuilder().apply { internalId = 1 }.build())
+          .isEqualTo(ProfileId.newBuilder().setInternalId(1).build())
         assertThat(receivedClassroomId).isEqualTo(TEST_CLASSROOM_ID_1)
         assertThat(receivedTopicId).isEqualTo(FRACTIONS_TOPIC_ID)
         assertThat(receivedStoryId).isEqualTo(FRACTIONS_STORY_ID_0)

--- a/app/src/sharedTest/java/org/oppia/android/app/story/StoryActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/story/StoryActivityTest.kt
@@ -36,7 +36,6 @@ import org.oppia.android.app.application.testing.TestingBuildFlavorModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.model.ExplorationActivityParams
-import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.ScreenName
 import org.oppia.android.app.player.exploration.ExplorationActivity

--- a/app/src/sharedTest/java/org/oppia/android/app/story/StoryActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/story/StoryActivityTest.kt
@@ -37,6 +37,7 @@ import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.model.ExplorationActivityParams
 import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.ScreenName
 import org.oppia.android.app.player.exploration.ExplorationActivity
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
@@ -196,7 +197,7 @@ class StoryActivityTest {
         storyId = TEST_STORY_ID_0
         topicId = TEST_TOPIC_ID_0
         classroomId = TEST_CLASSROOM_ID_0
-        profileId = LegacyProfileId.newBuilder().apply { internalId = internalProfileId }.build()
+        profileId = ProfileId.newBuilder().apply { internalId = internalProfileId }.build()
         parentScreen = ExplorationActivityParams.ParentScreen.STORY_SCREEN
         isCheckpointingEnabled = true
       }.build()

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
@@ -57,6 +57,7 @@ import org.oppia.android.app.model.Spotlight.FeatureCase.TOPIC_LESSON_TAB
 import org.oppia.android.app.model.Spotlight.FeatureCase.TOPIC_REVISION_TAB
 import org.oppia.android.app.model.StoryActivityParams
 import org.oppia.android.app.model.TopicLessonsFragmentArguments
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.app.player.exploration.ExplorationActivity
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPosition
@@ -741,7 +742,7 @@ class TopicLessonsFragmentTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = profileId
+        profileId = this@TopicLessonsFragmentTest.profileId.toProfileIdPreservingZero()
         parentScreen = ExplorationActivityParams.ParentScreen.TOPIC_SCREEN_LESSONS_TAB
         checkpoint = ExplorationCheckpoint.newBuilder().apply {
           explorationTitle = "What is a Fraction?"
@@ -797,7 +798,7 @@ class TopicLessonsFragmentTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = profileId
+        profileId = this@TopicLessonsFragmentTest.profileId.toProfileIdPreservingZero()
         isCheckpointingEnabled = true
         parentScreen = ExplorationActivityParams.ParentScreen.TOPIC_SCREEN_LESSONS_TAB
       }.build()
@@ -835,7 +836,7 @@ class TopicLessonsFragmentTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = profileId
+        profileId = this@TopicLessonsFragmentTest.profileId.toProfileIdPreservingZero()
         isCheckpointingEnabled = true
         parentScreen = ExplorationActivityParams.ParentScreen.TOPIC_SCREEN_LESSONS_TAB
       }.build()
@@ -878,7 +879,7 @@ class TopicLessonsFragmentTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = profileId
+        profileId = this@TopicLessonsFragmentTest.profileId.toProfileIdPreservingZero()
         isCheckpointingEnabled = true
         parentScreen = ExplorationActivityParams.ParentScreen.TOPIC_SCREEN_LESSONS_TAB
       }.build()
@@ -920,7 +921,7 @@ class TopicLessonsFragmentTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = profileId
+        profileId = this@TopicLessonsFragmentTest.profileId.toProfileIdPreservingZero()
         isCheckpointingEnabled = false
         parentScreen = ExplorationActivityParams.ParentScreen.TOPIC_SCREEN_LESSONS_TAB
       }.build()

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
@@ -742,7 +742,7 @@ class TopicLessonsFragmentTest {
         storyId = FRACTIONS_STORY_ID_0
         topicId = FRACTIONS_TOPIC_ID
         classroomId = TEST_CLASSROOM_ID_1
-        profileId = this@TopicLessonsFragmentTest.profileId.toProfileIdPreservingZero()
+        profileId = this@TopicLessonsFragmentTest.profileId
         parentScreen = ExplorationActivityParams.ParentScreen.TOPIC_SCREEN_LESSONS_TAB
         checkpoint = ExplorationCheckpoint.newBuilder().apply {
           explorationTitle = "What is a Fraction?"

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
@@ -57,7 +57,6 @@ import org.oppia.android.app.model.Spotlight.FeatureCase.TOPIC_LESSON_TAB
 import org.oppia.android.app.model.Spotlight.FeatureCase.TOPIC_REVISION_TAB
 import org.oppia.android.app.model.StoryActivityParams
 import org.oppia.android.app.model.TopicLessonsFragmentArguments
-import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.app.player.exploration.ExplorationActivity
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPosition
@@ -144,6 +143,7 @@ import org.oppia.android.util.platformparameter.EnableTopicInfoTab
 import org.oppia.android.util.platformparameter.EnableTopicPracticeTab
 import org.oppia.android.util.platformparameter.PlatformParameterValue
 import org.oppia.android.util.profile.CurrentUserProfileIdIntentDecorator.extractCurrentUserProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject

--- a/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
@@ -144,6 +144,9 @@ class ExplorationActivityLocalTest {
   private lateinit var networkConnectionUtil: NetworkConnectionUtil
   private lateinit var explorationDataController: ExplorationDataController
   private val internalProfileId: Int = 0
+  private val profileId by lazy {
+    ProfileId.newBuilder().setInternalId(internalProfileId).build()
+  }
   private val afternoonUtcTimestampMillis = 1556101812000
 
   @Before
@@ -213,7 +216,7 @@ class ExplorationActivityLocalTest {
       )
     ).use {
       explorationDataController.startPlayingNewExploration(
-        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -267,7 +270,7 @@ class ExplorationActivityLocalTest {
       )
     ).use {
       explorationDataController.startPlayingNewExploration(
-        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -312,7 +315,7 @@ class ExplorationActivityLocalTest {
       )
     ).use {
       explorationDataController.startPlayingNewExploration(
-        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -378,7 +381,7 @@ class ExplorationActivityLocalTest {
       )
     ).use { scenario ->
       explorationDataController.startPlayingNewExploration(
-        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -437,7 +440,7 @@ class ExplorationActivityLocalTest {
       )
     ).use {
       explorationDataController.startPlayingNewExploration(
-        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -479,8 +482,8 @@ class ExplorationActivityLocalTest {
   }
 
   private fun markSpotlightSeen(feature: Spotlight.FeatureCase) {
-    val profileId = LegacyProfileId.newBuilder().setInternalId(internalProfileId).build()
-    spotlightStateController.markSpotlightViewed(profileId, feature)
+    val legacyProfileId = LegacyProfileId.newBuilder().setInternalId(internalProfileId).build()
+    spotlightStateController.markSpotlightViewed(legacyProfileId, feature)
     testCoroutineDispatchers.runCurrent()
   }
 
@@ -496,7 +499,7 @@ class ExplorationActivityLocalTest {
         networkConnectionUtil = activity.networkConnectionUtil
         explorationDataController = activity.explorationDataController
         explorationDataController.startPlayingNewExploration(
-          ProfileId.newBuilder().setInternalId(internalProfileId).build(),
+          profileId,
           classroomId,
           topicId,
           storyId,

--- a/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
@@ -437,7 +437,7 @@ class ExplorationActivityLocalTest {
       )
     ).use {
       explorationDataController.startPlayingNewExploration(
-        internalProfileId,
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,

--- a/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
@@ -40,6 +40,7 @@ import org.oppia.android.app.model.EventLog
 import org.oppia.android.app.model.EventLog.Context.ActivityContextCase.OPEN_EXPLORATION_ACTIVITY
 import org.oppia.android.app.model.ExplorationActivityParams
 import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.Spotlight
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.shim.IntentFactoryShimModule
@@ -212,7 +213,7 @@ class ExplorationActivityLocalTest {
       )
     ).use {
       explorationDataController.startPlayingNewExploration(
-        internalProfileId,
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -266,7 +267,7 @@ class ExplorationActivityLocalTest {
       )
     ).use {
       explorationDataController.startPlayingNewExploration(
-        internalProfileId,
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -311,7 +312,7 @@ class ExplorationActivityLocalTest {
       )
     ).use {
       explorationDataController.startPlayingNewExploration(
-        internalProfileId,
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -377,7 +378,7 @@ class ExplorationActivityLocalTest {
       )
     ).use { scenario ->
       explorationDataController.startPlayingNewExploration(
-        internalProfileId,
+        ProfileId.newBuilder().setInternalId(internalProfileId).build(),
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -495,7 +496,7 @@ class ExplorationActivityLocalTest {
         networkConnectionUtil = activity.networkConnectionUtil
         explorationDataController = activity.explorationDataController
         explorationDataController.startPlayingNewExploration(
-          internalProfileId,
+          ProfileId.newBuilder().setInternalId(internalProfileId).build(),
           classroomId,
           topicId,
           storyId,

--- a/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
@@ -165,7 +165,6 @@ class ExplorationActivityLocalTest {
   fun testExploration_onLaunch_logsEvent() {
     setUpTestApplicationComponent()
     getApplicationDependencies(
-      internalProfileId,
       TEST_CLASSROOM_ID_0,
       TEST_TOPIC_ID_0,
       TEST_STORY_ID_0,
@@ -198,7 +197,6 @@ class ExplorationActivityLocalTest {
     fakeOppiaClock.setCurrentTimeMs(afternoonUtcTimestampMillis)
 
     getApplicationDependencies(
-      internalProfileId,
       TEST_CLASSROOM_ID_0,
       TEST_TOPIC_ID_0,
       TEST_STORY_ID_0,
@@ -248,7 +246,6 @@ class ExplorationActivityLocalTest {
   fun testExplorationActivity_closeExploration_surveyGatingCriteriaNotMet_noSurveyPopup() {
     setUpTestWithNpsEnabled()
     getApplicationDependencies(
-      internalProfileId,
       TEST_CLASSROOM_ID_0,
       TEST_TOPIC_ID_0,
       TEST_STORY_ID_0,
@@ -297,7 +294,6 @@ class ExplorationActivityLocalTest {
     fakeOppiaClock.setCurrentTimeMs(afternoonUtcTimestampMillis)
 
     getApplicationDependencies(
-      internalProfileId,
       TEST_CLASSROOM_ID_0,
       TEST_TOPIC_ID_0,
       TEST_STORY_ID_0,
@@ -363,7 +359,6 @@ class ExplorationActivityLocalTest {
     fakeOppiaClock.setCurrentTimeMs(afternoonUtcTimestampMillis)
 
     getApplicationDependencies(
-      internalProfileId,
       TEST_CLASSROOM_ID_0,
       TEST_TOPIC_ID_0,
       TEST_STORY_ID_0,
@@ -422,7 +417,6 @@ class ExplorationActivityLocalTest {
     fakeOppiaClock.setCurrentTimeMs(afternoonUtcTimestampMillis)
 
     getApplicationDependencies(
-      internalProfileId,
       TEST_CLASSROOM_ID_0,
       TEST_TOPIC_ID_0,
       TEST_STORY_ID_0,
@@ -488,7 +482,6 @@ class ExplorationActivityLocalTest {
   }
 
   private fun getApplicationDependencies(
-    internalProfileId: Int,
     classroomId: String,
     topicId: String,
     storyId: String,

--- a/domain/src/main/java/org/oppia/android/domain/devoptions/ModifyLessonProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/devoptions/ModifyLessonProgressController.kt
@@ -11,6 +11,7 @@ import org.oppia.android.domain.topic.TopicListController
 import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders.Companion.transform
 import org.oppia.android.util.data.DataProviders.Companion.transformAsync
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.system.OppiaClock
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -102,7 +103,7 @@ class ModifyLessonProgressController @Inject constructor(
       topic.storyList.forEach { storySummary ->
         storySummary.chapterList.forEach { chapterSummary ->
           storyProgressController.recordCompletedChapter(
-            profileId = profileId,
+            profileId = profileId.toProfileIdPreservingZero(),
             topicId = topic.topicId,
             storyId = storySummary.storyId,
             explorationId = chapterSummary.explorationId,
@@ -125,7 +126,7 @@ class ModifyLessonProgressController @Inject constructor(
       val storySummary = topicController.retrieveStory(topicId = it.value, storyId = it.key)
       storySummary.chapterList.forEach { chapterSummary ->
         storyProgressController.recordCompletedChapter(
-          profileId = profileId,
+          profileId = profileId.toProfileIdPreservingZero(),
           topicId = it.value,
           storyId = storySummary.storyId,
           explorationId = chapterSummary.explorationId,
@@ -148,7 +149,7 @@ class ModifyLessonProgressController @Inject constructor(
   ) {
     chapterMap.forEach {
       storyProgressController.recordCompletedChapter(
-        profileId = profileId,
+        profileId = profileId.toProfileIdPreservingZero(),
         topicId = it.value.second,
         storyId = it.value.first,
         explorationId = it.key,

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationActiveTimeController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationActiveTimeController.kt
@@ -22,6 +22,7 @@ import org.oppia.android.util.data.DataProviders
 import org.oppia.android.util.data.DataProviders.Companion.transform
 import org.oppia.android.util.platformparameter.EnableNpsSurvey
 import org.oppia.android.util.platformparameter.PlatformParameterValue
+import org.oppia.android.util.profile.toLegacyProfileId
 import org.oppia.android.util.system.OppiaClock
 import org.oppia.android.util.threading.BackgroundDispatcher
 import java.util.UUID
@@ -535,7 +536,7 @@ class ExplorationActiveTimeController @Inject constructor(
       cacheStoreFactory.createPerProfile(
         CACHE_NAME,
         TopicLearningTimeDatabase.getDefaultInstance(),
-        profileId
+        profileId.toLegacyProfileId()
       ).also { cacheStore ->
         cacheStore.primeInMemoryAndDiskCacheAsync(
           updateMode = PersistentCacheStore.UpdateMode.UPDATE_IF_NEW_CACHE,

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationActiveTimeController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationActiveTimeController.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.TopicLearningTime
 import org.oppia.android.app.model.TopicLearningTimeDatabase
 import org.oppia.android.data.persistence.PersistentCacheStore
@@ -82,9 +82,9 @@ class ExplorationActiveTimeController @Inject constructor(
   }
 
   private val cacheStoreMap =
-    mutableMapOf<LegacyProfileId, PersistentCacheStore<TopicLearningTimeDatabase>>()
+    mutableMapOf<ProfileId, PersistentCacheStore<TopicLearningTimeDatabase>>()
 
-  override fun onExplorationStarted(profileId: LegacyProfileId, topicId: String) {
+  override fun onExplorationStarted(profileId: ProfileId, topicId: String) {
     this.explorationStarted = true
     if (enableNpsSurvey.value) {
       startSessionTimer(
@@ -133,7 +133,7 @@ class ExplorationActiveTimeController @Inject constructor(
   private fun startSessionTimer(
     isAppInForeground: Boolean,
     explorationStarted: Boolean,
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String
   ): DataProvider<Any?> {
     val sessionId = UUID.randomUUID().toString().also {
@@ -286,7 +286,7 @@ class ExplorationActiveTimeController @Inject constructor(
     beginTimerResultFlow: MutableStateFlow<AsyncResult<Any?>>,
     isAppInForeground: Boolean,
     isExplorationStarted: Boolean,
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
   ) {
     tryOperation(beginTimerResultFlow) {
@@ -394,7 +394,7 @@ class ExplorationActiveTimeController @Inject constructor(
     data class InitializeController(
       val isAppInForeground: Boolean,
       val isExplorationStarted: Boolean,
-      val profileId: LegacyProfileId,
+      val profileId: ProfileId,
       val topicId: String,
       override val sessionId: String,
       override val callbackFlow: MutableStateFlow<AsyncResult<Any?>>
@@ -473,7 +473,7 @@ class ExplorationActiveTimeController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this record operation
    */
   private fun recordAggregateTopicLearningTime(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     sessionDuration: Long
   ): DataProvider<Any?> {
@@ -510,7 +510,7 @@ class ExplorationActiveTimeController @Inject constructor(
 
   /** Returns the [TopicLearningTime] [DataProvider] for a specific topicId, per-profile basis. */
   fun retrieveAggregateTopicLearningTimeDataProvider(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String
   ): DataProvider<TopicLearningTime> {
     return retrieveCacheStore(profileId)
@@ -529,7 +529,7 @@ class ExplorationActiveTimeController @Inject constructor(
   }
 
   private fun retrieveCacheStore(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): PersistentCacheStore<TopicLearningTimeDatabase> {
     return cacheStoreMap.getOrPut(profileId) {
       cacheStoreFactory.createPerProfile(

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
@@ -95,7 +95,7 @@ class ExplorationDataController @Inject constructor(
 
   /**
    * Resumes the specified exploration indicated by [topicId], [storyId], and [explorationId] for
-   * the user corresponding to [internalProfileId] by restoring the provided
+   * the user corresponding to [profileId] by restoring the provided
    * [explorationCheckpoint], and returns a [DataProvider] tracking whether the start succeeded.
    *
    * This method behaves the same as [startPlayingNewExploration] except it resumes a previous

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
@@ -3,7 +3,7 @@ package org.oppia.android.domain.exploration
 import org.oppia.android.app.model.EphemeralExploration
 import org.oppia.android.app.model.Exploration
 import org.oppia.android.app.model.ExplorationCheckpoint
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.domain.exploration.lightweightcheckpointing.ExplorationCheckpointController
 import org.oppia.android.domain.oppialogger.exceptions.ExceptionsController
 import org.oppia.android.domain.translation.TranslationController
@@ -12,7 +12,6 @@ import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders
 import org.oppia.android.util.data.DataProviders.Companion.combineWith
 import org.oppia.android.util.locale.OppiaLocale
-import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
 private const val GET_EXPLORATION_BY_ID_PROVIDER_ID = "get_exploration_by_id_provider_id"
@@ -37,13 +36,11 @@ class ExplorationDataController @Inject constructor(
 ) {
   /** Returns an [EphemeralExploration] given an ID. */
   fun getExplorationById(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     id: String
   ): DataProvider<EphemeralExploration> {
     val translationLocaleProvider =
-      translationController.getWrittenTranslationContentLocale(
-        profileId.toProfileIdPreservingZero()
-      )
+      translationController.getWrittenTranslationContentLocale(profileId)
     val explorationProvider = dataProviders.createInMemoryDataProviderAsync(
       GET_EXPLORATION_BY_ID_PROVIDER_ID
     ) { retrieveExplorationById(id) }
@@ -78,14 +75,14 @@ class ExplorationDataController @Inject constructor(
    * @return a [DataProvider] to observe whether initiating the play request succeeded
    */
   fun startPlayingNewExploration(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
     explorationId: String
   ): DataProvider<Any?> {
     return startPlayingExploration(
-      internalProfileId,
+      profileId,
       classroomId,
       topicId,
       storyId,
@@ -110,7 +107,7 @@ class ExplorationDataController @Inject constructor(
    * used).
    */
   fun resumeExploration(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
@@ -118,7 +115,7 @@ class ExplorationDataController @Inject constructor(
     explorationCheckpoint: ExplorationCheckpoint
   ): DataProvider<Any?> {
     return startPlayingExploration(
-      internalProfileId,
+      profileId,
       classroomId,
       topicId,
       storyId,
@@ -142,14 +139,14 @@ class ExplorationDataController @Inject constructor(
    * lesson (otherwise [resumeExploration] should be used to resume the lesson).
    */
   fun restartExploration(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
     explorationId: String
   ): DataProvider<Any?> {
     return startPlayingExploration(
-      internalProfileId,
+      profileId,
       classroomId,
       topicId,
       storyId,
@@ -176,14 +173,14 @@ class ExplorationDataController @Inject constructor(
    * instead, depending on the specific situation.
    */
   fun replayExploration(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
     explorationId: String
   ): DataProvider<Any?> {
     return startPlayingExploration(
-      internalProfileId,
+      profileId,
       classroomId,
       topicId,
       storyId,
@@ -224,7 +221,7 @@ class ExplorationDataController @Inject constructor(
    *     requests, succeeded
    */
   private fun startPlayingExploration(
-    internalProfileId: Int,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
@@ -235,7 +232,7 @@ class ExplorationDataController @Inject constructor(
     isReplay: Boolean
   ): DataProvider<Any?> {
     return explorationProgressController.beginExplorationAsync(
-      LegacyProfileId.newBuilder().apply { internalId = internalProfileId }.build(),
+      profileId,
       classroomId,
       topicId,
       storyId,
@@ -270,7 +267,7 @@ class ExplorationDataController @Inject constructor(
    *     has to be retrieved
    * @return a [DataProvider] that indicates the success or failure of the retrieve operation
    */
-  fun getOldestExplorationDetailsDataProvider(profileId: LegacyProfileId) =
+  fun getOldestExplorationDetailsDataProvider(profileId: ProfileId) =
     explorationCheckpointController.retrieveOldestSavedExplorationCheckpointDetails(profileId)
 
   /**
@@ -281,7 +278,7 @@ class ExplorationDataController @Inject constructor(
    *     has to be retrieved
    * @param explorationId the ID of the exploration whose checkpoint has to be deleted
    */
-  fun deleteExplorationProgressById(profileId: LegacyProfileId, explorationId: String) {
+  fun deleteExplorationProgressById(profileId: ProfileId, explorationId: String) {
     explorationCheckpointController.deleteSavedExplorationCheckpoint(
       profileId,
       explorationId

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
@@ -67,8 +67,7 @@ class ExplorationDataController @Inject constructor(
    * and it will save the user's progress. See [resumeExploration], [restartExploration], and
    * [replayExploration] for other situations.
    *
-   * @param internalProfileId the ID corresponding to the profile for which exploration is to be
-   *     played
+   * @param profileId the ID corresponding to the profile for which exploration is to be played
    * @param topicId the ID corresponding to the topic for which exploration has to be played
    * @param storyId the ID corresponding to the story for which exploration has to be played
    * @param explorationId the ID of the exploration which has to be played
@@ -205,7 +204,7 @@ class ExplorationDataController @Inject constructor(
    * [stopPlayingExploration] may be optionally called to clean up the session--see the
    * documentation for that method for details.
    *
-   * @param internalProfileId the ID corresponding to the profile for which exploration has to be
+   * @param profileId the ID corresponding to the profile for which exploration has to be
    *     played
    * @param topicId the ID corresponding to the topic for which exploration has to be played
    * @param storyId the ID corresponding to the story for which exploration has to be played

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationDataController.kt
@@ -128,7 +128,7 @@ class ExplorationDataController @Inject constructor(
 
   /**
    * Restarts the specified exploration indicated by [topicId], [storyId], and [explorationId] for
-   * the user corresponding to [internalProfileId], and returns a [DataProvider] tracking whether
+   * the user corresponding to [profileId], and returns a [DataProvider] tracking whether
    * the start succeeded.
    *
    * This method behaves the same as [resumeExploration] except any prior progress the user might
@@ -159,7 +159,7 @@ class ExplorationDataController @Inject constructor(
 
   /**
    * Replays the specified exploration indicated by [topicId], [storyId], and [explorationId] for
-   * the user corresponding to [internalProfileId], and returns a [DataProvider] tracking whether
+   * the user corresponding to [profileId], and returns a [DataProvider] tracking whether
    * the start succeeded.
    *
    * This method behaves the same as [startPlayingNewExploration] except no progress is tracked

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgress.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgress.kt
@@ -4,7 +4,7 @@ import org.oppia.android.app.model.CheckpointState
 import org.oppia.android.app.model.EphemeralState
 import org.oppia.android.app.model.Exploration
 import org.oppia.android.app.model.ExplorationCheckpoint
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.State
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.state.StateDeck
@@ -19,7 +19,7 @@ private const val TERMINAL_INTERACTION_ID = "EndExploration"
  * instances, but calling code is responsible for ensuring it is properly reset.
  */
 internal class ExplorationProgress(private val oppiaLogger: OppiaLogger) {
-  internal lateinit var currentProfileId: LegacyProfileId
+  internal lateinit var currentProfileId: ProfileId
   internal lateinit var currentClassroomId: String
   internal lateinit var currentTopicId: String
   internal lateinit var currentStoryId: String

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
@@ -24,7 +24,6 @@ import org.oppia.android.app.model.HelpIndex.IndexTypeCase.INDEXTYPE_NOT_SET
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.LATEST_REVEALED_HINT_INDEX
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.NEXT_AVAILABLE_HINT_INDEX
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.SHOW_SOLUTION
-import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.UserAnswer
 import org.oppia.android.app.model.WrittenTranslationLanguageSelection
 import org.oppia.android.domain.classify.AnswerClassificationController
@@ -50,7 +49,7 @@ import org.oppia.android.util.data.DataProviders.Companion.transform
 import org.oppia.android.util.platformparameter.EnableFlashbackSupport
 import org.oppia.android.util.platformparameter.EnableLessonProgressVisualization
 import org.oppia.android.util.platformparameter.PlatformParameterValue
-import org.oppia.android.util.profile.toProfileIdPreservingZero
+import org.oppia.android.util.profile.toLegacyProfileId
 import org.oppia.android.util.system.OppiaClock
 import org.oppia.android.util.threading.BackgroundDispatcher
 import java.util.UUID
@@ -139,7 +138,7 @@ class ExplorationProgressController @Inject constructor(
 
   // TODO(#606): Replace this with a profile scope to avoid this hacky workaround (which is needed
   //  for getCurrentState).
-  private lateinit var profileId: LegacyProfileId
+  private lateinit var profileId: ProfileId
 
   private var mostRecentSessionId = MutableStateFlow<String?>(null)
   private val activeSessionId: String
@@ -163,7 +162,7 @@ class ExplorationProgressController @Inject constructor(
    * [submitAnswer].
    */
   internal fun beginExplorationAsync(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
@@ -443,9 +442,7 @@ class ExplorationProgressController @Inject constructor(
    */
   fun getCurrentState(): DataProvider<EphemeralState> {
     val writtenTranslationContentLocale =
-      translationController.getWrittenTranslationContentLocale(
-        profileId.toProfileIdPreservingZero()
-      )
+      translationController.getWrittenTranslationContentLocale(profileId)
     val ephemeralStateDataProvider =
       mostRecentEphemeralStateFlow.convertToSessionProvider(CURRENT_STATE_PROVIDER_ID)
     return writtenTranslationContentLocale.combineWith(
@@ -475,11 +472,11 @@ class ExplorationProgressController @Inject constructor(
    *     language
    */
   fun updateWrittenTranslationContentLanguageMidLesson(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     selection: WrittenTranslationLanguageSelection
   ): DataProvider<Any> {
     return translationController.updateWrittenTranslationContentLanguage(
-      profileId.toProfileIdPreservingZero(), selection
+      profileId, selection
     ).transform(UPDATE_WRITTEN_TRANSLATION_CONTENT_PROVIDER_ID) { previousSelection ->
       val explorationLogger = learnerAnalyticsLogger.explorationAnalyticsLogger.value
       val stateLogger = explorationLogger?.stateAnalyticsLogger?.value
@@ -507,12 +504,12 @@ class ExplorationProgressController @Inject constructor(
             is ControllerMessage.InitializeController -> {
               // Synchronously fetch the learner & installation IDs (these may result in file I/O).
               val learnerId = profileManagementController.fetchLearnerId(
-                message.profileId.toProfileIdPreservingZero()
+                message.profileId
               )
               val installationId = loggingIdentifierController.fetchInstallationId()
               val isContinueButtonAnimationSeen =
                 profileManagementController.fetchContinueAnimationSeenStatus(
-                  message.profileId.toProfileIdPreservingZero()
+                  message.profileId
                 ) ?: false
 
               // Ensure the state is completely recreated for each session to avoid leaking state
@@ -635,7 +632,7 @@ class ExplorationProgressController @Inject constructor(
 
   private suspend fun ControllerState.beginExplorationImpl(
     beginExplorationResultFlow: MutableStateFlow<AsyncResult<Any?>>,
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     classroomId: String,
     topicId: String,
     storyId: String,
@@ -880,9 +877,7 @@ class ExplorationProgressController @Inject constructor(
       }
 
       if (!isContinueButtonAnimationSeen) {
-        profileManagementController.markContinueButtonAnimationSeen(
-          profileId.toProfileIdPreservingZero()
-        )
+        profileManagementController.markContinueButtonAnimationSeen(profileId)
       }
       isContinueButtonAnimationSeen = true
     }
@@ -1201,7 +1196,7 @@ class ExplorationProgressController @Inject constructor(
     // Do not save checkpoints if shouldSavePartialProgress is false. This is expected to happen
     // when the current exploration has been already completed previously.
     if (!explorationProgress.shouldSavePartialProgress) return
-    val profileId: LegacyProfileId = explorationProgress.currentProfileId
+    val profileId: ProfileId = explorationProgress.currentProfileId
     val topicId: String = explorationProgress.currentTopicId
     val storyId: String = explorationProgress.currentStoryId
     val explorationId: String = explorationProgress.currentExplorationId
@@ -1267,7 +1262,7 @@ class ExplorationProgressController @Inject constructor(
    *     unsuccessfully
    */
   private suspend fun ControllerState.processSaveCheckpointResult(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String,
@@ -1328,7 +1323,7 @@ class ExplorationProgressController @Inject constructor(
     interactionId == "Continue"
 
   private fun markExplorationAsInProgressSaved(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String,
@@ -1344,7 +1339,7 @@ class ExplorationProgressController @Inject constructor(
   }
 
   private fun markExplorationAsInProgressNotSaved(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String,
@@ -1389,7 +1384,7 @@ class ExplorationProgressController @Inject constructor(
     val ephemeralStateFlow: MutableStateFlow<AsyncResult<EphemeralState>>,
     val commandQueue: SendChannel<ControllerMessage<*>>,
     private val installationId: String?,
-    private val profileId: LegacyProfileId,
+    private val profileId: ProfileId,
     private val learnerId: String?,
     private val learnerAnalyticsLogger: LearnerAnalyticsLogger,
     val startSessionTimeMs: Long,
@@ -1428,7 +1423,7 @@ class ExplorationProgressController @Inject constructor(
     fun initializeEventLogger(exploration: Exploration) {
       explorationAnalyticsLogger = learnerAnalyticsLogger.beginExploration(
         installationId,
-        profileId,
+        profileId.toLegacyProfileId(),
         learnerId,
         exploration,
         explorationProgress.currentClassroomId,
@@ -1541,7 +1536,7 @@ class ExplorationProgressController @Inject constructor(
 
     /** [ControllerMessage] for initializing a new play session. */
     data class InitializeController(
-      val profileId: LegacyProfileId,
+      val profileId: ProfileId,
       val classroomId: String,
       val topicId: String,
       val storyId: String,
@@ -1667,7 +1662,7 @@ class ExplorationProgressController @Inject constructor(
      * the app (e.g. that an exploration is considered 'in-progress' in such circumstances).
      */
     data class ProcessSavedCheckpointResult(
-      val profileId: LegacyProfileId,
+      val profileId: ProfileId,
       val topicId: String,
       val storyId: String,
       val explorationId: String,

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
@@ -17,6 +17,7 @@ import org.oppia.android.app.model.AnswerOutcome
 import org.oppia.android.app.model.CheckpointState
 import org.oppia.android.app.model.EphemeralState
 import org.oppia.android.app.model.Exploration
+import org.oppia.android.app.model.ExplorationCheckpoint
 import org.oppia.android.app.model.HelpIndex
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.EVERYTHING_REVEALED
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.INDEXTYPE_NOT_SET

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
@@ -17,15 +17,13 @@ import org.oppia.android.app.model.AnswerOutcome
 import org.oppia.android.app.model.CheckpointState
 import org.oppia.android.app.model.EphemeralState
 import org.oppia.android.app.model.Exploration
-import org.oppia.android.app.model.ProfileId
-import org.oppia.android.app.model.Exploration
-import org.oppia.android.app.model.ProfileIdCheckpoint
 import org.oppia.android.app.model.HelpIndex
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.EVERYTHING_REVEALED
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.INDEXTYPE_NOT_SET
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.LATEST_REVEALED_HINT_INDEX
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.NEXT_AVAILABLE_HINT_INDEX
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.SHOW_SOLUTION
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.UserAnswer
 import org.oppia.android.app.model.WrittenTranslationLanguageSelection
 import org.oppia.android.domain.classify.AnswerClassificationController

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressController.kt
@@ -17,7 +17,9 @@ import org.oppia.android.app.model.AnswerOutcome
 import org.oppia.android.app.model.CheckpointState
 import org.oppia.android.app.model.EphemeralState
 import org.oppia.android.app.model.Exploration
-import org.oppia.android.app.model.ExplorationCheckpoint
+import org.oppia.android.app.model.ProfileId
+import org.oppia.android.app.model.Exploration
+import org.oppia.android.app.model.ProfileIdCheckpoint
 import org.oppia.android.app.model.HelpIndex
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.EVERYTHING_REVEALED
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.INDEXTYPE_NOT_SET

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressListener.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationProgressListener.kt
@@ -1,6 +1,6 @@
 package org.oppia.android.domain.exploration
 
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 
 /**
  * Listener for when an exploration has started or ended.
@@ -12,7 +12,7 @@ import org.oppia.android.app.model.LegacyProfileId
  */
 interface ExplorationProgressListener {
   /** Called when an exploration has started. */
-  fun onExplorationStarted(profileId: LegacyProfileId, topicId: String)
+  fun onExplorationStarted(profileId: ProfileId, topicId: String)
 
   /** Called when an exploration has ended. */
   fun onExplorationEnded()

--- a/domain/src/main/java/org/oppia/android/domain/exploration/TimerSessionState.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/TimerSessionState.kt
@@ -1,6 +1,6 @@
 package org.oppia.android.domain.exploration
 
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 
 /**
  * Private class that encapsulates the mutable state of an [ExplorationActiveTimeController].
@@ -12,7 +12,7 @@ internal class TimerSessionState {
   internal var sessionStartTime: Long = 0L
 
   /** The profileId of the profile currently logged in. */
-  internal lateinit var currentProfileId: LegacyProfileId
+  internal lateinit var currentProfileId: ProfileId
 
   /** The id of the topic that the current exploration belongs to. */
   internal lateinit var currentTopicId: String

--- a/domain/src/main/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointController.kt
@@ -178,7 +178,7 @@ class ExplorationCheckpointController @Inject constructor(
             AsyncResult.Failure(
               ExplorationCheckpointNotFoundException(
                 "Checkpoint with the explorationId $explorationId was not found " +
-                  "for profileId $profileId."
+                  "for profileId ${profileId.internalId}."
               )
             )
           }
@@ -259,7 +259,7 @@ class ExplorationCheckpointController @Inject constructor(
         AsyncResult.Failure(
           ExplorationCheckpointNotFoundException(
             "No saved checkpoint with explorationId ${explorationId!!} found for " +
-              "the profileId ${profileId!!}."
+              "the profileId ${profileId!!.internalId}."
           )
         )
       ExplorationCheckpointActionStatus.SUCCESS -> AsyncResult.Success(null)

--- a/domain/src/main/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointController.kt
@@ -10,7 +10,6 @@ import org.oppia.android.app.model.ExplorationCheckpoint
 import org.oppia.android.app.model.ExplorationCheckpointDatabase
 import org.oppia.android.app.model.ExplorationCheckpointDetails
 import org.oppia.android.app.model.ProfileId
-import org.oppia.android.util.profile.toLegacyProfileId
 import org.oppia.android.app.model.State
 import org.oppia.android.data.persistence.PersistentCacheStore
 import org.oppia.android.data.persistence.PersistentCacheStore.PublishMode
@@ -23,6 +22,7 @@ import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders
 import org.oppia.android.util.data.DataProviders.Companion.transform
 import org.oppia.android.util.data.DataProviders.Companion.transformAsync
+import org.oppia.android.util.profile.toLegacyProfileId
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/domain/src/main/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointController.kt
@@ -9,7 +9,7 @@ import org.oppia.android.app.model.Exploration
 import org.oppia.android.app.model.ExplorationCheckpoint
 import org.oppia.android.app.model.ExplorationCheckpointDatabase
 import org.oppia.android.app.model.ExplorationCheckpointDetails
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.State
 import org.oppia.android.data.persistence.PersistentCacheStore
 import org.oppia.android.data.persistence.PersistentCacheStore.PublishMode
@@ -68,7 +68,7 @@ class ExplorationCheckpointController @Inject constructor(
   }
 
   private val cacheStoreMap =
-    mutableMapOf<LegacyProfileId, PersistentCacheStore<ExplorationCheckpointDatabase>>()
+    mutableMapOf<ProfileId, PersistentCacheStore<ExplorationCheckpointDatabase>>()
 
   /**
    * Records an exploration checkpoint for the specified profile.
@@ -82,7 +82,7 @@ class ExplorationCheckpointController @Inject constructor(
    *     completion of deferred.
    */
   internal fun recordExplorationCheckpointAsync(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     explorationId: String,
     explorationCheckpoint: ExplorationCheckpoint
   ): Deferred<CheckpointState> {
@@ -129,7 +129,7 @@ class ExplorationCheckpointController @Inject constructor(
    * Returns a [DataProvider] for the [Deferred] returned from [recordExplorationCheckpointAsync].
    */
   fun recordExplorationCheckpoint(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     explorationId: String,
     explorationCheckpoint: ExplorationCheckpoint
   ): DataProvider<Any?> {
@@ -147,7 +147,7 @@ class ExplorationCheckpointController @Inject constructor(
 
   /** Returns the saved checkpoint for a specified explorationId and profileId. */
   fun retrieveExplorationCheckpoint(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     explorationId: String
   ): DataProvider<ExplorationCheckpoint> {
     return retrieveCacheStore(profileId)
@@ -178,7 +178,7 @@ class ExplorationCheckpointController @Inject constructor(
             AsyncResult.Failure(
               ExplorationCheckpointNotFoundException(
                 "Checkpoint with the explorationId $explorationId was not found " +
-                  "for profileId ${profileId.internalId}."
+                  "for profileId $profileId."
               )
             )
           }
@@ -193,7 +193,7 @@ class ExplorationCheckpointController @Inject constructor(
    *      and explorationVersion of the oldest saved checkpoint for the specified profile.
    */
   fun retrieveOldestSavedExplorationCheckpointDetails(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): DataProvider<ExplorationCheckpointDetails> {
     return retrieveCacheStore(profileId)
       .transform(
@@ -214,7 +214,7 @@ class ExplorationCheckpointController @Inject constructor(
 
   /** Deletes the saved checkpoint for a specified explorationId and profileId. */
   fun deleteSavedExplorationCheckpoint(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     explorationId: String
   ): DataProvider<Any?> {
     val deferred = retrieveCacheStore(profileId).storeDataWithCustomChannelAsync(
@@ -252,14 +252,14 @@ class ExplorationCheckpointController @Inject constructor(
   private suspend fun getDeferredResult(
     deferred: Deferred<ExplorationCheckpointActionStatus>,
     explorationId: String?,
-    profileId: LegacyProfileId?,
+    profileId: ProfileId?,
   ): AsyncResult<Any?> {
     return when (deferred.await()) {
       ExplorationCheckpointActionStatus.CHECKPOINT_NOT_FOUND ->
         AsyncResult.Failure(
           ExplorationCheckpointNotFoundException(
             "No saved checkpoint with explorationId ${explorationId!!} found for " +
-              "the profileId ${profileId!!.internalId}."
+              "the profileId ${profileId!!}."
           )
         )
       ExplorationCheckpointActionStatus.SUCCESS -> AsyncResult.Success(null)
@@ -267,7 +267,7 @@ class ExplorationCheckpointController @Inject constructor(
   }
 
   private fun retrieveCacheStore(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): PersistentCacheStore<ExplorationCheckpointDatabase> {
     val cacheStore = if (profileId in cacheStoreMap) {
       cacheStoreMap[profileId]!!

--- a/domain/src/main/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointController.kt
@@ -10,6 +10,7 @@ import org.oppia.android.app.model.ExplorationCheckpoint
 import org.oppia.android.app.model.ExplorationCheckpointDatabase
 import org.oppia.android.app.model.ExplorationCheckpointDetails
 import org.oppia.android.app.model.ProfileId
+import org.oppia.android.util.profile.toLegacyProfileId
 import org.oppia.android.app.model.State
 import org.oppia.android.data.persistence.PersistentCacheStore
 import org.oppia.android.data.persistence.PersistentCacheStore.PublishMode
@@ -276,7 +277,7 @@ class ExplorationCheckpointController @Inject constructor(
         cacheStoreFactory.createPerProfile(
           CACHE_NAME,
           ExplorationCheckpointDatabase.getDefaultInstance(),
-          profileId
+          profileId.toLegacyProfileId()
         )
       cacheStoreMap[profileId] = cacheStore
       cacheStore

--- a/domain/src/main/java/org/oppia/android/domain/survey/SurveyGatingController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/survey/SurveyGatingController.kt
@@ -84,7 +84,7 @@ class SurveyGatingController @Inject constructor(
     topicId: String
   ): DataProvider<Long> {
     return activeTimeController.retrieveAggregateTopicLearningTimeDataProvider(
-      profileId, topicId
+      profileId.toProfileIdPreservingZero(), topicId
     ).transform(
       GET_TOPIC_LEARNING_TIME_PROVIDER_ID,
       TopicLearningTime::getTopicLearningTimeMs

--- a/domain/src/main/java/org/oppia/android/domain/topic/StoryProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/StoryProgressController.kt
@@ -3,7 +3,7 @@ package org.oppia.android.domain.topic
 import kotlinx.coroutines.Deferred
 import org.oppia.android.app.model.ChapterPlayState
 import org.oppia.android.app.model.ChapterProgress
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.StoryProgress
 import org.oppia.android.app.model.TopicProgress
 import org.oppia.android.app.model.TopicProgressDatabase
@@ -70,7 +70,7 @@ class StoryProgressController @Inject constructor(
   }
 
   private val cacheStoreMap =
-    mutableMapOf<LegacyProfileId, PersistentCacheStore<TopicProgressDatabase>>()
+    mutableMapOf<ProfileId, PersistentCacheStore<TopicProgressDatabase>>()
 
   /**
    * Records the specified chapter completed within the context of the specified exploration, story,
@@ -85,7 +85,7 @@ class StoryProgressController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this record progress operation
    */
   fun recordCompletedChapter(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String,
@@ -148,7 +148,7 @@ class StoryProgressController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this record progress operation
    */
   fun recordChapterAsInProgressSaved(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String,
@@ -231,7 +231,7 @@ class StoryProgressController @Inject constructor(
    * @return a [DataProvider] that indicates the success/failure of this record progress operation
    */
   fun recordChapterAsInProgressNotSaved(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String,
@@ -302,7 +302,7 @@ class StoryProgressController @Inject constructor(
 
   /** Returns the [ChapterPlayState] [DataProvider] for a particular explorationId and profile. */
   fun retrieveChapterPlayStateByExplorationId(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String
@@ -320,7 +320,7 @@ class StoryProgressController @Inject constructor(
 
   /** Returns list of [TopicProgress] [DataProvider] for a particular profile. */
   internal fun retrieveTopicProgressListDataProvider(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): DataProvider<List<TopicProgress>> {
     return retrieveCacheStore(profileId)
       .transformAsync(RETRIEVE_TOPIC_PROGRESS_LIST_DATA_PROVIDER_ID) { topicProgressDatabase ->
@@ -332,7 +332,7 @@ class StoryProgressController @Inject constructor(
 
   /** Returns a [TopicProgress] [DataProvider] for a specific topicId, per-profile basis. */
   private fun retrieveTopicProgressDataProvider(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String
   ): DataProvider<TopicProgress> {
     return retrieveTopicsProgressDataProvider(profileId, listOf(topicId))
@@ -346,7 +346,7 @@ class StoryProgressController @Inject constructor(
    * The provider defaults the progress for any IDs that don't have progress corresponding to them.
    */
   internal fun retrieveTopicsProgressDataProvider(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicIds: List<String>
   ): DataProvider<List<TopicProgress>> {
     return retrieveCacheStore(profileId)
@@ -359,7 +359,7 @@ class StoryProgressController @Inject constructor(
 
   /** Returns a [StoryProgress] [DataProvider] for a specific storyId, per-profile basis. */
   internal fun retrieveStoryProgressDataProvider(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String
   ): DataProvider<StoryProgress> {
@@ -378,7 +378,7 @@ class StoryProgressController @Inject constructor(
   }
 
   private fun retrieveCacheStore(
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ): PersistentCacheStore<TopicProgressDatabase> {
     val cacheStore = if (profileId in cacheStoreMap) {
       cacheStoreMap[profileId]!!

--- a/domain/src/main/java/org/oppia/android/domain/topic/StoryProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/StoryProgressController.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.Deferred
 import org.oppia.android.app.model.ChapterPlayState
 import org.oppia.android.app.model.ChapterProgress
 import org.oppia.android.app.model.ProfileId
+import org.oppia.android.util.profile.toLegacyProfileId
 import org.oppia.android.app.model.StoryProgress
 import org.oppia.android.app.model.TopicProgress
 import org.oppia.android.app.model.TopicProgressDatabase
@@ -387,7 +388,7 @@ class StoryProgressController @Inject constructor(
         cacheStoreFactory.createPerProfile(
           CACHE_NAME,
           TopicProgressDatabase.getDefaultInstance(),
-          profileId
+          profileId.toLegacyProfileId()
         )
       cacheStoreMap[profileId] = cacheStore
       cacheStore

--- a/domain/src/main/java/org/oppia/android/domain/topic/StoryProgressController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/StoryProgressController.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.Deferred
 import org.oppia.android.app.model.ChapterPlayState
 import org.oppia.android.app.model.ChapterProgress
 import org.oppia.android.app.model.ProfileId
-import org.oppia.android.util.profile.toLegacyProfileId
 import org.oppia.android.app.model.StoryProgress
 import org.oppia.android.app.model.TopicProgress
 import org.oppia.android.app.model.TopicProgressDatabase
@@ -17,6 +16,7 @@ import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders
 import org.oppia.android.util.data.DataProviders.Companion.transform
 import org.oppia.android.util.data.DataProviders.Companion.transformAsync
+import org.oppia.android.util.profile.toLegacyProfileId
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/domain/src/main/java/org/oppia/android/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/TopicController.kt
@@ -157,7 +157,9 @@ class TopicController @Inject constructor(
         AsyncResult.Success(topics)
       }
     val topicsProgressDataProvider =
-      storyProgressController.retrieveTopicsProgressDataProvider(profileId.toProfileIdPreservingZero(), topicIds)
+      storyProgressController.retrieveTopicsProgressDataProvider(
+        profileId.toProfileIdPreservingZero(), topicIds
+      )
 
     val topicsCombinedProvider = topicsDataProvider.combineWith(
       topicsProgressDataProvider,
@@ -193,7 +195,9 @@ class TopicController @Inject constructor(
         return@createInMemoryDataProviderAsync AsyncResult.Success(retrieveStory(topicId, storyId))
       }
     val storyProgressDataProvider =
-      storyProgressController.retrieveStoryProgressDataProvider(profileId.toProfileIdPreservingZero(), topicId, storyId)
+      storyProgressController.retrieveStoryProgressDataProvider(
+        profileId.toProfileIdPreservingZero(), topicId, storyId
+      )
 
     val storyCombinedProvider = storyDataProvider.combineWith(
       storyProgressDataProvider,
@@ -320,7 +324,9 @@ class TopicController @Inject constructor(
    */
   fun getCompletedStoryList(profileId: LegacyProfileId): DataProvider<CompletedStoryList> {
     val retrieveTopicProgressListProvider =
-      storyProgressController.retrieveTopicProgressListDataProvider(profileId.toProfileIdPreservingZero())
+      storyProgressController.retrieveTopicProgressListDataProvider(
+        profileId.toProfileIdPreservingZero()
+      )
     val translationLocaleProvider =
       translationController.getWrittenTranslationContentLocale(
         profileId.toProfileIdPreservingZero()
@@ -347,7 +353,9 @@ class TopicController @Inject constructor(
    */
   fun getOngoingTopicList(profileId: LegacyProfileId): DataProvider<OngoingTopicList> {
     val retrieveTopicProgressListProvider =
-      storyProgressController.retrieveTopicProgressListDataProvider(profileId.toProfileIdPreservingZero())
+      storyProgressController.retrieveTopicProgressListDataProvider(
+        profileId.toProfileIdPreservingZero()
+      )
     val translationLocaleProvider =
       translationController.getWrittenTranslationContentLocale(
         profileId.toProfileIdPreservingZero()

--- a/domain/src/main/java/org/oppia/android/domain/topic/TopicController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/TopicController.kt
@@ -157,7 +157,7 @@ class TopicController @Inject constructor(
         AsyncResult.Success(topics)
       }
     val topicsProgressDataProvider =
-      storyProgressController.retrieveTopicsProgressDataProvider(profileId, topicIds)
+      storyProgressController.retrieveTopicsProgressDataProvider(profileId.toProfileIdPreservingZero(), topicIds)
 
     val topicsCombinedProvider = topicsDataProvider.combineWith(
       topicsProgressDataProvider,
@@ -193,7 +193,7 @@ class TopicController @Inject constructor(
         return@createInMemoryDataProviderAsync AsyncResult.Success(retrieveStory(topicId, storyId))
       }
     val storyProgressDataProvider =
-      storyProgressController.retrieveStoryProgressDataProvider(profileId, topicId, storyId)
+      storyProgressController.retrieveStoryProgressDataProvider(profileId.toProfileIdPreservingZero(), topicId, storyId)
 
     val storyCombinedProvider = storyDataProvider.combineWith(
       storyProgressDataProvider,
@@ -320,7 +320,7 @@ class TopicController @Inject constructor(
    */
   fun getCompletedStoryList(profileId: LegacyProfileId): DataProvider<CompletedStoryList> {
     val retrieveTopicProgressListProvider =
-      storyProgressController.retrieveTopicProgressListDataProvider(profileId)
+      storyProgressController.retrieveTopicProgressListDataProvider(profileId.toProfileIdPreservingZero())
     val translationLocaleProvider =
       translationController.getWrittenTranslationContentLocale(
         profileId.toProfileIdPreservingZero()
@@ -347,7 +347,7 @@ class TopicController @Inject constructor(
    */
   fun getOngoingTopicList(profileId: LegacyProfileId): DataProvider<OngoingTopicList> {
     val retrieveTopicProgressListProvider =
-      storyProgressController.retrieveTopicProgressListDataProvider(profileId)
+      storyProgressController.retrieveTopicProgressListDataProvider(profileId.toProfileIdPreservingZero())
     val translationLocaleProvider =
       translationController.getWrittenTranslationContentLocale(
         profileId.toProfileIdPreservingZero()

--- a/domain/src/main/java/org/oppia/android/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/TopicListController.kt
@@ -129,7 +129,7 @@ class TopicListController @Inject constructor(
    */
   fun getPromotedActivityList(profileId: LegacyProfileId): DataProvider<PromotedActivityList> {
     val retrieveTopicProgressListProvider =
-      storyProgressController.retrieveTopicProgressListDataProvider(profileId)
+      storyProgressController.retrieveTopicProgressListDataProvider(profileId.toProfileIdPreservingZero())
     val translationLocaleProvider =
       translationController.getWrittenTranslationContentLocale(
         profileId.toProfileIdPreservingZero()

--- a/domain/src/main/java/org/oppia/android/domain/topic/TopicListController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/topic/TopicListController.kt
@@ -129,7 +129,9 @@ class TopicListController @Inject constructor(
    */
   fun getPromotedActivityList(profileId: LegacyProfileId): DataProvider<PromotedActivityList> {
     val retrieveTopicProgressListProvider =
-      storyProgressController.retrieveTopicProgressListDataProvider(profileId.toProfileIdPreservingZero())
+      storyProgressController.retrieveTopicProgressListDataProvider(
+        profileId.toProfileIdPreservingZero()
+      )
     val translationLocaleProvider =
       translationController.getWrittenTranslationContentLocale(
         profileId.toProfileIdPreservingZero()

--- a/domain/src/test/java/org/oppia/android/domain/audio/AudioPlayerControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/audio/AudioPlayerControllerTest.kt
@@ -949,7 +949,11 @@ class AudioPlayerControllerTest {
   ) {
     val playingProvider =
       explorationDataController.startPlayingNewExploration(
-        profileId = profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
+        profileId = profileId.toProfileIdPreservingZero(),
+        classroomId,
+        topicId,
+        storyId,
+        explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(playingProvider)
     monitorFactory.waitForNextSuccessfulResult(explorationProgressController.getCurrentState())
@@ -957,7 +961,9 @@ class AudioPlayerControllerTest {
 
   private fun loadExploration(explorationId: String): Exploration {
     return monitorFactory.waitForNextSuccessfulResult(
-      explorationDataController.getExplorationById(profileId.toProfileIdPreservingZero(), explorationId)
+      explorationDataController.getExplorationById(
+        profileId.toProfileIdPreservingZero(), explorationId
+      )
     ).exploration
   }
 

--- a/domain/src/test/java/org/oppia/android/domain/audio/AudioPlayerControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/audio/AudioPlayerControllerTest.kt
@@ -949,7 +949,7 @@ class AudioPlayerControllerTest {
   ) {
     val playingProvider =
       explorationDataController.startPlayingNewExploration(
-        internalProfileId = 0, classroomId, topicId, storyId, explorationId
+        profileId = profileId.toProfileIdPreservingZero(), classroomId, topicId, storyId, explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(playingProvider)
     monitorFactory.waitForNextSuccessfulResult(explorationProgressController.getCurrentState())
@@ -957,7 +957,7 @@ class AudioPlayerControllerTest {
 
   private fun loadExploration(explorationId: String): Exploration {
     return monitorFactory.waitForNextSuccessfulResult(
-      explorationDataController.getExplorationById(profileId, explorationId)
+      explorationDataController.getExplorationById(profileId.toProfileIdPreservingZero(), explorationId)
     ).exploration
   }
 

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationActiveTimeControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationActiveTimeControllerTest.kt
@@ -497,7 +497,7 @@ class ExplorationActiveTimeControllerTest {
   ) {
     val startPlayingProvider =
       explorationDataController.startPlayingNewExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId, classroomId, topicId, storyId, explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationActiveTimeControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationActiveTimeControllerTest.kt
@@ -13,7 +13,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.domain.classify.InteractionsModule
 import org.oppia.android.domain.classify.rules.algebraicexpressioninput.AlgebraicExpressionInputModule
 import org.oppia.android.domain.classify.rules.continueinteraction.ContinueModule
@@ -94,8 +94,8 @@ class ExplorationActiveTimeControllerTest {
   @Inject
   lateinit var explorationDataController: ExplorationDataController
 
-  private val firstTestProfile = LegacyProfileId.newBuilder().setInternalId(0).build()
-  private val secondTestProfile = LegacyProfileId.newBuilder().setInternalId(1).build()
+  private val firstTestProfile = ProfileId.newBuilder().setInternalId(0).build()
+  private val secondTestProfile = ProfileId.newBuilder().setInternalId(1).build()
 
   @Before
   fun setUp() {
@@ -493,7 +493,7 @@ class ExplorationActiveTimeControllerTest {
     topicId: String,
     storyId: String,
     explorationId: String,
-    profileId: LegacyProfileId
+    profileId: ProfileId
   ) {
     val startPlayingProvider =
       explorationDataController.startPlayingNewExploration(

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationDataControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationDataControllerTest.kt
@@ -14,7 +14,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.app.model.ExplorationCheckpoint
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.domain.classify.InteractionsModule
 import org.oppia.android.domain.classify.rules.algebraicexpressioninput.AlgebraicExpressionInputModule
 import org.oppia.android.domain.classify.rules.continueinteraction.ContinueModule
@@ -91,7 +91,7 @@ class ExplorationDataControllerTest {
   @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
   @Inject lateinit var explorationCheckpointController: ExplorationCheckpointController
 
-  private val profileId = LegacyProfileId.newBuilder().setInternalId(0).build()
+  private val profileId = ProfileId.newBuilder().setInternalId(0).build()
 
   @Before
   fun setUp() {
@@ -196,7 +196,7 @@ class ExplorationDataControllerTest {
   fun testStartPlayingNewExploration_returnsSuccess() {
     val startProvider =
       explorationDataController.startPlayingNewExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -272,7 +272,7 @@ class ExplorationDataControllerTest {
 
     val secondStartProvider =
       explorationDataController.startPlayingNewExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0, TEST_STORY_ID_0,
         TEST_EXPLORATION_ID_2
@@ -294,7 +294,7 @@ class ExplorationDataControllerTest {
     val checkpoint = retrieveExplorationCheckpoint(TEST_EXPLORATION_ID_2)
     val secondStartProvider =
       explorationDataController.resumeExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -309,7 +309,7 @@ class ExplorationDataControllerTest {
   fun testRestartExploration_returnsSuccess() {
     val startProvider =
       explorationDataController.restartExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -331,7 +331,7 @@ class ExplorationDataControllerTest {
 
     val secondStartProvider =
       explorationDataController.restartExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -345,7 +345,7 @@ class ExplorationDataControllerTest {
   fun testReplayExploration_returnsSuccess() {
     val startProvider =
       explorationDataController.replayExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -367,7 +367,7 @@ class ExplorationDataControllerTest {
 
     val secondStartProvider =
       explorationDataController.replayExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -388,7 +388,7 @@ class ExplorationDataControllerTest {
 
     val dataProvider =
       explorationDataController.replayExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_1,
         TEST_STORY_ID_2,
@@ -448,7 +448,7 @@ class ExplorationDataControllerTest {
   ) {
     val startPlayingProvider =
       explorationDataController.startPlayingNewExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId, classroomId, topicId, storyId, explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }
@@ -461,7 +461,7 @@ class ExplorationDataControllerTest {
   ) {
     val startPlayingProvider =
       explorationDataController.restartExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId, classroomId, topicId, storyId, explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }
@@ -474,7 +474,7 @@ class ExplorationDataControllerTest {
   ) {
     val startPlayingProvider =
       explorationDataController.replayExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId, classroomId, topicId, storyId, explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }
@@ -501,7 +501,7 @@ class ExplorationDataControllerTest {
     val checkpoint = retrieveExplorationCheckpoint(explorationId)
     val resumeProvider =
       explorationDataController.resumeExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId, checkpoint
+        profileId, classroomId, topicId, storyId, explorationId, checkpoint
       )
     monitorFactory.waitForNextSuccessfulResult(resumeProvider)
   }

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerLessonProgressTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerLessonProgressTest.kt
@@ -18,8 +18,8 @@ import org.oppia.android.app.model.EphemeralState
 import org.oppia.android.app.model.Fraction
 import org.oppia.android.app.model.InteractionObject
 import org.oppia.android.app.model.ItemSelectionAnswerState
-import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.ListOfSetsOfTranslatableHtmlContentIds
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.RatioExpression
 import org.oppia.android.app.model.SetOfTranslatableHtmlContentIds
 import org.oppia.android.app.model.TranslatableHtmlContentId
@@ -72,7 +72,6 @@ import org.oppia.android.util.logging.GlobalLogLevel
 import org.oppia.android.util.logging.LogLevel
 import org.oppia.android.util.logging.SyncStatusModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
-import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -105,7 +104,7 @@ class ExplorationProgressControllerLessonProgressTest {
   @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
 
-  private val profileId = LegacyProfileId.newBuilder().setInternalId(0).build()
+  private val profileId = ProfileId.newBuilder().setInternalId(0).build()
 
   @Before
   fun setUp() {
@@ -246,7 +245,7 @@ class ExplorationProgressControllerLessonProgressTest {
     storyId: String = TEST_STORY_ID_0
   ) {
     val startPlayingProvider = explorationDataController.startPlayingNewExploration(
-      profileId.toProfileIdPreservingZero(), TEST_CLASSROOM_ID_0, topicId, storyId, explorationId
+      profileId, TEST_CLASSROOM_ID_0, topicId, storyId, explorationId
     )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerLessonProgressTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerLessonProgressTest.kt
@@ -62,7 +62,6 @@ import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestCoroutineDispatchers
 import org.oppia.android.testing.threading.TestDispatcherModule
 import org.oppia.android.testing.time.FakeOppiaClockModule
-import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.caching.AssetModule
 import org.oppia.android.util.data.DataProvidersInjector
 import org.oppia.android.util.data.DataProvidersInjectorProvider
@@ -73,6 +72,7 @@ import org.oppia.android.util.logging.GlobalLogLevel
 import org.oppia.android.util.logging.LogLevel
 import org.oppia.android.util.logging.SyncStatusModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerLessonProgressTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerLessonProgressTest.kt
@@ -62,6 +62,7 @@ import org.oppia.android.testing.robolectric.RobolectricModule
 import org.oppia.android.testing.threading.TestCoroutineDispatchers
 import org.oppia.android.testing.threading.TestDispatcherModule
 import org.oppia.android.testing.time.FakeOppiaClockModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.util.caching.AssetModule
 import org.oppia.android.util.data.DataProvidersInjector
 import org.oppia.android.util.data.DataProvidersInjectorProvider
@@ -245,7 +246,7 @@ class ExplorationProgressControllerLessonProgressTest {
     storyId: String = TEST_STORY_ID_0
   ) {
     val startPlayingProvider = explorationDataController.startPlayingNewExploration(
-      profileId.internalId, TEST_CLASSROOM_ID_0, topicId, storyId, explorationId
+      profileId.toProfileIdPreservingZero(), TEST_CLASSROOM_ID_0, topicId, storyId, explorationId
     )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
@@ -4225,7 +4225,7 @@ class ExplorationProgressControllerTest {
   }
 
   private fun logIntoAnalyticsReadyAdminProfile() {
-    val rootProfileId = ProfileId.getDefaultInstance()
+    val rootProfileId = ProfileId.newBuilder().setInternalId(0).build()
     val addProfileProvider = profileManagementController.addProfile(
       name = "Admin",
       pin = "",

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationProgressControllerTest.kt
@@ -41,10 +41,10 @@ import org.oppia.android.app.model.HelpIndex.IndexTypeCase.NEXT_AVAILABLE_HINT_I
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.SHOW_SOLUTION
 import org.oppia.android.app.model.InteractionObject
 import org.oppia.android.app.model.ItemSelectionAnswerState
-import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.ListOfSetsOfTranslatableHtmlContentIds
 import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.model.Point2d
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.RatioExpression
 import org.oppia.android.app.model.SetOfTranslatableHtmlContentIds
 import org.oppia.android.app.model.TranslatableHtmlContentId
@@ -115,7 +115,6 @@ import org.oppia.android.util.logging.GlobalLogLevel
 import org.oppia.android.util.logging.LogLevel
 import org.oppia.android.util.logging.SyncStatusModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
-import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import java.util.Locale
@@ -162,7 +161,7 @@ class ExplorationProgressControllerTest {
   @Inject lateinit var profileManagementController: ProfileManagementController
   @Inject lateinit var explorationActiveTimeController: ExplorationActiveTimeController
 
-  private val profileId = LegacyProfileId.newBuilder().setInternalId(0).build()
+  private val profileId = ProfileId.newBuilder().setInternalId(0).build()
 
   @Before
   fun setUp() {
@@ -192,7 +191,7 @@ class ExplorationProgressControllerTest {
   fun testPlayExploration_invalid_returnsSuccess() {
     val resultDataProvider =
       explorationDataController.replayExploration(
-        profileId.internalId,
+        profileId,
         INVALID_CLASSROOM_ID,
         INVALID_TOPIC_ID,
         INVALID_STORY_ID,
@@ -219,7 +218,7 @@ class ExplorationProgressControllerTest {
   fun testPlayExploration_valid_returnsSuccess() {
     val resultDataProvider =
       explorationDataController.replayExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -268,7 +267,7 @@ class ExplorationProgressControllerTest {
   @Test
   fun testEphemeralState_profile1ClicksContinue_switchToProfile2_shouldIndicateButtonAnimation() {
     oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
-    val profileId2 = LegacyProfileId.newBuilder().setInternalId(1).build()
+    val profileId2 = ProfileId.newBuilder().setInternalId(1).build()
     startPlayingNewExploration(
       TEST_CLASSROOM_ID_0, TEST_TOPIC_ID_0, TEST_STORY_ID_0, TEST_EXPLORATION_ID_2
     )
@@ -358,7 +357,7 @@ class ExplorationProgressControllerTest {
     // Try playing another exploration without finishing the previous one.
     val resultDataProvider =
       explorationDataController.replayExploration(
-        profileId.internalId,
+        profileId,
         TEST_CLASSROOM_ID_0,
         TEST_TOPIC_ID_0,
         TEST_STORY_ID_0,
@@ -2192,7 +2191,7 @@ class ExplorationProgressControllerTest {
 
   @Test
   fun testGetCurrentState_englishLangProfile_includesTranslationContextForEnglish() {
-    val englishProfileId = LegacyProfileId.newBuilder().apply { internalId = 1 }.build()
+    val englishProfileId = ProfileId.newBuilder().apply { internalId = 1 }.build()
     updateContentLanguage(englishProfileId, OppiaLanguage.ENGLISH)
     startPlayingNewExploration(
       TEST_CLASSROOM_ID_0,
@@ -2213,7 +2212,7 @@ class ExplorationProgressControllerTest {
 
   @Test
   fun testGetCurrentState_englishLangProfile_switchToArabic_includesTranslationContextForArabic() {
-    val englishProfileId = LegacyProfileId.newBuilder().apply { internalId = 1 }.build()
+    val englishProfileId = ProfileId.newBuilder().apply { internalId = 1 }.build()
     updateContentLanguage(englishProfileId, OppiaLanguage.ENGLISH)
     startPlayingNewExploration(
       TEST_CLASSROOM_ID_0,
@@ -2236,8 +2235,8 @@ class ExplorationProgressControllerTest {
 
   @Test
   fun testGetCurrentState_arabicLangProfile_includesTranslationContextForArabic() {
-    val englishProfileId = LegacyProfileId.newBuilder().apply { internalId = 1 }.build()
-    val arabicProfileId = LegacyProfileId.newBuilder().apply { internalId = 2 }.build()
+    val englishProfileId = ProfileId.newBuilder().apply { internalId = 1 }.build()
+    val arabicProfileId = ProfileId.newBuilder().apply { internalId = 2 }.build()
     updateContentLanguage(englishProfileId, OppiaLanguage.ENGLISH)
     updateContentLanguage(arabicProfileId, OppiaLanguage.ARABIC)
     startPlayingNewExploration(
@@ -3169,7 +3168,7 @@ class ExplorationProgressControllerTest {
     // Verify that the learner's profile-wide content language has changed.
     val contentLangProvider =
       translationController.getWrittenTranslationContentLanguage(
-        profileId.toProfileIdPreservingZero()
+        profileId
       )
     val contentLanguage = monitorFactory.waitForNextSuccessfulResult(contentLangProvider)
     assertThat(contentLanguage).isEqualTo(OppiaLanguage.SWAHILI)
@@ -3203,8 +3202,8 @@ class ExplorationProgressControllerTest {
 
   @Test
   fun testUpdateLanguageMidLesson_englishToSwahili_diffProfile_doesNotChangeOtherProfilesLang() {
-    val englishProfileId = LegacyProfileId.newBuilder().apply { internalId = 1 }.build()
-    val arabicProfileId = LegacyProfileId.newBuilder().apply { internalId = 2 }.build()
+    val englishProfileId = ProfileId.newBuilder().apply { internalId = 1 }.build()
+    val arabicProfileId = ProfileId.newBuilder().apply { internalId = 2 }.build()
     updateContentLanguage(englishProfileId, OppiaLanguage.ENGLISH)
     updateContentLanguage(arabicProfileId, OppiaLanguage.ARABIC)
     startPlayingNewExploration(
@@ -3227,7 +3226,7 @@ class ExplorationProgressControllerTest {
     // Verify that the other learner's profile-wide content language hasn't changed.
     val contentLangProvider =
       translationController.getWrittenTranslationContentLanguage(
-        arabicProfileId.toProfileIdPreservingZero()
+        arabicProfileId
       )
     val contentLanguage = monitorFactory.waitForNextSuccessfulResult(contentLangProvider)
     assertThat(contentLanguage).isEqualTo(OppiaLanguage.ARABIC)
@@ -3253,7 +3252,7 @@ class ExplorationProgressControllerTest {
     // Verify that the learner's profile-wide content language has changed.
     val contentLangProvider =
       translationController.getWrittenTranslationContentLanguage(
-        profileId.toProfileIdPreservingZero()
+        profileId
       )
     val contentLanguage = monitorFactory.waitForNextSuccessfulResult(contentLangProvider)
     assertThat(contentLanguage).isEqualTo(OppiaLanguage.ENGLISH)
@@ -3709,11 +3708,11 @@ class ExplorationProgressControllerTest {
     topicId: String,
     storyId: String,
     explorationId: String,
-    profileId: LegacyProfileId = this.profileId
+    profileId: ProfileId = this.profileId
   ) {
     val startPlayingProvider =
       explorationDataController.startPlayingNewExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId, classroomId, topicId, storyId, explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }
@@ -3724,11 +3723,11 @@ class ExplorationProgressControllerTest {
     storyId: String,
     explorationId: String,
     explorationCheckpoint: ExplorationCheckpoint,
-    profileId: LegacyProfileId = this.profileId
+    profileId: ProfileId = this.profileId
   ) {
     val startPlayingProvider =
       explorationDataController.resumeExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId, explorationCheckpoint
+        profileId, classroomId, topicId, storyId, explorationId, explorationCheckpoint
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }
@@ -3738,11 +3737,11 @@ class ExplorationProgressControllerTest {
     topicId: String,
     storyId: String,
     explorationId: String,
-    profileId: LegacyProfileId = this.profileId
+    profileId: ProfileId = this.profileId
   ) {
     val startPlayingProvider =
       explorationDataController.restartExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId, classroomId, topicId, storyId, explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }
@@ -3752,18 +3751,18 @@ class ExplorationProgressControllerTest {
     topicId: String,
     storyId: String,
     explorationId: String,
-    profileId: LegacyProfileId = this.profileId
+    profileId: ProfileId = this.profileId
   ) {
     val startPlayingProvider =
       explorationDataController.replayExploration(
-        profileId.internalId, classroomId, topicId, storyId, explorationId
+        profileId, classroomId, topicId, storyId, explorationId
       )
     monitorFactory.waitForNextSuccessfulResult(startPlayingProvider)
   }
 
   private fun retrieveExplorationCheckpoint(
     explorationId: String,
-    profileId: LegacyProfileId = this.profileId
+    profileId: ProfileId = this.profileId
   ): ExplorationCheckpoint {
     return monitorFactory.waitForNextSuccessfulResult(
       explorationCheckpointController.retrieveExplorationCheckpoint(profileId, explorationId)
@@ -4164,9 +4163,9 @@ class ExplorationProgressControllerTest {
     Locale.setDefault(locale)
   }
 
-  private fun updateContentLanguage(profileId: LegacyProfileId, language: OppiaLanguage) {
+  private fun updateContentLanguage(profileId: ProfileId, language: OppiaLanguage) {
     val updateProvider = translationController.updateWrittenTranslationContentLanguage(
-      profileId.toProfileIdPreservingZero(),
+      profileId,
       WrittenTranslationLanguageSelection.newBuilder().apply {
         selectedLanguage = language
       }.build()
@@ -4226,7 +4225,7 @@ class ExplorationProgressControllerTest {
   }
 
   private fun logIntoAnalyticsReadyAdminProfile() {
-    val rootProfileId = LegacyProfileId.getDefaultInstance()
+    val rootProfileId = ProfileId.getDefaultInstance()
     val addProfileProvider = profileManagementController.addProfile(
       name = "Admin",
       pin = "",
@@ -4237,7 +4236,7 @@ class ExplorationProgressControllerTest {
     )
     monitorFactory.waitForNextSuccessfulResult(addProfileProvider)
     monitorFactory.waitForNextSuccessfulResult(
-      profileManagementController.loginToProfile(rootProfileId.toProfileIdPreservingZero())
+      profileManagementController.loginToProfile(rootProfileId)
     )
   }
 

--- a/domain/src/test/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointControllerTest.kt
@@ -18,7 +18,7 @@ import org.oppia.android.app.model.CheckpointState
 import org.oppia.android.app.model.ExplorationCheckpoint
 import org.oppia.android.app.model.HelpIndex.IndexTypeCase.NEXT_AVAILABLE_HINT_INDEX
 import org.oppia.android.app.model.InteractionObject
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.model.UserAnswer
 import org.oppia.android.domain.classify.InteractionsModule
 import org.oppia.android.domain.classify.rules.algebraicexpressioninput.AlgebraicExpressionInputModule
@@ -74,6 +74,7 @@ import org.oppia.android.util.logging.GlobalLogLevel
 import org.oppia.android.util.logging.LogLevel
 import org.oppia.android.util.logging.SyncStatusModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
+import org.oppia.android.util.profile.toLegacyProfileId
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -117,8 +118,8 @@ class ExplorationCheckpointControllerTest {
   @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
   @Inject lateinit var fakeExplorationRetriever: FakeExplorationRetriever
 
-  private val firstTestProfile = LegacyProfileId.newBuilder().setInternalId(0).build()
-  private val secondTestProfile = LegacyProfileId.newBuilder().setInternalId(1).build()
+  private val firstTestProfile = ProfileId.newBuilder().setInternalId(0).build()
+  private val secondTestProfile = ProfileId.newBuilder().setInternalId(1).build()
 
   @Before
   fun setUp() {
@@ -160,7 +161,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoint_retrieveSavedCheckpoint_isSuccessful() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -176,7 +177,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoint_retrieveUnsavedCheckpoint_isFailure() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -193,7 +194,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoint_retrieveCheckpointWithDifferentProfileId_isFailure() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -210,11 +211,11 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoint_updateSavedCheckpoint_checkUpdatedCheckpointIsRetrieved() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
     explorationCheckpointTestHelper.updateCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -232,11 +233,11 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoints_retrieveOldestCheckpointDetails_correctCheckpointRetrieved() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration1(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_1_CURRENT_VERSION
     )
 
@@ -264,7 +265,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testCheckpointController_saveCheckpoint_deleteSavedCheckpoint_isSuccessful() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -280,7 +281,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testCheckpointController_saveCheckpoint_deleteSavedCheckpoint_checkpointWasDeleted() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
     val deleteCheckpointProvider =
@@ -335,7 +336,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCompatibleCheckpoint_retrieveCheckpoint_isSuccessful() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile,
+      profileId = firstTestProfile.toLegacyProfileId(),
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -832,7 +833,7 @@ class ExplorationCheckpointControllerTest {
     }
   }
 
-  private fun saveCheckpoint(profileId: LegacyProfileId, index: Int): Any? {
+  private fun saveCheckpoint(profileId: ProfileId, index: Int): Any? {
     val recordProvider = explorationCheckpointController.recordExplorationCheckpoint(
       profileId = profileId,
       explorationId = createExplorationIdForIndex(index),
@@ -841,7 +842,7 @@ class ExplorationCheckpointControllerTest {
     return monitorFactory.waitForNextSuccessfulResult(recordProvider)
   }
 
-  private fun saveMultipleCheckpoints(profileId: LegacyProfileId, numberOfCheckpoints: Int) {
+  private fun saveMultipleCheckpoints(profileId: ProfileId, numberOfCheckpoints: Int) {
     for (index in 0 until numberOfCheckpoints) {
       saveCheckpoint(profileId, index)
     }
@@ -885,7 +886,7 @@ class ExplorationCheckpointControllerTest {
       .build()
 
   private fun retrieveExplorationCheckpointWithOverride(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     expIdToLoadInstead: String
   ): DataProvider<ExplorationCheckpoint> {
     fakeExplorationRetriever.setExplorationProxy(
@@ -898,7 +899,7 @@ class ExplorationCheckpointControllerTest {
   }
 
   private fun createCheckpointForTestExploration(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     playRoutine: () -> Unit
   ) {
     fakeExplorationRetriever.setExplorationProxy(

--- a/domain/src/test/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointControllerTest.kt
@@ -74,7 +74,6 @@ import org.oppia.android.util.logging.GlobalLogLevel
 import org.oppia.android.util.logging.LogLevel
 import org.oppia.android.util.logging.SyncStatusModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
-import org.oppia.android.util.profile.toLegacyProfileId
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject

--- a/domain/src/test/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointControllerTest.kt
@@ -906,7 +906,7 @@ class ExplorationCheckpointControllerTest {
       expIdToLoadInstead = "test_checkpointing_base_exploration"
     )
     explorationDataController.startPlayingNewExploration(
-      internalProfileId = profileId.internalId,
+      profileId = profileId,
       classroomId = "<none>",
       topicId = "<none>",
       storyId = "<none>",

--- a/domain/src/test/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/lightweightcheckpointing/ExplorationCheckpointControllerTest.kt
@@ -161,7 +161,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoint_retrieveSavedCheckpoint_isSuccessful() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile.toLegacyProfileId(),
+      profileId = firstTestProfile,
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -177,7 +177,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoint_retrieveUnsavedCheckpoint_isFailure() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile.toLegacyProfileId(),
+      profileId = firstTestProfile,
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -194,7 +194,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoint_retrieveCheckpointWithDifferentProfileId_isFailure() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile.toLegacyProfileId(),
+      profileId = firstTestProfile,
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -211,11 +211,11 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoint_updateSavedCheckpoint_checkUpdatedCheckpointIsRetrieved() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile.toLegacyProfileId(),
+      profileId = firstTestProfile,
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
     explorationCheckpointTestHelper.updateCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile.toLegacyProfileId(),
+      profileId = firstTestProfile,
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -233,11 +233,11 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCheckpoints_retrieveOldestCheckpointDetails_correctCheckpointRetrieved() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile.toLegacyProfileId(),
+      profileId = firstTestProfile,
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration1(
-      profileId = firstTestProfile.toLegacyProfileId(),
+      profileId = firstTestProfile,
       version = FRACTIONS_STORY_0_EXPLORATION_1_CURRENT_VERSION
     )
 
@@ -265,7 +265,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testCheckpointController_saveCheckpoint_deleteSavedCheckpoint_isSuccessful() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile.toLegacyProfileId(),
+      profileId = firstTestProfile,
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 
@@ -281,7 +281,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testCheckpointController_saveCheckpoint_deleteSavedCheckpoint_checkpointWasDeleted() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile.toLegacyProfileId(),
+      profileId = firstTestProfile,
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
     val deleteCheckpointProvider =
@@ -336,7 +336,7 @@ class ExplorationCheckpointControllerTest {
   @Test
   fun testController_saveCompatibleCheckpoint_retrieveCheckpoint_isSuccessful() {
     explorationCheckpointTestHelper.saveCheckpointForFractionsStory0Exploration0(
-      profileId = firstTestProfile.toLegacyProfileId(),
+      profileId = firstTestProfile,
       version = FRACTIONS_STORY_0_EXPLORATION_0_CURRENT_VERSION
     )
 

--- a/domain/src/test/java/org/oppia/android/domain/oppialogger/analytics/LearnerAnalyticsLoggerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/oppialogger/analytics/LearnerAnalyticsLoggerTest.kt
@@ -66,6 +66,7 @@ import org.oppia.android.util.data.DataProvidersInjectorProvider
 import org.oppia.android.util.locale.LocaleProdModule
 import org.oppia.android.util.logging.LoggerModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.robolectric.shadows.ShadowLog
@@ -2311,7 +2312,7 @@ class LearnerAnalyticsLoggerTest {
 
   private fun loadExploration(expId: String): Exploration {
     return monitorFactory.waitForNextSuccessfulResult(
-      explorationDataController.getExplorationById(profileId, expId)
+      explorationDataController.getExplorationById(profileId.toProfileIdPreservingZero(), expId)
     ).exploration
   }
 

--- a/domain/src/test/java/org/oppia/android/domain/survey/SurveyGatingControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/survey/SurveyGatingControllerTest.kt
@@ -639,7 +639,7 @@ class SurveyGatingControllerTest {
     topicId: String
   ) {
     explorationActiveTimeController.onAppInForeground()
-    explorationActiveTimeController.onExplorationStarted(profileId, topicId)
+    explorationActiveTimeController.onExplorationStarted(profileId.toProfileIdPreservingZero(), topicId)
     testCoroutineDispatchers.advanceTimeBy(sessionLengthMs)
     explorationActiveTimeController.onExplorationEnded()
   }

--- a/domain/src/test/java/org/oppia/android/domain/survey/SurveyGatingControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/survey/SurveyGatingControllerTest.kt
@@ -639,7 +639,9 @@ class SurveyGatingControllerTest {
     topicId: String
   ) {
     explorationActiveTimeController.onAppInForeground()
-    explorationActiveTimeController.onExplorationStarted(profileId.toProfileIdPreservingZero(), topicId)
+    explorationActiveTimeController.onExplorationStarted(
+      profileId.toProfileIdPreservingZero(), topicId
+    )
     testCoroutineDispatchers.advanceTimeBy(sessionLengthMs)
     explorationActiveTimeController.onExplorationEnded()
   }

--- a/domain/src/test/java/org/oppia/android/domain/topic/StoryProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/topic/StoryProgressControllerTest.kt
@@ -13,7 +13,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.app.model.ChapterPlayState
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.domain.oppialogger.LogStorageModule
 import org.oppia.android.domain.oppialogger.LoggingIdentifierModule
 import org.oppia.android.domain.oppialogger.analytics.ApplicationLifecycleModule
@@ -55,11 +55,11 @@ class StoryProgressControllerTest {
   @Inject lateinit var fakeOppiaClock: FakeOppiaClock
   @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
 
-  private lateinit var profileId: LegacyProfileId
+  private lateinit var profileId: ProfileId
 
   @Before
   fun setUp() {
-    profileId = LegacyProfileId.newBuilder().setInternalId(0).build()
+    profileId = ProfileId.newBuilder().setInternalId(0).build()
     setUpTestApplicationComponent()
   }
 
@@ -281,7 +281,7 @@ class StoryProgressControllerTest {
   }
 
   private fun retrieveChapterPlayState(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     topicId: String,
     storyId: String,
     explorationId: String

--- a/domain/src/test/java/org/oppia/android/domain/topic/TopicControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/topic/TopicControllerTest.kt
@@ -1280,7 +1280,7 @@ class TopicControllerTest {
    */
   private fun markInProgressSavedFractionsStory0Exp1WithoutCompletingPreviousChapters() {
     val resultProvider = storyProgressController.recordChapterAsInProgressSaved(
-      profileId1,
+      profileId1.toProfileIdPreservingZero(),
       FRACTIONS_TOPIC_ID,
       FRACTIONS_STORY_ID_0,
       FRACTIONS_EXPLORATION_ID_1,

--- a/domain/src/test/java/org/oppia/android/domain/topic/TopicListControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/topic/TopicListControllerTest.kt
@@ -49,6 +49,7 @@ import org.oppia.android.util.logging.SyncStatusModule
 import org.oppia.android.util.networking.NetworkConnectionUtilDebugModule
 import org.oppia.android.util.parser.image.DefaultGcsPrefix
 import org.oppia.android.util.parser.image.ImageDownloadUrlTemplate
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import javax.inject.Inject
@@ -694,7 +695,7 @@ class TopicListControllerTest {
     val previousTopicId = "previous_topic_id"
     val recordProgressDataProvider =
       storyProgressController.recordChapterAsInProgressSaved(
-        profileId0,
+        profileId0.toProfileIdPreservingZero(),
         topicId = previousTopicId,
         storyId = "previous_story_id",
         explorationId = "previous_exploration_id",

--- a/model/src/main/proto/arguments.proto
+++ b/model/src/main/proto/arguments.proto
@@ -179,7 +179,7 @@ message ExplorationFragmentArguments {
 // Params required when creating a new ResumeLessonActivity.
 message ResumeLessonActivityParams {
   // The ID of the profile that wants to start an exploration play session.
-  ProfileId profile_id = 1;
+  LegacyProfileId profile_id = 1;
 
   // The ID of the classroom to which the opening exploration belongs.
   string classroom_id = 7;

--- a/model/src/main/proto/arguments.proto
+++ b/model/src/main/proto/arguments.proto
@@ -122,7 +122,7 @@ enum RecentlyPlayedActivityTitle {
 // Params required when creating a new ExplorationActivity.
 message ExplorationActivityParams {
   // The ID of the profile that wants to start an exploration play session.
-  LegacyProfileId profile_id = 1;
+  ProfileId profile_id = 1;
 
   // The ID of the classroom to which the opening exploration belongs.
   string classroom_id = 7;
@@ -158,7 +158,7 @@ message ExplorationActivityParams {
 // Arguments that must be passed to a new ExplorationFragment.
 message ExplorationFragmentArguments {
   // The ID of the profile that wants to start an exploration play session.
-  LegacyProfileId profile_id = 1;
+  ProfileId profile_id = 1;
 
   // The ID of the classroom to which the opening exploration belongs.
   string classroom_id = 6;
@@ -179,7 +179,7 @@ message ExplorationFragmentArguments {
 // Params required when creating a new ResumeLessonActivity.
 message ResumeLessonActivityParams {
   // The ID of the profile that wants to start an exploration play session.
-  LegacyProfileId profile_id = 1;
+  ProfileId profile_id = 1;
 
   // The ID of the classroom to which the opening exploration belongs.
   string classroom_id = 7;
@@ -203,7 +203,7 @@ message ResumeLessonActivityParams {
 // Arguments that must be passed to a new ResumeLessonFragment.
 message ResumeLessonFragmentArguments {
   // The ID of the profile that wants to start an exploration play session.
-  LegacyProfileId profile_id = 1;
+  ProfileId profile_id = 1;
 
   // The ID of the classroom to which the opening exploration belongs.
   string classroom_id = 7;

--- a/testing/src/main/java/org/oppia/android/testing/lightweightcheckpointing/ExplorationCheckpointTestHelper.kt
+++ b/testing/src/main/java/org/oppia/android/testing/lightweightcheckpointing/ExplorationCheckpointTestHelper.kt
@@ -12,6 +12,8 @@ import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import org.oppia.android.app.model.ExplorationCheckpoint
 import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.domain.exploration.lightweightcheckpointing.ExplorationCheckpointController
 import org.oppia.android.domain.exploration.lightweightcheckpointing.ExplorationCheckpointController.ExplorationCheckpointNotFoundException
 import org.oppia.android.domain.topic.FRACTIONS_EXPLORATION_ID_0
@@ -96,7 +98,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
    * @param profileId the profile ID for which the checkpoint has to be saved
    * @param version the version of the exploration for which the checkpoint has to be created
    */
-  fun saveCheckpointForFractionsStory0Exploration0(profileId: LegacyProfileId, version: Int) {
+  fun saveCheckpointForFractionsStory0Exploration0(profileId: ProfileId, version: Int) {
     val checkpoint = createExplorationCheckpoint(
       explorationTitle = FRACTIONS_EXPLORATION_0_TITLE,
       pendingStateName = FRACTIONS_STORY_0_EXPLORATION_0_FIRST_STATE_NAME,
@@ -110,13 +112,18 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     verifyProviderFinishesWithSuccess(saveCheckpointDataProvider)
   }
 
+  fun saveCheckpointForFractionsStory0Exploration0(profileId: LegacyProfileId, version: Int) {
+    saveCheckpointForFractionsStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
+  }
+
+
   /**
    * Saves a checkpoint for topic Fractions, story 0, exploration 1.
    *
    * @param profileId the profile ID for which the checkpoint has to be saved
    * @param version the version of the exploration for which the checkpoint has to be created
    */
-  fun saveCheckpointForFractionsStory0Exploration1(profileId: LegacyProfileId, version: Int) {
+  fun saveCheckpointForFractionsStory0Exploration1(profileId: ProfileId, version: Int) {
     val checkpoint = createExplorationCheckpoint(
       explorationTitle = FRACTIONS_EXPLORATION_1_TITLE,
       pendingStateName = FRACTIONS_STORY_0_EXPLORATION_1_FIRST_STATE_NAME,
@@ -130,6 +137,11 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     verifyProviderFinishesWithSuccess(saveCheckpointDataProvider)
   }
 
+  fun saveCheckpointForFractionsStory0Exploration1(profileId: LegacyProfileId, version: Int) {
+    saveCheckpointForFractionsStory0Exploration1(profileId.toProfileIdPreservingZero(), version)
+  }
+
+
   /**
    * Updates the saved checkpoint for Fractions, story 0, exploration 0. For this function to work
    * correctly it should be called after [saveCheckpointForFractionsStory0Exploration0].
@@ -137,7 +149,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
    * @param profileId the profile ID for which the checkpoint has to be saved
    * @param version the version of the exploration for which the checkpoint has to be created
    */
-  fun updateCheckpointForFractionsStory0Exploration0(profileId: LegacyProfileId, version: Int) {
+  fun updateCheckpointForFractionsStory0Exploration0(profileId: ProfileId, version: Int) {
     val checkpoint = createUpdatedExplorationCheckpoint(
       explorationTitle = FRACTIONS_EXPLORATION_0_TITLE,
       pendingStateName = FRACTIONS_STORY_0_EXPLORATION_0_SECOND_STATE_NAME,
@@ -151,6 +163,11 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     verifyProviderFinishesWithSuccess(saveCheckpointDataProvider)
   }
 
+  fun updateCheckpointForFractionsStory0Exploration0(profileId: LegacyProfileId, version: Int) {
+    updateCheckpointForFractionsStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
+  }
+
+
   /**
    * Updates the saved checkpoint for Fractions, story 0, exploration 1. For this function to work
    * correctly it should be called after [saveCheckpointForFractionsStory0Exploration1].
@@ -158,7 +175,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
    * @param profileId the profile ID for which the checkpoint has to be saved
    * @param version the version of the exploration for which the checkpoint has to be created
    */
-  fun updateCheckpointForFractionsStory0Exploration1(profileId: LegacyProfileId, version: Int) {
+  fun updateCheckpointForFractionsStory0Exploration1(profileId: ProfileId, version: Int) {
     val checkpoint = createUpdatedExplorationCheckpoint(
       explorationTitle = FRACTIONS_EXPLORATION_1_TITLE,
       pendingStateName = FRACTIONS_STORY_0_EXPLORATION_1_SECOND_STATE_NAME,
@@ -172,6 +189,11 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     verifyProviderFinishesWithSuccess(saveCheckpointDataProvider)
   }
 
+  fun updateCheckpointForFractionsStory0Exploration1(profileId: LegacyProfileId, version: Int) {
+    updateCheckpointForFractionsStory0Exploration1(profileId.toProfileIdPreservingZero(), version)
+  }
+
+
   /**
    * Saves a checkpoint for topic Ratios, story 0, exploration 0.
    *
@@ -179,7 +201,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
    * @param version the version of the exploration for which the checkpoint has to be created
    */
   fun saveCheckpointForRatiosStory0Exploration0(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     version: Int,
   ) {
     val checkpoint = createExplorationCheckpoint(
@@ -195,6 +217,14 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     verifyProviderFinishesWithSuccess(saveCheckpointDataProvider)
   }
 
+  fun saveCheckpointForRatiosStory0Exploration0(
+    profileId: LegacyProfileId,
+    version: Int,
+  ) {
+    saveCheckpointForRatiosStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
+  }
+
+
   /**
    * Updates the saved checkpoint for Fractions, story 0, exploration 0. For this function to work
    * correctly it should be called after [saveCheckpointForFractionsStory0Exploration0].
@@ -202,7 +232,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
    * @param profileId the profile ID for which the checkpoint has to be saved
    * @param version the version of the exploration for which the checkpoint has to be created
    */
-  fun updateCheckpointForRatiosStory0Exploration0(profileId: LegacyProfileId, version: Int) {
+  fun updateCheckpointForRatiosStory0Exploration0(profileId: ProfileId, version: Int) {
     val checkpoint = createUpdatedExplorationCheckpoint(
       explorationTitle = RATIOS_EXPLORATION_0_TITLE,
       pendingStateName = RATIOS_STORY_0_EXPLORATION_0_SECOND_STATE_NAME,
@@ -216,6 +246,11 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     verifyProviderFinishesWithSuccess(saveCheckpointDataProvider)
   }
 
+  fun updateCheckpointForRatiosStory0Exploration0(profileId: LegacyProfileId, version: Int) {
+    updateCheckpointForRatiosStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
+  }
+
+
   /**
    * Function to verify progress for the exploration specified by the explorationId exists in the
    * checkpoint database of the specified profileId.
@@ -223,7 +258,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
    * @param profileId the profile ID for which the save operation has to be verified
    * @param explorationId the ID of the exploration for which checkpoint was saved
    */
-  fun verifyExplorationProgressIsSaved(profileId: LegacyProfileId, explorationId: String) {
+  fun verifyExplorationProgressIsSaved(profileId: ProfileId, explorationId: String) {
 
     val retrieveCheckpointDataProvider =
       explorationCheckpointController.retrieveExplorationCheckpoint(
@@ -247,6 +282,11 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     }
   }
 
+  fun verifyExplorationProgressIsSaved(profileId: LegacyProfileId, explorationId: String) {
+    verifyExplorationProgressIsSaved(profileId.toProfileIdPreservingZero(), explorationId)
+  }
+
+
   /**
    * Function to verify no progress for the exploration specified by the explorationId exists in the
    * checkpoint database of the specified profileId.
@@ -254,7 +294,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
    * @param profileId the profile ID for which the delete operation has to be verified
    * @param explorationId the ID of the exploration for which checkpoint should be deleted
    */
-  fun verifyExplorationProgressIsDeleted(profileId: LegacyProfileId, explorationId: String) {
+  fun verifyExplorationProgressIsDeleted(profileId: ProfileId, explorationId: String) {
     val retrieveCheckpointDataProvider =
       explorationCheckpointController.retrieveExplorationCheckpoint(
         profileId,
@@ -278,6 +318,11 @@ class ExplorationCheckpointTestHelper @Inject constructor(
         .isInstanceOf(ExplorationCheckpointNotFoundException::class.java)
     }
   }
+
+  fun verifyExplorationProgressIsDeleted(profileId: LegacyProfileId, explorationId: String) {
+    verifyExplorationProgressIsDeleted(profileId.toProfileIdPreservingZero(), explorationId)
+  }
+
 
   private fun createExplorationCheckpoint(
     explorationTitle: String,

--- a/testing/src/main/java/org/oppia/android/testing/lightweightcheckpointing/ExplorationCheckpointTestHelper.kt
+++ b/testing/src/main/java/org/oppia/android/testing/lightweightcheckpointing/ExplorationCheckpointTestHelper.kt
@@ -112,6 +112,12 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     verifyProviderFinishesWithSuccess(saveCheckpointDataProvider)
   }
 
+  /**
+   * Saves a checkpoint for topic Fractions, story 0, exploration 0.
+   *
+   * @param profileId the legacy profile ID for which the checkpoint has to be saved
+   * @param version the version of the exploration for which the checkpoint has to be created
+   */
   fun saveCheckpointForFractionsStory0Exploration0(profileId: LegacyProfileId, version: Int) {
     saveCheckpointForFractionsStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
   }
@@ -136,6 +142,12 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     verifyProviderFinishesWithSuccess(saveCheckpointDataProvider)
   }
 
+  /**
+   * Saves a checkpoint for topic Fractions, story 0, exploration 1.
+   *
+   * @param profileId the legacy profile ID for which the checkpoint has to be saved
+   * @param version the version of the exploration for which the checkpoint has to be created
+   */
   fun saveCheckpointForFractionsStory0Exploration1(profileId: LegacyProfileId, version: Int) {
     saveCheckpointForFractionsStory0Exploration1(profileId.toProfileIdPreservingZero(), version)
   }
@@ -161,6 +173,12 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     verifyProviderFinishesWithSuccess(saveCheckpointDataProvider)
   }
 
+  /**
+   * Updates the saved checkpoint for Fractions, story 0, exploration 0.
+   *
+   * @param profileId the legacy profile ID for which the checkpoint has to be saved
+   * @param version the version of the exploration for which the checkpoint has to be created
+   */
   fun updateCheckpointForFractionsStory0Exploration0(profileId: LegacyProfileId, version: Int) {
     updateCheckpointForFractionsStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
   }
@@ -186,6 +204,12 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     verifyProviderFinishesWithSuccess(saveCheckpointDataProvider)
   }
 
+  /**
+   * Updates the saved checkpoint for Fractions, story 0, exploration 1.
+   *
+   * @param profileId the legacy profile ID for which the checkpoint has to be saved
+   * @param version the version of the exploration for which the checkpoint has to be created
+   */
   fun updateCheckpointForFractionsStory0Exploration1(profileId: LegacyProfileId, version: Int) {
     updateCheckpointForFractionsStory0Exploration1(profileId.toProfileIdPreservingZero(), version)
   }
@@ -213,6 +237,12 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     verifyProviderFinishesWithSuccess(saveCheckpointDataProvider)
   }
 
+  /**
+   * Saves a checkpoint for topic Ratios, story 0, exploration 0.
+   *
+   * @param profileId the legacy profile ID for which the checkpoint has to be saved
+   * @param version the version of the exploration for which the checkpoint has to be created
+   */
   fun saveCheckpointForRatiosStory0Exploration0(
     profileId: LegacyProfileId,
     version: Int,
@@ -241,6 +271,12 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     verifyProviderFinishesWithSuccess(saveCheckpointDataProvider)
   }
 
+  /**
+   * Updates the saved checkpoint for Ratios, story 0, exploration 0.
+   *
+   * @param profileId the legacy profile ID for which the checkpoint has to be saved
+   * @param version the version of the exploration for which the checkpoint has to be created
+   */
   fun updateCheckpointForRatiosStory0Exploration0(profileId: LegacyProfileId, version: Int) {
     updateCheckpointForRatiosStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
   }
@@ -276,6 +312,12 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     }
   }
 
+  /**
+   * Verifies that progress for the given [explorationId] exists for the specified [profileId].
+   *
+   * @param profileId the legacy profile ID for which the save operation has to be verified
+   * @param explorationId the ID of the exploration for which checkpoint was saved
+   */
   fun verifyExplorationProgressIsSaved(profileId: LegacyProfileId, explorationId: String) {
     verifyExplorationProgressIsSaved(profileId.toProfileIdPreservingZero(), explorationId)
   }
@@ -312,6 +354,12 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     }
   }
 
+  /**
+   * Verifies that no progress for the given [explorationId] exists for the specified [profileId].
+   *
+   * @param profileId the legacy profile ID for which the delete operation has to be verified
+   * @param explorationId the ID of the exploration for which checkpoint should be deleted
+   */
   fun verifyExplorationProgressIsDeleted(profileId: LegacyProfileId, explorationId: String) {
     verifyExplorationProgressIsDeleted(profileId.toProfileIdPreservingZero(), explorationId)
   }

--- a/testing/src/main/java/org/oppia/android/testing/lightweightcheckpointing/ExplorationCheckpointTestHelper.kt
+++ b/testing/src/main/java/org/oppia/android/testing/lightweightcheckpointing/ExplorationCheckpointTestHelper.kt
@@ -13,7 +13,6 @@ import org.mockito.MockitoAnnotations
 import org.oppia.android.app.model.ExplorationCheckpoint
 import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.ProfileId
-import org.oppia.android.util.profile.toProfileIdPreservingZero
 import org.oppia.android.domain.exploration.lightweightcheckpointing.ExplorationCheckpointController
 import org.oppia.android.domain.exploration.lightweightcheckpointing.ExplorationCheckpointController.ExplorationCheckpointNotFoundException
 import org.oppia.android.domain.topic.FRACTIONS_EXPLORATION_ID_0
@@ -25,6 +24,7 @@ import org.oppia.android.testing.time.FakeOppiaClock
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -116,7 +116,6 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     saveCheckpointForFractionsStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
   }
 
-
   /**
    * Saves a checkpoint for topic Fractions, story 0, exploration 1.
    *
@@ -140,7 +139,6 @@ class ExplorationCheckpointTestHelper @Inject constructor(
   fun saveCheckpointForFractionsStory0Exploration1(profileId: LegacyProfileId, version: Int) {
     saveCheckpointForFractionsStory0Exploration1(profileId.toProfileIdPreservingZero(), version)
   }
-
 
   /**
    * Updates the saved checkpoint for Fractions, story 0, exploration 0. For this function to work
@@ -167,7 +165,6 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     updateCheckpointForFractionsStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
   }
 
-
   /**
    * Updates the saved checkpoint for Fractions, story 0, exploration 1. For this function to work
    * correctly it should be called after [saveCheckpointForFractionsStory0Exploration1].
@@ -192,7 +189,6 @@ class ExplorationCheckpointTestHelper @Inject constructor(
   fun updateCheckpointForFractionsStory0Exploration1(profileId: LegacyProfileId, version: Int) {
     updateCheckpointForFractionsStory0Exploration1(profileId.toProfileIdPreservingZero(), version)
   }
-
 
   /**
    * Saves a checkpoint for topic Ratios, story 0, exploration 0.
@@ -224,7 +220,6 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     saveCheckpointForRatiosStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
   }
 
-
   /**
    * Updates the saved checkpoint for Fractions, story 0, exploration 0. For this function to work
    * correctly it should be called after [saveCheckpointForFractionsStory0Exploration0].
@@ -249,7 +244,6 @@ class ExplorationCheckpointTestHelper @Inject constructor(
   fun updateCheckpointForRatiosStory0Exploration0(profileId: LegacyProfileId, version: Int) {
     updateCheckpointForRatiosStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
   }
-
 
   /**
    * Function to verify progress for the exploration specified by the explorationId exists in the
@@ -286,7 +280,6 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     verifyExplorationProgressIsSaved(profileId.toProfileIdPreservingZero(), explorationId)
   }
 
-
   /**
    * Function to verify no progress for the exploration specified by the explorationId exists in the
    * checkpoint database of the specified profileId.
@@ -322,7 +315,6 @@ class ExplorationCheckpointTestHelper @Inject constructor(
   fun verifyExplorationProgressIsDeleted(profileId: LegacyProfileId, explorationId: String) {
     verifyExplorationProgressIsDeleted(profileId.toProfileIdPreservingZero(), explorationId)
   }
-
 
   private fun createExplorationCheckpoint(
     explorationTitle: String,

--- a/testing/src/main/java/org/oppia/android/testing/lightweightcheckpointing/ExplorationCheckpointTestHelper.kt
+++ b/testing/src/main/java/org/oppia/android/testing/lightweightcheckpointing/ExplorationCheckpointTestHelper.kt
@@ -119,6 +119,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
    * @param version the version of the exploration for which the checkpoint has to be created
    */
   fun saveCheckpointForFractionsStory0Exploration0(profileId: LegacyProfileId, version: Int) {
+    // TODO(#6203): Remove once app-layer tests are migrated to ProfileId.
     saveCheckpointForFractionsStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
   }
 
@@ -149,6 +150,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
    * @param version the version of the exploration for which the checkpoint has to be created
    */
   fun saveCheckpointForFractionsStory0Exploration1(profileId: LegacyProfileId, version: Int) {
+    // TODO(#6203): Remove once app-layer tests are migrated to ProfileId.
     saveCheckpointForFractionsStory0Exploration1(profileId.toProfileIdPreservingZero(), version)
   }
 
@@ -180,6 +182,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
    * @param version the version of the exploration for which the checkpoint has to be created
    */
   fun updateCheckpointForFractionsStory0Exploration0(profileId: LegacyProfileId, version: Int) {
+    // TODO(#6203): Remove once app-layer tests are migrated to ProfileId.
     updateCheckpointForFractionsStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
   }
 
@@ -211,6 +214,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
    * @param version the version of the exploration for which the checkpoint has to be created
    */
   fun updateCheckpointForFractionsStory0Exploration1(profileId: LegacyProfileId, version: Int) {
+    // TODO(#6203): Remove once app-layer tests are migrated to ProfileId.
     updateCheckpointForFractionsStory0Exploration1(profileId.toProfileIdPreservingZero(), version)
   }
 
@@ -247,6 +251,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
     profileId: LegacyProfileId,
     version: Int,
   ) {
+    // TODO(#6203): Remove once app-layer tests are migrated to ProfileId.
     saveCheckpointForRatiosStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
   }
 
@@ -278,6 +283,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
    * @param version the version of the exploration for which the checkpoint has to be created
    */
   fun updateCheckpointForRatiosStory0Exploration0(profileId: LegacyProfileId, version: Int) {
+    // TODO(#6203): Remove once app-layer tests are migrated to ProfileId.
     updateCheckpointForRatiosStory0Exploration0(profileId.toProfileIdPreservingZero(), version)
   }
 
@@ -319,6 +325,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
    * @param explorationId the ID of the exploration for which checkpoint was saved
    */
   fun verifyExplorationProgressIsSaved(profileId: LegacyProfileId, explorationId: String) {
+    // TODO(#6203): Remove once app-layer tests are migrated to ProfileId.
     verifyExplorationProgressIsSaved(profileId.toProfileIdPreservingZero(), explorationId)
   }
 
@@ -361,6 +368,7 @@ class ExplorationCheckpointTestHelper @Inject constructor(
    * @param explorationId the ID of the exploration for which checkpoint should be deleted
    */
   fun verifyExplorationProgressIsDeleted(profileId: LegacyProfileId, explorationId: String) {
+    // TODO(#6203): Remove once app-layer tests are migrated to ProfileId.
     verifyExplorationProgressIsDeleted(profileId.toProfileIdPreservingZero(), explorationId)
   }
 

--- a/testing/src/main/java/org/oppia/android/testing/story/StoryProgressTestHelper.kt
+++ b/testing/src/main/java/org/oppia/android/testing/story/StoryProgressTestHelper.kt
@@ -36,6 +36,7 @@ import org.oppia.android.testing.time.FakeOppiaClock
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.profile.toProfileIdPreservingZero
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -1001,7 +1002,7 @@ class StoryProgressTestHelper @Inject constructor(
   ) {
     primeClockForRecordingProgress()
     val resultProvider = storyProgressController.recordCompletedChapter(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       topicId,
       storyId,
       explorationId,
@@ -1019,7 +1020,7 @@ class StoryProgressTestHelper @Inject constructor(
   ) {
     primeClockForRecordingProgress()
     val resultProvider = storyProgressController.recordChapterAsInProgressNotSaved(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       topicId,
       storyId,
       explorationId,
@@ -1037,7 +1038,7 @@ class StoryProgressTestHelper @Inject constructor(
   ) {
     primeClockForRecordingProgress()
     val resultProvider = storyProgressController.recordChapterAsInProgressSaved(
-      profileId,
+      profileId.toProfileIdPreservingZero(),
       topicId,
       storyId,
       explorationId,

--- a/testing/src/test/java/org/oppia/android/testing/lightweightcheckpointing/ExplorationCheckpointTestHelperTest.kt
+++ b/testing/src/test/java/org/oppia/android/testing/lightweightcheckpointing/ExplorationCheckpointTestHelperTest.kt
@@ -14,7 +14,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.oppia.android.app.model.ExplorationCheckpoint
-import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.domain.classify.InteractionsModule
 import org.oppia.android.domain.classify.rules.algebraicexpressioninput.AlgebraicExpressionInputModule
 import org.oppia.android.domain.classify.rules.continueinteraction.ContinueModule
@@ -75,7 +75,7 @@ class ExplorationCheckpointTestHelperTest {
   @Inject lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
   @Inject lateinit var monitorFactory: DataProviderTestMonitor.Factory
 
-  private val profileId = LegacyProfileId.newBuilder().setInternalId(0).build()
+  private val profileId = ProfileId.newBuilder().setInternalId(0).build()
 
   @Before
   fun setUp() {
@@ -211,7 +211,7 @@ class ExplorationCheckpointTestHelperTest {
   }
 
   private fun retrieveCheckpoint(
-    profileId: LegacyProfileId,
+    profileId: ProfileId,
     explorationId: String
   ): ExplorationCheckpoint {
     val retrieveCheckpointProvider =


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fixes part of #6203.

This PR completes the migration for the domain-layer exploration and progress controllers. It migrates these controllers from using `LegacyProfileId` (and raw `Int` internal IDs) to the new `ProfileId` schema.

### 1. Domain Layer Controllers Migrated to `ProfileId`

- `ExplorationProgressController.kt` & `ExplorationDataController.kt`: Updated all internal state maps, data classes, and method signatures to utilize `ProfileId` instead of legacy types.
- `StoryProgressController.kt`, `ExplorationCheckpointController.kt`, and `ExplorationActiveTimeController.kt`: Signatures and internal progress tracking methods were migrated to `ProfileId`.
- **Note on Analytics:** The explicit boundary at `LearnerAnalyticsLogger.beginExploration` is maintained intentionally using `toLegacyProfileId()` since the logging infrastructure is not yet fully migrated.

### 2. `arguments.proto` Schema Migration

- Migrated the `profile_id` field in:
  - `ExplorationActivityParams`
  - `ExplorationFragmentArguments`
  - `ResumeLessonActivityParams`
  - `ResumeLessonFragmentArguments`
  
  from `LegacyProfileId` → `ProfileId` as required by Task 3.

- Added `toProfileIdPreservingZero()` at write boundaries (Activity/Fragment `createIntent()`/`newInstance()` functions) and `toLegacyProfileId()` at read boundaries (`onCreate()`/`onCreateView()`) in:
  - `ExplorationActivity`
  - `ExplorationFragment`
  - `ResumeLessonActivity`
  - `ResumeLessonFragment`

  to preserve app-layer compatibility until a follow-up migration.

- Removed the now-redundant `toProfileIdPreservingZero()` call in `ExplorationFragmentPresenter` since `profileId` is already `ProfileId`.

### 3. Domain Layer Tests Fully Migrated

- `ExplorationDataControllerTest.kt`
- `ExplorationProgressControllerTest.kt`
- `ExplorationActiveTimeControllerTest.kt`
- `ExplorationCheckpointControllerTest.kt`
- `StoryProgressControllerTest.kt`

Changes:
- Removed all instances of `.internalId` and legacy types.
- Updated all test helpers to instantiate and pass `ProfileId` objects natively.

- `ResumeLessonFragmentTest.kt`: Updated assertion to compare against `ProfileId` instead of `LegacyProfileId` to reflect the proto field migration.

### 4. App-Layer Boundary Isolation (Temporary Compatibility)

Because the App Layer is slated for migration in a future task, strict type-safe boundaries were introduced at presenter call-sites:

- `TopicLessonsFragmentPresenter.kt`
- `RecentlyPlayedFragmentPresenter.kt`
- `StoryFragmentPresenter.kt`
- `ResumeLessonFragmentPresenter.kt`

  Added `toProfileIdPreservingZero()` to calls accessing `ExplorationDataController`.

- `ExplorationActivityPresenter.kt` & `StateViewModel.kt`

  Refactored:
  - `deleteExplorationProgressById`
  - `getOldestExplorationDetailsDataProvider`
  - `updateWrittenTranslationContentLanguageMidLesson`

  to convert the internally held `LegacyProfileId` at the boundary.

- `StateFragmentTestActivityPresenter.kt`

  Wrapped raw `Int` profile values in `ProfileId.newBuilder().setInternalId(..).build()`.


- **App Tests**
  - `ExplorationActivityTest.kt`
  - `ExplorationActivityLocalTest.kt`

  Safely wrapped injected test properties (`internalProfileId`) in `ProfileId` prior to domain controller interaction.


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).
