### PR TITLE
Fix #6330: Preserve frozen version codes in Play Console track updates

### DIFF
--- a/scripts/assets/test_file_exemptions.textproto
+++ b/scripts/assets/test_file_exemptions.textproto
@@ -4260,6 +4260,10 @@ test_file_exemption {
   test_file_not_required: true
 }
 test_file_exemption {
+  exempted_file_path: "scripts/src/java/org/oppia/android/scripts/release/FrozenReleaseConfig.kt"
+  test_file_not_required: true
+}
+test_file_exemption {
   exempted_file_path: "scripts/src/java/org/oppia/android/scripts/release/PlayConsoleClient.kt"
   test_file_not_required: true
 }

--- a/scripts/src/java/org/oppia/android/scripts/release/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/release/BUILD.bazel
@@ -17,10 +17,17 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "frozen_release_config",
+    srcs = ["FrozenReleaseConfig.kt"],
+    visibility = ["//scripts:oppia_script_library_visibility"],
+)
+
+kt_jvm_library(
     name = "google_play_console_client",
     srcs = ["GooglePlayConsoleClient.kt"],
     visibility = ["//scripts:oppia_script_library_visibility"],
     deps = [
+        ":frozen_release_config",
         ":play_console_client",
         "//scripts/src/java/org/oppia/android/scripts/release/model:insert_edit_request",
         "//scripts/src/java/org/oppia/android/scripts/release/model:track_response",
@@ -89,6 +96,7 @@ kt_jvm_library(
     deps = [
         ":app_flavor",
         ":changelog_existence_checker",
+        ":frozen_release_config",
         ":google_play_console_client",
         ":pending_release_checker",
         ":play_console_client",
@@ -101,6 +109,7 @@ kt_jvm_library(
     srcs = ["UploadChangelogToPlayConsole.kt"],
     visibility = ["//scripts:oppia_script_binary_visibility"],
     deps = [
+        ":frozen_release_config",
         ":google_play_console_client",
         ":play_console_client",
     ],
@@ -122,6 +131,7 @@ kt_jvm_library(
     srcs = ["UpdateRolloutFraction.kt"],
     visibility = ["//scripts:oppia_script_binary_visibility"],
     deps = [
+        ":frozen_release_config",
         ":google_play_console_client",
         ":play_console_client",
     ],

--- a/scripts/src/java/org/oppia/android/scripts/release/FakePlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/FakePlayConsoleClient.kt
@@ -78,7 +78,12 @@ class FakePlayConsoleClient : PlayConsoleClient {
     maybeFailCall("setTrackRelease")
     trackUpdates.add(
       TrackUpdate(
-        packageName, editId, track, versionCode, rolloutFraction, releaseNotes, preservedVersionCodes
+        packageName,
+        editId, track,
+        versionCode,
+        rolloutFraction,
+        releaseNotes,
+        preservedVersionCodes
       )
     )
   }

--- a/scripts/src/java/org/oppia/android/scripts/release/FakePlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/FakePlayConsoleClient.kt
@@ -72,11 +72,12 @@ class FakePlayConsoleClient : PlayConsoleClient {
     track: String,
     versionCode: Long,
     rolloutFraction: Int,
-    releaseNotes: Map<String, String>
+    releaseNotes: Map<String, String>,
+    preservedVersionCodes: Set<Long>
   ) {
     maybeFailCall("setTrackRelease")
     trackUpdates.add(
-      TrackUpdate(packageName, editId, track, versionCode, rolloutFraction, releaseNotes)
+      TrackUpdate(packageName, editId, track, versionCode, rolloutFraction, releaseNotes, preservedVersionCodes)
     )
   }
 
@@ -132,7 +133,9 @@ class FakePlayConsoleClient : PlayConsoleClient {
    * @property track the Play Console track
    * @property versionCode the version code assigned to the track
    * @property rolloutFraction the staged rollout fraction (1.0 = full rollout)
-   * @property releaseNotes the release notes map (language code → text)
+   * @property releaseNotes the release notes map (language code to text)
+   * @property preservedVersionCodes the frozen OS-specific version codes included alongside
+   *     [versionCode] to prevent them being deactivated by the track update
    */
   data class TrackUpdate(
     val packageName: String,
@@ -140,6 +143,7 @@ class FakePlayConsoleClient : PlayConsoleClient {
     val track: String,
     val versionCode: Long,
     val rolloutFraction: Int,
-    val releaseNotes: Map<String, String>
+    val releaseNotes: Map<String, String>,
+    val preservedVersionCodes: Set<Long> = emptySet()
   )
 }

--- a/scripts/src/java/org/oppia/android/scripts/release/FakePlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/FakePlayConsoleClient.kt
@@ -77,7 +77,9 @@ class FakePlayConsoleClient : PlayConsoleClient {
   ) {
     maybeFailCall("setTrackRelease")
     trackUpdates.add(
-      TrackUpdate(packageName, editId, track, versionCode, rolloutFraction, releaseNotes, preservedVersionCodes)
+      TrackUpdate(
+      packageName, editId, track, versionCode, rolloutFraction, releaseNotes, preservedVersionCodes
+      )
     )
   }
 

--- a/scripts/src/java/org/oppia/android/scripts/release/FakePlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/FakePlayConsoleClient.kt
@@ -78,7 +78,7 @@ class FakePlayConsoleClient : PlayConsoleClient {
     maybeFailCall("setTrackRelease")
     trackUpdates.add(
       TrackUpdate(
-      packageName, editId, track, versionCode, rolloutFraction, releaseNotes, preservedVersionCodes
+        packageName, editId, track, versionCode, rolloutFraction, releaseNotes, preservedVersionCodes
       )
     )
   }

--- a/scripts/src/java/org/oppia/android/scripts/release/FakePlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/FakePlayConsoleClient.kt
@@ -73,17 +73,18 @@ class FakePlayConsoleClient : PlayConsoleClient {
     versionCode: Long,
     rolloutFraction: Int,
     releaseNotes: Map<String, String>,
-    preservedVersionCodes: Set<Long>
+    preservedReleases: List<PlayConsoleClient.TrackRelease>
   ) {
     maybeFailCall("setTrackRelease")
     trackUpdates.add(
       TrackUpdate(
         packageName,
-        editId, track,
+        editId,
+        track,
         versionCode,
         rolloutFraction,
         releaseNotes,
-        preservedVersionCodes
+        preservedReleases
       )
     )
   }
@@ -141,8 +142,8 @@ class FakePlayConsoleClient : PlayConsoleClient {
    * @property versionCode the version code assigned to the track
    * @property rolloutFraction the staged rollout fraction (1.0 = full rollout)
    * @property releaseNotes the release notes map (language code to text)
-   * @property preservedVersionCodes the frozen OS-specific version codes included alongside
-   *     [versionCode] to prevent them being deactivated by the track update
+   * @property preservedReleases the frozen OS-specific releases included alongside [versionCode]
+   *     to prevent them being deactivated by the track update
    */
   data class TrackUpdate(
     val packageName: String,
@@ -151,6 +152,6 @@ class FakePlayConsoleClient : PlayConsoleClient {
     val versionCode: Long,
     val rolloutFraction: Int,
     val releaseNotes: Map<String, String>,
-    val preservedVersionCodes: Set<Long> = emptySet()
+    val preservedReleases: List<PlayConsoleClient.TrackRelease> = emptyList()
   )
 }

--- a/scripts/src/java/org/oppia/android/scripts/release/FrozenReleaseConfig.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/FrozenReleaseConfig.kt
@@ -1,0 +1,24 @@
+package org.oppia.android.scripts.release
+
+/**
+ * Version codes of OS-specific frozen builds that must be preserved on their respective tracks.
+ *
+ * The Play Developer API replaces the entire track contents on each `tracks.update` call, so any
+ * release not explicitly included in the request would be silently deactivated. These are builds
+ * released once to support a specific minimum API level and kept active indefinitely so devices on
+ * that API level continue to receive the app.
+ *
+ * Releases are fetched live from the Play Console and filtered against these version codes. Matching
+ * releases are then passed through completely unmodified (preserving versionCodes, status,
+ * userFraction, and releaseNotes) into every [PlayConsoleClient.setTrackRelease] call.
+ *
+ * Currently frozen:
+ * - alpha vc 16: KitKat (API 16) build, frozen permanently.
+ *
+ * When a new API level is deprecated and its final build must be frozen, add its track and version
+ * code here. This single file is the source of truth consumed by [UploadBinaryToPlayConsole],
+ * [UpdateRolloutFraction], [UploadChangelogToPlayConsole], and [GooglePlayConsoleClient].
+ */
+val FROZEN_VERSION_CODES_PER_TRACK: Map<String, Set<Long>> = mapOf(
+  "alpha" to setOf(16L)
+)

--- a/scripts/src/java/org/oppia/android/scripts/release/GooglePlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/GooglePlayConsoleClient.kt
@@ -145,7 +145,11 @@ class GooglePlayConsoleClient(
     // if the release was previously live and is now being replaced); the entry is kept as long as
     // it still has at least one remaining version code.
     val frozenEntries = preservedReleases
-      .map { release -> release.copy(versionCodes = release.versionCodes.filter { it != versionCode }) }
+      .map { release ->
+        release.copy(
+          versionCodes = release.versionCodes.filter { it != versionCode }
+        )
+      }
       .filter { release -> release.versionCodes.isNotEmpty() }
       .map { release ->
         TrackUpdateRequest.ReleaseEntry(

--- a/scripts/src/java/org/oppia/android/scripts/release/GooglePlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/GooglePlayConsoleClient.kt
@@ -125,22 +125,35 @@ class GooglePlayConsoleClient(
     track: String,
     versionCode: Long,
     rolloutFraction: Int,
-    releaseNotes: Map<String, String>
+    releaseNotes: Map<String, String>,
+    preservedVersionCodes: Set<Long>
   ) {
     val fraction = rolloutFraction / 1000.0
     val status = if (rolloutFraction >= 1000) "completed" else "inProgress"
+    val newRelease = TrackUpdateRequest.ReleaseEntry(
+      versionCodes = listOf(versionCode.toString()),
+      status = status,
+      releaseNotes = releaseNotes.map { (lang, text) ->
+        TrackUpdateRequest.LocalizedText(language = lang, text = text)
+      },
+      userFraction = if (rolloutFraction < 1000) fraction else null
+    )
+    // Each frozen version code is re-included as a separate completed entry so the Play Developer
+    // API does not deactivate it. The API replaces the entire track contents on each update, so
+    // any version code not included in the request would be silently dropped.
+    val frozenEntries = preservedVersionCodes
+      .filter { it != versionCode }
+      .map { frozenVc ->
+        TrackUpdateRequest.ReleaseEntry(
+          versionCodes = listOf(frozenVc.toString()),
+          status = "completed",
+          releaseNotes = emptyList(),
+          userFraction = null
+        )
+      }
     val trackUpdate = TrackUpdateRequest(
       track = track,
-      releases = listOf(
-        TrackUpdateRequest.ReleaseEntry(
-          versionCodes = listOf(versionCode.toString()),
-          status = status,
-          releaseNotes = releaseNotes.map { (lang, text) ->
-            TrackUpdateRequest.LocalizedText(language = lang, text = text)
-          },
-          userFraction = if (rolloutFraction < 1000) fraction else null
-        )
-      )
+      releases = listOf(newRelease) + frozenEntries
     )
     val response = playConsoleService
       .updateTrack(packageName, editId, track, authorizationBearer, trackUpdate)

--- a/scripts/src/java/org/oppia/android/scripts/release/GooglePlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/GooglePlayConsoleClient.kt
@@ -138,19 +138,14 @@ class GooglePlayConsoleClient(
       },
       userFraction = if (rolloutFraction < 1000) fraction else null
     )
-    // Pass each preserved release through completely unmodified so the Play Console API does not
-    // treat it as changed. versionCodes, status, userFraction, and releaseNotes are all copied
-    // exactly as fetched, ensuring the diff Play Console sees is scoped only to the new release.
-    // The new upload's version code is stripped from any preserved release that contains it (e.g.
-    // if the release was previously live and is now being replaced); the entry is kept as long as
-    // it still has at least one remaining version code.
+    // Only releases whose version codes appear in FROZEN_VERSION_CODES_PER_TRACK for this track
+    // are included in the request. This is a defence-in-depth guard: callers already pre-filter
+    // preservedReleases to frozen-only entries, but enforcing the invariant here ensures a mistaken
+    // call can never accidentally preserve a non-frozen release (e.g. a half-rolled-out release
+    // whose versionCode happens to be in the list).
+    val frozenVersionCodes = FROZEN_VERSION_CODES_PER_TRACK[track] ?: emptySet()
     val frozenEntries = preservedReleases
-      .map { release ->
-        release.copy(
-          versionCodes = release.versionCodes.filter { it != versionCode }
-        )
-      }
-      .filter { release -> release.versionCodes.isNotEmpty() }
+      .filter { release -> release.versionCodes.any { it in frozenVersionCodes } }
       .map { release ->
         TrackUpdateRequest.ReleaseEntry(
           versionCodes = release.versionCodes.map { it.toString() },

--- a/scripts/src/java/org/oppia/android/scripts/release/GooglePlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/GooglePlayConsoleClient.kt
@@ -141,8 +141,12 @@ class GooglePlayConsoleClient(
     // Pass each preserved release through completely unmodified so the Play Console API does not
     // treat it as changed. versionCodes, status, userFraction, and releaseNotes are all copied
     // exactly as fetched, ensuring the diff Play Console sees is scoped only to the new release.
+    // The new upload's version code is stripped from any preserved release that contains it (e.g.
+    // if the release was previously live and is now being replaced); the entry is kept as long as
+    // it still has at least one remaining version code.
     val frozenEntries = preservedReleases
-      .filter { release -> release.versionCodes.none { it == versionCode } }
+      .map { release -> release.copy(versionCodes = release.versionCodes.filter { it != versionCode }) }
+      .filter { release -> release.versionCodes.isNotEmpty() }
       .map { release ->
         TrackUpdateRequest.ReleaseEntry(
           versionCodes = release.versionCodes.map { it.toString() },

--- a/scripts/src/java/org/oppia/android/scripts/release/GooglePlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/GooglePlayConsoleClient.kt
@@ -126,7 +126,7 @@ class GooglePlayConsoleClient(
     versionCode: Long,
     rolloutFraction: Int,
     releaseNotes: Map<String, String>,
-    preservedVersionCodes: Set<Long>
+    preservedReleases: List<PlayConsoleClient.TrackRelease>
   ) {
     val fraction = rolloutFraction / 1000.0
     val status = if (rolloutFraction >= 1000) "completed" else "inProgress"
@@ -138,17 +138,19 @@ class GooglePlayConsoleClient(
       },
       userFraction = if (rolloutFraction < 1000) fraction else null
     )
-    // Each frozen version code is re-included as a separate completed entry so the Play Developer
-    // API does not deactivate it. The API replaces the entire track contents on each update, so
-    // any version code not included in the request would be silently dropped.
-    val frozenEntries = preservedVersionCodes
-      .filter { it != versionCode }
-      .map { frozenVc ->
+    // Pass each preserved release through completely unmodified so the Play Console API does not
+    // treat it as changed. versionCodes, status, userFraction, and releaseNotes are all copied
+    // exactly as fetched, ensuring the diff Play Console sees is scoped only to the new release.
+    val frozenEntries = preservedReleases
+      .filter { release -> release.versionCodes.none { it == versionCode } }
+      .map { release ->
         TrackUpdateRequest.ReleaseEntry(
-          versionCodes = listOf(frozenVc.toString()),
-          status = "completed",
-          releaseNotes = emptyList(),
-          userFraction = null
+          versionCodes = release.versionCodes.map { it.toString() },
+          status = release.status,
+          releaseNotes = release.releaseNotes.map { (lang, text) ->
+            TrackUpdateRequest.LocalizedText(language = lang, text = text)
+          },
+          userFraction = release.rolloutFraction?.let { it / 1000.0 }
         )
       }
     val trackUpdate = TrackUpdateRequest(
@@ -188,7 +190,8 @@ class GooglePlayConsoleClient(
     return PlayConsoleClient.TrackRelease(
       versionCodes = versionCodes?.map { it.toLong() } ?: emptyList(),
       status = status,
-      rolloutFraction = userFraction?.let { (it * 1000).roundToInt() }
+      rolloutFraction = userFraction?.let { (it * 1000).roundToInt() },
+      releaseNotes = releaseNotes?.associate { it.language to it.text } ?: emptyMap()
     )
   }
 }

--- a/scripts/src/java/org/oppia/android/scripts/release/PlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/PlayConsoleClient.kt
@@ -76,7 +76,7 @@ interface PlayConsoleClient {
     versionCode: Long,
     rolloutFraction: Int,
     releaseNotes: Map<String, String>,
-    preservedVersionCodes: Set<Long> = emptySet()
+    preservedReleases: List<TrackRelease> = emptyList()
   )
 
   /**
@@ -98,10 +98,13 @@ interface PlayConsoleClient {
    * @property rolloutFraction the staged rollout fraction as an integer in [0, 1000], where
    *     1000 = 100%. Null for [status] values that do not have a rollout percentage
    *     ("completed", "halted", "draft").
+   * @property releaseNotes map of BCP-47 language codes to release notes text, as returned by
+   *     the Play Developer API. Empty if no release notes were set for this release.
    */
   data class TrackRelease(
     val versionCodes: List<Long>,
     val status: String,
-    val rolloutFraction: Int? = null
+    val rolloutFraction: Int? = null,
+    val releaseNotes: Map<String, String> = emptyMap()
   )
 }

--- a/scripts/src/java/org/oppia/android/scripts/release/PlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/PlayConsoleClient.kt
@@ -52,6 +52,12 @@ interface PlayConsoleClient {
    *
    * Must be called after [uploadAab] and before [commitEdit].
    *
+   * If [preservedVersionCodes] is non-empty, each listed version code is included as an additional
+   * `completed` entry in the track update request alongside the new release. This is required for
+   * OS-level frozen builds that must remain active on the track indefinitely (see #6258, #6330):
+   * the Play Developer API replaces the entire track contents on each `tracks.update` call, so any
+   * version code not explicitly included in the request is deactivated.
+   *
    * @param packageName the application package name
    * @param editId the active edit session ID returned by [createEdit]
    * @param track the Play Console track (e.g. "alpha", "beta", "production")
@@ -60,6 +66,8 @@ interface PlayConsoleClient {
    *     1000 means full rollout (status: "completed") and any value below 1000 produces a staged
    *     rollout (status: "inProgress"). For example: 250 = 25%, 334 = 33.4%, 1000 = 100%.
    * @param releaseNotes map of BCP-47 language codes to release notes text (max 500 chars each)
+   * @param preservedVersionCodes version codes of frozen OS-specific builds that must be kept
+   *     alive on the track alongside [versionCode]; defaults to empty (no preserved builds)
    */
   fun setTrackRelease(
     packageName: String,
@@ -67,7 +75,8 @@ interface PlayConsoleClient {
     track: String,
     versionCode: Long,
     rolloutFraction: Int,
-    releaseNotes: Map<String, String>
+    releaseNotes: Map<String, String>,
+    preservedVersionCodes: Set<Long> = emptySet()
   )
 
   /**

--- a/scripts/src/java/org/oppia/android/scripts/release/UpdateRolloutFraction.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UpdateRolloutFraction.kt
@@ -126,7 +126,10 @@ fun updateRollout(
   val editId = client.createEdit(packageName)
   println("  Edit session: $editId")
 
-  client.setTrackRelease(packageName, editId, track, versionCode, rolloutFraction, releaseNotes)
+  client.setTrackRelease(
+    packageName, editId, track, versionCode, rolloutFraction, releaseNotes,
+    FROZEN_VERSION_CODES_PER_TRACK[track] ?: emptySet()
+  )
   println("  Rollout fraction updated.")
 
   client.commitEdit(packageName, editId)
@@ -182,3 +185,22 @@ private const val MAX_RELEASE_NOTES_LENGTH = 500
 
 /** Relative path within the workspace root where changelog files are stored. */
 private const val CHANGELOGS_DIR = "config/changelogs"
+
+/**
+ * Version codes that must be preserved alongside any new release on their respective tracks.
+ *
+ * The Play Developer API replaces the entire track contents on each `tracks.update` call, so any
+ * version code not explicitly included in the request would be silently deactivated. These are
+ * OS-level frozen builds released once to support a specific minimum API level and kept active
+ * indefinitely so devices on that API level continue to receive the app.
+ *
+ * Currently frozen:
+ * - alpha vc 16: KitKat (API 16) build, frozen permanently per #6258.
+ *
+ * When a new API level is deprecated and its final build must be frozen, add its version code to
+ * the appropriate track(s) here. Keep this map in sync with the equivalent constants in
+ * [UploadBinaryToPlayConsole] and [UploadChangelogToPlayConsole].
+ */
+private val FROZEN_VERSION_CODES_PER_TRACK: Map<String, Set<Long>> = mapOf(
+  "alpha" to setOf(16L)
+)

--- a/scripts/src/java/org/oppia/android/scripts/release/UpdateRolloutFraction.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UpdateRolloutFraction.kt
@@ -192,25 +192,3 @@ private const val MAX_RELEASE_NOTES_LENGTH = 500
 /** Relative path within the workspace root where changelog files are stored. */
 private const val CHANGELOGS_DIR = "config/changelogs"
 
-/**
- * Version codes of OS-specific frozen builds that must be preserved on their respective tracks.
- *
- * The Play Developer API replaces the entire track contents on each `tracks.update` call, so any
- * release not explicitly included in the request would be silently deactivated. These are builds
- * released once to support a specific minimum API level and kept active indefinitely so devices on
- * that API level continue to receive the app.
- *
- * The already-fetched live releases are filtered against these version codes. Those matching
- * releases are then passed through completely unmodified (preserving their versionCodes, status,
- * userFraction, and releaseNotes).
- *
- * Currently frozen:
- * - alpha vc 16: KitKat (API 16) build, frozen permanently.
- *
- * When a new API level is deprecated and its final build must be frozen, add its version code to
- * the appropriate track(s) here. Keep this map in sync with the equivalent constants in
- * [UploadBinaryToPlayConsole] and [UploadChangelogToPlayConsole].
- */
-private val FROZEN_VERSION_CODES_PER_TRACK: Map<String, Set<Long>> = mapOf(
-  "alpha" to setOf(16L)
-)

--- a/scripts/src/java/org/oppia/android/scripts/release/UpdateRolloutFraction.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UpdateRolloutFraction.kt
@@ -121,14 +121,20 @@ fun updateRollout(
     )
   }
 
-  println("Updating rollout fraction to ${rolloutFraction / 10.0}%...")
+  // Filter the already-fetched live releases to find frozen OS-specific builds and pass them
+  // through completely unmodified (preserving versionCodes, status, userFraction, and
+  // releaseNotes) so the Play Console API does not treat them as changed.
+  val frozenVersionCodes = FROZEN_VERSION_CODES_PER_TRACK[track] ?: emptySet()
+  val frozenReleases = liveReleases.filter { release ->
+    release.versionCodes.any { it in frozenVersionCodes }
+  }
 
   val editId = client.createEdit(packageName)
   println("  Edit session: $editId")
 
   client.setTrackRelease(
     packageName, editId, track, versionCode, rolloutFraction, releaseNotes,
-    FROZEN_VERSION_CODES_PER_TRACK[track] ?: emptySet()
+    frozenReleases
   )
   println("  Rollout fraction updated.")
 
@@ -187,15 +193,19 @@ private const val MAX_RELEASE_NOTES_LENGTH = 500
 private const val CHANGELOGS_DIR = "config/changelogs"
 
 /**
- * Version codes that must be preserved alongside any new release on their respective tracks.
+ * Version codes of OS-specific frozen builds that must be preserved on their respective tracks.
  *
  * The Play Developer API replaces the entire track contents on each `tracks.update` call, so any
- * version code not explicitly included in the request would be silently deactivated. These are
- * OS-level frozen builds released once to support a specific minimum API level and kept active
- * indefinitely so devices on that API level continue to receive the app.
+ * release not explicitly included in the request would be silently deactivated. These are builds
+ * released once to support a specific minimum API level and kept active indefinitely so devices on
+ * that API level continue to receive the app.
+ *
+ * The already-fetched live releases are filtered against these version codes. Those matching
+ * releases are then passed through completely unmodified (preserving their versionCodes, status,
+ * userFraction, and releaseNotes).
  *
  * Currently frozen:
- * - alpha vc 16: KitKat (API 16) build, frozen permanently per #6258.
+ * - alpha vc 16: KitKat (API 16) build, frozen permanently.
  *
  * When a new API level is deprecated and its final build must be frozen, add its version code to
  * the appropriate track(s) here. Keep this map in sync with the equivalent constants in

--- a/scripts/src/java/org/oppia/android/scripts/release/UpdateRolloutFraction.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UpdateRolloutFraction.kt
@@ -191,4 +191,3 @@ private const val MAX_RELEASE_NOTES_LENGTH = 500
 
 /** Relative path within the workspace root where changelog files are stored. */
 private const val CHANGELOGS_DIR = "config/changelogs"
-

--- a/scripts/src/java/org/oppia/android/scripts/release/UploadBinaryToPlayConsole.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UploadBinaryToPlayConsole.kt
@@ -124,6 +124,17 @@ private fun runUpload(
     properties.majorMinorVersion,
     properties.flavor.id
   )
+  // Fetch the current track state so frozen OS-specific releases can be passed through
+  // completely unmodified in the setTrackRelease call. The Play Console API replaces the entire
+  // track on each update, so any release not included would be silently deactivated.
+  val frozenVersionCodes = FROZEN_VERSION_CODES_PER_TRACK[track] ?: emptySet()
+  val frozenReleases = if (frozenVersionCodes.isNotEmpty()) {
+    println("Fetching current track state to preserve frozen release(s)...")
+    client.getTrackReleases(PACKAGE_NAME, track, existingEditId = editId)
+      .filter { release -> release.versionCodes.any { it in frozenVersionCodes } }
+  } else {
+    emptyList()
+  }
   client.setTrackRelease(
     PACKAGE_NAME,
     editId,
@@ -131,7 +142,7 @@ private fun runUpload(
     uploadedVersionCode,
     rolloutFraction,
     releaseNotes,
-    FROZEN_VERSION_CODES_PER_TRACK[track] ?: emptySet()
+    frozenReleases
   )
   println("Track '$track' updated.")
 
@@ -228,15 +239,19 @@ private const val MAX_RELEASE_NOTES_LENGTH = 500
 private val VALID_TRACKS = setOf("alpha", "beta", "production")
 
 /**
- * Version codes that must be preserved alongside any new release on their respective tracks.
+ * Version codes of OS-specific frozen builds that must be preserved on their respective tracks.
  *
  * The Play Developer API replaces the entire track contents on each `tracks.update` call, so any
- * version code not explicitly included in the request would be silently deactivated. These are
- * OS-level frozen builds released once to support a specific minimum API level and kept active
- * indefinitely so devices on that API level continue to receive the app.
+ * release not explicitly included in the request would be silently deactivated. These are builds
+ * released once to support a specific minimum API level and kept active indefinitely so devices on
+ * that API level continue to receive the app.
+ *
+ * The current track state is fetched before each [setTrackRelease] call to find the releases
+ * matching these version codes. Those releases are then passed through unmodified (preserving
+ * their versionCodes, status, userFraction, and releaseNotes).
  *
  * Currently frozen:
- * - alpha vc 16: KitKat (API 16) build, frozen permanently per #6258.
+ * - alpha vc 16: KitKat (API 16) build, frozen permanently.
  *
  * When a new API level is deprecated and its final build must be frozen, add its version code to
  * the appropriate track(s) here. Keep this map in sync with the equivalent constants in

--- a/scripts/src/java/org/oppia/android/scripts/release/UploadBinaryToPlayConsole.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UploadBinaryToPlayConsole.kt
@@ -238,4 +238,3 @@ private const val PACKAGE_NAME = "org.oppia.android"
 private const val CHANGELOGS_DIR = "config/changelogs"
 private const val MAX_RELEASE_NOTES_LENGTH = 500
 private val VALID_TRACKS = setOf("alpha", "beta", "production")
-

--- a/scripts/src/java/org/oppia/android/scripts/release/UploadBinaryToPlayConsole.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UploadBinaryToPlayConsole.kt
@@ -85,13 +85,14 @@ fun main(args: Array<String>) {
  * @param track the Play Console track ("alpha", "beta", or "production")
  * @param rolloutFraction the rollout fraction as an integer in [0, 1000]
  */
-private fun runUpload(
+internal fun runUpload(
   client: PlayConsoleClient,
   workspaceRoot: String,
   aabPath: String,
   properties: AabProperties,
   track: String,
-  rolloutFraction: Int
+  rolloutFraction: Int,
+  frozenVersionCodesPerTrack: Map<String, Set<Long>> = FROZEN_VERSION_CODES_PER_TRACK
 ) {
   println("Running pre-upload precondition checks...")
   PendingReleaseChecker(client).verify(PACKAGE_NAME, track)
@@ -127,7 +128,7 @@ private fun runUpload(
   // Fetch the current track state so frozen OS-specific releases can be passed through
   // completely unmodified in the setTrackRelease call. The Play Console API replaces the entire
   // track on each update, so any release not included would be silently deactivated.
-  val frozenVersionCodes = FROZEN_VERSION_CODES_PER_TRACK[track] ?: emptySet()
+  val frozenVersionCodes = frozenVersionCodesPerTrack[track] ?: emptySet()
   val frozenReleases = if (frozenVersionCodes.isNotEmpty()) {
     println("Fetching current track state to preserve frozen release(s)...")
     client.getTrackReleases(PACKAGE_NAME, track, existingEditId = editId)
@@ -184,7 +185,7 @@ private val AAB_FILENAME_REGEX =
  *
  * @return parsed [AabProperties], or `null` if the filename does not match the expected format
  */
-private fun parseAabFilename(aabName: String): AabProperties? {
+internal fun parseAabFilename(aabName: String): AabProperties? {
   val match = AAB_FILENAME_REGEX.find(aabName) ?: return null
   val (major, minor, rc, flavorId) = match.destructured
   val flavor = AppFlavor.fromId(flavorId) ?: return null
@@ -238,25 +239,3 @@ private const val CHANGELOGS_DIR = "config/changelogs"
 private const val MAX_RELEASE_NOTES_LENGTH = 500
 private val VALID_TRACKS = setOf("alpha", "beta", "production")
 
-/**
- * Version codes of OS-specific frozen builds that must be preserved on their respective tracks.
- *
- * The Play Developer API replaces the entire track contents on each `tracks.update` call, so any
- * release not explicitly included in the request would be silently deactivated. These are builds
- * released once to support a specific minimum API level and kept active indefinitely so devices on
- * that API level continue to receive the app.
- *
- * The current track state is fetched before each [setTrackRelease] call to find the releases
- * matching these version codes. Those releases are then passed through unmodified (preserving
- * their versionCodes, status, userFraction, and releaseNotes).
- *
- * Currently frozen:
- * - alpha vc 16: KitKat (API 16) build, frozen permanently.
- *
- * When a new API level is deprecated and its final build must be frozen, add its version code to
- * the appropriate track(s) here. Keep this map in sync with the equivalent constants in
- * [UploadChangelogToPlayConsole] and [UpdateRolloutFraction].
- */
-private val FROZEN_VERSION_CODES_PER_TRACK: Map<String, Set<Long>> = mapOf(
-  "alpha" to setOf(16L)
-)

--- a/scripts/src/java/org/oppia/android/scripts/release/UploadBinaryToPlayConsole.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UploadBinaryToPlayConsole.kt
@@ -130,7 +130,8 @@ private fun runUpload(
     track,
     uploadedVersionCode,
     rolloutFraction,
-    releaseNotes
+    releaseNotes,
+    FROZEN_VERSION_CODES_PER_TRACK[track] ?: emptySet()
   )
   println("Track '$track' updated.")
 
@@ -225,3 +226,22 @@ private const val PACKAGE_NAME = "org.oppia.android"
 private const val CHANGELOGS_DIR = "config/changelogs"
 private const val MAX_RELEASE_NOTES_LENGTH = 500
 private val VALID_TRACKS = setOf("alpha", "beta", "production")
+
+/**
+ * Version codes that must be preserved alongside any new release on their respective tracks.
+ *
+ * The Play Developer API replaces the entire track contents on each `tracks.update` call, so any
+ * version code not explicitly included in the request would be silently deactivated. These are
+ * OS-level frozen builds released once to support a specific minimum API level and kept active
+ * indefinitely so devices on that API level continue to receive the app.
+ *
+ * Currently frozen:
+ * - alpha vc 16: KitKat (API 16) build, frozen permanently per #6258.
+ *
+ * When a new API level is deprecated and its final build must be frozen, add its version code to
+ * the appropriate track(s) here. Keep this map in sync with the equivalent constants in
+ * [UploadChangelogToPlayConsole] and [UpdateRolloutFraction].
+ */
+private val FROZEN_VERSION_CODES_PER_TRACK: Map<String, Set<Long>> = mapOf(
+  "alpha" to setOf(16L)
+)

--- a/scripts/src/java/org/oppia/android/scripts/release/UploadBinaryToPlayConsole.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UploadBinaryToPlayConsole.kt
@@ -85,7 +85,7 @@ fun main(args: Array<String>) {
  * @param track the Play Console track ("alpha", "beta", or "production")
  * @param rolloutFraction the rollout fraction as an integer in [0, 1000]
  */
-internal fun runUpload(
+fun runUpload(
   client: PlayConsoleClient,
   workspaceRoot: String,
   aabPath: String,
@@ -185,7 +185,7 @@ private val AAB_FILENAME_REGEX =
  *
  * @return parsed [AabProperties], or `null` if the filename does not match the expected format
  */
-internal fun parseAabFilename(aabName: String): AabProperties? {
+fun parseAabFilename(aabName: String): AabProperties? {
   val match = AAB_FILENAME_REGEX.find(aabName) ?: return null
   val (major, minor, rc, flavorId) = match.destructured
   val flavor = AppFlavor.fromId(flavorId) ?: return null

--- a/scripts/src/java/org/oppia/android/scripts/release/UploadChangelogToPlayConsole.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UploadChangelogToPlayConsole.kt
@@ -219,7 +219,9 @@ private fun uploadChangelogToTrack(
   val editId = client.createEdit(packageName)
   println("  Edit session: $editId")
 
-  client.setTrackRelease(packageName, editId, track, versionCode, rolloutFraction, newNotes, frozenVersionCodes)
+  client.setTrackRelease(
+  packageName, editId, track, versionCode, rolloutFraction, newNotes, frozenVersionCodes
+  )
   println("  Track release notes updated.")
 
   client.commitEdit(packageName, editId)

--- a/scripts/src/java/org/oppia/android/scripts/release/UploadChangelogToPlayConsole.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UploadChangelogToPlayConsole.kt
@@ -98,9 +98,15 @@ fun maybeUploadUpdatedChangelogs(
     // releases are already at 100% so fall back to 1000.
     val rolloutFraction =
       releases.firstOrNull { it.status == "inProgress" }?.rolloutFraction ?: 1000
+    // The already-fetched releases are filtered to find frozen OS-specific builds and passed
+    // through completely unmodified (preserving versionCodes, status, userFraction, and
+    // releaseNotes) so the Play Console API does not treat them as changed.
+    val frozenVersionCodes = FROZEN_VERSION_CODES_PER_TRACK[track] ?: emptySet()
+    val frozenReleases = releases.filter { release ->
+      release.versionCodes.any { it in frozenVersionCodes }
+    }
     uploadChangelogToTrack(
-      client, packageName, track, versionCode, rolloutFraction, notes,
-      FROZEN_VERSION_CODES_PER_TRACK[track] ?: emptySet()
+      client, packageName, track, versionCode, rolloutFraction, notes, frozenReleases
     )
     updatedCount++
   }
@@ -184,8 +190,8 @@ private fun detectChangelogDiff(localNotes: String, deployedNotes: String): Bool
  * pass the existing [rolloutFraction] from the live release to avoid inadvertently altering the
  * staged rollout percentage.
  *
- * Any [frozenVersionCodes] are re-included as separate completed entries so the Play Developer
- * API does not deactivate them during the track update (see #6330).
+ * Any [frozenReleases] are passed through completely unmodified alongside the updated release so
+ * the Play Console API does not deactivate them during the track update.
  *
  * @param client the [PlayConsoleClient] used for all API calls
  * @param packageName the application package name (e.g. `"org.oppia.android"`)
@@ -195,7 +201,8 @@ private fun detectChangelogDiff(localNotes: String, deployedNotes: String): Bool
  *     through unchanged so the rollout percentage is preserved)
  * @param newNotes map of BCP-47 language codes to updated release notes text (max 500 chars each);
  *     must contain at least an `"en-US"` entry
- * @param frozenVersionCodes version codes of OS-specific frozen builds to preserve on the track
+ * @param frozenReleases OS-specific frozen releases to preserve on the track, passed through
+ *     unmodified (preserving their versionCodes, status, userFraction, and releaseNotes)
  */
 private fun uploadChangelogToTrack(
   client: PlayConsoleClient,
@@ -204,7 +211,7 @@ private fun uploadChangelogToTrack(
   versionCode: Long,
   rolloutFraction: Int,
   newNotes: Map<String, String>,
-  frozenVersionCodes: Set<Long> = emptySet()
+  frozenReleases: List<PlayConsoleClient.TrackRelease> = emptyList()
 ) {
   require(newNotes.containsKey("en-US")) {
     "newNotes must contain an 'en-US' entry. Got keys: ${newNotes.keys}"
@@ -220,7 +227,7 @@ private fun uploadChangelogToTrack(
   println("  Edit session: $editId")
 
   client.setTrackRelease(
-    packageName, editId, track, versionCode, rolloutFraction, newNotes, frozenVersionCodes
+    packageName, editId, track, versionCode, rolloutFraction, newNotes, frozenReleases
   )
   println("  Track release notes updated.")
 
@@ -277,15 +284,19 @@ private const val MAX_RELEASE_NOTES_LENGTH = 500
 private const val CHANGELOGS_DIR = "config/changelogs"
 
 /**
- * Version codes that must be preserved alongside any new release on their respective tracks.
+ * Version codes of OS-specific frozen builds that must be preserved on their respective tracks.
  *
  * The Play Developer API replaces the entire track contents on each `tracks.update` call, so any
- * version code not explicitly included in the request would be silently deactivated. These are
- * OS-level frozen builds released once to support a specific minimum API level and kept active
- * indefinitely so devices on that API level continue to receive the app.
+ * release not explicitly included in the request would be silently deactivated. These are builds
+ * released once to support a specific minimum API level and kept active indefinitely so devices on
+ * that API level continue to receive the app.
+ *
+ * The already-fetched live releases are filtered against these version codes. Those matching
+ * releases are then passed through completely unmodified (preserving their versionCodes, status,
+ * userFraction, and releaseNotes).
  *
  * Currently frozen:
- * - alpha vc 16: KitKat (API 16) build, frozen permanently per #6258.
+ * - alpha vc 16: KitKat (API 16) build, frozen permanently.
  *
  * When a new API level is deprecated and its final build must be frozen, add its version code to
  * the appropriate track(s) here. Keep this map in sync with the equivalent constants in

--- a/scripts/src/java/org/oppia/android/scripts/release/UploadChangelogToPlayConsole.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UploadChangelogToPlayConsole.kt
@@ -290,4 +290,3 @@ private const val MAX_RELEASE_NOTES_LENGTH = 500
 
 /** Relative path within the workspace root where changelog files are stored. */
 private const val CHANGELOGS_DIR = "config/changelogs"
-

--- a/scripts/src/java/org/oppia/android/scripts/release/UploadChangelogToPlayConsole.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UploadChangelogToPlayConsole.kt
@@ -98,7 +98,10 @@ fun maybeUploadUpdatedChangelogs(
     // releases are already at 100% so fall back to 1000.
     val rolloutFraction =
       releases.firstOrNull { it.status == "inProgress" }?.rolloutFraction ?: 1000
-    uploadChangelogToTrack(client, packageName, track, versionCode, rolloutFraction, notes)
+    uploadChangelogToTrack(
+      client, packageName, track, versionCode, rolloutFraction, notes,
+      FROZEN_VERSION_CODES_PER_TRACK[track] ?: emptySet()
+    )
     updatedCount++
   }
 
@@ -177,9 +180,12 @@ private fun detectChangelogDiff(localNotes: String, deployedNotes: String): Bool
  * Uploads updated release notes to a live Play Console track within a new edit session.
  *
  * Creates a new edit, updates the release notes for [versionCode] on [track], and commits the
- * edit. This is a *changelog-only* update — the binary itself is not changed. The caller must
+ * edit. This is a *changelog-only* update -- the binary itself is not changed. The caller must
  * pass the existing [rolloutFraction] from the live release to avoid inadvertently altering the
  * staged rollout percentage.
+ *
+ * Any [frozenVersionCodes] are re-included as separate completed entries so the Play Developer
+ * API does not deactivate them during the track update (see #6330).
  *
  * @param client the [PlayConsoleClient] used for all API calls
  * @param packageName the application package name (e.g. `"org.oppia.android"`)
@@ -189,6 +195,7 @@ private fun detectChangelogDiff(localNotes: String, deployedNotes: String): Bool
  *     through unchanged so the rollout percentage is preserved)
  * @param newNotes map of BCP-47 language codes to updated release notes text (max 500 chars each);
  *     must contain at least an `"en-US"` entry
+ * @param frozenVersionCodes version codes of OS-specific frozen builds to preserve on the track
  */
 private fun uploadChangelogToTrack(
   client: PlayConsoleClient,
@@ -196,7 +203,8 @@ private fun uploadChangelogToTrack(
   track: String,
   versionCode: Long,
   rolloutFraction: Int,
-  newNotes: Map<String, String>
+  newNotes: Map<String, String>,
+  frozenVersionCodes: Set<Long> = emptySet()
 ) {
   require(newNotes.containsKey("en-US")) {
     "newNotes must contain an 'en-US' entry. Got keys: ${newNotes.keys}"
@@ -211,7 +219,7 @@ private fun uploadChangelogToTrack(
   val editId = client.createEdit(packageName)
   println("  Edit session: $editId")
 
-  client.setTrackRelease(packageName, editId, track, versionCode, rolloutFraction, newNotes)
+  client.setTrackRelease(packageName, editId, track, versionCode, rolloutFraction, newNotes, frozenVersionCodes)
   println("  Track release notes updated.")
 
   client.commitEdit(packageName, editId)
@@ -265,3 +273,22 @@ private const val MAX_RELEASE_NOTES_LENGTH = 500
 
 /** Relative path within the workspace root where changelog files are stored. */
 private const val CHANGELOGS_DIR = "config/changelogs"
+
+/**
+ * Version codes that must be preserved alongside any new release on their respective tracks.
+ *
+ * The Play Developer API replaces the entire track contents on each `tracks.update` call, so any
+ * version code not explicitly included in the request would be silently deactivated. These are
+ * OS-level frozen builds released once to support a specific minimum API level and kept active
+ * indefinitely so devices on that API level continue to receive the app.
+ *
+ * Currently frozen:
+ * - alpha vc 16: KitKat (API 16) build, frozen permanently per #6258.
+ *
+ * When a new API level is deprecated and its final build must be frozen, add its version code to
+ * the appropriate track(s) here. Keep this map in sync with the equivalent constants in
+ * [UploadBinaryToPlayConsole] and [UpdateRolloutFraction].
+ */
+private val FROZEN_VERSION_CODES_PER_TRACK: Map<String, Set<Long>> = mapOf(
+  "alpha" to setOf(16L)
+)

--- a/scripts/src/java/org/oppia/android/scripts/release/UploadChangelogToPlayConsole.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UploadChangelogToPlayConsole.kt
@@ -105,6 +105,14 @@ fun maybeUploadUpdatedChangelogs(
     val frozenReleases = releases.filter { release ->
       release.versionCodes.any { it in frozenVersionCodes }
     }
+    // Skip if the live notes already match the local file — avoids wasted API calls and
+    // prevents spurious review re-triggers on tracks where nothing has changed.
+    val deployedNotes = releases
+      .firstOrNull { it.status in LIVE_STATUSES }
+      ?.releaseNotes
+      ?.get("en-US")
+      ?: ""
+    if (!detectChangelogDiff(notes["en-US"] ?: "", deployedNotes)) continue
     uploadChangelogToTrack(
       client, packageName, track, versionCode, rolloutFraction, notes, frozenReleases
     )
@@ -283,25 +291,3 @@ private const val MAX_RELEASE_NOTES_LENGTH = 500
 /** Relative path within the workspace root where changelog files are stored. */
 private const val CHANGELOGS_DIR = "config/changelogs"
 
-/**
- * Version codes of OS-specific frozen builds that must be preserved on their respective tracks.
- *
- * The Play Developer API replaces the entire track contents on each `tracks.update` call, so any
- * release not explicitly included in the request would be silently deactivated. These are builds
- * released once to support a specific minimum API level and kept active indefinitely so devices on
- * that API level continue to receive the app.
- *
- * The already-fetched live releases are filtered against these version codes. Those matching
- * releases are then passed through completely unmodified (preserving their versionCodes, status,
- * userFraction, and releaseNotes).
- *
- * Currently frozen:
- * - alpha vc 16: KitKat (API 16) build, frozen permanently.
- *
- * When a new API level is deprecated and its final build must be frozen, add its version code to
- * the appropriate track(s) here. Keep this map in sync with the equivalent constants in
- * [UploadBinaryToPlayConsole] and [UpdateRolloutFraction].
- */
-private val FROZEN_VERSION_CODES_PER_TRACK: Map<String, Set<Long>> = mapOf(
-  "alpha" to setOf(16L)
-)

--- a/scripts/src/java/org/oppia/android/scripts/release/UploadChangelogToPlayConsole.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UploadChangelogToPlayConsole.kt
@@ -220,7 +220,7 @@ private fun uploadChangelogToTrack(
   println("  Edit session: $editId")
 
   client.setTrackRelease(
-  packageName, editId, track, versionCode, rolloutFraction, newNotes, frozenVersionCodes
+    packageName, editId, track, versionCode, rolloutFraction, newNotes, frozenVersionCodes
   )
   println("  Track release notes updated.")
 

--- a/scripts/src/java/org/oppia/android/scripts/release/model/TrackResponse.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/model/TrackResponse.kt
@@ -23,12 +23,26 @@ data class TrackResponse(
    * @property status the release lifecycle status. One of: `"statusUnspecified"`, `"draft"`,
    *     `"inProgress"`, `"halted"`, or `"completed"`.
    * @property userFraction the fraction of users receiving this release in a staged rollout
-   *     (range 0.0–1.0, e.g. 0.25 for 25%), or null for completed/halted releases
+   *     (range 0.0-1.0, e.g. 0.25 for 25%), or null for completed/halted releases
+   * @property releaseNotes the localised release notes for this release, or null if none were set
    */
   @JsonClass(generateAdapter = true)
   data class ReleaseEntry(
     @Json(name = "versionCodes") val versionCodes: List<String>?,
     @Json(name = "status") val status: String,
-    @Json(name = "userFraction") val userFraction: Double? = null
+    @Json(name = "userFraction") val userFraction: Double? = null,
+    @Json(name = "releaseNotes") val releaseNotes: List<LocalizedText>? = null
+  )
+
+  /**
+   * Represents a localised text entry, used for release notes.
+   *
+   * @property language the BCP-47 language tag (e.g. `"en-US"`)
+   * @property text the release note text for that language
+   */
+  @JsonClass(generateAdapter = true)
+  data class LocalizedText(
+    @Json(name = "language") val language: String,
+    @Json(name = "text") val text: String
   )
 }

--- a/scripts/src/javatests/org/oppia/android/scripts/release/BUILD.bazel
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/BUILD.bazel
@@ -52,6 +52,8 @@ kt_jvm_test(
     name = "UploadBinaryToPlayConsoleTest",
     srcs = ["UploadBinaryToPlayConsoleTest.kt"],
     deps = [
+        "//scripts/src/java/org/oppia/android/scripts/release:fake_play_console_client",
+        "//scripts/src/java/org/oppia/android/scripts/release:play_console_client",
         "//scripts/src/java/org/oppia/android/scripts/release:upload_binary_to_play_console_lib",
         "//testing:assertion_helpers",
         "//third_party:com_google_truth_truth",

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
@@ -424,7 +424,8 @@ class UpdateRolloutFractionTest {
 
     assertThat(fakeClient.trackUpdates).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].versionCode).isEqualTo(201L)
-    assertThat(fakeClient.trackUpdates[0].preservedVersionCodes).containsExactly(16L)
+    assertThat(fakeClient.trackUpdates[0].preservedReleases).hasSize(1)
+    assertThat(fakeClient.trackUpdates[0].preservedReleases[0].versionCodes).containsExactly(16L)
   }
 
   @Test
@@ -444,7 +445,7 @@ class UpdateRolloutFractionTest {
 
     assertThat(fakeClient.trackUpdates).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].track).isEqualTo("beta")
-    assertThat(fakeClient.trackUpdates[0].preservedVersionCodes).isEmpty()
+    assertThat(fakeClient.trackUpdates[0].preservedReleases).isEmpty()
   }
 
   // ---------------------------------------------------------------------------

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
@@ -418,7 +418,9 @@ class UpdateRolloutFractionTest {
     )
     createSharedChangelog(testVersion, notes = "Release notes.")
 
-    updateRollout(fakeClient, tempFolder.root.absolutePath, testPackageName, "alpha", testVersion, 500)
+    updateRollout(
+    fakeClient, tempFolder.root.absolutePath, testPackageName, "alpha", testVersion, 500
+    )
 
     assertThat(fakeClient.trackUpdates).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].versionCode).isEqualTo(201L)
@@ -432,7 +434,9 @@ class UpdateRolloutFractionTest {
       "beta",
       listOf(PlayConsoleClient.TrackRelease(listOf(201L), "inProgress", rolloutFraction = 250))
     )
-    createSharedChangelog(testVersion, notes = "Release notes.")
+    createSharedChangelog(
+    testVersion, notes = "Release notes."
+    )
 
     updateRollout(fakeClient, tempFolder.root.absolutePath, testPackageName, "beta", testVersion, 500)
 

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
@@ -402,6 +402,46 @@ class UpdateRolloutFractionTest {
   }
 
   // ---------------------------------------------------------------------------
+  // Frozen version code preservation (#6330)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun testUpdateRollout_alphaTrack_preservesFrozenKitKatVersionCodeInTrackUpdate() {
+    // vc 16 is permanently frozen on alpha; it must be re-included in every setTrackRelease call
+    // so the Play Console API does not deactivate it when the rollout fraction is updated.
+    fakeClient.setTrackReleases(
+      "alpha",
+      listOf(
+        PlayConsoleClient.TrackRelease(listOf(201L), "inProgress", rolloutFraction = 250),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
+    )
+    createSharedChangelog(testVersion, notes = "Release notes.")
+
+    updateRollout(fakeClient, tempFolder.root.absolutePath, testPackageName, "alpha", testVersion, 500)
+
+    assertThat(fakeClient.trackUpdates).hasSize(1)
+    assertThat(fakeClient.trackUpdates[0].versionCode).isEqualTo(201L)
+    assertThat(fakeClient.trackUpdates[0].preservedVersionCodes).containsExactly(16L)
+  }
+
+  @Test
+  fun testUpdateRollout_betaTrack_doesNotIncludeAnyFrozenVersionCodes() {
+    // Beta has no frozen builds; the rollout update should not include any preserved version codes.
+    fakeClient.setTrackReleases(
+      "beta",
+      listOf(PlayConsoleClient.TrackRelease(listOf(201L), "inProgress", rolloutFraction = 250))
+    )
+    createSharedChangelog(testVersion, notes = "Release notes.")
+
+    updateRollout(fakeClient, tempFolder.root.absolutePath, testPackageName, "beta", testVersion, 500)
+
+    assertThat(fakeClient.trackUpdates).hasSize(1)
+    assertThat(fakeClient.trackUpdates[0].track).isEqualTo("beta")
+    assertThat(fakeClient.trackUpdates[0].preservedVersionCodes).isEmpty()
+  }
+
+  // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
 

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
@@ -424,8 +424,14 @@ class UpdateRolloutFractionTest {
 
     assertThat(fakeClient.trackUpdates).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].versionCode).isEqualTo(201L)
+    assertThat(fakeClient.trackUpdates[0].rolloutFraction).isEqualTo(500)
     assertThat(fakeClient.trackUpdates[0].preservedReleases).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].preservedReleases[0].versionCodes).containsExactly(16L)
+    // Verify the frozen release is passed through completely unmodified (status, rolloutFraction,
+    // and releaseNotes must match the values configured in setTrackReleases above).
+    assertThat(fakeClient.trackUpdates[0].preservedReleases[0].status).isEqualTo("completed")
+    assertThat(fakeClient.trackUpdates[0].preservedReleases[0].rolloutFraction).isNull()
+    assertThat(fakeClient.trackUpdates[0].preservedReleases[0].releaseNotes).isEmpty()
   }
 
   @Test

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
@@ -451,6 +451,8 @@ class UpdateRolloutFractionTest {
 
     assertThat(fakeClient.trackUpdates).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].track).isEqualTo("beta")
+    assertThat(fakeClient.trackUpdates[0].versionCode).isEqualTo(201L)
+    assertThat(fakeClient.trackUpdates[0].rolloutFraction).isEqualTo(500)
     assertThat(fakeClient.trackUpdates[0].preservedReleases).isEmpty()
   }
 

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
@@ -402,7 +402,7 @@ class UpdateRolloutFractionTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Frozen version code preservation (#6330)
+  // Frozen version code preservation
   // ---------------------------------------------------------------------------
 
   @Test

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
@@ -419,7 +419,7 @@ class UpdateRolloutFractionTest {
     createSharedChangelog(testVersion, notes = "Release notes.")
 
     updateRollout(
-    fakeClient, tempFolder.root.absolutePath, testPackageName, "alpha", testVersion, 500
+      fakeClient, tempFolder.root.absolutePath, testPackageName, "alpha", testVersion, 500
     )
 
     assertThat(fakeClient.trackUpdates).hasSize(1)
@@ -435,10 +435,12 @@ class UpdateRolloutFractionTest {
       listOf(PlayConsoleClient.TrackRelease(listOf(201L), "inProgress", rolloutFraction = 250))
     )
     createSharedChangelog(
-    testVersion, notes = "Release notes."
+      testVersion, notes = "Release notes."
     )
 
-    updateRollout(fakeClient, tempFolder.root.absolutePath, testPackageName, "beta", testVersion, 500)
+    updateRollout(
+      fakeClient, tempFolder.root.absolutePath, testPackageName, "beta", testVersion, 500
+    )
 
     assertThat(fakeClient.trackUpdates).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].track).isEqualTo("beta")

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UploadBinaryToPlayConsoleTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UploadBinaryToPlayConsoleTest.kt
@@ -499,6 +499,46 @@ class UploadBinaryToPlayConsoleTest {
   }
 
   // ---------------------------------------------------------------------------
+  // Frozen version code preservation (#6330)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun testRunUpload_alphaTrack_includesFrozenKitKatVersionCodeInTrackUpdateRequest() {
+    // The alpha track has a permanently frozen KitKat build (vc 16) that must be re-included in
+    // every setTrackRelease call. Without it the Play Console API would deactivate vc 16.
+    val aab = createAab("oppia-android-0.17-rc01-alpha-e740815230.aab")
+    createChangelog("0.17", content = "Release notes.")
+    enqueueSuccessfulUpload(versionCode = 202L)
+
+    runMain(aab.absolutePath, track = "alpha")
+
+    // Request 8 (index 7) is the PUT setTrackRelease for the alpha track.
+    skipRequests(7)
+    val setTrackBody = server.takeRequest().body.readUtf8()
+    assertThat(setTrackBody).contains("\"16\"")
+    assertThat(setTrackBody).contains("\"202\"")
+    // The frozen entry must be marked completed (no userFraction), while the new release has its
+    // own status. Verify both version codes appear in the releases list.
+    assertThat(setTrackBody).contains("\"releases\"")
+  }
+
+  @Test
+  fun testRunUpload_betaTrack_doesNotIncludeAnyFrozenVersionCodesInTrackUpdateRequest() {
+    // Beta currently has no frozen builds; the setTrackRelease body should only contain the new vc.
+    val aab = createAab("oppia-android-0.17-rc01-beta-e740815230.aab")
+    createChangelog("0.17", content = "Release notes.")
+    enqueueSuccessfulUpload(versionCode = 202L)
+
+    runMain(aab.absolutePath, track = "beta")
+
+    // Request 8 (index 7) is the PUT setTrackRelease for the beta track.
+    skipRequests(7)
+    val setTrackBody = server.takeRequest().body.readUtf8()
+    assertThat(setTrackBody).contains("\"202\"")
+    assertThat(setTrackBody).doesNotContain("\"16\"")
+  }
+
+  // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
 

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UploadBinaryToPlayConsoleTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UploadBinaryToPlayConsoleTest.kt
@@ -523,8 +523,42 @@ class UploadBinaryToPlayConsoleTest {
     val setTrackBody = server.takeRequest().body.readUtf8()
     assertThat(setTrackBody).contains("\"16\"")
     assertThat(setTrackBody).contains("\"202\"")
-    // The frozen entry is passed through with "completed" status and no userFraction.
-    assertThat(setTrackBody).contains("\"releases\"")
+    // Exactly 2 releases must appear: the new upload and the frozen KitKat entry, no more.
+    assertThat(setTrackBody.split("\"versionCodes\"").size - 1).isEqualTo(2)
+    // The frozen entry is passed through with "completed" status.
+    assertThat(setTrackBody).contains("\"completed\"")
+  }
+
+  @Test
+  fun testRunUpload_alphaTrack_includesAllFrozenVersionCodesWhenMultipleFrozenBuildsExist() {
+    // Regression: when a second build is added to the frozen map (e.g. a future Lollipop freeze),
+    // both frozen version codes must survive in the setTrackRelease call alongside the new upload.
+    // Uses FakePlayConsoleClient with an injected two-entry frozen map to avoid HTTP mock overhead.
+    val fakeClient = FakePlayConsoleClient()
+    fakeClient.setTrackReleases(
+      "alpha",
+      listOf(
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed"),
+        PlayConsoleClient.TrackRelease(listOf(21L), "completed")
+      )
+    )
+    val aab = createAab("oppia-android-0.17-rc01-alpha-e740815230.aab")
+    createChangelog("0.17", content = "Release notes.")
+
+    runUpload(
+      client = fakeClient,
+      workspaceRoot = tempFolder.root.absolutePath,
+      aabPath = aab.absolutePath,
+      properties = parseAabFilename(aab.name)!!,
+      track = "alpha",
+      rolloutFraction = 10,
+      frozenVersionCodesPerTrack = mapOf("alpha" to setOf(16L, 21L))
+    )
+
+    val update = fakeClient.trackUpdates.single()
+    assertThat(update.preservedReleases).hasSize(2)
+    val preservedVcs = update.preservedReleases.flatMap { it.versionCodes }
+    assertThat(preservedVcs).containsExactly(16L, 21L)
   }
 
   @Test

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UploadBinaryToPlayConsoleTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UploadBinaryToPlayConsoleTest.kt
@@ -512,7 +512,8 @@ class UploadBinaryToPlayConsoleTest {
     // the production code can pass it through unmodified to the setTrackRelease PUT.
     enqueueSuccessfulUpload(
       versionCode = 202L,
-      frozenTrackBody = """{"releases":[{"versionCodes":["16"],"status":"completed"}]}"""
+      frozenTrackBody =
+        """{"releases":[{"versionCodes":["16"],"status":"completed"}]}"""
     )
 
     runMain(aab.absolutePath, track = "alpha")

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UploadBinaryToPlayConsoleTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UploadBinaryToPlayConsoleTest.kt
@@ -499,7 +499,7 @@ class UploadBinaryToPlayConsoleTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Frozen version code preservation (#6330)
+  // Frozen version code preservation
   // ---------------------------------------------------------------------------
 
   @Test

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UploadBinaryToPlayConsoleTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UploadBinaryToPlayConsoleTest.kt
@@ -226,9 +226,9 @@ class UploadBinaryToPlayConsoleTest {
     // rollout_fraction = 0 is valid; the full upload flow should complete without errors.
     runMain(aab.absolutePath, rolloutFraction = 0)
 
-    // Verify that commitEdit (the 9th and final request) was actually called, confirming the
+    // Verify that commitEdit (the 10th and final request) was actually called, confirming the
     // upload was committed and not aborted early.
-    skipRequests(8)
+    skipRequests(9)
     assertThat(server.takeRequest().path).endsWith(":commit")
   }
 
@@ -241,9 +241,9 @@ class UploadBinaryToPlayConsoleTest {
     // rollout_fraction = 1000 (100%) is valid; the full upload flow should complete.
     runMain(aab.absolutePath, rolloutFraction = 1000)
 
-    // Verify that commitEdit (the 9th and final request) was actually called, confirming the
+    // Verify that commitEdit (the 10th and final request) was actually called, confirming the
     // upload was committed and not aborted early.
-    skipRequests(8)
+    skipRequests(9)
     assertThat(server.takeRequest().path).endsWith(":commit")
   }
 
@@ -259,10 +259,10 @@ class UploadBinaryToPlayConsoleTest {
 
     runMain(aab.absolutePath)
 
-    // Verify the full 9-step flow completed by confirming commitEdit (step 9) was called.
-    // Flow: 2 (pending check) + 2 (upload) + 3 (version check) + 1 (setTrackRelease) +
-    // 1 (commitEdit). The :commit suffix on the path uniquely identifies the commit call.
-    skipRequests(8)
+    // Verify the full 10-step flow completed by confirming commitEdit (step 10) was called.
+    // Flow: 2 (pending check) + 2 (upload) + 3 (version check) + 1 (frozen GET) +
+    // 1 (setTrackRelease) + 1 (commitEdit). The :commit suffix uniquely identifies the call.
+    skipRequests(9)
     assertThat(server.takeRequest().path).endsWith(":commit")
   }
 
@@ -288,8 +288,8 @@ class UploadBinaryToPlayConsoleTest {
 
     runMain(aab.absolutePath)
 
-    // Flow: 2 (pending) + 2 (upload) + 3 (version check) = 7 previous requests.
-    skipRequests(7)
+    // Flow: 2 (pending) + 2 (upload) + 3 (version check) + 1 (frozen GET) = 8 previous requests.
+    skipRequests(8)
     val setTrackBody = server.takeRequest().body.readUtf8()
     assertThat(setTrackBody).contains("\"301\"")
   }
@@ -302,7 +302,7 @@ class UploadBinaryToPlayConsoleTest {
 
     runMain(aab.absolutePath)
 
-    skipRequests(7)
+    skipRequests(8)
     val setTrackBody = server.takeRequest().body.readUtf8()
     assertThat(setTrackBody).contains("User-facing release notes.")
     assertThat(setTrackBody).contains("en-US")
@@ -410,7 +410,7 @@ class UploadBinaryToPlayConsoleTest {
 
     runMain(aab.absolutePath, rolloutFraction = 1000)
 
-    skipRequests(7)
+    skipRequests(8)
     val setTrackBody = server.takeRequest().body.readUtf8()
     assertThat(setTrackBody).contains("\"status\":\"completed\"")
     assertThat(setTrackBody).doesNotContain("userFraction")
@@ -424,7 +424,7 @@ class UploadBinaryToPlayConsoleTest {
 
     runMain(aab.absolutePath, rolloutFraction = 250)
 
-    skipRequests(7)
+    skipRequests(8)
     val setTrackBody = server.takeRequest().body.readUtf8()
     assertThat(setTrackBody).contains("\"status\":\"inProgress\"")
     assertThat(setTrackBody).contains("0.25")
@@ -443,7 +443,7 @@ class UploadBinaryToPlayConsoleTest {
 
     runMain(aab.absolutePath)
 
-    skipRequests(7)
+    skipRequests(8)
     val setTrackBody = server.takeRequest().body.readUtf8()
     assertThat(setTrackBody).contains("Alpha-specific notes.")
     assertThat(setTrackBody).doesNotContain("Default notes.")
@@ -457,7 +457,7 @@ class UploadBinaryToPlayConsoleTest {
 
     runMain(aab.absolutePath)
 
-    skipRequests(7)
+    skipRequests(8)
     val setTrackBody = server.takeRequest().body.readUtf8()
     // When the changelog is empty, no release-note entries are included.
     assertThat(setTrackBody).contains("\"releaseNotes\":[]")
@@ -493,7 +493,7 @@ class UploadBinaryToPlayConsoleTest {
 
     runMain(aab.absolutePath)
 
-    skipRequests(7)
+    skipRequests(8)
     val setTrackBody = server.takeRequest().body.readUtf8()
     assertThat(setTrackBody).contains("b".repeat(500))
   }
@@ -508,30 +508,35 @@ class UploadBinaryToPlayConsoleTest {
     // every setTrackRelease call. Without it the Play Console API would deactivate vc 16.
     val aab = createAab("oppia-android-0.17-rc01-alpha-e740815230.aab")
     createChangelog("0.17", content = "Release notes.")
-    enqueueSuccessfulUpload(versionCode = 202L)
+    // Configure the frozen release lookup GET response (request 8, index 7) to return vc 16 so
+    // the production code can pass it through unmodified to the setTrackRelease PUT.
+    enqueueSuccessfulUpload(
+      versionCode = 202L,
+      frozenTrackBody = """{"releases":[{"versionCodes":["16"],"status":"completed"}]}"""
+    )
 
     runMain(aab.absolutePath, track = "alpha")
 
-    // Request 8 (index 7) is the PUT setTrackRelease for the alpha track.
-    skipRequests(7)
+    // Request 9 (index 8) is the PUT setTrackRelease for the alpha track.
+    skipRequests(8)
     val setTrackBody = server.takeRequest().body.readUtf8()
     assertThat(setTrackBody).contains("\"16\"")
     assertThat(setTrackBody).contains("\"202\"")
-    // The frozen entry must be marked completed (no userFraction), while the new release has its
-    // own status. Verify both version codes appear in the releases list.
+    // The frozen entry is passed through with "completed" status and no userFraction.
     assertThat(setTrackBody).contains("\"releases\"")
   }
 
   @Test
   fun testRunUpload_betaTrack_doesNotIncludeAnyFrozenVersionCodesInTrackUpdateRequest() {
     // Beta currently has no frozen builds; the setTrackRelease body should only contain the new vc.
+    // Beta has no frozen codes so no frozen-release GET is issued; the flow stays at 9 requests.
     val aab = createAab("oppia-android-0.17-rc01-beta-e740815230.aab")
     createChangelog("0.17", content = "Release notes.")
-    enqueueSuccessfulUpload(versionCode = 202L)
+    enqueueSuccessfulUpload(versionCode = 202L, frozenTrackBody = null)
 
     runMain(aab.absolutePath, track = "beta")
 
-    // Request 8 (index 7) is the PUT setTrackRelease for the beta track.
+    // Request 8 (index 7) is the PUT setTrackRelease for the beta track (no frozen GET precedes).
     skipRequests(7)
     val setTrackBody = server.takeRequest().body.readUtf8()
     assertThat(setTrackBody).contains("\"202\"")
@@ -632,12 +637,17 @@ class UploadBinaryToPlayConsoleTest {
   }
 
   /**
-   * Enqueues all 9 responses for a successful end-to-end upload flow:
+   * Enqueues all responses for a successful end-to-end upload flow:
    * - [enqueuePendingCheck] (2)
    * - [enqueueUpload] (2)
    * - [enqueueVersionCheck] (3)
+   * - frozen release lookup GET (1) -- only enqueued when [frozenTrackBody] is non-null
    * - setTrackRelease (1)
    * - commitEdit (1)
+   *
+   * For tracks that have frozen version codes (alpha), pass a non-null [frozenTrackBody] to
+   * simulate the GET response returned by the frozen-release lookup. For tracks without frozen
+   * codes (e.g. beta), pass `null` to omit the frozen GET entirely (9 responses total).
    */
   private fun enqueueSuccessfulUpload(
     versionCode: Long = 1L,
@@ -648,11 +658,18 @@ class UploadBinaryToPlayConsoleTest {
     betaBody: String =
       """{"releases":[]}""",
     productionBody: String =
+      """{"releases":[]}""",
+    frozenTrackBody: String? =
       """{"releases":[]}"""
   ) {
     enqueuePendingCheck(pendingBody)
     enqueueUpload(versionCode)
     enqueueVersionCheck(alphaBody, betaBody, productionBody)
+    // Frozen release lookup: enqueue only when the track has frozen version codes.
+    // Pass frozenTrackBody = null when testing tracks with no frozen codes (e.g. beta).
+    if (frozenTrackBody != null) {
+      server.enqueue(MockResponse().setBody(frozenTrackBody).setResponseCode(200))
+    }
     // setTrackRelease: Retrofit parses the body as TrackResponse even if we don't use it.
     server.enqueue(MockResponse().setBody("""{"releases":[]}""").setResponseCode(200))
     // commitEdit: Retrofit parses the body as EditResponse.

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UploadChangelogToPlayConsoleTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UploadChangelogToPlayConsoleTest.kt
@@ -548,6 +548,50 @@ class UploadChangelogToPlayConsoleTest {
   }
 
   // ---------------------------------------------------------------------------
+  // Frozen version code preservation (#6330)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun testMaybeUploadUpdatedChangelogs_alphaTrack_preservesFrozenKitKatVersionCodeInUpdate() {
+    // vc 16 is permanently frozen on alpha; it must be re-included in every setTrackRelease call
+    // so the Play Console API does not deactivate it during the changelog-only update.
+    fakeClient.setTrackReleases(
+      "alpha",
+      listOf(
+        PlayConsoleClient.TrackRelease(listOf(201L), "completed"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
+    )
+    createSharedChangelog(testVersion, notes = "Updated release notes.")
+
+    maybeUploadUpdatedChangelogs(
+      fakeClient, tempFolder.root.absolutePath, testPackageName, testVersion
+    )
+
+    assertThat(fakeClient.trackUpdates).hasSize(1)
+    assertThat(fakeClient.trackUpdates[0].versionCode).isEqualTo(201L)
+    assertThat(fakeClient.trackUpdates[0].preservedVersionCodes).containsExactly(16L)
+  }
+
+  @Test
+  fun testMaybeUploadUpdatedChangelogs_betaTrack_doesNotIncludeAnyFrozenVersionCodes() {
+    // Beta has no frozen builds; the update should not include any preserved version codes.
+    fakeClient.setTrackReleases(
+      "beta",
+      listOf(PlayConsoleClient.TrackRelease(listOf(201L), "completed"))
+    )
+    createSharedChangelog(testVersion, notes = "Updated release notes.")
+
+    maybeUploadUpdatedChangelogs(
+      fakeClient, tempFolder.root.absolutePath, testPackageName, testVersion
+    )
+
+    assertThat(fakeClient.trackUpdates).hasSize(1)
+    assertThat(fakeClient.trackUpdates[0].track).isEqualTo("beta")
+    assertThat(fakeClient.trackUpdates[0].preservedVersionCodes).isEmpty()
+  }
+
+  // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
 

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UploadChangelogToPlayConsoleTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UploadChangelogToPlayConsoleTest.kt
@@ -548,7 +548,7 @@ class UploadChangelogToPlayConsoleTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Frozen version code preservation (#6330)
+  // Frozen version code preservation
   // ---------------------------------------------------------------------------
 
   @Test

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UploadChangelogToPlayConsoleTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UploadChangelogToPlayConsoleTest.kt
@@ -570,7 +570,8 @@ class UploadChangelogToPlayConsoleTest {
 
     assertThat(fakeClient.trackUpdates).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].versionCode).isEqualTo(201L)
-    assertThat(fakeClient.trackUpdates[0].preservedVersionCodes).containsExactly(16L)
+    assertThat(fakeClient.trackUpdates[0].preservedReleases).hasSize(1)
+    assertThat(fakeClient.trackUpdates[0].preservedReleases[0].versionCodes).containsExactly(16L)
   }
 
   @Test
@@ -588,7 +589,7 @@ class UploadChangelogToPlayConsoleTest {
 
     assertThat(fakeClient.trackUpdates).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].track).isEqualTo("beta")
-    assertThat(fakeClient.trackUpdates[0].preservedVersionCodes).isEmpty()
+    assertThat(fakeClient.trackUpdates[0].preservedReleases).isEmpty()
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #6330
## Explanation
The Google Play Developer API's `edits.tracks.update` endpoint performs a **full replacement** of a track's release list. Any release not explicitly included in the request body is silently deactivated. As a result, three scripts: `UploadBinaryToPlayConsole`, `UploadChangelogToPlayConsole`, and `UpdateRolloutFraction` -- were inadvertently dropping the permanently frozen KitKat build (alpha track, version code 16) every time they called `setTrackRelease`, because they only sent the current active release in the request.

This PR fixes the issue by fetching the current track state before each `setTrackRelease` call, filtering the response to identify releases matching a hardcoded set of frozen version codes (`FROZEN_VERSION_CODES_PER_TRACK`), and passing those releases through **completely unmodified** alongside the new release in the `TrackUpdateRequest`. This means the frozen entry's `versionCodes`, `status`, `userFraction`, and `releaseNotes` all arrive at the API identical to what is already live, so the Play Console has no reason to treat the frozen release as changed.

Concretely:
- `TrackResponse.ReleaseEntry` now deserializes `releaseNotes` from the API response.
- `PlayConsoleClient.TrackRelease` now carries a `releaseNotes: Map<String, String>` field.
- `PlayConsoleClient.setTrackRelease` now accepts `preservedReleases: List<TrackRelease>` instead of a set of version codes, making the caller responsible for providing the full release data.
- In `UploadBinaryToPlayConsole`, an additional `getTrackReleases` call is issued (reusing the existing edit ID) to fetch the frozen releases before `setTrackRelease`. The call is skipped for tracks with no frozen codes (e.g. beta).
- In `UploadChangelogToPlayConsole` and `UpdateRolloutFraction`, no extra API call is needed: the live releases are already in hand and are simply filtered against `FROZEN_VERSION_CODES_PER_TRACK`.

The frozen version codes are defined as a hardcoded `Map<String, Set<Long>>` in each of the three affected scripts. Hardcoding is intentional: the Play Console API does not expose a reliable way to distinguish permanently frozen builds from ordinary completed ones, and an explicit, auditable constant is safer and easier to review than any inference-based approach.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved designated frozen releases when uploading binaries, updating staged rollouts, or publishing changelogs.
  * Retained existing release notes and rollout details during Play Console track updates.
  * Prevented frozen builds from being unintentionally deactivated during updates.

* **Tests**
  * Added coverage confirming frozen releases remain active on tracks where required.
  * Added validation that tracks without frozen releases remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->