### PR TITLE
Fix part of 6106: Implement Deploy Updated Changelog workflow

### DIFF
--- a/.github/workflows/deploy_updated_changelog.yml
+++ b/.github/workflows/deploy_updated_changelog.yml
@@ -173,11 +173,9 @@ jobs:
       #   3. Uploads updated notes to any track where a changelog file is found.
       # The script skips tracks with no matching changelog file silently.
       - name: Upload updated changelog to Play Console
-        env:
-          PLAY_CONSOLE_PACKAGE_NAME: ${{ secrets.PLAY_CONSOLE_PACKAGE_NAME }}
         run: |
           bazel run //scripts:upload_changelog_to_play_console -- \
             "$GITHUB_WORKSPACE" \
-            "$PLAY_CONSOLE_PACKAGE_NAME" \
+            "org.oppia.android" \
             "$VERSION" \
             "$(gcloud auth print-access-token)"

--- a/.github/workflows/deploy_updated_changelog.yml
+++ b/.github/workflows/deploy_updated_changelog.yml
@@ -3,7 +3,8 @@
 # on Play Console and upload any differences.
 #
 # Triggered automatically on push to develop (detects the modified changelog file and extracts
-# version and optional flavor) or manually via workflow_dispatch (coordinator provides both).
+# the version from the filename) or manually via workflow_dispatch (coordinator provides version
+# and optional flavor).
 #
 # Flavor-specific changelogs (e.g. config/changelogs/0.17_alpha.md) take precedence over the
 # generic changelog (e.g. config/changelogs/0.17.md) for the matching flavor's track.
@@ -33,43 +34,44 @@ on:
       flavor:
         description: "Optional app flavor for a flavor-specific changelog (leave blank to use the generic changelog for all flavors)."
         required: false
-        type: choice
-        options:
-          - ""
-          - alpha
-          - beta
-          - ga
+        # type: string allows empty/blank values; type: choice with an empty option is invalid in
+        # workflow_dispatch and causes the workflow to fail at parse time.
+        type: string
 
 concurrency:
   # Only one changelog upload at a time to avoid concurrent edit conflicts on Play Console.
-  group: deploy-updated-changelog-${{ github.ref }}
+  # The group is intentionally not scoped to github.ref so that push and dispatch triggers
+  # across different refs are also serialized — Play Console edits must be globally exclusive.
+  group: deploy-updated-changelog
   cancel-in-progress: false
 
 jobs:
 
-  # Runs only on push: uses the GitHub API to list files changed in this commit and extracts the
-  # changelog version and optional flavor from the filename (e.g. 0.17_alpha.md → 0.17, alpha).
+  # Runs only on push: uses the GitHub API to list files changed across the entire push (not just
+  # the head commit) and extracts the changelog version from the filename (e.g. 0.17_alpha.md →
+  # 0.17). The compare endpoint covers all commits in the push so a changelog changed in an
+  # earlier commit is still detected even if the head commit did not touch it.
   # No checkout required since the GitHub API provides the changed-file list directly.
   resolve_push:
     name: Resolve version (push)
     if: github.event_name == 'push'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.detect.outputs.version }}
-      flavor: ${{ steps.detect.outputs.flavor }}
     steps:
       - name: Detect changed changelog file
         id: detect
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          CHANGED=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}" \
+          CHANGED=$(gh api "repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }}" \
             --jq '[.files[].filename | select(test("^config/changelogs/.+\\.md$"))] | first // ""')
 
           if [[ -z "$CHANGED" ]]; then
             echo "No changelog files changed in this push — skipping upload."
             echo "version=" >> $GITHUB_OUTPUT
-            echo "flavor=" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -84,24 +86,26 @@ jobs:
           fi
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "flavor=$FLAVOR" >> $GITHUB_OUTPUT
           echo "Detected: version=$VERSION, flavor=${FLAVOR:-<generic>}"
 
-  # Runs only on workflow_dispatch: reads and validates the version and flavor provided by the
-  # release coordinator.
+  # Runs only on workflow_dispatch: reads and validates the version provided by the release
+  # coordinator. Inputs are passed via env vars to prevent shell injection before the regex guard.
   resolve_dispatch:
     name: Resolve version (dispatch)
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
+    permissions: {}
     outputs:
       version: ${{ steps.resolve.outputs.version }}
