### PR TITLE
Fix part of #6105: Add StudyGuideSection to topic.proto on the asset pipeline branch

### DIFF
--- a/model/src/main/proto/topic.proto
+++ b/model/src/main/proto/topic.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package model;
 
 import "subtitled_html.proto";
+import "subtitled_unicode.proto";
 import "thumbnail.proto";
 import "translation.proto";
 import "voiceover.proto";
@@ -770,8 +771,21 @@ message SubtopicRecord {
   // The thumbnail corresponding to this subtopic.
   LessonThumbnail subtopic_thumbnail = 6;
 
+  // The ordered list of sections in this subtopic's study guide. This is stored in addition to the
+  // existing page contents.
+  repeated StudyGuideSection sections = 8;
+
   // The old title corresponding to the subtopic (as a string).
   reserved 1;
+}
+
+// Corresponds to one section in a study guide.
+message StudyGuideSection {
+  // The heading shown above this section's content.
+  SubtitledUnicode heading = 1;
+
+  // The main content displayed in this section.
+  SubtitledHtml content = 2;
 }
 
 // Top-level proto used to store the aggregate learning duration timestamps in a topic,


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fixes part of #6105

This ports the already-reviewed proto change from #6261 onto `introduce-asset-download-script`: the `StudyGuideSection` message and the `SubtopicRecord.sections` field in `model/src/main/proto/topic.proto`.

The branch head currently fails to compile because #6266's `DtoProtoToLegacyProtoConverter` uses `StudyGuideSection`/`addAllSections()`, but this branch's `topic.proto` never received the #6261 change (this was the pending CI failure noted in the #6266 review thread). With this change, `bazel build //scripts:download_lessons`, `DtoProtoToLegacyProtoConverterTest`, and `GaeSubtopicPageTest` all pass on this branch.

This also unblocks the develop-side PR that updates the `oppia_android_asset_pipeline` WORKSPACE pin so alpha/prod lesson assets can be rebuilt with study guide sections.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).