### PR TITLE
Fix #6327: Update `deploy_updated_changelog.yml` concurrency group

### DIFF
--- a/.github/workflows/deploy_updated_changelog.yml
+++ b/.github/workflows/deploy_updated_changelog.yml
@@ -42,7 +42,7 @@ concurrency:
   # Only one changelog upload at a time to avoid concurrent edit conflicts on Play Console.
   # The group is intentionally not scoped to github.ref so that push and dispatch triggers
   # across different refs are also serialized — Play Console edits must be globally exclusive.
-  group: deploy-updated-changelog
+  group: play-console-edit-session
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Fixes #6327
## Explanation

`deploy_updated_changelog.yml` uses its own concurrency group (`deploy-updated-changelog`) instead of the shared `play-console-edit-session` group used by `deploy_to_play_console.yml` and `update_rollout.yml`.

All three workflows open a Play Console edit session via the Play Developer API, which enforces a single active edit per package at a time. Without a shared concurrency group, two of these workflows can run simultaneously and collide on the same edit session — causing one to fail with a "cannot create edit, another is already open" error.

**Change:** Update `deploy_updated_changelog.yml` concurrency group from `deploy-updated-changelog` to `play-console-edit-session` so all three workflows are globally serialized.

## Disclosure of LLM Usage
I did not use LLM for this PR.