-      flavor: ${{ steps.resolve.outputs.flavor }}
     steps:
       - name: Validate and resolve inputs
         id: resolve
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_FLAVOR: ${{ github.event.inputs.flavor }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
-          FLAVOR="${{ github.event.inputs.flavor }}"
+          VERSION="$INPUT_VERSION"
+          FLAVOR="$INPUT_FLAVOR"
 
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Invalid version '$VERSION'. Must be in major.minor format (e.g. '0.17')."
@@ -109,7 +113,6 @@ jobs:
           fi
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "flavor=$FLAVOR" >> $GITHUB_OUTPUT
           echo "Resolved: version=$VERSION, flavor=${FLAVOR:-<generic>}"
 
   # Uploads the changelog to Play Console. Runs only when a version was successfully resolved by
@@ -170,9 +173,11 @@ jobs:
       #   3. Uploads updated notes to any track where a changelog file is found.
       # The script skips tracks with no matching changelog file silently.
       - name: Upload updated changelog to Play Console
+        env:
+          PLAY_CONSOLE_PACKAGE_NAME: ${{ secrets.PLAY_CONSOLE_PACKAGE_NAME }}
         run: |
           bazel run //scripts:upload_changelog_to_play_console -- \
             "$GITHUB_WORKSPACE" \
-            "${{ secrets.PLAY_CONSOLE_PACKAGE_NAME }}" \
-            "${{ env.VERSION }}" \
+            "$PLAY_CONSOLE_PACKAGE_NAME" \
+            "$VERSION" \
             "$(gcloud auth print-access-token)"

--- a/.github/workflows/deploy_updated_changelog.yml
+++ b/.github/workflows/deploy_updated_changelog.yml
@@ -1,0 +1,178 @@
+# Detects when a changelog file in config/changelogs/ is pushed to develop, then runs
+# UploadChangelogToPlayConsole to compare the local changelog against the deployed release notes
+# on Play Console and upload any differences.
+#
+# Triggered automatically on push to develop (detects the modified changelog file and extracts
+# version and optional flavor) or manually via workflow_dispatch (coordinator provides both).
+#
+# Flavor-specific changelogs (e.g. config/changelogs/0.17_alpha.md) take precedence over the
+# generic changelog (e.g. config/changelogs/0.17.md) for the matching flavor's track.
+#
+# Prerequisites:
+#   - A live release for the changelog version must already exist on Play Console. The script
+#     fails with an error if the version is not yet live (preventing race conditions against the
+#     initial binary deployment done by deploy_to_play_console.yml).
+#   - The GCP service account must have "Release to production" permission in Play Console.
+#
+# Authentication uses Workload Identity Federation, identical to build_and_sign.yml.
+
+name: Deploy Updated Changelog
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'config/changelogs/**.md'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Changelog version in major.minor format (e.g. '0.17'). Must match a file in config/changelogs/<version>[_flavor].md."
+        required: true
+        type: string
+      flavor:
+        description: "Optional app flavor for a flavor-specific changelog (leave blank to use the generic changelog for all flavors)."
+        required: false
+        type: choice
+        options:
+          - ""
+          - alpha
+          - beta
+          - ga
+
+concurrency:
+  # Only one changelog upload at a time to avoid concurrent edit conflicts on Play Console.
+  group: deploy-updated-changelog-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+
+  # Runs only on push: uses the GitHub API to list files changed in this commit and extracts the
+  # changelog version and optional flavor from the filename (e.g. 0.17_alpha.md → 0.17, alpha).
+  # No checkout required since the GitHub API provides the changed-file list directly.
+  resolve_push:
+    name: Resolve version (push)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.detect.outputs.version }}
+      flavor: ${{ steps.detect.outputs.flavor }}
+    steps:
+      - name: Detect changed changelog file
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CHANGED=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}" \
+            --jq '[.files[].filename | select(test("^config/changelogs/.+\\.md$"))] | first // ""')
+
+          if [[ -z "$CHANGED" ]]; then
+            echo "No changelog files changed in this push — skipping upload."
+            echo "version=" >> $GITHUB_OUTPUT
+            echo "flavor=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          BASENAME=$(basename "$CHANGED" .md)
+          VERSION="${BASENAME%%_*}"
+          FLAVOR_SUFFIX="${BASENAME#${VERSION}}"
+          FLAVOR="${FLAVOR_SUFFIX#_}"
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version '$VERSION' extracted from '$CHANGED'."
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "flavor=$FLAVOR" >> $GITHUB_OUTPUT
+          echo "Detected: version=$VERSION, flavor=${FLAVOR:-<generic>}"
+
+  # Runs only on workflow_dispatch: reads and validates the version and flavor provided by the
+  # release coordinator.
+  resolve_dispatch:
+    name: Resolve version (dispatch)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      flavor: ${{ steps.resolve.outputs.flavor }}
+    steps:
+      - name: Validate and resolve inputs
+        id: resolve
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          FLAVOR="${{ github.event.inputs.flavor }}"
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version '$VERSION'. Must be in major.minor format (e.g. '0.17')."
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "flavor=$FLAVOR" >> $GITHUB_OUTPUT
+          echo "Resolved: version=$VERSION, flavor=${FLAVOR:-<generic>}"
+
+  # Uploads the changelog to Play Console. Runs only when a version was successfully resolved by
+  # either of the preceding jobs, and shows as skipped in the GitHub Actions UI otherwise.
+  upload_changelog:
+    name: Upload changelog to Play Console
+    needs: [resolve_push, resolve_dispatch]
+    if: |
+      always() && !cancelled() &&
+      (needs.resolve_push.outputs.version != '' || needs.resolve_dispatch.outputs.version != '')
+    runs-on: ubuntu-24.04
+    environment: oppia-android-release-env
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate changelog version
+        run: |
+          VERSION="${{ needs.resolve_push.outputs.version || needs.resolve_dispatch.outputs.version }}"
+
+          # Verify that at least one changelog file exists for this version. The upload script
+          # resolves the correct file per track (track-specific first, then shared fallback), so
+          # we only need to confirm that the coordinator hasn't specified a non-existent version.
+          GENERIC="config/changelogs/${VERSION}.md"
+          FLAVOR_SPECIFIC=$(find config/changelogs -name "${VERSION}_*.md" 2>/dev/null | head -1)
+
+          if [[ ! -f "$GENERIC" && -z "$FLAVOR_SPECIFIC" ]]; then
+            echo "::error::No changelog file found for version $VERSION in config/changelogs/. "\
+              "Expected config/changelogs/${VERSION}[_<track>].md."
+            exit 1
+          fi
+
+          echo "Changelog validated: version=$VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Set up Bazel
+        uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: 6.5.0
+
+      - name: Set up build environment
+        uses: ./.github/actions/set-up-android-bazel-build-environment
+
+      - name: Authenticate to GCP via Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_PLAY_CONSOLE_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      # Runs UploadChangelogToPlayConsole which:
+      #   1. Audits alpha, beta, and production tracks for live releases.
+      #   2. For each live track, resolves the changelog file (track-specific first, then shared).
+      #   3. Uploads updated notes to any track where a changelog file is found.
+      # The script skips tracks with no matching changelog file silently.
+      - name: Upload updated changelog to Play Console
+        run: |
+          bazel run //scripts:upload_changelog_to_play_console -- \
+            "$GITHUB_WORKSPACE" \
+            "${{ secrets.PLAY_CONSOLE_PACKAGE_NAME }}" \
+            "${{ env.VERSION }}" \
+            "$(gcloud auth print-access-token)"

