### PR TITLE
Fix part of #6106: Updates changelog workflow

### DIFF
--- a/.github/workflows/deploy_updated_changelog.yml
+++ b/.github/workflows/deploy_updated_changelog.yml
@@ -166,7 +166,7 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_PLAY_CONSOLE_SERVICE_ACCOUNT }}
+          service_account: ${{ secrets.GCP_RELEASE_SERVICE_ACCOUNT }}
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/deploy_updated_changelog.yml
+++ b/.github/workflows/deploy_updated_changelog.yml
@@ -25,6 +25,9 @@ on:
       - develop
     paths:
       - 'config/changelogs/**.md'
+  pull_request:
+    paths:
+      - 'config/changelogs/**.md'
   workflow_dispatch:
     inputs:
       version:
@@ -39,13 +42,50 @@ on:
         type: string
 
 concurrency:
-  # Only one changelog upload at a time to avoid concurrent edit conflicts on Play Console.
-  # The group is intentionally not scoped to github.ref so that push and dispatch triggers
-  # across different refs are also serialized — Play Console edits must be globally exclusive.
-  group: deploy-updated-changelog
-  cancel-in-progress: false
+  # Serialize deploy runs globally to avoid concurrent Play Console edit sessions.
+  # PR validation runs are scoped per PR and can cancel each other (but not deploy runs).
+  group: ${{ github.event_name == 'pull_request' && format('changelog-validate-{0}', github.event.pull_request.number) || 'deploy-updated-changelog' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+
+  # Runs on pull_request: validates that every changelog file touched by the PR
+  # is within the 500-character limit enforced by Play Console at upload time.
+  # Catching this at PR review is far less disruptive than discovering it post-merge.
+  validate_changelog:
+    name: Validate changelog character limit
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Check 500-character limit for changed changelogs
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch origin "$BASE_REF" --depth=1
+          CHANGED=$(git diff --name-only "origin/${BASE_REF}" -- 'config/changelogs/*.md')
+          if [[ -z "$CHANGED" ]]; then
+            echo "No changelog files changed — nothing to validate."
+            exit 0
+          fi
+          FAILED=false
+          for file in $CHANGED; do
+            if [[ ! -f "$file" ]]; then continue; fi
+            char_count=$(python3 -c "print(len(open('$file').read().rstrip()))")
+            if [[ "$char_count" -gt 500 ]]; then
+              echo "::error file=$file::Changelog '$file' exceeds the 500-character Play Console limit (${char_count}/500 chars). Shorten it before merging."
+              FAILED=true
+            else
+              echo "✓ $file: ${char_count}/500 characters"
+            fi
+          done
+          if [[ "$FAILED" == "true" ]]; then exit 1; fi
 
   # Runs only on push: uses the GitHub API to list files changed across the entire push (not just
   # the head commit) and extracts the changelog version from the filename (e.g. 0.17_alpha.md →

--- a/.github/workflows/deploy_updated_changelog.yml
+++ b/.github/workflows/deploy_updated_changelog.yml
@@ -25,9 +25,6 @@ on:
       - develop
     paths:
       - 'config/changelogs/**.md'
-  pull_request:
-    paths:
-      - 'config/changelogs/**.md'
   workflow_dispatch:
     inputs:
       version:
@@ -42,50 +39,13 @@ on:
         type: string
 
 concurrency:
-  # Serialize deploy runs globally to avoid concurrent Play Console edit sessions.
-  # PR validation runs are scoped per PR and can cancel each other (but not deploy runs).
-  group: ${{ github.event_name == 'pull_request' && format('changelog-validate-{0}', github.event.pull_request.number) || 'deploy-updated-changelog' }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Only one changelog upload at a time to avoid concurrent edit conflicts on Play Console.
+  # The group is intentionally not scoped to github.ref so that push and dispatch triggers
+  # across different refs are also serialized — Play Console edits must be globally exclusive.
+  group: deploy-updated-changelog
+  cancel-in-progress: false
 
 jobs:
-
-  # Runs on pull_request: validates that every changelog file touched by the PR
-  # is within the 500-character limit enforced by Play Console at upload time.
-  # Catching this at PR review is far less disruptive than discovering it post-merge.
-  validate_changelog:
-    name: Validate changelog character limit
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Check 500-character limit for changed changelogs
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          git fetch origin "$BASE_REF" --depth=1
-          CHANGED=$(git diff --name-only "origin/${BASE_REF}" -- 'config/changelogs/*.md')
-          if [[ -z "$CHANGED" ]]; then
-            echo "No changelog files changed — nothing to validate."
-            exit 0
-          fi
-          FAILED=false
-          for file in $CHANGED; do
-            if [[ ! -f "$file" ]]; then continue; fi
-            char_count=$(python3 -c "print(len(open('$file').read().rstrip()))")
-            if [[ "$char_count" -gt 500 ]]; then
-              echo "::error file=$file::Changelog '$file' exceeds the 500-character Play Console limit (${char_count}/500 chars). Shorten it before merging."
-              FAILED=true
-            else
-              echo "✓ $file: ${char_count}/500 characters"
-            fi
-          done
-          if [[ "$FAILED" == "true" ]]; then exit 1; fi
 
   # Runs only on push: uses the GitHub API to list files changed across the entire push (not just
   # the head commit) and extracts the changelog version from the filename (e.g. 0.17_alpha.md →


### PR DESCRIPTION
Fixes part of #6106

## Explanation
Changes `GCP_PLAY_CONSOLE_SERVICE_ACCOUNT` → `GCP_RELEASE_SERVICE_ACCOUNT`

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).