### PR TITLE
Fix #6330: Merge frozen version codes into new release entry

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/release/FakePlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/FakePlayConsoleClient.kt
@@ -73,7 +73,7 @@ class FakePlayConsoleClient : PlayConsoleClient {
     versionCode: Long,
     rolloutFraction: Int,
     releaseNotes: Map<String, String>,
-    preservedReleases: List<PlayConsoleClient.TrackRelease>
+    frozenVersionCodes: List<Long>
   ) {
     maybeFailCall("setTrackRelease")
     trackUpdates.add(
@@ -84,7 +84,7 @@ class FakePlayConsoleClient : PlayConsoleClient {
         versionCode,
         rolloutFraction,
         releaseNotes,
-        preservedReleases
+        frozenVersionCodes
       )
     )
   }
@@ -142,8 +142,8 @@ class FakePlayConsoleClient : PlayConsoleClient {
    * @property versionCode the version code assigned to the track
    * @property rolloutFraction the staged rollout fraction (1.0 = full rollout)
    * @property releaseNotes the release notes map (language code to text)
-   * @property preservedReleases the frozen OS-specific releases included alongside [versionCode]
-   *     to prevent them being deactivated by the track update
+   * @property frozenVersionCodes the frozen OS-specific version codes merged into the new release
+   *     entry alongside [versionCode] to prevent them being deactivated by the track update
    */
   data class TrackUpdate(
     val packageName: String,
@@ -152,6 +152,6 @@ class FakePlayConsoleClient : PlayConsoleClient {
     val versionCode: Long,
     val rolloutFraction: Int,
     val releaseNotes: Map<String, String>,
-    val preservedReleases: List<PlayConsoleClient.TrackRelease> = emptyList()
+    val frozenVersionCodes: List<Long> = emptyList()
   )
 }

--- a/scripts/src/java/org/oppia/android/scripts/release/FrozenReleaseConfig.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/FrozenReleaseConfig.kt
@@ -8,16 +8,17 @@ package org.oppia.android.scripts.release
  * released once to support a specific minimum API level and kept active indefinitely so devices on
  * that API level continue to receive the app.
  *
- * Releases are fetched live from the Play Console and filtered against these version codes. Matching
- * releases are then passed through completely unmodified (preserving versionCodes, status,
- * userFraction, and releaseNotes) into every [PlayConsoleClient.setTrackRelease] call.
+ * Frozen version codes are merged directly into the new release's `versionCodes` list on every
+ * [PlayConsoleClient.setTrackRelease] call. Callers must verify that each frozen version code is
+ * actually present on the live track before calling [PlayConsoleClient.setTrackRelease], and
+ * hard-crash if any are missing (as that would indicate a major release state inconsistency).
  *
  * Currently frozen:
  * - alpha vc 16: KitKat (API 16) build, frozen permanently.
  *
  * When a new API level is deprecated and its final build must be frozen, add its track and version
  * code here. This single file is the source of truth consumed by [UploadBinaryToPlayConsole],
- * [UpdateRolloutFraction], [UploadChangelogToPlayConsole], and [GooglePlayConsoleClient].
+ * [UpdateRolloutFraction], and [UploadChangelogToPlayConsole].
  */
 val FROZEN_VERSION_CODES_PER_TRACK: Map<String, Set<Long>> = mapOf(
   "alpha" to setOf(16L)

--- a/scripts/src/java/org/oppia/android/scripts/release/GooglePlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/GooglePlayConsoleClient.kt
@@ -126,39 +126,27 @@ class GooglePlayConsoleClient(
     versionCode: Long,
     rolloutFraction: Int,
     releaseNotes: Map<String, String>,
-    preservedReleases: List<PlayConsoleClient.TrackRelease>
+    frozenVersionCodes: List<Long>
   ) {
     val fraction = rolloutFraction / 1000.0
     val status = if (rolloutFraction >= 1000) "completed" else "inProgress"
-    val newRelease = TrackUpdateRequest.ReleaseEntry(
-      versionCodes = listOf(versionCode.toString()),
-      status = status,
-      releaseNotes = releaseNotes.map { (lang, text) ->
-        TrackUpdateRequest.LocalizedText(language = lang, text = text)
-      },
-      userFraction = if (rolloutFraction < 1000) fraction else null
-    )
-    // Only releases whose version codes appear in FROZEN_VERSION_CODES_PER_TRACK for this track
-    // are included in the request. This is a defence-in-depth guard: callers already pre-filter
-    // preservedReleases to frozen-only entries, but enforcing the invariant here ensures a mistaken
-    // call can never accidentally preserve a non-frozen release (e.g. a half-rolled-out release
-    // whose versionCode happens to be in the list).
-    val frozenVersionCodes = FROZEN_VERSION_CODES_PER_TRACK[track] ?: emptySet()
-    val frozenEntries = preservedReleases
-      .filter { release -> release.versionCodes.any { it in frozenVersionCodes } }
-      .map { release ->
-        TrackUpdateRequest.ReleaseEntry(
-          versionCodes = release.versionCodes.map { it.toString() },
-          status = release.status,
-          releaseNotes = release.releaseNotes.map { (lang, text) ->
-            TrackUpdateRequest.LocalizedText(language = lang, text = text)
-          },
-          userFraction = release.rolloutFraction?.let { it / 1000.0 }
-        )
-      }
+    // Merge the new version code with any frozen version codes into a single release entry.
+    // The Play Developer API rejects two separate release entries when one supersedes the other
+    // (e.g. a new alpha and the frozen KitKat build), so merging all version codes into a single
+    // entry is the only valid way to keep OS-level frozen builds active alongside the new binary.
+    val allVersionCodes = listOf(versionCode) + frozenVersionCodes
     val trackUpdate = TrackUpdateRequest(
       track = track,
-      releases = listOf(newRelease) + frozenEntries
+      releases = listOf(
+        TrackUpdateRequest.ReleaseEntry(
+          versionCodes = allVersionCodes.map { it.toString() },
+          status = status,
+          releaseNotes = releaseNotes.map { (lang, text) ->
+            TrackUpdateRequest.LocalizedText(language = lang, text = text)
+          },
+          userFraction = if (rolloutFraction < 1000) fraction else null
+        )
+      )
     )
     val response = playConsoleService
       .updateTrack(packageName, editId, track, authorizationBearer, trackUpdate)

--- a/scripts/src/java/org/oppia/android/scripts/release/PlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/PlayConsoleClient.kt
@@ -52,11 +52,16 @@ interface PlayConsoleClient {
    *
    * Must be called after [uploadAab] and before [commitEdit].
    *
-   * If [preservedVersionCodes] is non-empty, each listed version code is included as an additional
-   * `completed` entry in the track update request alongside the new release. This is required for
-   * OS-level frozen builds that must remain active on the track indefinitely (see #6258, #6330):
-   * the Play Developer API replaces the entire track contents on each `tracks.update` call, so any
-   * version code not explicitly included in the request is deactivated.
+   * If [frozenVersionCodes] is non-empty, those version codes are merged into the same release
+   * entry as [versionCode]. This is required for OS-level frozen builds that must remain active
+   * on the track indefinitely (see #6330): the Play Developer API replaces the entire track
+   * contents on each `tracks.update` call, so any version code not explicitly included is
+   * deactivated. Merging frozen VCs into the single new release (rather than sending two separate
+   * release entries) is the only valid approach — the API rejects two releases on the same track
+   * when one supersedes the other.
+   *
+   * Callers are responsible for verifying that every code in [frozenVersionCodes] actually exists
+   * on the live track before calling this method (and hard-crashing if it does not).
    *
    * @param packageName the application package name
    * @param editId the active edit session ID returned by [createEdit]
@@ -66,8 +71,8 @@ interface PlayConsoleClient {
    *     1000 means full rollout (status: "completed") and any value below 1000 produces a staged
    *     rollout (status: "inProgress"). For example: 250 = 25%, 334 = 33.4%, 1000 = 100%.
    * @param releaseNotes map of BCP-47 language codes to release notes text (max 500 chars each)
-   * @param preservedVersionCodes version codes of frozen OS-specific builds that must be kept
-   *     alive on the track alongside [versionCode]; defaults to empty (no preserved builds)
+   * @param frozenVersionCodes version codes of frozen OS-specific builds to merge into the same
+   *     release entry as [versionCode]; defaults to empty (no frozen builds on this track)
    */
   fun setTrackRelease(
     packageName: String,
@@ -76,7 +81,7 @@ interface PlayConsoleClient {
     versionCode: Long,
     rolloutFraction: Int,
     releaseNotes: Map<String, String>,
-    preservedReleases: List<TrackRelease> = emptyList()
+    frozenVersionCodes: List<Long> = emptyList()
   )
 
   /**

--- a/scripts/src/java/org/oppia/android/scripts/release/UpdateRolloutFraction.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UpdateRolloutFraction.kt
@@ -121,12 +121,14 @@ fun updateRollout(
     )
   }
 
-  // Filter the already-fetched live releases to find frozen OS-specific builds and pass them
-  // through completely unmodified (preserving versionCodes, status, userFraction, and
-  // releaseNotes) so the Play Console API does not treat them as changed.
   val frozenVersionCodes = FROZEN_VERSION_CODES_PER_TRACK[track] ?: emptySet()
-  val frozenReleases = liveReleases.filter { release ->
-    release.versionCodes.any { it in frozenVersionCodes }
+  if (frozenVersionCodes.isNotEmpty()) {
+    val liveVersionCodes = liveReleases.flatMap { it.versionCodes }.toSet()
+    val missingFrozen = frozenVersionCodes - liveVersionCodes
+    check(missingFrozen.isEmpty()) {
+      "Invariant disruption: frozen version code(s) $missingFrozen expected on track '$track' " +
+        "are missing from the live track. This indicates a major release state inconsistency."
+    }
   }
 
   val editId = client.createEdit(packageName)
@@ -134,7 +136,7 @@ fun updateRollout(
 
   client.setTrackRelease(
     packageName, editId, track, versionCode, rolloutFraction, releaseNotes,
-    frozenReleases
+    frozenVersionCodes.toList()
   )
   println("  Rollout fraction updated.")
 

--- a/scripts/src/java/org/oppia/android/scripts/release/UploadBinaryToPlayConsole.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UploadBinaryToPlayConsole.kt
@@ -125,16 +125,21 @@ fun runUpload(
     properties.majorMinorVersion,
     properties.flavor.id
   )
-  // Fetch the current track state so frozen OS-specific releases can be passed through
-  // completely unmodified in the setTrackRelease call. The Play Console API replaces the entire
-  // track on each update, so any release not included would be silently deactivated.
   val frozenVersionCodes = frozenVersionCodesPerTrack[track] ?: emptySet()
-  val frozenReleases = if (frozenVersionCodes.isNotEmpty()) {
-    println("Fetching current track state to preserve frozen release(s)...")
-    client.getTrackReleases(PACKAGE_NAME, track, existingEditId = editId)
-      .filter { release -> release.versionCodes.any { it in frozenVersionCodes } }
-  } else {
-    emptyList()
+  if (frozenVersionCodes.isNotEmpty()) {
+    // The Play Developer API merges frozen version codes into the new release entry's versionCodes
+    // list on each update. Before passing them, verify they're actually on the live track — if
+    // any are missing, something has gone seriously wrong with the track state.
+    println("Verifying frozen version code(s) $frozenVersionCodes are present on track '$track'...")
+    val liveVersionCodes = client.getTrackReleases(PACKAGE_NAME, track, existingEditId = editId)
+      .flatMap { it.versionCodes }
+      .toSet()
+    val missingFrozen = frozenVersionCodes - liveVersionCodes
+    check(missingFrozen.isEmpty()) {
+      "Invariant disruption: frozen version code(s) $missingFrozen expected on track '$track' " +
+        "are missing from the live track. This indicates a major release state inconsistency."
+    }
+    println("Frozen version code(s) confirmed present on track '$track'.")
   }
   client.setTrackRelease(
     PACKAGE_NAME,
@@ -143,7 +148,7 @@ fun runUpload(
     uploadedVersionCode,
     rolloutFraction,
     releaseNotes,
-    frozenReleases
+    frozenVersionCodes.toList()
   )
   println("Track '$track' updated.")
 

--- a/scripts/src/java/org/oppia/android/scripts/release/UploadChangelogToPlayConsole.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/UploadChangelogToPlayConsole.kt
@@ -98,12 +98,14 @@ fun maybeUploadUpdatedChangelogs(
     // releases are already at 100% so fall back to 1000.
     val rolloutFraction =
       releases.firstOrNull { it.status == "inProgress" }?.rolloutFraction ?: 1000
-    // The already-fetched releases are filtered to find frozen OS-specific builds and passed
-    // through completely unmodified (preserving versionCodes, status, userFraction, and
-    // releaseNotes) so the Play Console API does not treat them as changed.
     val frozenVersionCodes = FROZEN_VERSION_CODES_PER_TRACK[track] ?: emptySet()
-    val frozenReleases = releases.filter { release ->
-      release.versionCodes.any { it in frozenVersionCodes }
+    if (frozenVersionCodes.isNotEmpty()) {
+      val liveVersionCodes = releases.flatMap { it.versionCodes }.toSet()
+      val missingFrozen = frozenVersionCodes - liveVersionCodes
+      check(missingFrozen.isEmpty()) {
+        "Invariant disruption: frozen version code(s) $missingFrozen expected on track '$track' " +
+          "are missing from the live track. This indicates a major release state inconsistency."
+      }
     }
     // Skip if the live notes already match the local file — avoids wasted API calls and
     // prevents spurious review re-triggers on tracks where nothing has changed.
@@ -114,7 +116,7 @@ fun maybeUploadUpdatedChangelogs(
       ?: ""
     if (!detectChangelogDiff(notes["en-US"] ?: "", deployedNotes)) continue
     uploadChangelogToTrack(
-      client, packageName, track, versionCode, rolloutFraction, notes, frozenReleases
+      client, packageName, track, versionCode, rolloutFraction, notes, frozenVersionCodes.toList()
     )
     updatedCount++
   }
@@ -198,8 +200,8 @@ private fun detectChangelogDiff(localNotes: String, deployedNotes: String): Bool
  * pass the existing [rolloutFraction] from the live release to avoid inadvertently altering the
  * staged rollout percentage.
  *
- * Any [frozenReleases] are passed through completely unmodified alongside the updated release so
- * the Play Console API does not deactivate them during the track update.
+ * Any [frozenVersionCodes] are merged into the new release's versionCodes list so that the
+ * Play Console API does not deactivate them during the track update.
  *
  * @param client the [PlayConsoleClient] used for all API calls
  * @param packageName the application package name (e.g. `"org.oppia.android"`)
@@ -209,8 +211,8 @@ private fun detectChangelogDiff(localNotes: String, deployedNotes: String): Bool
  *     through unchanged so the rollout percentage is preserved)
  * @param newNotes map of BCP-47 language codes to updated release notes text (max 500 chars each);
  *     must contain at least an `"en-US"` entry
- * @param frozenReleases OS-specific frozen releases to preserve on the track, passed through
- *     unmodified (preserving their versionCodes, status, userFraction, and releaseNotes)
+ * @param frozenVersionCodes frozen OS-specific version codes to merge into the new release entry
+ *     alongside [versionCode] to prevent them being deactivated by the track update
  */
 private fun uploadChangelogToTrack(
   client: PlayConsoleClient,
@@ -219,7 +221,7 @@ private fun uploadChangelogToTrack(
   versionCode: Long,
   rolloutFraction: Int,
   newNotes: Map<String, String>,
-  frozenReleases: List<PlayConsoleClient.TrackRelease> = emptyList()
+  frozenVersionCodes: List<Long> = emptyList()
 ) {
   require(newNotes.containsKey("en-US")) {
     "newNotes must contain an 'en-US' entry. Got keys: ${newNotes.keys}"
@@ -235,7 +237,7 @@ private fun uploadChangelogToTrack(
   println("  Edit session: $editId")
 
   client.setTrackRelease(
-    packageName, editId, track, versionCode, rolloutFraction, newNotes, frozenReleases
+    packageName, editId, track, versionCode, rolloutFraction, newNotes, frozenVersionCodes
   )
   println("  Track release notes updated.")
 

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
@@ -89,7 +89,8 @@ class UpdateRolloutFractionTest {
       listOf(
         PlayConsoleClient.TrackRelease(
           versionCodes = listOf(100L), status = "inProgress", rolloutFraction = 250
-        )
+        ),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
       )
     )
     createSharedChangelog(testVersion, "Notes.")
@@ -123,7 +124,8 @@ class UpdateRolloutFractionTest {
       listOf(
         PlayConsoleClient.TrackRelease(
           versionCodes = listOf(98L, 100L, 99L), status = "inProgress", rolloutFraction = 100
-        )
+        ),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
       )
     )
     createSharedChangelog(testVersion, "Notes.")
@@ -206,7 +208,10 @@ class UpdateRolloutFractionTest {
   fun testUpdateRollout_withSharedChangelogFile_preservesNotesInUpdate() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "inProgress"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "inProgress"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     createSharedChangelog(testVersion, "Shared release notes.")
 
@@ -222,7 +227,10 @@ class UpdateRolloutFractionTest {
   fun testUpdateRollout_withTrackSpecificChangelogFile_usesTrackSpecificNotes() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "inProgress"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "inProgress"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     createSharedChangelog(testVersion, "Shared notes.")
     createTrackChangelog(testVersion, "alpha", "Alpha-specific notes.")
@@ -239,7 +247,10 @@ class UpdateRolloutFractionTest {
   fun testUpdateRollout_withNoChangelogFile_doesNotFailButPassesEmptyNotes() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "inProgress"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "inProgress"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     // No changelog file created.
     File(tempFolder.root, "config/changelogs").mkdirs()
@@ -276,7 +287,10 @@ class UpdateRolloutFractionTest {
   fun testUpdateRollout_createsEditThenSetsReleaseThenCommits() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "inProgress"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "inProgress"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     createSharedChangelog(testVersion, "Notes.")
 
@@ -407,8 +421,8 @@ class UpdateRolloutFractionTest {
 
   @Test
   fun testUpdateRollout_alphaTrack_preservesFrozenKitKatVersionCodeInTrackUpdate() {
-    // vc 16 is permanently frozen on alpha; it must be re-included in every setTrackRelease call
-    // so the Play Console API does not deactivate it when the rollout fraction is updated.
+    // vc 16 is permanently frozen on alpha; it must be merged into the new release entry on every
+    // setTrackRelease call so the Play Console API does not deactivate it when the rollout updates.
     fakeClient.setTrackReleases(
       "alpha",
       listOf(
@@ -425,18 +439,14 @@ class UpdateRolloutFractionTest {
     assertThat(fakeClient.trackUpdates).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].versionCode).isEqualTo(201L)
     assertThat(fakeClient.trackUpdates[0].rolloutFraction).isEqualTo(500)
-    assertThat(fakeClient.trackUpdates[0].preservedReleases).hasSize(1)
-    assertThat(fakeClient.trackUpdates[0].preservedReleases[0].versionCodes).containsExactly(16L)
-    // Verify the frozen release is passed through completely unmodified (status, rolloutFraction,
-    // and releaseNotes must match the values configured in setTrackReleases above).
-    assertThat(fakeClient.trackUpdates[0].preservedReleases[0].status).isEqualTo("completed")
-    assertThat(fakeClient.trackUpdates[0].preservedReleases[0].rolloutFraction).isNull()
-    assertThat(fakeClient.trackUpdates[0].preservedReleases[0].releaseNotes).isEmpty()
+    // The frozen KitKat version code (16) is passed as frozenVersionCodes so it is merged into
+    // the new release entry rather than sent as a separate release.
+    assertThat(fakeClient.trackUpdates[0].frozenVersionCodes).containsExactly(16L)
   }
 
   @Test
   fun testUpdateRollout_betaTrack_doesNotIncludeAnyFrozenVersionCodes() {
-    // Beta has no frozen builds; the rollout update should not include any preserved version codes.
+    // Beta has no frozen builds; the rollout update should not include any frozen version codes.
     fakeClient.setTrackReleases(
       "beta",
       listOf(PlayConsoleClient.TrackRelease(listOf(201L), "inProgress", rolloutFraction = 250))
@@ -453,7 +463,7 @@ class UpdateRolloutFractionTest {
     assertThat(fakeClient.trackUpdates[0].track).isEqualTo("beta")
     assertThat(fakeClient.trackUpdates[0].versionCode).isEqualTo(201L)
     assertThat(fakeClient.trackUpdates[0].rolloutFraction).isEqualTo(500)
-    assertThat(fakeClient.trackUpdates[0].preservedReleases).isEmpty()
+    assertThat(fakeClient.trackUpdates[0].frozenVersionCodes).isEmpty()
   }
 
   // ---------------------------------------------------------------------------

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UploadBinaryToPlayConsoleTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UploadBinaryToPlayConsoleTest.kt
@@ -504,12 +504,12 @@ class UploadBinaryToPlayConsoleTest {
 
   @Test
   fun testRunUpload_alphaTrack_includesFrozenKitKatVersionCodeInTrackUpdateRequest() {
-    // The alpha track has a permanently frozen KitKat build (vc 16) that must be re-included in
-    // every setTrackRelease call. Without it the Play Console API would deactivate vc 16.
+    // The alpha track has a permanently frozen KitKat build (vc 16) that must be merged into
+    // every new release entry. Without it the Play Console API would deactivate vc 16.
     val aab = createAab("oppia-android-0.17-rc01-alpha-e740815230.aab")
     createChangelog("0.17", content = "Release notes.")
     // Configure the frozen release lookup GET response (request 8, index 7) to return vc 16 so
-    // the production code can pass it through unmodified to the setTrackRelease PUT.
+    // the production code can verify it's present before merging it into the new release entry.
     enqueueSuccessfulUpload(
       versionCode = 202L,
       frozenTrackBody =
@@ -523,16 +523,15 @@ class UploadBinaryToPlayConsoleTest {
     val setTrackBody = server.takeRequest().body.readUtf8()
     assertThat(setTrackBody).contains("\"16\"")
     assertThat(setTrackBody).contains("\"202\"")
-    // Exactly 2 releases must appear: the new upload and the frozen KitKat entry, no more.
-    assertThat(setTrackBody.split("\"versionCodes\"").size - 1).isEqualTo(2)
-    // The frozen entry is passed through with "completed" status.
+    // Both version codes are merged into a SINGLE release entry (not two separate ones).
+    assertThat(setTrackBody.split("\"versionCodes\"").size - 1).isEqualTo(1)
     assertThat(setTrackBody).contains("\"completed\"")
   }
 
   @Test
   fun testRunUpload_alphaTrack_includesAllFrozenVersionCodesWhenMultipleFrozenBuildsExist() {
     // Regression: when a second build is added to the frozen map (e.g. a future Lollipop freeze),
-    // both frozen version codes must survive in the setTrackRelease call alongside the new upload.
+    // both frozen version codes must be merged into the new release entry alongside the new upload.
     // Uses FakePlayConsoleClient with an injected two-entry frozen map to avoid HTTP mock overhead.
     val fakeClient = FakePlayConsoleClient()
     fakeClient.setTrackReleases(
@@ -556,9 +555,7 @@ class UploadBinaryToPlayConsoleTest {
     )
 
     val update = fakeClient.trackUpdates.single()
-    assertThat(update.preservedReleases).hasSize(2)
-    val preservedVcs = update.preservedReleases.flatMap { it.versionCodes }
-    assertThat(preservedVcs).containsExactly(16L, 21L)
+    assertThat(update.frozenVersionCodes).containsExactly(16L, 21L)
   }
 
   @Test
@@ -695,7 +692,7 @@ class UploadBinaryToPlayConsoleTest {
     productionBody: String =
       """{"releases":[]}""",
     frozenTrackBody: String? =
-      """{"releases":[]}"""
+      """{"releases":[{"versionCodes":["16"],"status":"completed"}]}"""
   ) {
     enqueuePendingCheck(pendingBody)
     enqueueUpload(versionCode)

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UploadChangelogToPlayConsoleTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UploadChangelogToPlayConsoleTest.kt
@@ -79,7 +79,10 @@ class UploadChangelogToPlayConsoleTest {
   fun testMaybeUploadUpdatedChangelogs_completedAlphaTrack_uploadsCorrectNotes() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     createSharedChangelog(testVersion, testNotes)
 
@@ -145,7 +148,10 @@ class UploadChangelogToPlayConsoleTest {
   fun testMaybeUploadUpdatedChangelogs_liveTrackWithSharedChangelogOnly_usesSharedNotes() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     createSharedChangelog(testVersion, "Shared notes.")
 
@@ -161,7 +167,10 @@ class UploadChangelogToPlayConsoleTest {
   fun testMaybeUploadUpdatedChangelogs_trackSpecificChangelog_usesTrackSpecificNotes() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     createSharedChangelog(testVersion, "Shared notes.")
     createTrackChangelog(testVersion, "alpha", "Alpha-specific notes.")
@@ -211,7 +220,10 @@ class UploadChangelogToPlayConsoleTest {
   fun testMaybeUploadUpdatedChangelogs_changelogWithTrailingWhitespace_uploadsTrimmedNotes() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     createSharedChangelog(testVersion, "  Release notes.  \n")
 
@@ -248,7 +260,10 @@ class UploadChangelogToPlayConsoleTest {
   fun testMaybeUploadUpdatedChangelogs_multipleLiveTracks_uploadsCorrectNotesToAll() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     fakeClient.setTrackReleases(
       "production",
@@ -272,7 +287,10 @@ class UploadChangelogToPlayConsoleTest {
   fun testMaybeUploadUpdatedChangelogs_oneTrackHasNoFile_uploadsOnlyToTrackWithFile() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     fakeClient.setTrackReleases(
       "beta",
@@ -295,7 +313,10 @@ class UploadChangelogToPlayConsoleTest {
   fun testMaybeUploadUpdatedChangelogs_allThreeTracksLive_uploadsCorrectNotesToAll() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     fakeClient.setTrackReleases(
       "beta",
@@ -325,7 +346,10 @@ class UploadChangelogToPlayConsoleTest {
   fun testMaybeUploadUpdatedChangelogs_singleVersionCode_usesItForUpdate() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     createSharedChangelog(testVersion, "Notes.")
 
@@ -341,7 +365,8 @@ class UploadChangelogToPlayConsoleTest {
     fakeClient.setTrackReleases(
       "alpha",
       listOf(
-        PlayConsoleClient.TrackRelease(versionCodes = listOf(98L, 100L, 99L), status = "completed")
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(98L, 100L, 99L), status = "completed"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
       )
     )
     createSharedChangelog(testVersion, "Notes.")
@@ -378,7 +403,10 @@ class UploadChangelogToPlayConsoleTest {
   fun testMaybeUploadUpdatedChangelogs_completedRelease_usesFullRolloutFraction() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     createSharedChangelog(testVersion, "Notes.")
 
@@ -396,7 +424,8 @@ class UploadChangelogToPlayConsoleTest {
       listOf(
         PlayConsoleClient.TrackRelease(
           versionCodes = listOf(100L), status = "inProgress", rolloutFraction = 250
-        )
+        ),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
       )
     )
     createSharedChangelog(testVersion, "Notes.")
@@ -415,7 +444,8 @@ class UploadChangelogToPlayConsoleTest {
       listOf(
         PlayConsoleClient.TrackRelease(
           versionCodes = listOf(100L), status = "inProgress", rolloutFraction = 1000
-        )
+        ),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
       )
     )
     createSharedChangelog(testVersion, "Notes.")
@@ -435,7 +465,10 @@ class UploadChangelogToPlayConsoleTest {
   fun testMaybeUploadUpdatedChangelogs_singleLiveTrack_createsEditBeforeSettingNotes() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     createSharedChangelog(testVersion, "Notes.")
 
@@ -451,7 +484,10 @@ class UploadChangelogToPlayConsoleTest {
   fun testMaybeUploadUpdatedChangelogs_singleLiveTrack_commitsEditAfterSettingNotes() {
     fakeClient.setTrackReleases(
       "alpha",
-      listOf(PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"))
+      listOf(
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"),
+        PlayConsoleClient.TrackRelease(listOf(16L), "completed")
+      )
     )
     createSharedChangelog(testVersion, "Notes.")
 
@@ -553,8 +589,8 @@ class UploadChangelogToPlayConsoleTest {
 
   @Test
   fun testMaybeUploadUpdatedChangelogs_alphaTrack_preservesFrozenKitKatVersionCodeInUpdate() {
-    // vc 16 is permanently frozen on alpha; it must be re-included in every setTrackRelease call
-    // so the Play Console API does not deactivate it during the changelog-only update.
+    // vc 16 is permanently frozen on alpha; it must be merged into the new release entry on every
+    // setTrackRelease call so the Play Console API does not deactivate it during changelog updates.
     fakeClient.setTrackReleases(
       "alpha",
       listOf(
@@ -570,13 +606,13 @@ class UploadChangelogToPlayConsoleTest {
 
     assertThat(fakeClient.trackUpdates).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].versionCode).isEqualTo(201L)
-    assertThat(fakeClient.trackUpdates[0].preservedReleases).hasSize(1)
-    assertThat(fakeClient.trackUpdates[0].preservedReleases[0].versionCodes).containsExactly(16L)
+    // The frozen KitKat version code (16) is merged into the new release entry via frozenVersionCodes.
+    assertThat(fakeClient.trackUpdates[0].frozenVersionCodes).containsExactly(16L)
   }
 
   @Test
   fun testMaybeUploadUpdatedChangelogs_betaTrack_doesNotIncludeAnyFrozenVersionCodes() {
-    // Beta has no frozen builds; the update should not include any preserved version codes.
+    // Beta has no frozen builds; the update should not include any frozen version codes.
     fakeClient.setTrackReleases(
       "beta",
       listOf(PlayConsoleClient.TrackRelease(listOf(201L), "completed"))
@@ -589,7 +625,7 @@ class UploadChangelogToPlayConsoleTest {
 
     assertThat(fakeClient.trackUpdates).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].track).isEqualTo("beta")
-    assertThat(fakeClient.trackUpdates[0].preservedReleases).isEmpty()
+    assertThat(fakeClient.trackUpdates[0].frozenVersionCodes).isEmpty()
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #6330
## Explanation
The previous approach to preserving OS-specific frozen builds (e.g. the permanent KitKat/API-16 alpha build, version code `16`) was to send them as separate release entries alongside the new upload in every `tracks.update` API call. This was rejected by the Play Developer API: when two release entries are present on the same track and one's version code supersedes the other's, the API either rejects the entire update or silently deactivates the frozen build, which is precisely what was observed during deployment.

The correct approach, confirmed with Ben, is to merge all version codes into a single release entry. The new binary's version code and any frozen version codes are placed together in the same `versionCodes` array. The API treats this as one cohesive release and keeps all included version codes active.

What changed:

* `PlayConsoleClient`: `setTrackRelease` now takes `frozenVersionCodes: List` instead of `frozenReleases: List`. The interface KDoc explains the merge-based approach and why two separate release entries are rejected.
* `GooglePlayConsoleClien`: `setTrackRelease` now builds a single `ReleaseEntry` containing `listOf(versionCode) + frozenVersionCodes` before the API call.
* `FrozenReleaseConfig`: `KDoc` updated to reflect the new merge-based strategy.
* `FakePlayConsoleClient`: `TrackUpdate` now records `frozenVersionCodes: List` (replacing the old `preservedReleases: List`) for test-side verification.
* `UploadBinaryToPlayConsole`, `UpdateRolloutFraction`, `UploadChangelogToPlayConsole`: each now performs an invariant check before calling `setTrackRelease`: it verifies that every frozen version code in `FROZEN_VERSION_CODES_PER_TRACK` is actually present on the live track. If any are missing, the script hard-crashes with a clear diagnostic message rather than proceeding silently. This prevents a quiet track-state inconsistency from causing a broken release.
* All associated unit tests updated: VC `16` added to alpha track setups, and `frozenVersionCodes` assertions replace the old `preservedReleases` assertions.


## Disclosure of LLM Usage

Parts of this PR were developed with AI assistance (Gemini). All generated code was manually reviewed, understood, and verified against the test suite before submission. 

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).