--- a/.github/workflows/deploy_updated_changelog.yml
+++ b/.github/workflows/deploy_updated_changelog.yml
@@ -68,10 +68,14 @@ jobs:
         run: |
           CHANGED=$(gh api "repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }}" \
             --jq '[.files[].filename | select(test("^config/changelogs/.+\\.md$"))] | first // ""')
+          # Only the first changed changelog file is processed. If multiple changelog files are
+          # updated in the same push the coordinator should use workflow_dispatch to trigger a
+          # separate run for each additional version. Handling all files in a single run would
+          # risk concurrent Play Console edit sessions, which are globally exclusive.
 
           if [[ -z "$CHANGED" ]]; then
             echo "No changelog files changed in this push — skipping upload."
-            echo "version=" >> $GITHUB_OUTPUT
+            echo "version=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -85,7 +89,7 @@ jobs:
             exit 1
           fi
 
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Detected: version=$VERSION, flavor=${FLAVOR:-<generic>}"
 
   # Runs only on workflow_dispatch: reads and validates the version provided by the release
@@ -112,7 +116,7 @@ jobs:
             exit 1
           fi
 
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved: version=$VERSION, flavor=${FLAVOR:-<generic>}"
 
   # Uploads the changelog to Play Console. Runs only when a version was successfully resolved by
@@ -139,7 +143,7 @@ jobs:
           # resolves the correct file per track (track-specific first, then shared fallback), so
           # we only need to confirm that the coordinator hasn't specified a non-existent version.
           GENERIC="config/changelogs/${VERSION}.md"
-          FLAVOR_SPECIFIC=$(find config/changelogs -name "${VERSION}_*.md" 2>/dev/null | head -1)
+          FLAVOR_SPECIFIC=$(find config/changelogs -name "${VERSION}_*.md" -print -quit 2>/dev/null)
 
           if [[ ! -f "$GENERIC" && -z "$FLAVOR_SPECIFIC" ]]; then
             echo "::error::No changelog file found for version $VERSION in config/changelogs/. "\


### PR DESCRIPTION
Fixes part of #6106

## Files Created
`.github/workflows/deploy_updated_changelog.yml`

## Explanation

Adds `deploy_updated_changelog.yml`: a workflow that automatically detects changelog edits and uploads corrected release notes to Play Console. This handles the case where a coordinator fixes a mistake in the changelog after a release is already live.
**Trigger behavior:**
- **On push**: Fires when any `config/changelogs/**.md` file is modified on `develop` branch. Automatically extracts the version from the changed filename --no manual input needed.
- **Manual (`workflow_dispatch`)**: Coordinator provides the version explicitly for re-runs or testing.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated changelog uploads for Android releases when changelog notes are updated.
  * Supports manual triggering for on-demand updates.
* **Bug Fixes**
  * Added validation to ensure the expected changelog file exists before upload.
  * Prevents overlapping uploads to reduce release-note conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->