### PR TITLE
Fix #6186: Separate add break between binary_deployable.jar and remaining build process.

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -95,10 +95,10 @@ jobs:
           if [[ "${{ matrix.flavor }}" == "dev" ]]; then
             bazel build -- //:oppia_${{ matrix.flavor }}
           else
-            # Build the deployable (pre-Proguard-map) AAB first, then shutdown Bazel to release
+            # Build the oppia_flavor_binary_deploy.jar first (pre-Proguard-map), then shutdown Bazel to release
             # JVM memory accumulated during the heavy Proguard step. This avoids OOM crashes
-            # error code 14 when building the final AAB that packages the Proguard map.
-            bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}_deployable
+            # when building the final AAB that packages the Proguard map.
+            bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}_binary_deploy.jar
             bazel shutdown
             bazel build --compilation_mode=opt -- //:oppia_${{ matrix.flavor }}
           fi

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -212,14 +212,14 @@ jobs:
         run: |
           cd head
           git log -n 1
-          # Build dev (no Proguard) and Proguard-enabled deployable targets first.
-          bazel build -- //:oppia_dev //:oppia_alpha_deployable //:oppia_beta_deployable //:oppia_ga_deployable
-          cp bazel-bin/oppia_dev.aab ../develop/oppia_dev_with_changes.aab
-          # Shutdown Bazel to release JVM memory accumulated during Proguard, then build the
-          # lightweight final AABs that package the Proguard map. This avoids OOM crashes
-          # (error code 14).
+          bazel build -- //:oppia_dev
+          # Build the oppia_flavor_binary_deploy.jar first (pre-Proguard-map), then shutdown Bazel to release
+          # JVM memory accumulated during the heavy Proguard step. This avoids OOM crashes
+          # when building the final AAB that packages the Proguard map.
+          bazel build -- //:oppia_alpha_binary_deploy.jar //:oppia_beta_binary_deploy.jar //:oppia_ga_binary_deploy.jar
           bazel shutdown
           bazel build -- //:oppia_alpha //:oppia_beta //:oppia_ga
+          cp bazel-bin/oppia_dev.aab ../develop/oppia_dev_with_changes.aab
           cp bazel-bin/oppia_alpha.aab ../develop/oppia_alpha_with_changes.aab
           cp bazel-bin/oppia_beta.aab ../develop/oppia_beta_with_changes.aab
           cp bazel-bin/oppia_ga.aab ../develop/oppia_ga_with_changes.aab
@@ -230,14 +230,14 @@ jobs:
         run: |
           cd base
           git log -n 1
-          # Build dev (no Proguard) and Proguard-enabled deployable targets first.
-          bazel build -- //:oppia_dev //:oppia_alpha_deployable //:oppia_beta_deployable //:oppia_ga_deployable
-          cp bazel-bin/oppia_dev.aab ../develop/oppia_dev_without_changes.aab
-          # Shutdown Bazel to release JVM memory accumulated during Proguard, then build the
-          # lightweight final AABs that package the Proguard map. This avoids OOM crashes
-          # (error code 14).
+          bazel build -- //:oppia_dev
+          # Build the oppia_flavor_binary_deploy.jar first (pre-Proguard-map), then shutdown Bazel to release
+          # JVM memory accumulated during the heavy Proguard step. This avoids OOM crashes
+          # when building the final AAB that packages the Proguard map.
+          bazel build -- //:oppia_alpha_binary_deploy.jar //:oppia_beta_binary_deploy.jar //:oppia_ga_binary_deploy.jar
           bazel shutdown
           bazel build -- //:oppia_alpha //:oppia_beta //:oppia_ga
+          cp bazel-bin/oppia_dev.aab ../develop/oppia_dev_without_changes.aab
           cp bazel-bin/oppia_alpha.aab ../develop/oppia_alpha_without_changes.aab
           cp bazel-bin/oppia_beta.aab ../develop/oppia_beta_without_changes.aab
           cp bazel-bin/oppia_ga.aab ../develop/oppia_ga_without_changes.aab


### PR DESCRIPTION
## Explanation
Fixes #6186
 - In `build_tests.yml` and `stats.yml` breaking adding bazel shutdown between building up-to `//:oppia_flavor_binary_deploy.jar` (last target before proguard gets triggered)  and remaining build process to free up JVM memory and avoiding OOM issues ultimately causing proguard flakes in CI.
## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated Android build workflows for non-development release variants.
  * Optimized the build sequence to generate deployment artifacts before final app bundles.
  * Streamlined branch comparison builds while preserving development, alpha, beta, and GA app bundle outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->