### PR TITLE
Fixes #6291: coderabbit autotext fix

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,7 +3,7 @@ language: en-US
 reviews:
   # Provide more detailed, quality-focused feedback.
   profile: assertive
-  review_status: true
+  review_status: false
   auto_review:
     # Note: We'll only turn this on once we are happy with the review
     # results. To generate a review manually, post a comment with the

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,6 +3,7 @@ language: en-US
 reviews:
   # Provide more detailed, quality-focused feedback.
   profile: assertive
+  review_status: true
   auto_review:
     # Note: We'll only turn this on once we are happy with the review
     # results. To generate a review manually, post a comment with the


### PR DESCRIPTION
Fixes #6291

## Summary

This PR adds the `review_status` configuration under the `reviews` section in `.coderabbit.yaml` and sets it to `false`, following the official CodeRabbit configuration documentation.

Setting this option to `false` disables the automatic review status announcement that is posted when auto reviews are disabled.

The change aligns the configuration with the official CodeRabbit documentation while leaving the existing auto-review configuration unchanged.

## Changes

- Add the `review_status` configuration under the `reviews` section.
- Set `review_status` to `false` to disable automatic review status announcements.
- Align the CodeRabbit configuration with the official documentation.