### PR TITLE
Fix #6309: Throw actionable exception on zero or negative version code

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/build/TransformAndroidManifest.kt
+++ b/scripts/src/java/org/oppia/android/scripts/build/TransformAndroidManifest.kt
@@ -196,6 +196,13 @@ private class TransformAndroidManifest(
   }
 
   private fun computeVersionCode(): Int {
+    if (gitClient.isShallowRepository) {
+      error(
+        "You're in a shallow clone of the repository. " +
+          "Please run 'git fetch --unshallow' and try again."
+      )
+    }
+
     val developCommitCount = gitClient.countCommits(gitClient.branchMergeBase)
     // The number of potential releases since the new version strategy was introduced.
     val possibleReleaseCount = developCommitCount - NEW_VERSION_STRATEGY_STARTING_COMMIT_NUMBER
@@ -206,8 +213,7 @@ private class TransformAndroidManifest(
       BASE_VERSION_CODE + releaseVersionOffset + rcVersionOffset + flavorVersionOffset
     check(versionCode > 0) {
       "Computed version code ($versionCode) is zero or negative. " +
-        "This is likely due to using a shallow Git clone. " +
-        "Please run 'git fetch --unshallow' and try again."
+        "Please check versioning inputs (flavor offset, base version code, etc.)."
     }
     return versionCode
   }

--- a/scripts/src/java/org/oppia/android/scripts/build/TransformAndroidManifest.kt
+++ b/scripts/src/java/org/oppia/android/scripts/build/TransformAndroidManifest.kt
@@ -202,7 +202,14 @@ private class TransformAndroidManifest(
     val releaseVersionOffset = possibleReleaseCount * VERSION_CODES_PER_RELEASE
     val rcVersionOffset = (releaseCandidateNumber - 1) * MAX_FLAVORS_PER_RC
     val flavorVersionOffset = buildFlavor.index
-    return BASE_VERSION_CODE + releaseVersionOffset + rcVersionOffset + flavorVersionOffset
+    val versionCode =
+      BASE_VERSION_CODE + releaseVersionOffset + rcVersionOffset + flavorVersionOffset
+    check(versionCode > 0) {
+      "Computed version code ($versionCode) is zero or negative. " +
+        "This is likely due to using a shallow Git clone. " +
+        "Please run 'git fetch --unshallow' and try again."
+    }
+    return versionCode
   }
 
   // The format here is defined as part of the app's release process.

--- a/scripts/src/java/org/oppia/android/scripts/common/GitClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/common/GitClient.kt
@@ -21,6 +21,9 @@ class GitClient(
   /** The hash of of the latest commit common between the current & HEAD branches. */
   val branchMergeBase: String by lazy { retrieveBranchMergeBase() }
 
+  /** Whether the local Git repository is a shallow clone. */
+  val isShallowRepository: Boolean by lazy { retrieveIsShallowRepository() }
+
   private val resolvedBaseCommit: String by lazy {
     executeGitCommandWithOneLineOutput("rev-parse $baseCommit")
   }
@@ -57,6 +60,10 @@ class GitClient(
         println("WARNING: Provided base commit $resolvedBaseCommit doesn't match merge-base: $it.")
       }
     }
+  }
+
+  private fun retrieveIsShallowRepository(): Boolean {
+    return executeGitCommandWithOneLineOutput("rev-parse --is-shallow-repository").toBooleanStrict()
   }
 
   private fun retrieveChangedFilesWithPotentialDuplicates(): List<String> =

--- a/scripts/src/javatests/org/oppia/android/scripts/build/TransformAndroidManifestTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/build/TransformAndroidManifestTest.kt
@@ -738,8 +738,36 @@ class TransformAndroidManifestTest {
   }
 
   @Test
