### PR TITLE
Fix part of #6106: Adds missing fixes to workflows

### DIFF
--- a/.github/workflows/deploy_to_firebase.yml
+++ b/.github/workflows/deploy_to_firebase.yml
@@ -62,6 +62,8 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_RELEASE_SERVICE_ACCOUNT }}
+          create_credentials_file: true
+          export_environment_variables: true
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/deploy_to_firebase.yml
+++ b/.github/workflows/deploy_to_firebase.yml
@@ -33,6 +33,9 @@ jobs:
     name: Deploy to Firebase App Distribution
     runs-on: ubuntu-24.04
     environment: oppia-android-release-env
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy_to_play_console.yml
+++ b/.github/workflows/deploy_to_play_console.yml
@@ -24,10 +24,10 @@ on:
           - beta
           - production
       rollout_fraction:
-        description: "Rollout fraction for staged rollouts, between 0.0 and 1.0 (e.g. 0.1 for 10%). Use 1.0 for a full rollout."
+        description: "Rollout fraction as an integer between 0 and 1000 (e.g. 100 for 10%, 1000 for full rollout)."
         required: false
         type: string
-        default: "1.0"
+        default: "1000"
 
 concurrency:
   # Shared with update_rollout.yml and the changelog upload workflow to prevent simultaneous
@@ -58,8 +58,8 @@ jobs:
             exit 1
           fi
 
-          if ! [[ "$ROLLOUT" =~ ^(0(\.[0-9]+)?|1(\.0+)?)$ ]]; then
-            echo "::error::Invalid rollout_fraction: '$ROLLOUT'. Must be a decimal between 0.0 and 1.0."
+          if ! [[ "$ROLLOUT" =~ ^[0-9]+$ ]] || [[ "$ROLLOUT" -lt 0 ]] || [[ "$ROLLOUT" -gt 1000 ]]; then
+            echo "::error::Invalid rollout_fraction: '$ROLLOUT'. Must be an integer between 0 and 1000 (e.g. 100 for 10%)."
             exit 1
           fi
 
@@ -109,7 +109,9 @@ jobs:
       # (pending release, version inversion, changelog existence) before uploading the AAB.
       - name: Upload AAB to Play Console
         run: |
-          bazel run //scripts:upload_binary_to_play_console -- \
+          bazel run //scripts:upload_binary_to_play_console \
+            --action_env=GOOGLE_APPLICATION_CREDENTIALS \
+            -- \
             "$(pwd)" \
             "$AAB_LOCAL_PATH" \
             "${{ github.event.inputs.track }}" \

--- a/.github/workflows/deploy_to_play_console.yml
+++ b/.github/workflows/deploy_to_play_console.yml
@@ -75,6 +75,8 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_RELEASE_SERVICE_ACCOUNT }}
+          create_credentials_file: true
+          export_environment_variables: true
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/deploy_updated_changelog.yml
+++ b/.github/workflows/deploy_updated_changelog.yml
@@ -166,7 +166,7 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_PLAY_CONSOLE_SERVICE_ACCOUNT }}
+          service_account: ${{ secrets.GCP_RELEASE_SERVICE_ACCOUNT }}
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/deploy_updated_changelog.yml
+++ b/.github/workflows/deploy_updated_changelog.yml
@@ -167,6 +167,8 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_RELEASE_SERVICE_ACCOUNT }}
+          create_credentials_file: true
+          export_environment_variables: true
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -260,27 +260,13 @@ jobs:
   check_changelog_limit:
     name: Check changelog character limit
     runs-on: ubuntu-24.04
-    if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          fetch-depth: 0
 
-      - name: Check 500-character limit for changed changelogs
-        env:
-          BASE_REF: ${{ github.base_ref }}
+      - name: Check 500-character limit for changelog files
         run: |
-          git fetch origin "$BASE_REF" --depth=1
-          CHANGED=$(git diff --name-only "origin/${BASE_REF}" -- 'config/changelogs/*.md')
-          if [[ -z "$CHANGED" ]]; then
-            echo "No changelog files changed — nothing to validate."
-            exit 0
-          fi
           FAILED=false
