### PR TITLE
Fix part of #6106: Adds Release Workflow Manual Fallbacks wiki page

### DIFF
--- a/wiki/In-Depth-Release-Reference.md
+++ b/wiki/In-Depth-Release-Reference.md
@@ -1,10 +1,238 @@
 # In-Depth Release Reference
 
 This page is the manual fallback reference for every automated step in the Oppia Android
-release pipeline (PR series #6106). It covers what to do when an automated workflow fails or
-needs to be run manually outside of its normal trigger. It is linked from the
+release pipeline. It covers what to do when an automated workflow fails or needs to be run
+manually outside of its normal trigger. It is linked from the
 [Release Playbook](Release-Playbook.md).
+
+For the standard step-by-step coordinator guide see the
+[Release Playbook](Release-Playbook.md). For conceptual background see the
+[App and Feature Release Process](app-and-feature-release-process.md).
 
 ---
 
-*Content coming soon.*
+## Table of Contents
+
+1. [generate\_changelog.yml fails](#1-generate_changelogymlfails)
+2. [auto\_release\_alpha.yml fails](#2-auto_release_alphaymlfails)
+3. [pull\_latest\_lesson\_versions.yml fails](#3-pull_latest_lesson_versionsymlfails)
+4. [deploy\_updated\_changelog.yml fails](#4-deploy_updated_changelogymlfails)
+5. [build\_and\_sign.yml fails](#5-build_and_signymlfails)
+6. [deploy\_to\_firebase.yml fails](#6-deploy_to_firebaseymlfails)
+7. [deploy\_to\_play\_console.yml fails](#7-deploy_to_play_consoleymlfails)
+8. [update\_rollout.yml fails](#8-update_rolloutymlfails)
+
+---
+
+## 1. `generate_changelog.yml` fails
+
+**Normal trigger:** Push to `develop` that modifies `version.bzl`, or manual dispatch.
+
+**What it does:** Runs `GenerateChangelogs.kt` (Vertex AI) and opens a changelog PR.
+
+**Manual fallback:**
+
+1. Run the script locally:
+   ```bash
+   bazel run //scripts:generate_changelogs -- \
+     $(pwd) \
+     <version>          # e.g. 0.18
+     <github_token>     # PAT with repo scope
+   ```
+2. The script writes `config/changelogs/<version>.md` (and flavor variants if applicable).
+3. Commit the file and open a PR to `develop` manually.
+4. Review and edit the AI-generated notes before merging.
+
+> **Note:** If Vertex AI is unavailable, write the release notes manually based on `git log`
+> since the previous version tag.
+
+---
+
+## 2. `auto_release_alpha.yml` fails
+
+**Normal trigger:** Weekly cron, Tuesday 03:30 UTC.
+
+**What it does:** Finds the latest passing commit on `develop`, tags it as `latest-alpha`,
+and dispatches `build_and_sign.yml`.
+
+**Case A — No commits exist within the configured limit:**
+
+The workflow exits cleanly (no error). No action needed unless a release is urgent — in that
+case, manually dispatch the workflow or extend the commit search limit via `workflow_dispatch`
+inputs.
+
+**Case B — Commits exist but none have passing CI:**
+
+The workflow exits with an error. The alpha channel is blocked on CI flakiness.
+1. Investigate the failing CI checks on `develop` and fix the root cause.
+2. Once CI is green, either wait for the next Tuesday cron or manually dispatch
+   `auto_release_alpha.yml` via `workflow_dispatch`.
+
+**Case C — Workflow succeeded but `build_and_sign.yml` was not dispatched:**
+
+Manually force-push the `latest-alpha` tag to the desired commit and then trigger
+`build_and_sign.yml`:
+
+```bash
+git tag -f latest-alpha <commit-sha>
+git push -f upstream latest-alpha
+```
+
+Then trigger `build_and_sign.yml` via workflow_dispatch:
+- `flavor`: `alpha`
+- `source_ref`: `latest-alpha`
+
+---
+
+## 3. `pull_latest_lesson_versions.yml` fails
+
+**Normal trigger:** Weekly cron, Monday 02:30 UTC.
+
+**What it does:** Downloads the latest lesson versions from the Oppia production server and
+opens a PR updating `config/lessons/*.textproto`.
+
+**Manual fallback:**
+
+1. Obtain `prod_server.key` from the repository secret (ask the infrastructure team).
+2. Run locally for both flavors:
+   ```bash
+   bazel run //scripts:download_lesson_list -- \
+     https://www.oppia.org \
+     https://storage.googleapis.com \
+     oppiaserver-resources \
+     $(pwd)/prod_server.key \
+     $(pwd)/config/lessons/alpha_pinned_lesson_versions.textproto
+
+   bazel run //scripts:download_lesson_list -- \
+     https://www.oppia.org \
+     https://storage.googleapis.com \
+     oppiaserver-resources \
+     $(pwd)/prod_server.key \
+     $(pwd)/config/lessons/prod_pinned_lesson_versions.textproto
+   ```
+3. Commit both updated textproto files and open a PR to `develop`.
+4. Delete `prod_server.key` from your local machine after use.
+
+---
+
+## 4. `deploy_updated_changelog.yml` fails
+
+**Normal trigger:** Push to `develop` that modifies `config/changelogs/**.md`, or manual
+dispatch.
+
+**What it does:** Uploads updated release notes to Play Console for a live release.
+
+**Manual fallback — trigger via dispatch:**
+
+If the automatic trigger failed, re-run manually:
+
+1. Go to Actions → `deploy_updated_changelog.yml` → **Run workflow**.
+2. Fill in:
+   - `version`: e.g. `0.18`
+   - `flavor`: `alpha`, `beta`, or leave blank for the default changelog
+
+**Manual fallback — run script locally:**
+
+```bash
+bazel run //scripts:upload_changelog_to_play_console -- \
+  $(pwd) \
+  <version>   \
+  <flavor>    \
+  <play_console_credentials_json>
+```
+
+> **Note:** The script will fail if the version is not yet live on Play Console — this is by
+> design to prevent a race with the initial binary upload.
+
+---
+
+## 5. `build_and_sign.yml` fails
+
+**Normal trigger:** Manual dispatch (or dispatched by `auto_release_alpha.yml`).
+
+**What it does:** Builds the release AAB with Bazel and signs it via Cloud KMS.
+
+**Common failure causes and fixes:**
+
+| Symptom | Fix |
+|---|---|
+| Bazel build error | Check the build logs; likely a code issue on the `source_ref` branch |
+| Cloud KMS permission denied | Verify the Workload Identity Federation service account has `roles/cloudkms.signerVerifier` |
+| GCS upload failed | Check the GCS bucket exists and the service account has `roles/storage.objectAdmin` |
+| Approval gate timed out | Re-run the workflow and approve promptly |
+
+There is no local fallback for signing — the private key never leaves Cloud KMS by design.
+If KMS is unavailable, wait for the outage to resolve before retrying.
+
+---
+
+## 6. `deploy_to_firebase.yml` fails
+
+**Normal trigger:** Manual dispatch after `build_and_sign.yml` succeeds.
+
+**What it does:** Distributes the signed AAB to Firebase App Distribution.
+
+**Manual fallback:**
+
+1. Download the signed AAB from the GCS path shown in the `build_and_sign.yml` job summary:
+   ```bash
+   gcloud storage cp gs://oppia-android-<flavor>-releases/.../*.aab .
+   ```
+2. Upload to Firebase App Distribution manually using the Firebase CLI:
+   ```bash
+   firebase appdistribution:distribute oppia-android-*.aab \
+     --app <firebase-app-id> \
+     --groups <tester-group>
+   ```
+   Or upload via the Firebase console at https://console.firebase.google.com.
+
+---
+
+## 7. `deploy_to_play_console.yml` fails
+
+**Normal trigger:** Manual dispatch after QA sign-off.
+
+**What it does:** Uploads the AAB to a Play Console track at a given rollout fraction.
+
+**Common failure causes and fixes:**
+
+| Symptom | Fix |
+|---|---|
+| Version inversion error | Verify you are deploying a newer version than what is live on the target track |
+| Duplicate deploy error | The same commit SHA is already live — no action needed |
+| Changelog missing | Ensure `config/changelogs/<version>.md` exists and is merged to `develop` |
+| Active edit session conflict | Wait ~5 minutes for the previous Play API session to expire, then retry |
+
+**Manual fallback — Play Console web UI:**
+
+If the script cannot recover, upload the AAB directly:
+1. Go to [Play Console](https://play.google.com/console) → Oppia Android → the target track.
+2. Click **Create new release** and upload the AAB from GCS.
+3. Set the rollout percentage manually.
+
+---
+
+## 8. `update_rollout.yml` fails
+
+**Normal trigger:** Manual dispatch to increase staged rollout fraction.
+
+**What it does:** Calls the Play Developer API to update the rollout fraction for a live
+release without re-uploading the binary.
+
+**Manual fallback — Play Console web UI:**
+
+1. Go to [Play Console](https://play.google.com/console) → Oppia Android → the target track.
+2. Click **Manage rollout** on the current release.
+3. Increase the rollout percentage to the desired value.
+
+**Common failure causes:**
+
+| Symptom | Fix |
+|---|---|
+| Active edit session conflict | The `deploy_updated_changelog.yml` concurrency lock may be held — wait and retry |
+| Version not found on track | Verify `version` input matches a release currently live on the track |
+
+---
+
+*See also: [Release Playbook](Release-Playbook.md) ·
+[App and Feature Release Process](app-and-feature-release-process.md)*

--- a/wiki/In-Depth-Release-Reference.md
+++ b/wiki/In-Depth-Release-Reference.md
@@ -1,0 +1,10 @@
+# In-Depth Release Reference
+
+This page is the manual fallback reference for every automated step in the Oppia Android
+release pipeline (PR series #6106). It covers what to do when an automated workflow fails or
+needs to be run manually outside of its normal trigger. It is linked from the
+[Release Playbook](Release-Playbook.md).
+
+---
+
+*Content coming soon.*

--- a/wiki/In-Depth-Release-Reference.md
+++ b/wiki/In-Depth-Release-Reference.md
@@ -24,7 +24,7 @@ For the standard step-by-step coordinator guide see the
 
 ---
 
-## 1. `generate_changelog.yml` fails
+## 1. generate_changelog.yml fails
 
 **Normal trigger:** Push to `develop` that modifies `version.bzl`, or manual dispatch.
 
@@ -48,7 +48,7 @@ For the standard step-by-step coordinator guide see the
 
 ---
 
-## 2. `auto_release_alpha.yml` fails
+## 2. auto_release_alpha.yml fails
 
 **Normal trigger:** Weekly cron, Tuesday 03:30 UTC.
 
@@ -84,7 +84,7 @@ Then trigger `build_and_sign.yml` via workflow_dispatch:
 
 ---
 
-## 3. `pull_latest_lesson_versions.yml` fails
+## 3. pull_latest_lesson_versions.yml fails
 
 **Normal trigger:** Weekly cron, Monday 02:30 UTC.
 
@@ -101,21 +101,23 @@ opens a PR updating `config/lessons/*.textproto`.
      https://storage.googleapis.com \
      oppiaserver-resources \
      $(pwd)/prod_server.key \
-     $(pwd)/config/lessons/alpha_pinned_lesson_versions.textproto
+     $(pwd)/config/lessons/alpha_pinned_lesson_versions.textproto \
+     $(pwd)/scripts/assets/alpha_download_config.textproto
 
    bazel run //scripts:download_lesson_list -- \
      https://www.oppia.org \
      https://storage.googleapis.com \
      oppiaserver-resources \
      $(pwd)/prod_server.key \
-     $(pwd)/config/lessons/prod_pinned_lesson_versions.textproto
+     $(pwd)/config/lessons/prod_pinned_lesson_versions.textproto \
+     $(pwd)/scripts/assets/prod_download_config.textproto
    ```
 3. Commit both updated textproto files and open a PR to `develop`.
 4. Delete `prod_server.key` from your local machine after use.
 
 ---
 
-## 4. `deploy_updated_changelog.yml` fails
+## 4. deploy_updated_changelog.yml fails
 
 **Normal trigger:** Push to `develop` that modifies `config/changelogs/**.md`, or manual
 dispatch.
@@ -146,7 +148,7 @@ bazel run //scripts:upload_changelog_to_play_console -- \
 
 ---
 
-## 5. `build_and_sign.yml` fails
+## 5. build_and_sign.yml fails
 
 **Normal trigger:** Manual dispatch (or dispatched by `auto_release_alpha.yml`).
 
@@ -166,7 +168,7 @@ If KMS is unavailable, wait for the outage to resolve before retrying.
 
 ---
 
-## 6. `deploy_to_firebase.yml` fails
+## 6. deploy_to_firebase.yml fails
 
 **Normal trigger:** Manual dispatch after `build_and_sign.yml` succeeds.
 
@@ -188,7 +190,7 @@ If KMS is unavailable, wait for the outage to resolve before retrying.
 
 ---
 
-## 7. `deploy_to_play_console.yml` fails
+## 7. deploy_to_play_console.yml fails
 
 **Normal trigger:** Manual dispatch after QA sign-off.
 
@@ -212,7 +214,7 @@ If the script cannot recover, upload the AAB directly:
 
 ---
 
-## 8. `update_rollout.yml` fails
+## 8. update_rollout.yml fails
 
 **Normal trigger:** Manual dispatch to increase staged rollout fraction.
 
@@ -233,6 +235,3 @@ release without re-uploading the binary.
 | Version not found on track | Verify `version` input matches a release currently live on the track |
 
 ---
-
-*See also: [Release Playbook](Release-Playbook.md) ·
-[App and Feature Release Process](app-and-feature-release-process.md)*

--- a/wiki/In-Depth-Release-Reference.md
+++ b/wiki/In-Depth-Release-Reference.md
@@ -24,7 +24,7 @@ For the standard step-by-step coordinator guide see the
 
 ## 1. Generate Changelog fails
 
-**Normal trigger:** Push to `develop` that modifies `version.bzl`, or manual dispatch.
+**Normal trigger:** A push to `develop` that modifies `version.bzl`, or manual dispatch.
 
 **What it does:** Runs `GenerateChangelogs.kt` (Vertex AI) and opens a changelog PR.
 

--- a/wiki/In-Depth-Release-Reference.md
+++ b/wiki/In-Depth-Release-Reference.md
@@ -1,7 +1,6 @@
-# In-Depth Release Reference
+# Release Workflow Manual Fallbacks
 
-This page is the manual fallback reference for every automated step in the Oppia Android
-release pipeline. It covers what to do when an automated workflow fails or needs to be run
+This page covers what to do when an automated release workflow fails or needs to be run
 manually outside of its normal trigger.
 
 For the standard step-by-step coordinator guide see the
@@ -36,7 +35,7 @@ For the standard step-by-step coordinator guide see the
    bazel run //scripts:generate_changelogs -- \
      $(pwd) \
      <version>          # e.g. 0.18
-     <github_token>     # PAT with repo scope
+     <github_token>     # PAT with repo scope — see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
    ```
 2. The script writes `config/changelogs/<version>.md` (and flavor variants if applicable).
 3. Commit the file and open a PR to `develop` manually.
@@ -137,7 +136,6 @@ have access to the secret and can run the steps below or re-run the workflow dir
      $(pwd)/scripts/assets/prod_download_config.textproto
    ```
 3. Commit both updated textproto files and open a PR to `develop`.
-4. Delete `prod_server.key` from your local machine after use.
 
 ---
 
@@ -244,14 +242,21 @@ If the script cannot recover, upload the AAB directly:
 2. Click **Create new release** and upload the AAB from GCS.
 3. Set the rollout percentage manually.
 
-**To halt a rollout (freeze the current release):**
+**To preserve a previous release alongside a new one (keep two versions alive):**
+
+When a new release is deployed, Play Console may stop serving the previous binary to existing
+device configurations (e.g. keeping 16-kitkat alive alongside release 17). To retain both:
 
 1. Go to [Play Console](https://play.google.com/console) → Oppia Android → the target track.
-2. Find the active release and click **Manage rollout**.
-3. Click **Halt rollout** to stop further distribution at the current percentage.
+2. Click **Create new release** and upload the new AAB.
+3. Under **APKs and AABs**, click **Add from library** and select the old version code you
+   want to continue serving to existing users.
+4. Both version codes will now be listed in the same release entry — the new one as the
+   primary, the old one as retained. Publish the release.
 
-> **Note:** Halting a rollout does not remove the release from devices already updated; it
-> only prevents new devices from receiving it. Resume rollout from the same screen when ready.
+> **Note:** The automated `deploy_to_play_console.yml` script handles this automatically via
+> the frozen version codes configuration. Manual steps above are only needed if the script
+> cannot run or the old version code was accidentally dropped from the track.
 
 ---
 

--- a/wiki/In-Depth-Release-Reference.md
+++ b/wiki/In-Depth-Release-Reference.md
@@ -2,8 +2,7 @@
 
 This page is the manual fallback reference for every automated step in the Oppia Android
 release pipeline. It covers what to do when an automated workflow fails or needs to be run
-manually outside of its normal trigger. It is linked from the
-[Release Playbook](Release-Playbook.md).
+manually outside of its normal trigger.
 
 For the standard step-by-step coordinator guide see the
 [Release Playbook](Release-Playbook.md). For conceptual background see the
@@ -13,18 +12,18 @@ For the standard step-by-step coordinator guide see the
 
 ## Table of Contents
 
-1. [generate\_changelog.yml fails](#1-generate_changelogymlfails)
-2. [auto\_release\_alpha.yml fails](#2-auto_release_alphaymlfails)
-3. [pull\_latest\_lesson\_versions.yml fails](#3-pull_latest_lesson_versionsymlfails)
-4. [deploy\_updated\_changelog.yml fails](#4-deploy_updated_changelogymlfails)
-5. [build\_and\_sign.yml fails](#5-build_and_signymlfails)
-6. [deploy\_to\_firebase.yml fails](#6-deploy_to_firebaseymlfails)
-7. [deploy\_to\_play\_console.yml fails](#7-deploy_to_play_consoleymlfails)
-8. [update\_rollout.yml fails](#8-update_rolloutymlfails)
+1. [Generate Changelog fails](#1-generate-changelog-fails)
+2. [Auto Release Alpha fails](#2-auto-release-alpha-fails)
+3. [Pull Latest Lesson Versions fails](#3-pull-latest-lesson-versions-fails)
+4. [Deploy Updated Changelog fails](#4-deploy-updated-changelog-fails)
+5. [Build and Sign Release fails](#5-build-and-sign-release-fails)
+6. [Deploy to Firebase fails](#6-deploy-to-firebase-fails)
+7. [Deploy to Play Console fails](#7-deploy-to-play-console-fails)
+8. [Update Rollout fails](#8-update-rollout-fails)
 
 ---
 
-## 1. generate_changelog.yml fails
+## 1. Generate Changelog fails
 
 **Normal trigger:** Push to `develop` that modifies `version.bzl`, or manual dispatch.
 
@@ -48,52 +47,76 @@ For the standard step-by-step coordinator guide see the
 
 ---
 
-## 2. auto_release_alpha.yml fails
+## 2. Auto Release Alpha fails
 
 **Normal trigger:** Weekly cron, Tuesday 03:30 UTC.
 
 **What it does:** Finds the latest passing commit on `develop`, tags it as `latest-alpha`,
-and dispatches `build_and_sign.yml`.
+and dispatches Build and Sign Release.
 
-**Case A — No commits exist within the configured limit:**
+**Case A — No new commits since the latest-alpha tag:**
 
-The workflow exits cleanly (no error). No action needed unless a release is urgent — in that
-case, manually dispatch the workflow or extend the commit search limit via `workflow_dispatch`
-inputs.
+The workflow exits cleanly (no error). No action is needed. If a release is urgent, manually
+trigger the workflow:
+1. Go to **Actions** → **Auto Release Alpha** → **Run workflow**.
+2. Click **Run workflow** (no inputs required).
+
+The script will re-evaluate recent commits against the current `latest-alpha` tag and
+dispatch Build and Sign Release if a newer passing commit is found.
 
 **Case B — Commits exist but none have passing CI:**
 
 The workflow exits with an error. The alpha channel is blocked on CI flakiness.
 1. Investigate the failing CI checks on `develop` and fix the root cause.
-2. Once CI is green, either wait for the next Tuesday cron or manually dispatch
-   `auto_release_alpha.yml` via `workflow_dispatch`.
+2. Once CI is green, either wait for the next Tuesday cron or manually trigger via
+   **Actions** → **Auto Release Alpha** → **Run workflow**.
 
-**Case C — Workflow succeeded but `build_and_sign.yml` was not dispatched:**
+**Case C — Workflow succeeded but Build and Sign Release was not dispatched:**
 
-Manually force-push the `latest-alpha` tag to the desired commit and then trigger
-`build_and_sign.yml`:
+This can happen when `FindAlphaCandidate` finds no commits newer than the existing
+`latest-alpha` tag — i.e., the tag already points to the newest passing commit on `develop`
+so the dispatch step is intentionally skipped. It can also occur if the `gh workflow run`
+API call to dispatch Build and Sign Release fails transiently after the tag was already
+updated.
 
-```bash
-git tag -f latest-alpha <commit-sha>
-git push -f upstream latest-alpha
-```
+To manually trigger a build for a specific commit:
 
-Then trigger `build_and_sign.yml` via workflow_dispatch:
-- `flavor`: `alpha`
-- `source_ref`: `latest-alpha`
+1. Force-push the `latest-alpha` tag to the desired commit:
+   ```bash
+   git tag -f latest-alpha <commit-sha>
+   git push -f upstream latest-alpha
+   ```
+2. Trigger Build and Sign Release via **Actions** → **Build and Sign Release** →
+   **Run workflow**:
+   - **flavor**: `alpha`
+   - **source_ref**: `latest-alpha`
 
 ---
 
-## 3. pull_latest_lesson_versions.yml fails
+## 3. Pull Latest Lesson Versions fails
 
-**Normal trigger:** Weekly cron, Monday 02:30 UTC.
+**Normal trigger:** Weekly cron, Monday 02:00 UTC.
 
 **What it does:** Downloads the latest lesson versions from the Oppia production server and
 opens a PR updating `config/lessons/*.textproto`.
 
-**Manual fallback:**
+**Manual fallback — re-dispatch:**
 
-1. Obtain `prod_server.key` from the repository secret (ask the infrastructure team).
+If the failure was transient (network error, API rate limit), re-trigger the workflow:
+1. Go to **Actions** → **Pull Latest Lesson Versions** → **Run workflow**.
+2. Click **Run workflow**.
+
+Re-dispatch is sufficient for most transient failures. Use the local fallback below only if
+the GitHub Actions environment itself is unavailable or the stored secret is suspected to be
+incorrect.
+
+**Manual fallback — run locally:**
+
+The workflow uses a production API secret (`PROD_SERVER_LESSON_SECRET`) that is not
+distributed for security reasons. **Contact a tech lead** to perform this recovery — they
+have access to the secret and can run the steps below or re-run the workflow directly.
+
+1. Obtain `prod_server.key` from the secure secret store (tech lead only).
 2. Run locally for both flavors:
    ```bash
    bazel run //scripts:download_lesson_list -- \
@@ -117,7 +140,7 @@ opens a PR updating `config/lessons/*.textproto`.
 
 ---
 
-## 4. deploy_updated_changelog.yml fails
+## 4. Deploy Updated Changelog fails
 
 **Normal trigger:** Push to `develop` that modifies `config/changelogs/**.md`, or manual
 dispatch.
@@ -128,7 +151,7 @@ dispatch.
 
 If the automatic trigger failed, re-run manually:
 
-1. Go to Actions → `deploy_updated_changelog.yml` → **Run workflow**.
+1. Go to **Actions** → **Deploy Updated Changelog** → **Run workflow**.
 2. Fill in:
    - `version`: e.g. `0.18`
    - `flavor`: `alpha`, `beta`, or leave blank for the default changelog
@@ -143,14 +166,22 @@ bazel run //scripts:upload_changelog_to_play_console -- \
   <play_console_credentials_json>
 ```
 
+**Manual fallback — edit directly in Play Console:**
+
+Release notes can also be updated directly in the Play Console web UI:
+1. Go to [Play Console](https://play.google.com/console) → Oppia Android → the target track.
+2. Click **Manage release** on the live release → **Edit release**.
+3. Update the **Release notes** field and click **Save**.
+4. Submit the release for review or publish directly as appropriate.
+
 > **Note:** The script will fail if the version is not yet live on Play Console — this is by
 > design to prevent a race with the initial binary upload.
 
 ---
 
-## 5. build_and_sign.yml fails
+## 5. Build and Sign Release fails
 
-**Normal trigger:** Manual dispatch (or dispatched by `auto_release_alpha.yml`).
+**Normal trigger:** Manual dispatch (or dispatched by Auto Release Alpha).
 
 **What it does:** Builds the release AAB with Bazel and signs it via Cloud KMS.
 
@@ -168,15 +199,15 @@ If KMS is unavailable, wait for the outage to resolve before retrying.
 
 ---
 
-## 6. deploy_to_firebase.yml fails
+## 6. Deploy to Firebase fails
 
-**Normal trigger:** Manual dispatch after `build_and_sign.yml` succeeds.
+**Normal trigger:** Manual dispatch after Build and Sign Release succeeds.
 
 **What it does:** Distributes the signed AAB to Firebase App Distribution.
 
 **Manual fallback:**
 
-1. Download the signed AAB from the GCS path shown in the `build_and_sign.yml` job summary:
+1. Download the signed AAB from the GCS path shown in the Build and Sign Release job summary:
    ```bash
    gcloud storage cp gs://oppia-android-<flavor>-releases/.../*.aab .
    ```
@@ -190,7 +221,7 @@ If KMS is unavailable, wait for the outage to resolve before retrying.
 
 ---
 
-## 7. deploy_to_play_console.yml fails
+## 7. Deploy to Play Console fails
 
 **Normal trigger:** Manual dispatch after QA sign-off.
 
@@ -212,9 +243,18 @@ If the script cannot recover, upload the AAB directly:
 2. Click **Create new release** and upload the AAB from GCS.
 3. Set the rollout percentage manually.
 
+**To halt a rollout (freeze the current release):**
+
+1. Go to [Play Console](https://play.google.com/console) → Oppia Android → the target track.
+2. Find the active release and click **Manage rollout**.
+3. Click **Halt rollout** to stop further distribution at the current percentage.
+
+> **Note:** Halting a rollout does not remove the release from devices already updated; it
+> only prevents new devices from receiving it. Resume rollout from the same screen when ready.
+
 ---
 
-## 8. update_rollout.yml fails
+## 8. Update Rollout fails
 
 **Normal trigger:** Manual dispatch to increase staged rollout fraction.
 
@@ -231,7 +271,7 @@ release without re-uploading the binary.
 
 | Symptom | Fix |
 |---|---|
-| Active edit session conflict | The `deploy_updated_changelog.yml` concurrency lock may be held — wait and retry |
+| Active edit session conflict | The Deploy Updated Changelog concurrency lock may be held — wait and retry |
 | Version not found on track | Verify `version` input matches a release currently live on the track |
 
 ---

--- a/wiki/In-Depth-Release-Reference.md
+++ b/wiki/In-Depth-Release-Reference.md
@@ -42,8 +42,9 @@ For the standard step-by-step coordinator guide see the
 3. Commit the file and open a PR to `develop` manually.
 4. Review and edit the AI-generated notes before merging.
 
-> **Note:** If Vertex AI is unavailable, write the release notes manually based on `git log`
-> since the previous version tag.
+> **Note:** If Vertex AI is unavailable, the workflow still opens the changelog PR — it falls
+> back to a raw commit list and inserts an `<!-- LLM generation failed -->` marker. Review the
+> auto-created PR, fill in the user-facing summary manually, and merge it as normal.
 
 ---
 


### PR DESCRIPTION
Fixes part of #6106
## Explanation

The Oppia Android release pipeline has been progressively automated, but the tooling for manual fallback — what a coordinator should do when a workflow fails mid-run — has lived nowhere accessible. This PR adds the In-Depth Release Reference wiki page, which is the manual fallback guide for every automated workflow in the release pipeline.

The page covers all 8 workflows in order: generate_changelog.yml, auto_release_alpha.yml, pull_latest_lesson_versions.yml, deploy_updated_changelog.yml, build_and_sign.yml, deploy_to_firebase.yml, deploy_to_play_console.yml, and update_rollout.yml. For each, it documents the normal trigger and purpose, then gives copy-pasteable bazel run commands a coordinator can run locally to replicate what the workflow does. Where a workflow has multiple failure modes (e.g. auto_release_alpha.yml can fail with "no commits", "no passing CI", or a dispatch failure), each case is addressed separately.

The page is cross-linked from the Release Playbook so that every automated step in the playbook has a direct path to its manual equivalent.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage

AI was used for code completion, drafting wiki content, and research.