### PR TITLE
Fix #6149, Fix part of #6202: Use official setup-bazel workflow

### DIFF
--- a/.github/workflows/deploy_to_play_console.yml
+++ b/.github/workflows/deploy_to_play_console.yml
@@ -91,9 +91,9 @@ jobs:
           echo "ACCESS_TOKEN=$ACCESS_TOKEN" >> "$GITHUB_ENV"
 
       - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       - name: Set up build environment
         uses: ./.github/actions/set-up-android-bazel-build-environment
@@ -125,4 +125,3 @@ jobs:
             "${{ github.event.inputs.track }}" \
             "$ACCESS_TOKEN" \
             "${{ github.event.inputs.rollout_fraction }}"
-

--- a/.github/workflows/deploy_updated_changelog.yml
+++ b/.github/workflows/deploy_updated_changelog.yml
@@ -155,9 +155,9 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       - name: Set up build environment
         uses: ./.github/actions/set-up-android-bazel-build-environment

--- a/.github/workflows/update_rollout.yml
+++ b/.github/workflows/update_rollout.yml
@@ -69,9 +69,9 @@ jobs:
         id: validate
 
       - name: Set up Bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          version: 6.5.0
+          bazelisk-cache: true
 
       - name: Set up build environment
         uses: ./.github/actions/set-up-android-bazel-build-environment


### PR DESCRIPTION
## Explanation
Fixes #6149
Fixes part of #6202
 - Replace all workflows using unmaintained `abhinavsingh/setup-bazel` with bazel's own `bazel-contrib/setup-bazel`.
 - Enable `bazelisk-cache: true` to enable caching and preventing bazel being downloaded repeatedly.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).