### PR TITLE
Fix part of #6106: Fixes to Play Console and rollout workflows

### DIFF
--- a/.github/workflows/deploy_to_play_console.yml
+++ b/.github/workflows/deploy_to_play_console.yml
@@ -24,10 +24,10 @@ on:
           - beta
           - production
       rollout_fraction:
-        description: "Rollout fraction for staged rollouts, between 0.0 and 1.0 (e.g. 0.1 for 10%). Use 1.0 for a full rollout."
+        description: "Rollout fraction as an integer between 0 and 1000 (e.g. 100 for 10%, 1000 for full rollout)."
         required: false
         type: string
-        default: "1.0"
+        default: "1000"
 
 concurrency:
   # Shared with update_rollout.yml and the changelog upload workflow to prevent simultaneous
@@ -58,8 +58,8 @@ jobs:
             exit 1
           fi
 
-          if ! [[ "$ROLLOUT" =~ ^(0(\.[0-9]+)?|1(\.0+)?)$ ]]; then
-            echo "::error::Invalid rollout_fraction: '$ROLLOUT'. Must be a decimal between 0.0 and 1.0."
+          if ! [[ "$ROLLOUT" =~ ^[0-9]+$ ]] || [[ "$ROLLOUT" -lt 0 ]] || [[ "$ROLLOUT" -gt 1000 ]]; then
+            echo "::error::Invalid rollout_fraction: '$ROLLOUT'. Must be an integer between 0 and 1000 (e.g. 100 for 10%)."
             exit 1
           fi
 
@@ -109,7 +109,9 @@ jobs:
       # (pending release, version inversion, changelog existence) before uploading the AAB.
       - name: Upload AAB to Play Console
         run: |
-          bazel run //scripts:upload_binary_to_play_console -- \
+          bazel run //scripts:upload_binary_to_play_console \
+            --action_env=GOOGLE_APPLICATION_CREDENTIALS \
+            -- \
             "$(pwd)" \
             "$AAB_LOCAL_PATH" \
             "${{ github.event.inputs.track }}" \

--- a/.github/workflows/update_rollout.yml
+++ b/.github/workflows/update_rollout.yml
@@ -77,20 +77,26 @@ jobs:
         uses: ./.github/actions/set-up-android-bazel-build-environment
 
       - name: Authenticate to GCP via Workload Identity Federation
+        id: auth
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_PLAY_CONSOLE_SERVICE_ACCOUNT }}
+          token_format: 'access_token'
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Update rollout fraction
+        env:
+          ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
+          # Mask the token so it never appears in workflow logs.
+          echo "::add-mask::$ACCESS_TOKEN"
           bazel run //scripts:update_rollout_fraction -- \
             "$GITHUB_WORKSPACE" \
             "org.oppia.android" \
             "${{ github.event.inputs.track }}" \
             "${{ steps.validate.outputs.VERSION }}" \
             "${{ steps.validate.outputs.ROLLOUT }}" \
-            "$(gcloud auth print-access-token)"
+            "$ACCESS_TOKEN"


### PR DESCRIPTION
Fixes part of #6106

## Explanation

`deploy_to_play_console.yml`:

- `rollout_fraction` → integer 0-1000 (description, validation, default)
- Added `--action_env=GOOGLE_APPLICATION_CREDENTIALS` to `bazel run`

`update_rollout.yml`

- Added `id: auth` + `token_format: 'access_token'` to auth step
- Replaced `$(gcloud auth print-access-token)` with `${{ steps.auth.outputs.access_token }}` (masked)

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).