### PR TITLE
Fix part of #6106: Add chmod fix

### DIFF
--- a/.github/workflows/build_and_sign.yml
+++ b/.github/workflows/build_and_sign.yml
@@ -202,7 +202,8 @@ jobs:
         run: |
           WRITABLE_AAB_PATH="${{ github.workspace }}/unsigned-${AAB_NAME}"
           cp "$UNSIGNED_AAB_PATH" "$WRITABLE_AAB_PATH"
-          zip -d "$WRITABLE_AAB_PATH" "META-INF/*.RSA" "META-INF/*.SF" "META-INF/*.DSA"
+          chmod 755 "$WRITABLE_AAB_PATH"
+          zip -d "$WRITABLE_AAB_PATH" "META-INF/*.RSA" "META-INF/*.SF"
           echo "UNSIGNED_AAB_PATH=$WRITABLE_AAB_PATH" >> $GITHUB_ENV
 
       # Signs the unsigned AAB using Cloud KMS HSM. The private key never leaves the HSM —


### PR DESCRIPTION
Fixes part of #6106
## Explanation

In the `build_and_sign` workflow, after building the release AAB, the signing step copies the Bazel output artifact using `cp`:

```bash
cp "$UNSIGNED_AAB_PATH" "$WRITABLE_AAB_PATH"
```

Bazel's artifact cache files are read-only. The `cp` command inherits these permissions, so `$WRITABLE_AAB_PATH` ends up read-only. When the next step tries to strip existing META-INF signature entries with `zip -d`, it fails because `zip` needs write access to modify the file.

This PR fixes this by adding `chmod 755` on the copied file before running `zip -d`, making it writable:

```bash
chmod 755 "$WRITABLE_AAB_PATH"
zip -d "$WRITABLE_AAB_PATH" "META-INF/*.RSA" "META-INF/*.SF"
```

This PR also removes the `META-INF/*.DSA` pattern from the `zip -d` command. Oppia's AAB does not contain any `.DSA` signature file, so this pattern never matches anything (confirmed by the `zip warning: name not matched: META-INF/*.DSA` output observed locally). 

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).