### PR TITLE
Fix #6258: Deprecated Lollipop

### DIFF
--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -853,7 +853,7 @@ TEST_DEPS = [
     custom_package = "org.oppia.android.app.test",
     manifest_values = {
         "applicationId": "org.oppia.android",
-        "minSdkVersion": "21",
+        "minSdkVersion": "23",
         "targetSdkVersion": "30",
         "versionCode": "0",
         "versionName": "0.1-alpha",

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   package="org.oppia.android">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
       android:targetSdkVersion="35" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.INTERNET" />

--- a/app/src/main/AppAndroidManifest.xml
+++ b/app/src/main/AppAndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.android.app.ui">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
     android:targetSdkVersion="35" />
 </manifest>

--- a/app/src/main/DatabindingAdaptersManifest.xml
+++ b/app/src/main/DatabindingAdaptersManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.android.databinding.adapters">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
     android:targetSdkVersion="35" />
 </manifest>

--- a/app/src/main/DatabindingResourcesManifest.xml
+++ b/app/src/main/DatabindingResourcesManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.android.app.databinding">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
     android:targetSdkVersion="35" />
 </manifest>

--- a/app/src/main/RecyclerviewAdaptersManifest.xml
+++ b/app/src/main/RecyclerviewAdaptersManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.android.app.recyclerview.adapters">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
     android:targetSdkVersion="35" />
 </manifest>

--- a/app/src/main/ViewModelManifest.xml
+++ b/app/src/main/ViewModelManifest.xml
@@ -2,6 +2,6 @@
 <!-- TODO(#1632): Remove manifest -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.android.app.vm">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
     android:targetSdkVersion="35" />
 </manifest>

--- a/app/src/main/ViewModelsManifest.xml
+++ b/app/src/main/ViewModelsManifest.xml
@@ -2,6 +2,6 @@
 <!-- TODO(#1632): Remove manifest -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.android.app.view.models">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
     android:targetSdkVersion="35" />
 </manifest>

--- a/app/src/main/ViewsManifest.xml
+++ b/app/src/main/ViewsManifest.xml
@@ -2,6 +2,6 @@
 <!-- TODO(#1632): Remove manifest -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.android.app.views">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
     android:targetSdkVersion="35" />
 </manifest>

--- a/app/src/main/java/org/oppia/android/app/thirdparty/AndroidManifest.xml
+++ b/app/src/main/java/org/oppia/android/app/thirdparty/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.android.app.thirdparty">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
     android:targetSdkVersion="35" />
 </manifest>

--- a/app/src/main/res/layout/content_item.xml
+++ b/app/src/main/res/layout/content_item.xml
@@ -45,7 +45,6 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:breakStrategy="simple"
-      tools:targetApi="23"
       android:fontFamily="sans-serif"
       android:minWidth="48dp"
       android:minHeight="48dp"

--- a/app/src/main/res/layout/feedback_item.xml
+++ b/app/src/main/res/layout/feedback_item.xml
@@ -45,7 +45,6 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:breakStrategy="simple"
-      tools:targetApi="23"
       android:fontFamily="sans-serif"
       android:minWidth="48dp"
       android:minHeight="48dp"

--- a/app/src/sharedTest/java/org/oppia/android/app/notice/OsDeprecationNoticeDialogFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/notice/OsDeprecationNoticeDialogFragmentTest.kt
@@ -168,7 +168,7 @@ class OsDeprecationNoticeDialogFragmentTest {
         .onActionButtonClicked(
           DeprecationNoticeActionResponse.Dismiss(
             deprecationNoticeType = DeprecationNoticeType.OS_DEPRECATION,
-            deprecatedVersion = 21,
+            deprecatedVersion = 23,
           )
         )
     }

--- a/app/src/test/AndroidManifest.xml
+++ b/app/src/test/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   package="org.oppia.android.app.test">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
     android:targetSdkVersion="30" />
 
   <application>

--- a/build_flavors.bzl
+++ b/build_flavors.bzl
@@ -36,7 +36,7 @@ _PRODUCTION_PROGUARD_SPECS = [
 _FLAVOR_METADATA = {
     "dev": {
         "manifest": "//app:src/main/AndroidManifest.xml",
-        "min_sdk_version": 21,
+        "min_sdk_version": 23,
         "target_sdk_version": 35,
         "multidex": "native",
         "proguard_specs": [],  # Developer builds are not optimized.
@@ -50,7 +50,7 @@ _FLAVOR_METADATA = {
     },
     "alpha": {
         "manifest": "//app:src/main/AndroidManifest.xml",
-        "min_sdk_version": 21,
+        "min_sdk_version": 23,
         "target_sdk_version": 35,
         "multidex": "native",
         "proguard_specs": _PRODUCTION_PROGUARD_SPECS,
@@ -65,7 +65,7 @@ _FLAVOR_METADATA = {
     },
     "beta": {
         "manifest": "//app:src/main/AndroidManifest.xml",
-        "min_sdk_version": 21,
+        "min_sdk_version": 23,
         "target_sdk_version": 35,
         "multidex": "native",
         "proguard_specs": _PRODUCTION_PROGUARD_SPECS,
@@ -80,7 +80,7 @@ _FLAVOR_METADATA = {
     },
     "ga": {
         "manifest": "//app:src/main/AndroidManifest.xml",
-        "min_sdk_version": 21,
+        "min_sdk_version": 23,
         "target_sdk_version": 35,
         "multidex": "native",
         "proguard_specs": _PRODUCTION_PROGUARD_SPECS,

--- a/config/src/java/org/oppia/android/config/AndroidManifest.xml
+++ b/config/src/java/org/oppia/android/config/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.android.config">
 
-  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="35" />
+  <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="35" />
 </manifest>

--- a/config/src/java/org/oppia/android/config/platform/platform_parameters.textproto
+++ b/config/src/java/org/oppia/android/config/platform/platform_parameters.textproto
@@ -52,8 +52,8 @@ platform_parameter_definition {
   id: LOWEST_SUPPORTED_API_LEVEL
   remote_server_name: "lowest_supported_api_level"
   default_value: {
-    # The lowest supported version of the app is currently Lollipop.
-    integer: 21
+    # The lowest supported version of the app is currently Marshmallow.
+    integer: 23
   }
 }
 platform_parameter_definition {

--- a/data/src/main/AndroidManifest.xml
+++ b/data/src/main/AndroidManifest.xml
@@ -2,5 +2,5 @@
 <!-- TODO(#6010): Remove this manifest. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.oppia.android.data">
-    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="35" />
+    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="35" />
 </manifest>

--- a/data/src/test/AndroidManifest.xml
+++ b/data/src/test/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   package="org.oppia.android.data">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
     android:targetSdkVersion="30" />
 
   <application>

--- a/domain/domain_assets.bzl
+++ b/domain/domain_assets.bzl
@@ -139,7 +139,7 @@ def local_assets_library(
             '<?xml version="1.0" encoding="utf-8"?>',
             '<manifest xmlns:android="http://schemas.android.com/apk/res/android"',
             '    package="org.oppia.android.domain.assets.%s">' % name,
-            '    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="%d" />' % BUILD_SDK_VERSION,
+            '    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="%d" />' % BUILD_SDK_VERSION,
             "</manifest>",
         ],
     )

--- a/domain/src/main/AndroidManifest.xml
+++ b/domain/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.android.domain">
-  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="35" />
+  <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="35" />
 </manifest>

--- a/domain/src/test/AndroidManifest.xml
+++ b/domain/src/test/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   package="org.oppia.android.domain">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
     android:targetSdkVersion="30" />
 
   <application>

--- a/domain/src/test/java/org/oppia/android/domain/platformparameter/PlatformParameterModuleTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/platformparameter/PlatformParameterModuleTest.kt
@@ -158,7 +158,7 @@ class PlatformParameterModuleTest {
   private companion object {
     private const val TEST_APP_VERSION_NAME = "oppia-android-test-0123456789"
     private const val TEST_APP_VERSION_CODE = 125L
-    private const val TEST_LOWEST_SUPPORTED_API_LEVEL = 21
+    private const val TEST_LOWEST_SUPPORTED_API_LEVEL = 23
     private const val TEST_ENABLE_APP_AND_OS_DEPRECATION_DEFAULT_VALUE = false
   }
 }

--- a/instrumentation/BUILD.bazel
+++ b/instrumentation/BUILD.bazel
@@ -19,7 +19,7 @@ android_binary(
     manifest = "//instrumentation:src/java/AndroidManifest.xml",
     manifest_values = {
         "applicationId": "org.oppia.android",
-        "minSdkVersion": "21",
+        "minSdkVersion": "23",
         "targetSdkVersion": "33",
         "versionCode": "0",
         "versionName": "0.1-test",

--- a/instrumentation/src/javatests/AndroidManifest.xml
+++ b/instrumentation/src/javatests/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.android.app.instrumentation">
   <uses-sdk
-    android:minSdkVersion="21"
+    android:minSdkVersion="23"
     android:targetSdkVersion="30" />
   <instrumentation
     android:targetPackage="org.oppia.android"

--- a/scripts/src/java/org/oppia/android/scripts/lint/LintAnalysisReporter.kt
+++ b/scripts/src/java/org/oppia/android/scripts/lint/LintAnalysisReporter.kt
@@ -174,7 +174,7 @@ class LintAnalysisReporter(private val repoRoot: File) {
       // TODO(#5930): Remove this once lint no longer falsely triggers on Iterable#forEach.
       FalsePositiveIssue(
         issueId = "NewApi",
-        message = "Call requires API level 24 (current min is 21): `java.lang.Iterable#forEach`",
+        message = "Call requires API level 24 (current min is 23): `java.lang.Iterable#forEach`",
         severity = LintSeverity.ERROR,
         workaroundMessage = "Use safeForEach from IterableExtensions.kt instead of directly" +
           " calling forEach to avoid known lint false positives on API < 24."

--- a/scripts/src/java/org/oppia/android/scripts/lint/LintModelCreator.kt
+++ b/scripts/src/java/org/oppia/android/scripts/lint/LintModelCreator.kt
@@ -40,7 +40,7 @@ class LintModelCreator(
 
     // Build configurations for Android app layer configuration
     private const val PACKAGE_PREFIX = "org.oppia.android"
-    private const val MIN_SDK_VERSION = "21"
+    private const val MIN_SDK_VERSION = "23"
     private const val TARGET_SDK_VERSION = "35"
 
     // Model directories are stable and won't change frequently therefore a longer TTL

--- a/scripts/src/javatests/org/oppia/android/scripts/lint/AndroidLintRunnerTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/lint/AndroidLintRunnerTest.kt
@@ -43,7 +43,7 @@ class AndroidLintRunnerTest {
 
   companion object {
     private const val JAVA_VERSION = "11.0.6"
-    private const val MIN_SDK_VERSION = "21"
+    private const val MIN_SDK_VERSION = "23"
     private const val TARGET_SDK_VERSION = "35"
   }
 
@@ -683,14 +683,14 @@ class AndroidLintRunnerTest {
     val output = outputStream.toString()
     assertThat(output).contains("NewApi")
     assertThat(output)
-      .contains("val network = cm.activeNetwork")
+      .contains("val localeList = LocaleList.getDefault()")
     assertThat(output)
-      .doesNotContain("val network2 = cm.activeNetwork")
-    assertThat(output).contains("Line: 11")
+      .doesNotContain("val localeList2 = LocaleList.getDefault()")
+    assertThat(output).contains("Line: 10")
     assertThat(output)
       .contains(
-        "Call requires API level 23 (current min is 21): " +
-          "`android.net.ConnectivityManager#getActiveNetwork`"
+        "Call requires API level 24 (current min is 23): " +
+          "`android.os.LocaleList#getDefault`"
       )
     assertThat(exception.message).contains("${RED}ANDROID LINT CHECK ${BOLD}FAILED$RESET")
 
@@ -715,7 +715,7 @@ class AndroidLintRunnerTest {
     assertThat(output).contains("line=\"14\"")
     assertThat(output)
       .contains(
-        "Field requires API level 29 (current min is 21):" +
+        "Field requires API level 29 (current min is 23):" +
           " `android.media.MediaFormat#MIMETYPE_AUDIO_AC4`"
       )
 
@@ -1081,15 +1081,14 @@ class AndroidLintRunnerTest {
 
       import android.annotation.SuppressLint
       import android.content.Context
-      import android.net.ConnectivityManager
       import android.os.Build
+      import android.os.LocaleList
 
       @SuppressLint("MissingPermission")
       fun test(context: Context) {
-          val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-          val network = cm.activeNetwork
-          if (Build.VERSION.SDK_INT >= 23) {
-              val network2 = cm.activeNetwork // OK
+          val localeList = LocaleList.getDefault()
+          if (Build.VERSION.SDK_INT >= 24) {
+              val localeList2 = LocaleList.getDefault() // OK
           }
       }
       """.trimIndent()

--- a/scripts/src/javatests/org/oppia/android/scripts/lint/LintAnalysisReporterTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/lint/LintAnalysisReporterTest.kt
@@ -809,7 +809,7 @@ class LintAnalysisReporterTest {
       LintIssue(
         id = "NewApi",
         severity = LintSeverity.ERROR,
-        message = "Call requires API level 24 (current min is 21): `java.lang.Iterable#forEach`",
+        message = "Call requires API level 24 (current min is 23): `java.lang.Iterable#forEach`",
         category = "Correctness",
         explanation = "This check scans through all the Android API " +
           "calls in the application and warns about any calls that are not available",
@@ -839,7 +839,7 @@ class LintAnalysisReporterTest {
     )
     assertThat(output).contains(
       "Message: Call requires API level 24 " +
-        "(current min is 21): `java.lang.Iterable#forEach`"
+        "(current min is 23): `java.lang.Iterable#forEach`"
     )
     assertThat(output).contains(
       "Workaround:\n"

--- a/scripts/src/javatests/org/oppia/android/scripts/lint/LintModelCreatorTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/lint/LintModelCreatorTest.kt
@@ -69,7 +69,7 @@ class LintModelCreatorTest {
     val content = variantXmlFile.readText()
     assertThat(content).contains("<variant")
     assertThat(content).contains("name=\"main\"")
-    assertThat(content).contains("minSdkVersion=\"21\"")
+    assertThat(content).contains("minSdkVersion=\"23\"")
     assertThat(content).contains("targetSdkVersion=\"35\"")
     assertThat(content).contains("debuggable=\"true\"")
     assertThat(content).contains("package=\"org.oppia.android.app\"")

--- a/testing/src/main/AndroidManifest.xml
+++ b/testing/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.android.testing">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
       android:targetSdkVersion="35" />
 
   <application>

--- a/testing/src/test/AndroidManifest.xml
+++ b/testing/src/test/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
   package="org.oppia.android.testing">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
     android:targetSdkVersion="30" />
 
   <application>

--- a/tools/download_assets.bzl
+++ b/tools/download_assets.bzl
@@ -179,7 +179,7 @@ def downloaded_assets_library(name, download_config, pinned_versions, output_log
             '<?xml version="1.0" encoding="utf-8"?>',
             '<manifest xmlns:android="http://schemas.android.com/apk/res/android"',
             '    package="org.oppia.android.domain.assets.%s">' % name,
-            '    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="%d" />' % BUILD_SDK_VERSION,
+            '    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="%d" />' % BUILD_SDK_VERSION,
             "</manifest>",
         ],
         tags = tags,

--- a/utility/src/main/AndroidManifest.xml
+++ b/utility/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.oppia.android.util">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
       android:targetSdkVersion="35" />
 </manifest>

--- a/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
+++ b/utility/src/main/java/org/oppia/android/util/platformparameter/PlatformParameterConstants.kt
@@ -182,9 +182,9 @@ const val LOWEST_SUPPORTED_API_LEVEL = "lowest_supported_api_level"
  * Default value for the platform parameter that contains an integer indicating the lowest
  * supported Android API Level.
  *
- * The current minimum supported API level is 21 (Lollipop).
+ * The current minimum supported API level is 23 (Marshmallow).
  */
-const val LOWEST_SUPPORTED_API_LEVEL_DEFAULT_VALUE = 21
+const val LOWEST_SUPPORTED_API_LEVEL_DEFAULT_VALUE = 23
 
 /**
  * Qualifier for the platform parameter that controls the time interval in days between showing

--- a/utility/src/main/java/org/oppia/android/util/statusbar/StatusBarColor.kt
+++ b/utility/src/main/java/org/oppia/android/util/statusbar/StatusBarColor.kt
@@ -1,6 +1,5 @@
 package org.oppia.android.util.statusbar
 
-import android.os.Build
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
@@ -15,7 +14,7 @@ class StatusBarColor {
      * @param statusBarLight passed Boolean true if the status bar theme is light, else passed Boolean false
      */
     fun statusBarColorUpdate(colorId: Int, activity: AppCompatActivity, statusBarLight: Boolean) {
-      if (statusBarLight && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      if (statusBarLight) {
         // TODO(#3616): Migrate to the proper SDK 30+ APIs.
         @Suppress("DEPRECATION") // The code is correct for targeted versions of Android.
         activity.window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR

--- a/utility/src/test/AndroidManifest.xml
+++ b/utility/src/test/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   package="org.oppia.android.util">
-  <uses-sdk android:minSdkVersion="21"
+  <uses-sdk android:minSdkVersion="23"
     android:targetSdkVersion="30" />
 
   <application>

--- a/wiki/Android-Lint-Check.md
+++ b/wiki/Android-Lint-Check.md
@@ -183,7 +183,7 @@ Issue 2 of 3: NEW_API (Category: Correctness)
   Severity: Error (FALSE POSITIVE)
   Line: 15
   Error Line: items.forEach { item ->
-  Message: Call requires API level 24 (current min is 21): `java.lang.Iterable#forEach`
+  Message: Call requires API level 24 (current min is 23): `java.lang.Iterable#forEach`
   Workaround: Use safeForEach from IterableExtensions.kt instead of directly calling forEach to avoid known lint false positives on API < 24.
 ```
 
@@ -201,7 +201,7 @@ Issue 1 of 2: NEW_API (Category: Correctness)
   File: /path/to/app/src/main/java/org/oppia/android/app/utility/ClickableAreasImage.kt
   Line: 45
   Error Line: clickableAreas.forEach { clickableArea ->
-  Message: Call requires API level 24 (current min is 21): `java.lang.Iterable#forEach`
+  Message: Call requires API level 24 (current min is 23): `java.lang.Iterable#forEach`
   Explanation:
     This check scans through all the Android API calls in the application and warns about any calls that are not available on **all** versions targeted by this application...
 ```
@@ -295,7 +295,7 @@ Issue 2 of 3: NEW_API (Category: Correctness)
   Severity: Error (FALSE POSITIVE)
   Line: 15
   Error Line: items.forEach { item ->
-  Message: Call requires API level 24 (current min is 21): `java.lang.Iterable#forEach`
+  Message: Call requires API level 24 (current min is 23): `java.lang.Iterable#forEach`
   Workaround: Use safeForEach from IterableExtensions.kt instead of directly calling forEach to avoid known lint false positives on API < 24.
 ```
 


### PR DESCRIPTION
Fixes #6258
## Explanation
 - Changes minimum SDK version to 23.
 - Deprecates lollipop support and minimum version is now marshmellow.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).