### PR TITLE
Fix #6315, #6070: Re-pin lesson script & versions

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -292,6 +292,6 @@ pinned_maven_install()
 # Pinned lesson download pipeline script branch.
 git_repository(
     name = "oppia_android_asset_pipeline",
-    commit = "8210906da718968bdc1468af873b74db1a5284f9",
+    commit = "50b321afce8a67307ac2fcc328d0de28d00787b5",
     remote = "https://github.com/oppia/oppia-android.git",
 )

--- a/config/lessons/alpha_pinned_lesson_versions.textproto
+++ b/config/lessons/alpha_pinned_lesson_versions.textproto
@@ -58,7 +58,7 @@ tracked_topic_info {
     }
     chapter_info {
       exploration_id: "W0xq3jW5GzDF"
-      exploration_content_version: 875
+      exploration_content_version: 876
     }
     chapter_info {
       exploration_id: "53Ka3mQ6ra5A"
@@ -158,7 +158,7 @@ tracked_topic_info {
     content_version: 20
     chapter_info {
       exploration_id: "8HTzQQUPiK5i"
-      exploration_content_version: 557
+      exploration_content_version: 561
     }
     chapter_info {
       exploration_id: "40a3vjmZ7Fwu"
@@ -166,7 +166,7 @@ tracked_topic_info {
     }
     chapter_info {
       exploration_id: "WulCxGAmGE61"
-      exploration_content_version: 815
+      exploration_content_version: 816
     }
     chapter_info {
       exploration_id: "lOU0XPC2BnE9"
@@ -192,10 +192,10 @@ tracked_topic_info {
 }
 tracked_topic_info {
   id: "0abdeaJhmfPm"
-  content_version: 92
+  content_version: 95
   story_info {
     id: "3M5VBajMccXO"
-    content_version: 31
+    content_version: 34
     chapter_info {
       exploration_id: "umPkwp0L1M0-"
       exploration_content_version: 838
@@ -592,10 +592,50 @@ tracked_topic_info {
 }
 tracked_topic_info {
   id: "bdO7c687WBBW"
-  content_version: 21
+  content_version: 35
+  story_info {
+    id: "OVJ4RdjxbcAf"
+    content_version: 15
+    chapter_info {
+      exploration_id: "MXlPhsCBPGVc"
+      exploration_content_version: 68
+    }
+    chapter_info {
+      exploration_id: "g2Nl0LCoGsBI"
+      exploration_content_version: 37
+    }
+    chapter_info {
+      exploration_id: "7NmXKQQ9tRmg"
+      exploration_content_version: 30
+    }
+    chapter_info {
+      exploration_id: "mJkyVkrrVUTx"
+      exploration_content_version: 35
+    }
+    chapter_info {
+      exploration_id: "DYl70Ox4P3TI"
+      exploration_content_version: 26
+    }
+    chapter_info {
+      exploration_id: "7a5WD0pE4UoC"
+      exploration_content_version: 28
+    }
+    chapter_info {
+      exploration_id: "sNbyN5XtLxPk"
+      exploration_content_version: 24
+    }
+    chapter_info {
+      exploration_id: "fMkbtaKCXtpx"
+      exploration_content_version: 25
+    }
+  }
   subtopic_info {
     index: 1
     content_version: 2
+  }
+  subtopic_info {
+    index: 4
+    content_version: 1
   }
   subtopic_info {
     index: 2
@@ -1267,6 +1307,22 @@ tracked_skill_info {
   content_version: 5
 }
 tracked_skill_info {
+  id: "9VD60yhg3Bw6"
+  content_version: 4
+}
+tracked_skill_info {
+  id: "aa3aKg2eyfU5"
+  content_version: 3
+}
+tracked_skill_info {
+  id: "gIGajqYFUM2b"
+  content_version: 2
+}
+tracked_skill_info {
+  id: "gBgUXa3SVeP0"
+  content_version: 2
+}
+tracked_skill_info {
   id: "5a5rmYyFyOlr"
   content_version: 2
 }
@@ -1288,21 +1344,5 @@ tracked_skill_info {
 }
 tracked_skill_info {
   id: "QT67iLIRoHgq"
-  content_version: 2
-}
-tracked_skill_info {
-  id: "9VD60yhg3Bw6"
-  content_version: 4
-}
-tracked_skill_info {
-  id: "aa3aKg2eyfU5"
-  content_version: 3
-}
-tracked_skill_info {
-  id: "gIGajqYFUM2b"
-  content_version: 2
-}
-tracked_skill_info {
-  id: "gBgUXa3SVeP0"
   content_version: 2
 }

--- a/config/lessons/prod_pinned_lesson_versions.textproto
+++ b/config/lessons/prod_pinned_lesson_versions.textproto
@@ -58,7 +58,7 @@ tracked_topic_info {
     }
     chapter_info {
       exploration_id: "W0xq3jW5GzDF"
-      exploration_content_version: 875
+      exploration_content_version: 876
     }
     chapter_info {
       exploration_id: "53Ka3mQ6ra5A"
@@ -158,7 +158,7 @@ tracked_topic_info {
     content_version: 20
     chapter_info {
       exploration_id: "8HTzQQUPiK5i"
-      exploration_content_version: 557
+      exploration_content_version: 561
     }
     chapter_info {
       exploration_id: "40a3vjmZ7Fwu"
@@ -166,7 +166,7 @@ tracked_topic_info {
     }
     chapter_info {
       exploration_id: "WulCxGAmGE61"
-      exploration_content_version: 815
+      exploration_content_version: 816
     }
     chapter_info {
       exploration_id: "lOU0XPC2BnE9"
@@ -192,10 +192,10 @@ tracked_topic_info {
 }
 tracked_topic_info {
   id: "0abdeaJhmfPm"
-  content_version: 92
+  content_version: 95
   story_info {
     id: "3M5VBajMccXO"
-    content_version: 31
+    content_version: 34
     chapter_info {
       exploration_id: "umPkwp0L1M0-"
       exploration_content_version: 838


### PR DESCRIPTION
## Explanation

Fixes #6315
Fixes #6070

This pins the release builds to a version of the lesson download script (see commit 50b321afce8a67307ac2fcc328d0de28d00787b5) that fixes issues (see #6315) related to recent lesson & web backend updates. It also includes new version pinnings per those changes.

Note that this version of the script will also run much more efficiently since it won't be pulling every version of incompatible topics, and `NumberWithUnits` will be correctly imported for alpha lessons. For this reason #6070 can also be closed since technically `NumberWithUnits` _was_ already supported.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## For UI-specific PRs only
N/A -- This is an infrastructure change.