### PR TITLE
Fix part of #6106: Add App and Feature Release Process wiki page

### DIFF
--- a/wiki/app-and-feature-release-process.md
+++ b/wiki/app-and-feature-release-process.md
@@ -12,14 +12,14 @@ reaches end users.
 1. [Prerequisites & Roles](#1-prerequisites--roles)
 2. [Binary Release Lifecycle](#2-binary-release-lifecycle)
    - [2.1 Version numbering](#21-version-numbering)
-   - [2.2 Changelog management](#22-changelog-management--generate_changelogymll)
+   - [2.2 Changelog management](#22-changelog-management)
    - [2.3 Release branch creation](#23-release-branch-creation)
-   - [2.4 Build & Sign](#24-build--sign--build_and_signyml)
-   - [2.5 QA via Firebase App Distribution](#25-qa-via-firebase-app-distribution--deploy_to_firebaseyml)
-   - [2.6 Deploy to Play Console](#26-deploy-to-play-console--deploy_to_play_consoleyml)
-   - [2.7 Staged rollout management](#27-staged-rollout-management--update_rolloutyml)
-   - [2.8 Changelog updates post-release](#28-changelog-updates-post-release--deploy_updated_changelogyml)
-   - [2.9 Automated alpha releases](#29-automated-alpha-releases--auto_release_alphayml)
+   - [2.4 Build & Sign](#24-build--sign)
+   - [2.5 QA via Firebase App Distribution](#25-qa-via-firebase-app-distribution)
+   - [2.6 Deploy to Play Console](#26-deploy-to-play-console)
+   - [2.7 Staged rollout management](#27-staged-rollout-management)
+   - [2.8 Changelog updates post-release](#28-changelog-updates-post-release)
+   - [2.9 Automated alpha releases](#29-automated-alpha-releases)
 3. [Feature Flag Lifecycle](#3-feature-flag-lifecycle)
 4. [Diagrams](#4-diagrams)
    - [4.1 End-to-end binary release flow](#41-end-to-end-binary-release-flow)
@@ -66,7 +66,7 @@ MINOR_VERSION = 18
 - Committing a `MINOR_VERSION` bump to `develop` automatically triggers changelog generation
   (see §2.2).
 
-### 2.2 Changelog management — `generate_changelog.yml`
+### 2.2 Changelog management
 
 **Trigger:** Automatically on every push to `develop` that modifies `version.bzl`, or manually
 via `workflow_dispatch`.
@@ -108,7 +108,7 @@ After the version bump and changelog PR have landed on `develop`:
 
 ---
 
-### 2.4 Build & Sign — `build_and_sign.yml`
+### 2.4 Build & Sign
 
 **Trigger:** Manual (`workflow_dispatch`) — requires coordinator to fill in the inputs below.
 
@@ -135,7 +135,7 @@ After the version bump and changelog PR have landed on `develop`:
 
 ---
 
-### 2.5 QA via Firebase App Distribution — `deploy_to_firebase.yml`
+### 2.5 QA via Firebase App Distribution
 
 **Trigger:** Manual (`workflow_dispatch`) — run this after `build_and_sign.yml` succeeds.
 
@@ -157,7 +157,7 @@ before the coordinator proceeds to the Play Console deployment.
 
 ---
 
-### 2.6 Deploy to Play Console — `deploy_to_play_console.yml`
+### 2.6 Deploy to Play Console
 
 **Trigger:** Manual (`workflow_dispatch`) — run this after QA sign-off.
 
@@ -185,7 +185,7 @@ before the coordinator proceeds to the Play Console deployment.
 
 ---
 
-### 2.7 Staged rollout management — `update_rollout.yml`
+### 2.7 Staged rollout management
 
 **Trigger:** Manual (`workflow_dispatch`) — run this each time you want to increase the rollout
 percentage for a live release.
@@ -214,7 +214,7 @@ Console edit sessions (the Play Developer API enforces a single active edit per 
 
 ---
 
-### 2.8 Changelog updates post-release — `deploy_updated_changelog.yml`
+### 2.8 Changelog updates post-release
 
 **Trigger:**
 - **Automatic** — on every push to `develop` that modifies any file matching
@@ -235,7 +235,7 @@ release goes live, and the changes will automatically sync to the Play Console s
 
 ---
 
-### 2.9 Automated alpha releases — `auto_release_alpha.yml`
+### 2.9 Automated alpha releases
 
 > **Note:** This workflow is introduced as part of the ongoing release automation project. It
 > handles the full weekly alpha release cycle without coordinator intervention.

--- a/wiki/app-and-feature-release-process.md
+++ b/wiki/app-and-feature-release-process.md
@@ -1,10 +1,8 @@
 # App and Feature Release Process
 
 This page describes the end-to-end lifecycle for releasing app binaries and managing feature flags
-in oppia-android. It supersedes the
-[old private release Google Doc](https://docs.google.com/document/d/1XAoXnQkn2oIAFkd6vY90tn_SSW3J9Eia0_4RhXhJSxQ/edit?tab=t.0#heading=h.1hlri65ueypl)
-and is intended for **release coordinators** and any contributor who wants to understand how a
-change reaches end users.
+in oppia-android. It is intended for **release coordinators** and any contributor who wants to
+understand how a change reaches end users.
 
 ---
 
@@ -103,8 +101,16 @@ Pushing this change automatically triggers changelog generation (§3.2).
 ### 3.2 Generate the changelog
 
 **Trigger:**
-- **Automatic** — on every push to `develop` that modifies `version.bzl`
+- **Automatic** — on every push to `develop` that modifies `version.bzl` (triggered by §3.1)
 - **Manual** — via `workflow_dispatch` of the **Generate Changelog** workflow
+
+**Coordinator action:**
+- **If triggered automatically:** No action is needed to start the workflow. Wait for the
+  changelog PR to be opened, then review and merge it (see below).
+- **If triggered manually:** Dispatch the **Generate Changelog** workflow from the Actions tab
+  (see [§8](#8-how-to-manually-trigger-a-workflow)), then wait for the PR to be opened.
+- **After the workflow completes:** Review the opened changelog PR. Edit the AI-generated release
+  notes if they need adjustment, then merge the PR.
 
 **What it does:**
 
@@ -123,9 +129,6 @@ Pushing this change automatically triggers changelog generation (§3.2).
 
 A flavor-specific file always takes precedence over the generic one for its corresponding Play
 Console track.
-
-**Coordinator action:** Review and merge the opened changelog PR. Edit the release notes if the
-AI summary needs adjustment before merging.
 
 ---
 

--- a/wiki/app-and-feature-release-process.md
+++ b/wiki/app-and-feature-release-process.md
@@ -20,6 +20,7 @@ reaches end users.
    - [2.7 Staged rollout management](#27-staged-rollout-management)
    - [2.8 Changelog updates post-release](#28-changelog-updates-post-release)
    - [2.9 Automated alpha releases](#29-automated-alpha-releases)
+   - [2.10 Automated lesson version updates](#210-automated-lesson-version-updates)
 3. [Feature Flag Lifecycle](#3-feature-flag-lifecycle)
 4. [Diagrams](#4-diagrams)
    - [4.1 End-to-end binary release flow](#41-end-to-end-binary-release-flow)
@@ -33,12 +34,20 @@ reaches end users.
 
 ### Release Coordinator
 The release coordinator is responsible for triggering all manual GitHub Actions workflows
-described in this page. The role requires the following access:
+described in this page. The release coordinator is either the tech lead, or any other approved
+`dev-workflow` or `infrastructure reviewer` codeowner.
+
+**Access required by the coordinator:**
 
 | Access | Purpose |
 |---|---|
 | GitHub: `oppia-android-release-env` environment | Approve build/sign/deploy jobs before they run |
 | GitHub: `oppia-android-automation-env` environment | Approve automated PR-creation workflows |
+
+**Access pre-configured for the automation (as GitHub environment secrets — no manual setup needed by the coordinator):**
+
+| Access | Purpose |
+|---|---|
 | GCP: Workload Identity Federation service account | Sign binaries via Cloud KMS, read/write GCS archive |
 | GCP: Cloud KMS — `oppia-android-release-key` | HSM-backed signing key (key never leaves KMS) |
 | Google Play Console: "Release to production" permission | Upload AABs and update track releases |
@@ -63,13 +72,13 @@ MINOR_VERSION = 18
 - `MINOR_VERSION` is incremented for each release (e.g. 0.17 → 0.18).
 - `MAJOR_VERSION` changes only for breaking platform changes or major product milestones.
 - The resulting `versionName` is `"{MAJOR}.{MINOR}"` (e.g. `"0.18"`).
-- Committing a `MINOR_VERSION` bump to `develop` automatically triggers changelog generation
-  (see §2.2).
+- A version update is performed by committing a `MINOR_VERSION` bump to `develop`.
+  This automatically triggers changelog generation (see [§2.2](#22-changelog-management)).
 
 ### 2.2 Changelog management
 
 **Trigger:** Automatically on every push to `develop` that modifies `version.bzl`, or manually
-via `workflow_dispatch`.
+via `workflow_dispatch` of the `generate_changelog.yml` workflow.
 
 **What it does:**
 
@@ -150,10 +159,15 @@ After the version bump and changelog PR have landed on `develop`:
 
 1. Downloads the signed AAB from GCS.
 2. Distributes it to Firebase App Distribution.
-3. Notifies the relevant tester group for the given flavor.
+3. Automatically notifies the relevant tester group for the given flavor (the tester group
+   assignment is configured in the workflow — no manual coordinator action needed for the
+   notification).
 
 QA testers can then install the build via the Firebase App Distribution app and validate it
 before the coordinator proceeds to the Play Console deployment.
+
+The app's Play Store listing is at:
+[https://play.google.com/store/apps/details?id=org.oppia.android](https://play.google.com/store/apps/details?id=org.oppia.android)
 
 ---
 
@@ -161,12 +175,15 @@ before the coordinator proceeds to the Play Console deployment.
 
 **Trigger:** Manual (`workflow_dispatch`) — run this after QA sign-off.
 
+> **Note:** This workflow runs in the `oppia-android-release-env` environment, which requires
+> an authorized reviewer to **approve** the run before any step executes.
+
 **Inputs:**
 
 | Input | Description | Example |
 |---|---|---|
 | `gcs_aab_path` | Full GCS path from `build_and_sign` | `gs://…/oppia-android-0.18-rc01-alpha-abc1234.aab` |
-| `track` | Play Console track to deploy to | `alpha`, `beta`, `production` |
+| `track` | Play Console track to deploy to | `alpha`, `beta`, `ga` |
 | `rollout_fraction` | Initial staged rollout as integer [0, 1000] where 1000 = 100% (optional, default: `1000`) | `100` for 10% |
 
 **What it does:**
@@ -237,12 +254,9 @@ release goes live, and the changes will automatically sync to the Play Console s
 
 ### 2.9 Automated alpha releases
 
-> **Note:** This workflow is introduced as part of the ongoing release automation project. It
-> handles the full weekly alpha release cycle without coordinator intervention.
-
 **Trigger:**
 - **Automatic** — weekly cron every **Tuesday at 03:30 UTC**
-- **Manual** — via `workflow_dispatch` (useful for off-schedule alpha cuts)
+- **Manual** — via `workflow_dispatch` of the `auto_release_alpha.yml` workflow (useful for off-schedule alpha cuts)
 
 **What it does:**
 
@@ -250,7 +264,9 @@ release goes live, and the changes will automatically sync to the Play Console s
    - Fetches the most recent commits on `develop` (up to a configurable limit, default 50).
    - Walks them newest-first, querying the GitHub Check Runs API for each commit.
    - Returns the **first (newest) SHA** where every check run has completed with a passing,
-     skipped, or neutral conclusion.
+     skipped, or neutral conclusion. A **neutral** conclusion covers check runs that completed
+     without a definitive pass or fail — for example, a check that was skipped because it did
+     not apply to that commit, or one cancelled by a later push to the same branch.
 2. Force-pushes the `latest-alpha` tag to that commit SHA.
 3. Dispatches `build_and_sign.yml` with `flavor=alpha` and `source_ref=latest-alpha`.
 
@@ -260,6 +276,31 @@ human sign-off on the actual binary.
 
 If no passing commit is found within the configured limit, the workflow exits with an error and
 the coordinator is notified.
+
+---
+
+### 2.10 Automated lesson version updates
+
+**Trigger:**
+- **Automatic** — weekly cron every **Monday at 02:30 UTC**
+- **Manual** — via `workflow_dispatch` of the `pull_latest_lesson_versions.yml` workflow
+
+**What it does:**
+
+1. Runs the `download_lesson_list` Bazel script against the live Oppia production server for
+   both `alpha` and `prod` flavors.
+2. Updates the pinned lesson version files:
+   - `config/lessons/alpha_pinned_lesson_versions.textproto`
+   - `config/lessons/prod_pinned_lesson_versions.textproto`
+3. Opens a PR to `develop` on the dedicated `automated/lesson-versions` branch containing only
+   the updated textproto diff (idempotent — if files are already current, no commit or PR is
+   created).
+
+**Coordinator action:** Review and merge the opened lesson-versions PR.
+
+> **Note:** The workflow uses `BOT_TOKEN` rather than `GITHUB_TOKEN` for PR creation so that
+> CI is properly triggered on the opened PR. The dedicated branch is force-pushed on every run,
+> keeping the PR diff clean regardless of how many runs have occurred.
 
 ---
 
@@ -274,18 +315,23 @@ page for the complete guide on defining, enabling, graduating, and removing flag
 
 **Summary of states:**
 
-| State | Who sees it |
+The table below summarises the progression stages. The exact enum values and enabling
+conditions are defined in [`PlatformParameterValue`](../app/src/main/java/org/oppia/android/app/model/)
+and documented in full on the
+[Platform Parameters & Feature Flags](Platform-Parameters-&-Feature-Flags.md) wiki page.
+
+| Stage | Who sees it |
 |---|---|
-| `DevOnly` | Local development builds only |
-| `InternalTest` | Internal/debug flavor builds |
-| `Alpha` | Alpha Play Store track |
-| `Beta` | Beta Play Store track |
-| `GA` | General availability (all users) |
+| Dev-only | Local development builds only |
+| Internal/test | Internal/debug flavor builds |
+| Alpha | Alpha Play Store track |
+| Beta | Beta Play Store track |
+| GA (general availability) | All users |
 | Removed | Flag wrapper deleted; feature is unconditional |
 
-Graduating a flag from one state to the next does **not** require a new binary release — it is
+Graduating a flag from one stage to the next does **not** require a new binary release — it is
 done by updating the flag's default value in code and merging to `develop`. The change reaches
-users on the next alpha automation cycle or the next manual release, depending on the target state.
+users on the next alpha automation cycle or the next manual release, depending on the target stage.
 
 ---
 
@@ -350,6 +396,7 @@ stateDiagram-v2
 | `update_rollout.yml` | Manual | `track`, `version`, `rollout_fraction` [0-1000] | Increase staged rollout percentage |
 | `deploy_updated_changelog.yml` | Push to develop (`changelogs/**`) / manual | `version`, `flavor` | Sync edited release notes to Play Console |
 | `auto_release_alpha.yml` | Weekly cron (Tue 03:30 UTC) / manual | `branch`, `commit_limit` | Automated weekly alpha cut |
+| `pull_latest_lesson_versions.yml` | Weekly cron (Mon 02:30 UTC) / manual | — | Update pinned lesson version textprotos, open PR |
 
 ---
 

--- a/wiki/app-and-feature-release-process.md
+++ b/wiki/app-and-feature-release-process.md
@@ -274,8 +274,12 @@ A release coordinator still approves the build step via `oppia-android-release-e
 signing runs — the automation removes the manual "find a good commit and tag it" step, not the
 human sign-off on the actual binary.
 
-If no passing commit is found within the configured limit, the workflow exits with an error and
-the coordinator is notified.
+If no passing commit is found within the configured limit, the outcome depends on why:
+
+- **Commits exist but none have passing CI** — the workflow exits with an error to alert
+  repository maintainers that the alpha channel is blocked on CI flakiness.
+- **No commits at all within the limit** — the workflow logs this and exits cleanly without
+  failing, since there is nothing new to release.
 
 ---
 
@@ -362,12 +366,14 @@ flowchart TD
 flowchart TD
     A["Weekly cron — Tuesday 03:30 UTC\n(or manual dispatch)"] --> B["auto_release_alpha.yml"]
     B --> C["FindAlphaCandidate\nwalks develop commits newest-first\nqueries GitHub Check Runs API"]
-    C --> D{"Any commit with\nall CI checks passing?"}
-    D -- "No" --> E["Workflow exits with error\nCoordinator notified"]
-    D -- "Yes" --> F["Force-push latest-alpha tag\nto candidate SHA"]
-    F --> G["Dispatch build_and_sign.yml\nflavor=alpha, source_ref=latest-alpha"]
-    G --> H["Coordinator approves in\noppia-android-release-env"]
-    H --> I["Signed alpha AAB archived in GCS ✓"]
+    C --> D{"Commits exist\nwithin limit?"}
+    D -- "No commits" --> E["Log: nothing to release\nWorkflow exits cleanly (no error)"]
+    D -- "Commits exist" --> F{"Any with all\nCI checks passing?"}
+    F -- "No" --> G["Exit with error\n(alpha blocked on CI flakiness)\nMaintainers notified"]
+    F -- "Yes" --> H["Force-push latest-alpha tag\nto candidate SHA"]
+    H --> I["Dispatch build_and_sign.yml\nflavor=alpha, source_ref=latest-alpha"]
+    I --> J["Coordinator approves in\noppia-android-release-env"]
+    J --> K["Signed alpha AAB archived in GCS ✓"]
 ```
 
 ### 4.3 Feature flag lifecycle
@@ -397,6 +403,37 @@ stateDiagram-v2
 | `deploy_updated_changelog.yml` | Push to develop (`changelogs/**`) / manual | `version`, `flavor` | Sync edited release notes to Play Console |
 | `auto_release_alpha.yml` | Weekly cron (Tue 03:30 UTC) / manual | `branch`, `commit_limit` | Automated weekly alpha cut |
 | `pull_latest_lesson_versions.yml` | Weekly cron (Mon 02:30 UTC) / manual | — | Update pinned lesson version textprotos, open PR |
+
+---
+
+## 6. How to Manually Trigger a Workflow
+
+All manual workflows in this release process use GitHub's `workflow_dispatch` trigger. Here is
+how to run one:
+
+**Step 1 — Open the Actions tab and select the workflow**
+
+Navigate to the **Actions** tab of the `oppia/oppia-android` repository and click the workflow
+you want to run from the left-hand sidebar. Then click the **"Run workflow"** button on the
+right.
+
+![Step 1: Select the workflow and click Run workflow](SCREENSHOT_1_URL)
+
+**Step 2 — Fill in the inputs**
+
+A dropdown appears with a branch selector and the workflow's input fields. Select the correct
+branch and fill in all required inputs (refer to the relevant section above for the expected
+values).
+
+![Step 2: Fill in the workflow inputs](SCREENSHOT_2_URL)
+
+**Step 3 — Confirm and approve**
+
+Click **"Run workflow"** to queue the run. For workflows that run in the
+`oppia-android-release-env` environment, a reviewer approval gate will appear — an authorized
+reviewer must approve the run in the GitHub Actions UI before any step executes.
+
+![Step 3: Approve the run in the release environment](SCREENSHOT_3_URL)
 
 ---
 

--- a/wiki/app-and-feature-release-process.md
+++ b/wiki/app-and-feature-release-process.md
@@ -1,12 +1,356 @@
 # App and Feature Release Process
 
-<!-- TODO: Fill in this wiki page as part of PR 2.6 -->
+This page describes the end-to-end lifecycle for releasing app binaries and managing feature flags
+in oppia-android. It is the canonical replacement for the old private release Google Doc and is
+intended for **release coordinators** and any contributor who wants to understand how a change
+reaches end users.
 
-This page describes the end-to-end lifecycle for releasing app binaries and features in oppia-android,
-covering the automated pipeline, manual gates, and rollout strategy.
+---
 
-## Sections (coming soon)
+## Table of Contents
 
-- Binary release lifecycle
-- Feature flag lifecycle
-- Lifecycle diagrams
+1. [Prerequisites & Roles](#1-prerequisites--roles)
+2. [Binary Release Lifecycle](#2-binary-release-lifecycle)
+   - [2.1 Version numbering](#21-version-numbering)
+   - [2.2 Changelog management](#22-changelog-management--generate_changelogymll)
+   - [2.3 Release branch creation](#23-release-branch-creation)
+   - [2.4 Build & Sign](#24-build--sign--build_and_signyml)
+   - [2.5 QA via Firebase App Distribution](#25-qa-via-firebase-app-distribution--deploy_to_firebaseyml)
+   - [2.6 Deploy to Play Console](#26-deploy-to-play-console--deploy_to_play_consoleyml)
+   - [2.7 Staged rollout management](#27-staged-rollout-management--update_rolloutyml)
+   - [2.8 Changelog updates post-release](#28-changelog-updates-post-release--deploy_updated_changelogyml)
+   - [2.9 Automated alpha releases](#29-automated-alpha-releases--auto_release_alphayml)
+3. [Feature Flag Lifecycle](#3-feature-flag-lifecycle)
+4. [Diagrams](#4-diagrams)
+   - [4.1 End-to-end binary release flow](#41-end-to-end-binary-release-flow)
+   - [4.2 Automated alpha release flow](#42-automated-alpha-release-flow)
+   - [4.3 Feature flag lifecycle](#43-feature-flag-lifecycle)
+5. [Workflow Quick-Access Table](#5-workflow-quick-access-table)
+
+---
+
+## 1. Prerequisites & Roles
+
+### Release Coordinator
+The release coordinator is responsible for triggering all manual GitHub Actions workflows
+described in this page. The role requires the following access:
+
+| Access | Purpose |
+|---|---|
+| GitHub: `oppia-android-release-env` environment | Approve build/sign/deploy jobs before they run |
+| GitHub: `oppia-android-automation-env` environment | Approve automated PR-creation workflows |
+| GCP: Workload Identity Federation service account | Sign binaries via Cloud KMS, read/write GCS archive |
+| GCP: Cloud KMS — `oppia-android-release-key` | HSM-backed signing key (key never leaves KMS) |
+| Google Play Console: "Release to production" permission | Upload AABs and update track releases |
+
+> **Note:** The `oppia-android-release-env` environment enforces a **required reviewer approval**
+> gate. No build, signing, or deployment step executes until an authorized reviewer explicitly
+> approves the run in the GitHub Actions UI.
+
+---
+
+## 2. Binary Release Lifecycle
+
+### 2.1 Version numbering
+
+The app's version is maintained in [`version.bzl`](../version.bzl) at the repository root:
+
+```python
+MAJOR_VERSION = 0
+MINOR_VERSION = 18
+```
+
+- `MINOR_VERSION` is incremented for each release (e.g. 0.17 → 0.18).
+- `MAJOR_VERSION` changes only for breaking platform changes or major product milestones.
+- The resulting `versionName` is `"{MAJOR}.{MINOR}"` (e.g. `"0.18"`).
+- Committing a `MINOR_VERSION` bump to `develop` automatically triggers changelog generation
+  (see §2.2).
+
+### 2.2 Changelog management — `generate_changelog.yml`
+
+**Trigger:** Automatically on every push to `develop` that modifies `version.bzl`, or manually
+via `workflow_dispatch`.
+
+**What it does:**
+
+1. Identifies all commits on `develop` since the previous version tag.
+2. Passes them to `GenerateChangelogs.kt`, which uses Vertex AI to produce user-facing release
+   notes.
+3. Opens a PR to `develop` adding a new changelog file.
+
+**Changelog file paths:**
+
+| File | Applies to |
+|---|---|
+| `config/changelogs/0.18.md` | All flavors (default) |
+| `config/changelogs/0.18_alpha.md` | Alpha flavor only (overrides default) |
+| `config/changelogs/0.18_beta.md` | Beta flavor only (overrides default) |
+
+A flavor-specific file always takes precedence over the generic one for its corresponding Play
+Console track.
+
+**Coordinator action:** Review and merge the opened changelog PR. Edit the release notes if the
+AI summary needs adjustment before merging.
+
+---
+
+### 2.3 Release branch creation
+
+After the version bump and changelog PR have landed on `develop`:
+
+1. Cut a release branch from `develop` HEAD:
+   ```
+   git checkout -b release-0.18 upstream/develop
+   git push upstream release-0.18
+   ```
+2. Do **not** commit directly to the release branch after the cut. If a critical fix is needed,
+   merge it to `develop` first and then cherry-pick the commit onto the release branch.
+
+---
+
+### 2.4 Build & Sign — `build_and_sign.yml`
+
+**Trigger:** Manual (`workflow_dispatch`) — requires coordinator to fill in the inputs below.
+
+**Inputs:**
+
+| Input | Description | Example |
+|---|---|---|
+| `flavor` | App flavor to build | `alpha`, `beta`, `ga` |
+| `source_ref` | Branch or tag to build from | `release-0.18`, `latest-alpha` |
+
+**What it does:**
+
+1. Checks out the specified `source_ref`.
+2. Builds the release AAB using Bazel.
+3. Signs the AAB using Cloud KMS (HSM-backed — the private key never leaves KMS).
+4. Archives the signed AAB to GCS:
+   ```
+   gs://oppia-android-{flavor}-releases/{version}/RC{n}/oppia-android-{version}-rc{n}-{flavor}-{sha}.aab
+   ```
+5. Prints the full GCS path in the job summary — **copy this path** for use in the next steps.
+
+> **Note:** This workflow runs in the `oppia-android-release-env` GitHub environment, which
+> requires an authorized reviewer to **approve** the run before any step executes.
+
+---
+
+### 2.5 QA via Firebase App Distribution — `deploy_to_firebase.yml`
+
+**Trigger:** Manual (`workflow_dispatch`) — run this after `build_and_sign.yml` succeeds.
+
+**Inputs:**
+
+| Input | Description |
+|---|---|
+| `gcs_aab_path` | Full GCS path from the `build_and_sign` job output |
+| `release_notes` | Optional QA notes shown to testers in the Firebase console |
+
+**What it does:**
+
+1. Downloads the signed AAB from GCS.
+2. Distributes it to Firebase App Distribution.
+3. Notifies the relevant tester group for the given flavor.
+
+QA testers can then install the build via the Firebase App Distribution app and validate it
+before the coordinator proceeds to the Play Console deployment.
+
+---
+
+### 2.6 Deploy to Play Console — `deploy_to_play_console.yml`
+
+**Trigger:** Manual (`workflow_dispatch`) — run this after QA sign-off.
+
+**Inputs:**
+
+| Input | Description | Example |
+|---|---|---|
+| `gcs_aab_path` | Full GCS path from `build_and_sign` | `gs://…/oppia-android-0.18-rc01-alpha-abc1234.aab` |
+| `track` | Play Console track to deploy to | `alpha`, `beta`, `production` |
+| `rollout_fraction` | Initial staged rollout as integer [0, 1000] where 1000 = 100% (optional, default: `1000`) | `100` for 10% |
+
+**What it does:**
+
+1. Downloads the signed AAB from GCS.
+2. Runs `UploadBinaryToPlayConsole.kt`, which enforces the following preconditions before uploading:
+   - **No version inversion** — fails if the version being deployed is lower than what's currently
+     live on the target track.
+   - **No duplicate deploy** — fails if the commit SHA is already live on that track.
+   - **Changelog must exist** — fails if `config/changelogs/{version}.md` (or a flavor override)
+     does not exist.
+3. Uploads the AAB to the specified Play Console track at the requested rollout fraction.
+
+> **Note:** Start with a low rollout fraction (e.g. 10%) and monitor crash rates in Firebase
+> Crashlytics before expanding.
+
+---
+
+### 2.7 Staged rollout management — `update_rollout.yml`
+
+**Trigger:** Manual (`workflow_dispatch`) — run this each time you want to increase the rollout
+percentage for a live release.
+
+**Inputs:**
+
+| Input | Description | Example |
+|---|---|---|
+| `track` | Play Console track to update | `alpha`, `beta`, `production` |
+| `version` | Version in `major.minor` format — must match a live release on the track | `0.18` |
+| `rollout_fraction` | New rollout as integer [0, 1000] where 1000 = 100% | `500` for 50% |
+
+**What it does:**
+
+Calls `UpdateRolloutFraction.kt`, which uses the Play Developer API to update the staged rollout
+fraction for the current live release on the target track — **without re-uploading the binary**.
+
+**Typical progression:**
+
+```
+10% → (monitor 24h) → 25% → (monitor 48h) → 50% → (monitor) → 100%
+```
+
+A concurrency lock shared with `deploy_updated_changelog.yml` prevents two simultaneous Play
+Console edit sessions (the Play Developer API enforces a single active edit per package at a time).
+
+---
+
+### 2.8 Changelog updates post-release — `deploy_updated_changelog.yml`
+
+**Trigger:**
+- **Automatic** — on every push to `develop` that modifies any file matching
+  `config/changelogs/**.md`
+- **Manual** — via `workflow_dispatch` with `version` and optional `flavor` inputs
+
+**What it does:**
+
+1. Identifies the changelog file for the specified version (and flavor, if provided).
+2. Runs `UploadChangelogToPlayConsole.kt`, which:
+   - **Fails** if the version is not yet live on Play Console — this prevents a race condition
+     against the initial binary deployment.
+   - Compares the local release notes against what is currently deployed on Play Console.
+   - Uploads only the changed or added translations.
+
+This means you can edit `config/changelogs/0.18.md` directly on `develop` at any time after a
+release goes live, and the changes will automatically sync to the Play Console store listing.
+
+---
+
+### 2.9 Automated alpha releases — `auto_release_alpha.yml`
+
+> **Note:** This workflow is introduced as part of the ongoing release automation project. It
+> handles the full weekly alpha release cycle without coordinator intervention.
+
+**Trigger:**
+- **Automatic** — weekly cron every **Tuesday at 03:30 UTC**
+- **Manual** — via `workflow_dispatch` (useful for off-schedule alpha cuts)
+
+**What it does:**
+
+1. Runs `FindAlphaCandidate.kt`, which:
+   - Fetches the most recent commits on `develop` (up to a configurable limit, default 50).
+   - Walks them newest-first, querying the GitHub Check Runs API for each commit.
+   - Returns the **first (newest) SHA** where every check run has completed with a passing,
+     skipped, or neutral conclusion.
+2. Force-pushes the `latest-alpha` tag to that commit SHA.
+3. Dispatches `build_and_sign.yml` with `flavor=alpha` and `source_ref=latest-alpha`.
+
+A release coordinator still approves the build step via `oppia-android-release-env` before
+signing runs — the automation removes the manual "find a good commit and tag it" step, not the
+human sign-off on the actual binary.
+
+If no passing commit is found within the configured limit, the workflow exits with an error and
+the coordinator is notified.
+
+---
+
+## 3. Feature Flag Lifecycle
+
+Feature flags (called **platform parameters** in this codebase) allow features to be developed
+and deployed incrementally — enabled for one flavor or environment at a time — without gating
+on a full release.
+
+See the **[Platform Parameters & Feature Flags](Platform-Parameters-&-Feature-Flags.md)** wiki
+page for the complete guide on defining, enabling, graduating, and removing flags.
+
+**Summary of states:**
+
+| State | Who sees it |
+|---|---|
+| `DevOnly` | Local development builds only |
+| `InternalTest` | Internal/debug flavor builds |
+| `Alpha` | Alpha Play Store track |
+| `Beta` | Beta Play Store track |
+| `GA` | General availability (all users) |
+| Removed | Flag wrapper deleted; feature is unconditional |
+
+Graduating a flag from one state to the next does **not** require a new binary release — it is
+done by updating the flag's default value in code and merging to `develop`. The change reaches
+users on the next alpha automation cycle or the next manual release, depending on the target state.
+
+---
+
+## 4. Diagrams
+
+### 4.1 End-to-end binary release flow
+
+```mermaid
+flowchart TD
+    A["Bump MINOR_VERSION in version.bzl → develop"] --> B["generate_changelog.yml\n(Vertex AI generates release notes)"]
+    B --> C["Coordinator merges changelog PR"]
+    C --> D["Cut release-X.Y branch from develop"]
+    D --> E["build_and_sign.yml\nflavor + source_ref=release-X.Y\n(requires reviewer approval)"]
+    E --> F["Signed AAB archived in GCS"]
+    F --> G["deploy_to_firebase.yml\nQA testers install & validate"]
+    G --> H{"QA pass?"}
+    H -- "No" --> I["Fix on develop → cherry-pick\n→ rebuild"]
+    I --> E
+    H -- "Yes" --> J["deploy_to_play_console.yml\nrollout_fraction=10%"]
+    J --> K["update_rollout.yml\n25% → 50% → 100%"]
+    K --> L["Full rollout complete ✓"]
+    J --> M["deploy_updated_changelog.yml\n(auto on changelog edits)"]
+```
+
+### 4.2 Automated alpha release flow
+
+```mermaid
+flowchart TD
+    A["Weekly cron — Tuesday 03:30 UTC\n(or manual dispatch)"] --> B["auto_release_alpha.yml"]
+    B --> C["FindAlphaCandidate\nwalks develop commits newest-first\nqueries GitHub Check Runs API"]
+    C --> D{"Any commit with\nall CI checks passing?"}
+    D -- "No" --> E["Workflow exits with error\nCoordinator notified"]
+    D -- "Yes" --> F["Force-push latest-alpha tag\nto candidate SHA"]
+    F --> G["Dispatch build_and_sign.yml\nflavor=alpha, source_ref=latest-alpha"]
+    G --> H["Coordinator approves in\noppia-android-release-env"]
+    H --> I["Signed alpha AAB archived in GCS ✓"]
+```
+
+### 4.3 Feature flag lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> DevOnly : Define flag\n(disabled in all envs)
+    DevOnly --> InternalTest : Enable for debug builds
+    InternalTest --> Alpha : Enable for alpha flavor
+    Alpha --> Beta : Enable for beta flavor
+    Beta --> GA : Enable for GA flavor
+    GA --> Removed : Delete flag wrapper\n(feature is unconditional)
+    Removed --> [*]
+```
+
+---
+
+## 5. Workflow Quick-Access Table
+
+| Workflow file | Trigger | Key inputs | Purpose |
+|---|---|---|---|
+| `generate_changelog.yml` | Push to develop (version.bzl) / manual | `version` | Generate AI release notes, open changelog PR |
+| `build_and_sign.yml` | Manual + reviewer approval | `flavor`, `source_ref` | Build AAB, sign via KMS, archive to GCS |
+| `deploy_to_firebase.yml` | Manual | `gcs_aab_path` | Distribute to QA testers via Firebase |
+| `deploy_to_play_console.yml` | Manual | `gcs_aab_path`, `track`, `rollout_fraction` [0-1000] | Upload to Play Console track |
+| `update_rollout.yml` | Manual | `track`, `version`, `rollout_fraction` [0-1000] | Increase staged rollout percentage |
+| `deploy_updated_changelog.yml` | Push to develop (`changelogs/**`) / manual | `version`, `flavor` | Sync edited release notes to Play Console |
+| `auto_release_alpha.yml` | Weekly cron (Tue 03:30 UTC) / manual | `branch`, `commit_limit` | Automated weekly alpha cut |
+
+---
+
+*See also: [Interpreting CI Results](Interpreting-CI-Results.md) · [Platform Parameters & Feature Flags](Platform-Parameters-&-Feature-Flags.md) · [Instructions for Making a Code Change](Instructions-for-making-a-code-change.md)*

--- a/wiki/app-and-feature-release-process.md
+++ b/wiki/app-and-feature-release-process.md
@@ -1,32 +1,36 @@
 # App and Feature Release Process
 
 This page describes the end-to-end lifecycle for releasing app binaries and managing feature flags
-in oppia-android. It is the canonical replacement for the old private release Google Doc and is
-intended for **release coordinators** and any contributor who wants to understand how a change
-reaches end users.
+in oppia-android. It supersedes the
+[old private release Google Doc](https://docs.google.com/document/d/1XAoXnQkn2oIAFkd6vY90tn_SSW3J9Eia0_4RhXhJSxQ/edit?tab=t.0#heading=h.1hlri65ueypl)
+and is intended for **release coordinators** and any contributor who wants to understand how a
+change reaches end users.
 
 ---
 
 ## Table of Contents
 
 1. [Prerequisites & Roles](#1-prerequisites--roles)
-2. [Binary Release Lifecycle](#2-binary-release-lifecycle)
-   - [2.1 Version numbering](#21-version-numbering)
-   - [2.2 Changelog management](#22-changelog-management)
-   - [2.3 Release branch creation](#23-release-branch-creation)
-   - [2.4 Build & Sign](#24-build--sign)
-   - [2.5 QA via Firebase App Distribution](#25-qa-via-firebase-app-distribution)
-   - [2.6 Deploy to Play Console](#26-deploy-to-play-console)
-   - [2.7 Staged rollout management](#27-staged-rollout-management)
-   - [2.8 Changelog updates post-release](#28-changelog-updates-post-release)
-   - [2.9 Automated alpha releases](#29-automated-alpha-releases)
-   - [2.10 Automated lesson version updates](#210-automated-lesson-version-updates)
-3. [Feature Flag Lifecycle](#3-feature-flag-lifecycle)
-4. [Diagrams](#4-diagrams)
-   - [4.1 End-to-end binary release flow](#41-end-to-end-binary-release-flow)
-   - [4.2 Automated alpha release flow](#42-automated-alpha-release-flow)
-   - [4.3 Feature flag lifecycle](#43-feature-flag-lifecycle)
-5. [Workflow Quick-Access Table](#5-workflow-quick-access-table)
+2. [How Version Numbers Work](#2-how-version-numbers-work)
+3. [Binary Release Lifecycle](#3-binary-release-lifecycle)
+   - [3.1 Bump the version](#31-bump-the-version)
+   - [3.2 Generate the changelog](#32-generate-the-changelog)
+   - [3.3 Create the release branch](#33-create-the-release-branch)
+   - [3.4 Build and sign the release](#34-build-and-sign-the-release)
+   - [3.5 Validate via Firebase App Distribution](#35-validate-via-firebase-app-distribution)
+   - [3.6 Deploy to Play Console](#36-deploy-to-play-console)
+   - [3.7 Manage the staged rollout](#37-manage-the-staged-rollout)
+   - [3.8 Update the changelog post-release](#38-update-the-changelog-post-release)
+4. [Automated Processes](#4-automated-processes)
+   - [4.1 Run automated alpha releases](#41-run-automated-alpha-releases)
+   - [4.2 Update pinned lesson versions](#42-update-pinned-lesson-versions)
+5. [Feature Flag Lifecycle](#5-feature-flag-lifecycle)
+6. [Diagrams](#6-diagrams)
+   - [6.1 End-to-end binary release flow](#61-end-to-end-binary-release-flow)
+   - [6.2 Automated alpha release flow](#62-automated-alpha-release-flow)
+   - [6.3 Feature flag lifecycle](#63-feature-flag-lifecycle)
+7. [Workflow Quick-Access Table](#7-workflow-quick-access-table)
+8. [How to Manually Trigger a Workflow](#8-how-to-manually-trigger-a-workflow)
 
 ---
 
@@ -52,15 +56,14 @@ described in this page. The release coordinator is either the tech lead, or any 
 | GCP: Cloud KMS — `oppia-android-release-key` | HSM-backed signing key (key never leaves KMS) |
 | Google Play Console: "Release to production" permission | Upload AABs and update track releases |
 
+
 > **Note:** The `oppia-android-release-env` environment enforces a **required reviewer approval**
 > gate. No build, signing, or deployment step executes until an authorized reviewer explicitly
 > approves the run in the GitHub Actions UI.
 
 ---
 
-## 2. Binary Release Lifecycle
-
-### 2.1 Version numbering
+## 2. How Version Numbers Work
 
 The app's version is maintained in [`version.bzl`](../version.bzl) at the repository root:
 
@@ -72,13 +75,36 @@ MINOR_VERSION = 18
 - `MINOR_VERSION` is incremented for each release (e.g. 0.17 → 0.18).
 - `MAJOR_VERSION` changes only for breaking platform changes or major product milestones.
 - The resulting `versionName` is `"{MAJOR}.{MINOR}"` (e.g. `"0.18"`).
-- A version update is performed by committing a `MINOR_VERSION` bump to `develop`.
-  This automatically triggers changelog generation (see [§2.2](#22-changelog-management)).
+- Bumping `MINOR_VERSION` on `develop` automatically triggers changelog generation
+  (see [§3.2](#32-generate-the-changelog)).
 
-### 2.2 Changelog management
+---
 
-**Trigger:** Automatically on every push to `develop` that modifies `version.bzl`, or manually
-via `workflow_dispatch` of the **Generate Changelog** workflow.
+## 3. Binary Release Lifecycle
+
+### 3.1 Bump the version
+
+**Trigger:** Manual — the coordinator commits a `MINOR_VERSION` increment to `version.bzl` on
+`develop` to start the release cycle.
+
+**Coordinator action:**
+
+1. Edit [`version.bzl`](../version.bzl) and increment `MINOR_VERSION` (e.g. `17` → `18`).
+2. Commit and push the change directly to `develop`:
+   ```
+   git commit -m "Bump MINOR_VERSION to 18 for release 0.18"
+   git push upstream develop
+   ```
+
+Pushing this change automatically triggers changelog generation (§3.2).
+
+---
+
+### 3.2 Generate the changelog
+
+**Trigger:**
+- **Automatic** — on every push to `develop` that modifies `version.bzl`
+- **Manual** — via `workflow_dispatch` of the **Generate Changelog** workflow
 
 **What it does:**
 
@@ -103,9 +129,11 @@ AI summary needs adjustment before merging.
 
 ---
 
-### 2.3 Release branch creation
+### 3.3 Create the release branch
 
-After the version bump and changelog PR have landed on `develop`:
+**Trigger:** Manual — after the version bump and changelog PR have landed on `develop`.
+
+**Coordinator action:**
 
 1. Cut a release branch from `develop` HEAD:
    ```
@@ -117,9 +145,12 @@ After the version bump and changelog PR have landed on `develop`:
 
 ---
 
-### 2.4 Build & Sign
+### 3.4 Build and sign the release
 
-**Trigger:** Manual (`workflow_dispatch`) — requires coordinator to fill in the inputs below.
+**Trigger:** Manual (`workflow_dispatch`) — run this after the release branch is ready.
+
+> **Note:** This workflow runs in the `oppia-android-release-env` GitHub environment, which
+> requires an authorized reviewer to **approve** the run before any step executes.
 
 **Inputs:**
 
@@ -139,14 +170,14 @@ After the version bump and changelog PR have landed on `develop`:
    ```
 5. Prints the full GCS path in the job summary — **copy this path** for use in the next steps.
 
-> **Note:** This workflow runs in the `oppia-android-release-env` GitHub environment, which
-> requires an authorized reviewer to **approve** the run before any step executes.
+**Coordinator action:** Dispatch the workflow, approve the run in the `oppia-android-release-env`
+environment, and copy the GCS path from the job summary once it completes.
 
 ---
 
-### 2.5 QA via Firebase App Distribution
+### 3.5 Validate via Firebase App Distribution
 
-**Trigger:** Manual (`workflow_dispatch`) — run this after **Build and Sign Release** succeeds.
+**Trigger:** Manual (`workflow_dispatch`) — run this after **Build and sign the release** succeeds.
 
 **Inputs:**
 
@@ -170,9 +201,12 @@ before the coordinator proceeds to the Play Console deployment.
 The app's Play Store listing is at:
 [https://play.google.com/store/apps/details?id=org.oppia.android](https://play.google.com/store/apps/details?id=org.oppia.android)
 
+**Coordinator action:** Dispatch the workflow and wait for QA testers to confirm the build is
+ready. Proceed to §3.6 only after receiving QA sign-off.
+
 ---
 
-### 2.6 Deploy to Play Console
+### 3.6 Deploy to Play Console
 
 **Trigger:** Manual (`workflow_dispatch`) — run this after QA sign-off.
 
@@ -201,9 +235,12 @@ The app's Play Store listing is at:
 > **Note:** Start with a low rollout fraction (e.g. 10%) and monitor crash rates in Firebase
 > Crashlytics before expanding.
 
+**Coordinator action:** Dispatch the workflow with a low initial `rollout_fraction` (e.g. `100`
+for 10%), approve the run, and monitor Crashlytics before proceeding to §3.7.
+
 ---
 
-### 2.7 Staged rollout management
+### 3.7 Manage the staged rollout
 
 **Trigger:** Manual (`workflow_dispatch`) — run this each time you want to increase the rollout
 percentage for a live release.
@@ -230,9 +267,12 @@ fraction for the current live release on the target track — **without re-uploa
 A concurrency lock shared with `deploy_updated_changelog.yml` prevents two simultaneous Play
 Console edit sessions (the Play Developer API enforces a single active edit per package at a time).
 
+**Coordinator action:** Dispatch the workflow after each monitoring window. Repeat until
+`rollout_fraction=1000` (100%).
+
 ---
 
-### 2.8 Changelog updates post-release
+### 3.8 Update the changelog post-release
 
 **Trigger:**
 - **Automatic** — on every push to `develop` that modifies any file matching
@@ -251,9 +291,17 @@ Console edit sessions (the Play Developer API enforces a single active edit per 
 This means you can edit `config/changelogs/0.18.md` directly on `develop` at any time after a
 release goes live, and the changes will automatically sync to the Play Console store listing.
 
+**Coordinator action:** Edit the changelog file on `develop` and push — the sync runs
+automatically. No additional action is required unless the workflow fails.
+
 ---
 
-### 2.9 Automated alpha releases
+## 4. Automated Processes
+
+These workflows run on a schedule without manual coordinator intervention. The coordinator's
+only role is to review and merge any PRs they open.
+
+### 4.1 Run automated alpha releases
 
 **Trigger:**
 - **Automatic** — weekly cron every **Tuesday at 03:30 UTC**
@@ -282,9 +330,12 @@ If no passing commit is found within the configured limit, the outcome depends o
 - **No commits at all within the limit** — the workflow logs this and exits cleanly without
   failing, since there is nothing new to release.
 
+**Coordinator action:** Approve the dispatched `build_and_sign.yml` run in the
+`oppia-android-release-env` environment.
+
 ---
 
-### 2.10 Automated lesson version updates
+### 4.2 Update pinned lesson versions
 
 **Trigger:**
 - **Automatic** — weekly cron every **Monday at 02:30 UTC**
@@ -301,13 +352,15 @@ If no passing commit is found within the configured limit, the outcome depends o
    the updated textproto diff (idempotent — if files are already current, no commit or PR is
    created).
 
-**Coordinator action:** Review and merge the opened lesson-versions PR.
-
 > **Note:** The workflow uses `BOT_TOKEN` rather than `GITHUB_TOKEN` for PR creation so that
 > CI is properly triggered on the opened PR. The dedicated branch is force-pushed on every run,
 > keeping the PR diff clean regardless of how many runs have occurred.
 
-## 3. Feature Flag Lifecycle
+**Coordinator action:** Review and merge the opened lesson-versions PR.
+
+---
+
+## 5. Feature Flag Lifecycle
 
 Feature flags (called **platform parameters** in this codebase) allow features to be developed
 and deployed incrementally — enabled for one flavor or environment at a time — without gating
@@ -319,9 +372,9 @@ the full progression model and the exact code constructs involved.
 
 ---
 
-## 4. Diagrams
+## 6. Diagrams
 
-### 4.1 End-to-end binary release flow
+### 6.1 End-to-end binary release flow
 
 ```mermaid
 flowchart TD
@@ -340,7 +393,7 @@ flowchart TD
     J --> M["deploy_updated_changelog.yml\n(auto on changelog edits)"]
 ```
 
-### 4.2 Automated alpha release flow
+### 6.2 Automated alpha release flow
 
 ```mermaid
 flowchart TD
@@ -356,14 +409,14 @@ flowchart TD
     J --> K["Signed alpha AAB archived in GCS ✓"]
 ```
 
-### 4.3 Feature flag lifecycle
+### 6.3 Feature flag lifecycle
 
 See the [Platform Parameters & Feature Flags](Platform-Parameters-&-Feature-Flags.md) wiki
 page for the definitive guide on the feature flag progression model.
 
 ---
 
-## 5. Workflow Quick-Access Table
+## 7. Workflow Quick-Access Table
 
 | Workflow file | Trigger | Key inputs | Purpose |
 |---|---|---|---|
@@ -378,7 +431,7 @@ page for the definitive guide on the feature flag progression model.
 
 ---
 
-## 6. How to Manually Trigger a Workflow
+## 8. How to Manually Trigger a Workflow
 
 All manual workflows in this release process use GitHub's `workflow_dispatch` trigger. Here is
 how to run one:

--- a/wiki/app-and-feature-release-process.md
+++ b/wiki/app-and-feature-release-process.md
@@ -417,7 +417,7 @@ Navigate to the **Actions** tab of the `oppia/oppia-android` repository and clic
 you want to run from the left-hand sidebar. Then click the **"Run workflow"** button on the
 right.
 
-![Step 1: Select the workflow and click Run workflow](https://github.com/user-attachments/assets/cbb9eec6-0763-48b7-a027-62b33d855b84")
+![Step 1: Select the workflow and click Run workflow](https://github.com/user-attachments/assets/cbb9eec6-0763-48b7-a027-62b33d855b84)
 
 **Step 2 — Fill in the inputs**
 

--- a/wiki/app-and-feature-release-process.md
+++ b/wiki/app-and-feature-release-process.md
@@ -306,8 +306,6 @@ If no passing commit is found within the configured limit, the outcome depends o
 > CI is properly triggered on the opened PR. The dedicated branch is force-pushed on every run,
 > keeping the PR diff clean regardless of how many runs have occurred.
 
----
-
 ## 3. Feature Flag Lifecycle
 
 Feature flags (called **platform parameters** in this codebase) allow features to be developed
@@ -315,27 +313,8 @@ and deployed incrementally — enabled for one flavor or environment at a time �
 on a full release.
 
 See the **[Platform Parameters & Feature Flags](Platform-Parameters-&-Feature-Flags.md)** wiki
-page for the complete guide on defining, enabling, graduating, and removing flags.
-
-**Summary of states:**
-
-The table below summarises the progression stages. The exact enum values and enabling
-conditions are defined in [`PlatformParameterValue`](../app/src/main/java/org/oppia/android/app/model/)
-and documented in full on the
-[Platform Parameters & Feature Flags](Platform-Parameters-&-Feature-Flags.md) wiki page.
-
-| Stage | Who sees it |
-|---|---|
-| Dev-only | Local development builds only |
-| Internal/test | Internal/debug flavor builds |
-| Alpha | Alpha Play Store track |
-| Beta | Beta Play Store track |
-| GA (general availability) | All users |
-| Removed | Flag wrapper deleted; feature is unconditional |
-
-Graduating a flag from one stage to the next does **not** require a new binary release — it is
-done by updating the flag's default value in code and merging to `develop`. The change reaches
-users on the next alpha automation cycle or the next manual release, depending on the target stage.
+page for the complete guide on defining, enabling, graduating, and removing flags, including
+the full progression model and the exact code constructs involved.
 
 ---
 
@@ -378,16 +357,8 @@ flowchart TD
 
 ### 4.3 Feature flag lifecycle
 
-```mermaid
-stateDiagram-v2
-    [*] --> DevOnly : Define flag\n(disabled in all envs)
-    DevOnly --> InternalTest : Enable for debug builds
-    InternalTest --> Alpha : Enable for alpha flavor
-    Alpha --> Beta : Enable for beta flavor
-    Beta --> GA : Enable for GA flavor
-    GA --> Removed : Delete flag wrapper\n(feature is unconditional)
-    Removed --> [*]
-```
+See the [Platform Parameters & Feature Flags](Platform-Parameters-&-Feature-Flags.md) wiki
+page for the definitive guide on the feature flag progression model.
 
 ---
 

--- a/wiki/app-and-feature-release-process.md
+++ b/wiki/app-and-feature-release-process.md
@@ -78,7 +78,7 @@ MINOR_VERSION = 18
 ### 2.2 Changelog management
 
 **Trigger:** Automatically on every push to `develop` that modifies `version.bzl`, or manually
-via `workflow_dispatch` of the `generate_changelog.yml` workflow.
+via `workflow_dispatch` of the **Generate Changelog** workflow.
 
 **What it does:**
 
@@ -146,7 +146,7 @@ After the version bump and changelog PR have landed on `develop`:
 
 ### 2.5 QA via Firebase App Distribution
 
-**Trigger:** Manual (`workflow_dispatch`) — run this after `build_and_sign.yml` succeeds.
+**Trigger:** Manual (`workflow_dispatch`) — run this after **Build and Sign Release** succeeds.
 
 **Inputs:**
 
@@ -159,9 +159,10 @@ After the version bump and changelog PR have landed on `develop`:
 
 1. Downloads the signed AAB from GCS.
 2. Distributes it to Firebase App Distribution.
-3. Automatically notifies the relevant tester group for the given flavor (the tester group
-   assignment is configured in the workflow — no manual coordinator action needed for the
-   notification).
+3. Associates the release with the `{flavor}-qa-testers` group (e.g. `alpha-qa-testers`);
+   Firebase automatically emails all testers in that group. Tester group membership is
+   managed from the Firebase console — no additional coordinator action is needed for
+   the notification to go out.
 
 QA testers can then install the build via the Firebase App Distribution app and validate it
 before the coordinator proceeds to the Play Console deployment.
@@ -256,7 +257,7 @@ release goes live, and the changes will automatically sync to the Play Console s
 
 **Trigger:**
 - **Automatic** — weekly cron every **Tuesday at 03:30 UTC**
-- **Manual** — via `workflow_dispatch` of the `auto_release_alpha.yml` workflow (useful for off-schedule alpha cuts)
+- **Manual** — via `workflow_dispatch` of the **Auto Release Alpha** workflow (useful for off-schedule alpha cuts)
 
 **What it does:**
 
@@ -287,7 +288,7 @@ If no passing commit is found within the configured limit, the outcome depends o
 
 **Trigger:**
 - **Automatic** — weekly cron every **Monday at 02:30 UTC**
-- **Manual** — via `workflow_dispatch` of the `pull_latest_lesson_versions.yml` workflow
+- **Manual** — via `workflow_dispatch` of the **Pull Latest Lesson Versions** workflow
 
 **What it does:**
 

--- a/wiki/app-and-feature-release-process.md
+++ b/wiki/app-and-feature-release-process.md
@@ -417,7 +417,7 @@ Navigate to the **Actions** tab of the `oppia/oppia-android` repository and clic
 you want to run from the left-hand sidebar. Then click the **"Run workflow"** button on the
 right.
 
-![Step 1: Select the workflow and click Run workflow](SCREENSHOT_1_URL)
+![Step 1: Select the workflow and click Run workflow](https://github.com/user-attachments/assets/cbb9eec6-0763-48b7-a027-62b33d855b84")
 
 **Step 2 — Fill in the inputs**
 
@@ -425,7 +425,7 @@ A dropdown appears with a branch selector and the workflow's input fields. Selec
 branch and fill in all required inputs (refer to the relevant section above for the expected
 values).
 
-![Step 2: Fill in the workflow inputs](SCREENSHOT_2_URL)
+![Step 2: Fill in the workflow inputs](https://github.com/user-attachments/assets/f9805dbb-5c12-48f5-a23f-f7dbb4247668)
 
 **Step 3 — Confirm and approve**
 
@@ -433,7 +433,7 @@ Click **"Run workflow"** to queue the run. For workflows that run in the
 `oppia-android-release-env` environment, a reviewer approval gate will appear — an authorized
 reviewer must approve the run in the GitHub Actions UI before any step executes.
 
-![Step 3: Approve the run in the release environment](SCREENSHOT_3_URL)
+![Step 3: Approve the run in the release environment](https://github.com/user-attachments/assets/80b5ffc1-4154-416e-b19a-fd3e8e3258f0)
 
 ---
 

--- a/wiki/app-and-feature-release-process.md
+++ b/wiki/app-and-feature-release-process.md
@@ -1,0 +1,12 @@
+# App and Feature Release Process
+
+<!-- TODO: Fill in this wiki page as part of PR 2.6 -->
+
+This page describes the end-to-end lifecycle for releasing app binaries and features in oppia-android,
+covering the automated pipeline, manual gates, and rollout strategy.
+
+## Sections (coming soon)
+
+- Binary release lifecycle
+- Feature flag lifecycle
+- Lifecycle diagrams


### PR DESCRIPTION
Fixes part of #6106

## Explanation

Adds the **App and Feature Release Process** wiki page — the canonical, coordinator-facing documentation for the oppia-android binary release lifecycle and feature flag workflow.

This wiki replaces the previous private release Google Doc and serves as the canonical, coordinator-facing documentation for the app and feature release process.

### What the page covers

| Section | Content |
|---|---|
| §1 Prerequisites & Roles | Required GitHub environments, GCP permissions, and Play Console access |
| §2 Binary Release Lifecycle | Nine subsections covering version numbering, changelog generation, release branch creation, build & sign, Firebase QA, Play Console deploy, staged rollout, post-release changelog updates, and automated alpha releases |
| §3 Feature Flag Lifecycle | How feature flags are created, enabled per-flavor, and retired |
| §4 Diagrams | Mermaid diagrams for the end-to-end release flow, automated alpha flow, and feature flag lifecycle |
| §5 Workflow Quick-Access Table | Summary of every workflow file, its trigger, and key inputs |

Each §2.x subsection documents the corresponding GitHub Actions workflow (trigger, required inputs, what it does, and failure guidance) so coordinators have a single reference rather than reading each `.yml` file individually.

## Disclosure of LLM Usage
AI was used for writing and research.
## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).