-  fun testUtility_developBranch_shallowClone_negativeVersionCode_throwsException() {
+  fun testUtility_developBranch_shallowClone_throwsException() {
     initializeShallowGitRepositoryWithHistory()
+
+    val exception = assertThrows<IllegalStateException>() {
+      runScript(
+        tempFolder.root.absolutePath,
+        tempFolder.newFile(TEST_MANIFEST_FILE_NAME).apply {
+          writeText(TEST_MANIFEST_CONTENT_WITHOUT_VERSIONS)
+        }.absolutePath,
+        File(tempFolder.root, TRANSFORMED_MANIFEST_FILE_NAME).absolutePath,
+        BUILD_FLAVOR,
+        MAJOR_VERSION,
+        MINOR_VERSION,
+        APPLICATION_RELATIVE_QUALIFIED_CLASS,
+        "false",
+        "false"
+      )
+    }
+
+    assertThat(exception)
+      .hasMessageThat()
+      .contains("You're in a shallow clone")
+    assertThat(exception)
+      .hasMessageThat()
+      .contains("git fetch --unshallow")
+  }
+
+  @Test
+  fun testUtility_developBranch_invalidVersioning_negativeVersionCode_throwsException() {
+    initializeGitRepositoryWithLowCommitCount()
 
     val exception = assertThrows<IllegalStateException>() {
       runScript(
@@ -762,10 +790,7 @@ class TransformAndroidManifestTest {
       .contains("Computed version code")
     assertThat(exception)
       .hasMessageThat()
-      .contains("zero or negative")
-    assertThat(exception)
-      .hasMessageThat()
-      .contains("git fetch --unshallow")
+      .contains("Please check versioning inputs")
   }
 
   /** Runs the transform_android_manifest utility. */
@@ -783,7 +808,16 @@ class TransformAndroidManifestTest {
   }
 
   private fun initializeShallowGitRepositoryWithHistory() {
-    // Initialize the git repository with a small number of commits to simulate a shallow clone.
+    // Initialize the git repository with a small number of commits and a shallow file.
+    testGitRepository.init()
+    testGitRepository.setUser(email = "test@oppia.org", name = "Test User")
+    testGitRepository.initializeHistoricalCommits(commitCount = 10)
+    testGitRepository.createRemoteBranchRef("origin/develop")
+    File(tempFolder.root, ".git/shallow").createNewFile()
+  }
+
+  private fun initializeGitRepositoryWithLowCommitCount() {
+    // Initialize the git repository with a small number of commits to simulate invalid version math.
     testGitRepository.init()
     testGitRepository.setUser(email = "test@oppia.org", name = "Test User")
     testGitRepository.initializeHistoricalCommits(commitCount = 10)

--- a/scripts/src/javatests/org/oppia/android/scripts/build/TransformAndroidManifestTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/build/TransformAndroidManifestTest.kt
@@ -737,6 +737,37 @@ class TransformAndroidManifestTest {
     )
   }
 
+  @Test
+  fun testUtility_developBranch_shallowClone_negativeVersionCode_throwsException() {
+    initializeShallowGitRepositoryWithHistory()
+
+    val exception = assertThrows<IllegalStateException>() {
+      runScript(
+        tempFolder.root.absolutePath,
+        tempFolder.newFile(TEST_MANIFEST_FILE_NAME).apply {
+          writeText(TEST_MANIFEST_CONTENT_WITHOUT_VERSIONS)
+        }.absolutePath,
+        File(tempFolder.root, TRANSFORMED_MANIFEST_FILE_NAME).absolutePath,
+        BUILD_FLAVOR,
+        MAJOR_VERSION,
+        MINOR_VERSION,
+        APPLICATION_RELATIVE_QUALIFIED_CLASS,
+        "false",
+        "false"
+      )
+    }
+
+    assertThat(exception)
+      .hasMessageThat()
+      .contains("Computed version code")
+    assertThat(exception)
+      .hasMessageThat()
+      .contains("zero or negative")
+    assertThat(exception)
+      .hasMessageThat()
+      .contains("git fetch --unshallow")
+  }
+
   /** Runs the transform_android_manifest utility. */
   private fun runScript(vararg args: String) {
     main(args.toList().toTypedArray())
@@ -748,6 +779,14 @@ class TransformAndroidManifestTest {
     testGitRepository.init()
     testGitRepository.setUser(email = "test@oppia.org", name = "Test User")
     testGitRepository.initializeHistoricalCommits(commitCount = 2289)
+    testGitRepository.createRemoteBranchRef("origin/develop")
+  }
+
+  private fun initializeShallowGitRepositoryWithHistory() {
+    // Initialize the git repository with a small number of commits to simulate a shallow clone.
+    testGitRepository.init()
+    testGitRepository.setUser(email = "test@oppia.org", name = "Test User")
+    testGitRepository.initializeHistoricalCommits(commitCount = 10)
     testGitRepository.createRemoteBranchRef("origin/develop")
   }
 


### PR DESCRIPTION
**Explanation**
Fixes #6309

This prevents shallow Git clone math from silently breaking the build pipeline.

When a user clones with `--depth`, `countCommits` returns a small number (e.g., 10). Subtracting the starting commit number (2289) results in a heavily negative value, which Android OS rejects.

This PR adds a `check(versionCode > 0)` state validation that catches this specific scenario and throws an `IllegalStateException` instructing the user to run `git fetch --unshallow` before proceeding. A regression test simulating a 10-commit shallow clone has been added to verify this behavior.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " 
- [x] The explanation section above starts with "Fixes #bugnum: " 
- [x] Any changes to scripts/assets files have their rationale included in the PR explanation.
- [x] The PR follows the style guide.
- [x] The PR is made from a branch that's not called "develop" and is up-to-date with "develop".
- [x] The PR does not contain any unnecessary code changes from Android Studio.
- [x] The PR is assigned to the appropriate reviewers.