-          for file in $CHANGED; do
+          for file in config/changelogs/*.md; do
             if [[ ! -f "$file" ]]; then continue; fi
             char_count=$(python3 -c "print(len(open('$file').read().rstrip()))")
             if [[ "$char_count" -gt 500 ]]; then

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -266,7 +266,7 @@ jobs:
       - name: Check 500-character limit for changelog files
         run: |
           FAILED=false
-          for file in config/changelogs/*.md; do
+          for file in config/changelogs/[0-9]*.md; do
             if [[ ! -f "$file" ]]; then continue; fi
             char_count=$(python3 -c "print(len(open('$file').read().rstrip()))")
             if [[ "$char_count" -gt 500 ]]; then

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -256,3 +256,38 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           bazel run //scripts:maven_dependencies_list_check -- $(pwd) third_party/maven_install.json scripts/assets/maven_dependencies.pb
+
+  check_changelog_limit:
+    name: Check changelog character limit
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Check 500-character limit for changed changelogs
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch origin "$BASE_REF" --depth=1
+          CHANGED=$(git diff --name-only "origin/${BASE_REF}" -- 'config/changelogs/*.md')
+          if [[ -z "$CHANGED" ]]; then
+            echo "No changelog files changed — nothing to validate."
+            exit 0
+          fi
+          FAILED=false
+          for file in $CHANGED; do
+            if [[ ! -f "$file" ]]; then continue; fi
+            char_count=$(python3 -c "print(len(open('$file').read().rstrip()))")
+            if [[ "$char_count" -gt 500 ]]; then
+              echo "::error file=$file::Changelog '$file' exceeds the 500-character Play Console limit (${char_count}/500 chars). Shorten it before merging."
+              FAILED=true
+            else
+              echo "✓ $file: ${char_count}/500 characters"
+            fi
+          done
+          if [[ "$FAILED" == "true" ]]; then exit 1; fi

--- a/.github/workflows/update_rollout.yml
+++ b/.github/workflows/update_rollout.yml
@@ -77,16 +77,22 @@ jobs:
         uses: ./.github/actions/set-up-android-bazel-build-environment
 
       - name: Authenticate to GCP via Workload Identity Federation
+        id: auth
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_PLAY_CONSOLE_SERVICE_ACCOUNT }}
+          token_format: 'access_token'
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Update rollout fraction
+        env:
+          ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
+          # Mask the token so it never appears in workflow logs.
+          echo "::add-mask::$ACCESS_TOKEN"
           bazel run //scripts:update_rollout_fraction -- \
             "$GITHUB_WORKSPACE" \
             "org.oppia.android" \

--- a/.github/workflows/update_rollout.yml
+++ b/.github/workflows/update_rollout.yml
@@ -81,18 +81,20 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_PLAY_CONSOLE_SERVICE_ACCOUNT }}
+          service_account: ${{ secrets.GCP_RELEASE_SERVICE_ACCOUNT }}
           token_format: 'access_token'
+
+      - name: Set and mask GCP access token
+        run: |
+          ACCESS_TOKEN="${{ steps.auth.outputs.access_token }}"
+          echo "::add-mask::$ACCESS_TOKEN"
+          echo "ACCESS_TOKEN=$ACCESS_TOKEN" >> "$GITHUB_ENV"
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Update rollout fraction
-        env:
-          ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
-          # Mask the token so it never appears in workflow logs.
-          echo "::add-mask::$ACCESS_TOKEN"
           bazel run //scripts:update_rollout_fraction -- \
             "$GITHUB_WORKSPACE" \
             "org.oppia.android" \

--- a/.github/workflows/update_rollout.yml
+++ b/.github/workflows/update_rollout.yml
@@ -99,4 +99,4 @@ jobs:
             "${{ github.event.inputs.track }}" \
             "${{ steps.validate.outputs.VERSION }}" \
             "${{ steps.validate.outputs.ROLLOUT }}" \
-            "$(gcloud auth print-access-token)"
+            "$ACCESS_TOKEN"


### PR DESCRIPTION
Fixes part of #6106

## Explanation

`deploy_to_firebase.yml`

- Adds missing `permissions: id-token: write` on the job 

`deploy_to_play_console.yml`:

- `rollout_fraction` → integer 0-1000 (description, validation, default)
- Added `--action_env=GOOGLE_APPLICATION_CREDENTIALS` to `bazel run`

`update_rollout.yml`

- Added `id: auth` + `token_format: 'access_token'` to auth step
- Replaced `$(gcloud auth print-access-token)` with `${{ steps.auth.outputs.access_token }}` (masked)

`deploy_updated_changelog.yml`
- Changes `GCP_PLAY_CONSOLE_SERVICE_ACCOUNT` → `GCP_RELEASE_SERVICE_ACCOUNT`

`static_checks.yml`
- Added check_changelog_limit 

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).