### PR TITLE
Fix part of #6106: Use pre-Proguard application source target in Phase 2

### DIFF
--- a/.github/workflows/build_and_sign.yml
+++ b/.github/workflows/build_and_sign.yml
@@ -5,10 +5,11 @@
 # The build is split into three phases to avoid JVM OOM on GitHub Actions runners:
 #   Phase 1: Pre-build all Kotlin scripts (including sign_release_binary) in opt mode so
 #            they are cached before the app binary build starts.
-#   Phase 2: Build the deployable target (//:oppia_${FLAVOR}_deployable) — this compiles
-#            the binary up to the Proguard step, which is the memory-intensive phase.
-#   Phase 3: Build the full AAB (//:oppia_${FLAVOR}) — all compilation is cached; Bazel
-#            only packages the final AAB, which has much lower peak memory.
+#   Phase 2: Build the application source package for the flavor — caches all compilation
+#            and dexing work before Proguard runs. Proguard is triggered by the
+#            android_binary() rule in Phase 3, not by this target.
+#   Phase 3: Build the full AAB (//:oppia_${FLAVOR}) — Proguard and AAB packaging run
+#            here on already-cached sources, with much lower peak memory usage.
 # A bazel shutdown is issued between each phase to free accumulated JVM heap.
 #
 # The private key NEVER leaves the KMS HSM boundary — only the AAB digest is sent to KMS
@@ -130,27 +131,19 @@ jobs:
       - name: Shutdown Bazel after Phase 1
         run: bazel shutdown
 
-      # Build the deployable target — compiles up to (but not including) full AAB packaging.
-      # This is the Proguard-heavy step; splitting it from Phase 3 keeps peak memory lower.
-      - name: "Phase 2: Build app binary (deployable)"
+      # Build the application source package — caches all compilation and dexing work
+      # before Proguard runs. Proguard is triggered by the android_binary() rule in Phase 3,
+      # not by this target, so this step has much lower peak memory usage.
+      - name: "Phase 2: Build application source"
         run: |
           FLAVOR="${{ github.event.inputs.flavor }}"
-          ASSETS_TYPE=$([ "$FLAVOR" = "alpha" ] && echo "alpha" || echo "prod")
           bazel build --compilation_mode=opt \
-            //:oppia_${FLAVOR}_deployable \
-            --//config:assets_type=${ASSETS_TYPE} \
-            --//config:web_api_key_file=/tmp/prod_server.key \
-            --//config:download_firebase_config=true \
-            --//config:firebase_project_id=${{ secrets.FIREBASE_PROJECT_ID }} \
-            --//config:firebase_app_id=${{ secrets.FIREBASE_APP_ID }} \
-            --//config:download_license_texts=true \
-            --//config:enable_firebase_analytics=true \
-            --action_env=GOOGLE_APPLICATION_CREDENTIALS
+            //app/src/main/java/org/oppia/android/app/application/${FLAVOR}/...
 
       - name: Shutdown Bazel after Phase 2
         run: bazel shutdown
 
-      # All compilation is cached from Phase 2; this step only packages the final AAB.
+      # All source is cached from Phase 2. Proguard and AAB packaging run in this step.
       - name: "Phase 3: Build full AAB"
         run: |
           FLAVOR="${{ github.event.inputs.flavor }}"

--- a/.github/workflows/build_and_sign.yml
+++ b/.github/workflows/build_and_sign.yml
@@ -5,9 +5,9 @@
 # The build is split into three phases to avoid JVM OOM on GitHub Actions runners:
 #   Phase 1: Pre-build all Kotlin scripts (including sign_release_binary) in opt mode so
 #            they are cached before the app binary build starts.
-#   Phase 2: Build the application source package for the flavor — caches all compilation
-#            and dexing work before Proguard runs. Proguard is triggered by the
-#            android_binary() rule in Phase 3, not by this target.
+#   Phase 2: Build the deploy JAR (//:oppia_${FLAVOR}_binary_deploy.jar) — this target is
+#            part of the android_binary() build pathway and covers almost everything prior
+#            to the Proguard pass, using the same flags as Phase 3.
 #   Phase 3: Build the full AAB (//:oppia_${FLAVOR}) — Proguard and AAB packaging run
 #            here on already-cached sources, with much lower peak memory usage.
 # A bazel shutdown is issued between each phase to free accumulated JVM heap.
@@ -131,14 +131,23 @@ jobs:
       - name: Shutdown Bazel after Phase 1
         run: bazel shutdown
 
-      # Build the application source package — caches all compilation and dexing work
-      # before Proguard runs. Proguard is triggered by the android_binary() rule in Phase 3,
-      # not by this target, so this step has much lower peak memory usage.
-      - name: "Phase 2: Build application source"
+      # Build the deploy JAR — this target is part of the android_binary() build pathway
+      # and covers almost everything prior to the Proguard pass. The same flags as Phase 3
+      # are required since this is technically part of the binary build (not just source).
+      - name: "Phase 2: Build deploy JAR (pre-Proguard)"
         run: |
           FLAVOR="${{ github.event.inputs.flavor }}"
+          ASSETS_TYPE=$([ "$FLAVOR" = "alpha" ] && echo "alpha" || echo "prod")
           bazel build --compilation_mode=opt \
-            //app/src/main/java/org/oppia/android/app/application/${FLAVOR}/...
+            //:oppia_${FLAVOR}_binary_deploy.jar \
+            --//config:assets_type=${ASSETS_TYPE} \
+            --//config:web_api_key_file=/tmp/prod_server.key \
+            --//config:download_firebase_config=true \
+            --//config:firebase_project_id=${{ secrets.FIREBASE_PROJECT_ID }} \
+            --//config:firebase_app_id=${{ secrets.FIREBASE_APP_ID }} \
+            --//config:download_license_texts=true \
+            --//config:enable_firebase_analytics=true \
+            --action_env=GOOGLE_APPLICATION_CREDENTIALS
 
       - name: Shutdown Bazel after Phase 2
         run: bazel shutdown


### PR DESCRIPTION
Fixes part of #6106

## Explanation
Phase 2 previously built `//:oppia_${FLAVOR}_deployable`, which turns out to trigger Proguard hence defeating the purpose of the phase split. This changes Phase 2 to `build //:oppia_${FLAVOR}_binary_deploy.jar` instead, which is part of the `android_binary()` build pathway and covers almost everything prior to the Proguard pass. The same flags as Phase 3 are used here since this target is technically part of the binary build. Proguard now runs exclusively in Phase 3 (`//:oppia_${FLAVOR}`) on fully-cached sources, reducing peak memory during the most memory-intensive step.


## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).