### PR TITLE
Fix part of #6106: zip issue fix

### DIFF
--- a/.github/workflows/build_and_sign.yml
+++ b/.github/workflows/build_and_sign.yml
@@ -197,9 +197,13 @@ jobs:
       # jarsigner appends its signature alongside any existing signatures rather than replacing
       # them. Removing old signatures first ensures the signed AAB contains only the upload
       # certificate, which is required by Play Console.
+      # The AAB is first copied to the workspace because Bazel's output directory is read-only.
       - name: Strip pre-existing META-INF signatures from AAB
         run: |
-          zip -d "$UNSIGNED_AAB_PATH" "META-INF/*.RSA" "META-INF/*.SF" "META-INF/*.DSA"
+          WRITABLE_AAB_PATH="${{ github.workspace }}/unsigned-${AAB_NAME}"
+          cp "$UNSIGNED_AAB_PATH" "$WRITABLE_AAB_PATH"
+          zip -d "$WRITABLE_AAB_PATH" "META-INF/*.RSA" "META-INF/*.SF" "META-INF/*.DSA"
+          echo "UNSIGNED_AAB_PATH=$WRITABLE_AAB_PATH" >> $GITHUB_ENV
 
       # Signs the unsigned AAB using Cloud KMS HSM. The private key never leaves the HSM —
       # only the digest is sent to KMS and the signature returned via the jsign JCA provider.


### PR DESCRIPTION
Fixes part of #6106
## Explanation

Attempts to fix zip I/O error. 
- Copies the AAB from Bazel's read-only bazel-out to $GITHUB_WORKSPACE/unsigned-<name>.aab
- Runs zip -d on the writable copy
- Updates UNSIGNED_AAB_PATH in $GITHUB_ENV so the KMS signing step picks up the copy automatically

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).