### PR TITLE
Fix part of #6106: Adds Feature Development Guide

### DIFF
--- a/wiki/Feature-Development-Guide.md
+++ b/wiki/Feature-Development-Guide.md
@@ -5,17 +5,19 @@ feature flag, understand how it moves through the release pipeline, and request 
 in production.
 
 **For the technical mechanics of creating a flag** (constants, Dagger wiring, analytics logging),
-see the [Platform Parameters & Feature Flags](Platform-Parameters-&-Feature-Flags) wiki.
-
-## Table of Contents
-
-- [Gating a Feature Behind a Flag](#gating-a-feature-behind-a-flag)
-- [Navigating the Release Process](#navigating-the-release-process)
-- [Requesting Production Enablement](#requesting-production-enablement)
+see the [Platform Parameters & Feature Flags](Platform-Parameters-&-Feature-Flags.md) wiki.
 
 ---
 
-## Gating a Feature Behind a Flag
+## Table of Contents
+
+1. [Gating a Feature Behind a Flag](#1-gating-a-feature-behind-a-flag)
+2. [Navigating the Release Process](#2-navigating-the-release-process)
+3. [Requesting Production Enablement](#3-requesting-production-enablement)
+
+---
+
+## 1. Gating a Feature Behind a Flag
 
 Feature flags allow large features to land on `develop` incrementally and be enabled only when
 they are fully ready, without blocking other releases. Every integration point of a multi-sprint
@@ -30,7 +32,7 @@ Use a feature flag when your change:
 
 ### Gating code behind a flag
 
-After [creating the flag constant and Dagger binding](Platform-Parameters-&-Feature-Flags#how-to-create-a-feature-flag),
+After [creating the flag constant and Dagger binding](Platform-Parameters-&-Feature-Flags.md#how-to-create-a-feature-flag),
 inject the flag into any class that has a guarded entry point and check it before executing
 feature-specific logic:
 
@@ -58,7 +60,7 @@ class SomeController @Inject constructor(
 ### Writing tests
 
 Test both states of the flag. See
-[How to write tests related to Platform Parameters](Platform-Parameters-&-Feature-Flags#how-to-write-tests-related-to-platform-parameters)
+[How to write tests related to Platform Parameters](Platform-Parameters-&-Feature-Flags.md#how-to-write-tests-related-to-platform-parameters)
 for the full test setup patterns. At minimum:
 
 ```kotlin
@@ -79,7 +81,7 @@ fun testFeature_flagEnabled_works() {
 
 ---
 
-## Navigating the Release Process
+## 2. Navigating the Release Process
 
 Once your flagged feature lands on `develop`, it moves through a defined lifecycle before it
 reaches production. The lifecycle is:
@@ -134,11 +136,11 @@ the Oppia backend at runtime. This means:
 - A flag can be rolled back instantly if an issue is discovered, without requiring a hotfix release.
 
 For the binary release timeline (branch cut dates, alpha/beta/GA dates), refer to the
-[Release Playbook](Release-Playbook).
+[Release Playbook](Release-Playbook.md).
 
 ---
 
-## Requesting Production Enablement
+## 3. Requesting Production Enablement
 
 Once your feature has passed QA in beta and received team lead sign-off, you need to request
 that the release coordinator enable your flag in the production environment.
@@ -175,7 +177,7 @@ Production enablement happens as part of the monthly release cycle. If your requ
 **before the GA rollout step**, the coordinator will enable your flag during that cycle's GA
 rollout. If it arrives after, it targets the next release.
 
-Check the [Release Playbook](Release-Playbook) for the current cycle's GA date.
+Check the [Release Playbook](Release-Playbook.md) for the current cycle's GA date.
 
 ### After production enablement
 

--- a/wiki/Feature-Development-Guide.md
+++ b/wiki/Feature-Development-Guide.md
@@ -1,8 +1,11 @@
 # Feature Development Guide
 
-This guide is for **Android developers** who need to gate a feature behind a feature flag, understand how that flag progresses through the release pipeline, and request that it be enabled in production.
+This guide is for **Android developers** who need to ship a feature safely: gate it behind a
+feature flag, understand how it moves through the release pipeline, and request that it be enabled
+in production.
 
-For a full explanation of the Platform Parameter system and the Dagger wiring required to create flags, see the [Platform Parameters & Feature Flags](Platform-Parameters-&-Feature-Flags) wiki.
+**For the technical mechanics of creating a flag** (constants, Dagger wiring, analytics logging),
+see the [Platform Parameters & Feature Flags](Platform-Parameters-&-Feature-Flags) wiki.
 
 ## Table of Contents
 
@@ -14,25 +17,170 @@ For a full explanation of the Platform Parameter system and the Dagger wiring re
 
 ## Gating a Feature Behind a Flag
 
-> TODO: Explain the step-by-step process for gating new feature code behind a feature flag:
-> creating the constant in `FeatureFlagConstants.kt`, providing it in `PlatformParameterModule`,
-> injecting and checking it in the feature code, and writing tests with the flag both enabled
-> and disabled.
+Feature flags allow large features to land on `develop` incrementally and be enabled only when
+they are fully ready, without blocking other releases. Every integration point of a multi-sprint
+feature — UI entry points, background jobs, migrations — must be gated behind the flag.
+
+### When you need a flag
+
+Use a feature flag when your change:
+- Spans more than one release cycle.
+- Touches data migrations or irreversible schema changes.
+- Could partially break the app if released before all integration points are complete.
+
+### Gating code behind a flag
+
+After [creating the flag constant and Dagger binding](Platform-Parameters-&-Feature-Flags#how-to-create-a-feature-flag),
+inject the flag into any class that has a guarded entry point and check it before executing
+feature-specific logic:
+
+```kotlin
+class SomeController @Inject constructor(
+  @EnableMyNewFeature private val enableMyNewFeature: PlatformParameterValue<Boolean>
+) {
+  fun doSomething() {
+    if (!enableMyNewFeature.value) return   // <-- guard every entry point
+
+    // feature code here
+  }
+}
+```
+
+### Rules for gating
+
+| Rule | Why |
+|---|---|
+| Default value is **`false`** | The feature must be invisible until explicitly enabled. |
+| **Every** entry point is gated | A partially visible feature can corrupt data or confuse users. |
+| No flag checks inside feature-internal code | Gate at the boundary; internals assume the flag is already `true`. |
+| Flag check is the **first** thing in the guarded function | Keeps the guard obvious and avoids partial side effects. |
+
+### Writing tests
+
+Test both states of the flag. See
+[How to write tests related to Platform Parameters](Platform-Parameters-&-Feature-Flags#how-to-write-tests-related-to-platform-parameters)
+for the full test setup patterns. At minimum:
+
+```kotlin
+@Test
+fun testFeature_flagDisabled_doesNothing() {
+  // Set up with flag = false (default)
+  setUpWithFlag(enabled = false)
+  // Assert feature is not visible / not executed
+}
+
+@Test
+fun testFeature_flagEnabled_works() {
+  // Set up with flag = true
+  setUpWithFlag(enabled = true)
+  // Assert feature behaves correctly
+}
+```
 
 ---
 
 ## Navigating the Release Process
 
-> TODO: Explain the lifecycle of a feature flag across releases — how it starts `false` in alpha,
-> what the developer needs to verify during beta testing, and when it is safe to request
-> production enablement. Include a table showing the flag state at each release stage
-> (alpha / beta / GA) and reference the Release Playbook for the release timeline.
+Once your flagged feature lands on `develop`, it moves through a defined lifecycle before it
+reaches production. The lifecycle is:
+
+```
+develop (flag off) → alpha testing → product review → QA → team lead sign-off
+  → production enablement → cleanup
+```
+
+### Flag state across release stages
+
+| Stage | Where the flag lives | Flag state | Who controls it |
+|---|---|---|---|
+| **Development** | `develop` branch | `false` (default) | Developer |
+| **Alpha** | `release-X.Y` → alpha build | `true` (enabled via gating console for alpha) | Release coordinator |
+| **Beta** | `release-X.Y` → beta build | `true` (if alpha testing passed) | Release coordinator |
+| **Production (GA)** | GA rollout | `true` (after QA + sign-off) | CLaM lead / coordinator |
+| **Cleanup** | Next release cycle | Flag removed entirely | Developer |
+
+### What you need to do at each stage
+
+**Before alpha cut:**
+- Ensure all feature code is behind the flag and merged to `develop`.
+- Confirm the flag's default value is `false`.
+- Verify your tracking issue is linked in the PR description.
+
+**During alpha:**
+- The coordinator enables your flag in the alpha environment via the [Feature Gating Console](https://github.com/oppia/oppia/wiki/Launching-new-features#what-is-the-feature-gating-platform).
+- Participate in alpha testing — verify the feature works end-to-end in a real build.
+- Report any regressions on the tracking issue immediately.
+
+**During beta:**
+- If alpha testing passes and product review approves, the coordinator enables the flag in beta.
+- QA testers verify the feature in the beta build.
+
+**Production:**
+- After QA sign-off and team lead approval, the coordinator enables the flag in production.
+- See [Requesting Production Enablement](#requesting-production-enablement) below.
+
+**Cleanup (after production enablement):**
+- Once the flag is fully enabled in production and stable for at least one release cycle, remove
+  the flag constant, Dagger binding, gating check, and all flag-specific test branches.
+- Removal PR should reference the original tracking issue.
+
+### How feature releases fit into the binary release timeline
+
+Feature flags are enabled in the **Feature Gating Console** independently of binary releases.
+Enabling or disabling a flag does not require a new binary — the app fetches the flag state from
+the Oppia backend at runtime. This means:
+
+- A flag can be enabled for alpha users the moment the alpha binary is live.
+- A flag can be rolled back instantly if an issue is discovered, without requiring a hotfix release.
+
+For the binary release timeline (branch cut dates, alpha/beta/GA dates), refer to the
+[Release Playbook](Release-Playbook).
 
 ---
 
 ## Requesting Production Enablement
 
-> TODO: Explain how a developer requests that their feature flag be flipped to `true` in the
-> Feature Gating Console for production. Include: who to contact (CLaM lead / release
-> coordinator), what information to provide (flag name, issue number, verified beta status),
-> and what the expected timeline is relative to the monthly release cycle.
+Once your feature has passed QA in beta and received team lead sign-off, you need to request
+that the release coordinator enable your flag in the production environment.
+
+### When to request
+
+Only request production enablement when **all** of the following are true:
+
+- [ ] The feature has been live in the beta build for at least one release cycle with no regressions.
+- [ ] Product review has approved the feature for production.
+- [ ] QA has signed off on the beta build.
+- [ ] Team lead has approved.
+
+### How to request
+
+Post a comment on your feature's tracking issue with the following information:
+
+```
+**Production enablement request**
+
+- Flag name: `android_enable_<your_flag>` (as defined in FeatureFlagConstants.kt)
+- Tracking issue: #XXXX
+- Beta verification: [link to QA sign-off comment or test report]
+- Product approval: [link to product review approval]
+- Team lead sign-off: [link to sign-off comment]
+- Target release: X.Y (or "next available")
+```
+
+Then assign or ping the **CLaM lead** and the **release coordinator** for the current cycle.
+
+### Timeline
+
+Production enablement happens as part of the monthly release cycle. If your request arrives
+**before the GA rollout step**, the coordinator will enable your flag during that cycle's GA
+rollout. If it arrives after, it targets the next release.
+
+Check the [Release Playbook](Release-Playbook) for the current cycle's GA date.
+
+### After production enablement
+
+Once the coordinator confirms the flag is enabled in production:
+
+1. Monitor crash rates and error logs for at least one week.
+2. If stable, file a cleanup PR to remove the flag entirely (see [Cleanup](#what-you-need-to-do-at-each-stage)).
+3. Close the tracking issue once cleanup is merged.

--- a/wiki/Feature-Development-Guide.md
+++ b/wiki/Feature-Development-Guide.md
@@ -87,8 +87,9 @@ Once your flagged feature lands on `develop`, it moves through a defined lifecyc
 reaches production. The lifecycle is:
 
 ```
-develop (flag off) → alpha testing → product review → QA → team lead sign-off
-  → production enablement → cleanup
+develop (flag off) → alpha build (flag on via alpha textproto, if requested)
+  → product review → beta build (flag on via beta textproto)
+  → tech lead sign-off → production (flag on via GA textproto) → cleanup
 ```
 
 ### Flag state across release stages
@@ -96,9 +97,9 @@ develop (flag off) → alpha testing → product review → QA → team lead sig
 | Stage | Where the flag lives | Flag state | Who controls it |
 |---|---|---|---|
 | **Development** | `develop` branch | `false` (default) | Developer |
-| **Alpha** | `release-X.Y` → alpha build | `true` (enabled via gating console for alpha) | Release coordinator |
-| **Beta** | `release-X.Y` → beta build | `true` (if alpha testing passed) | Release coordinator |
-| **Production (GA)** | GA rollout | `true` (after QA + sign-off) | CLaM lead / coordinator |
+| **Alpha** | `release-X.Y` → alpha build | `true` (enabled via [`alpha/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/alpha/feature_flags_overrides.textproto)) | Release coordinator |
+| **Beta** | `release-X.Y` → beta build | `true` (enabled via [`beta/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/beta/feature_flags_overrides.textproto), if alpha passed) | Release coordinator |
+| **Production (GA)** | GA rollout | `true` (after QA + product sign-off) | Tech lead / release coordinator |
 | **Cleanup** | Next release cycle | Flag removed entirely | Developer |
 
 ### What you need to do at each stage
@@ -106,15 +107,18 @@ develop (flag off) → alpha testing → product review → QA → team lead sig
 **Before alpha cut:**
 - Ensure all feature code is behind the flag and merged to `develop`.
 - Confirm the flag's default value is `false`.
-- Verify your tracking issue is linked in the PR description.
+- Verify your tracking issue is up to date and linked from all feature PRs that have merged.
+- Add the feature's CUJs to the Android team's CUJ sheet.
 
 **During alpha:**
-- The coordinator enables your flag in the alpha environment via the [Feature Gating Console](https://github.com/oppia/oppia/wiki/Launching-new-features#what-is-the-feature-gating-platform).
+- The coordinator enables your flag for the alpha build by setting it to `true` in
+  [`alpha/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/alpha/feature_flags_overrides.textproto).
 - Participate in alpha testing — verify the feature works end-to-end in a real build.
-- Report any regressions on the tracking issue immediately.
+- File any regressions as separate issues, linked to the original tracking issue as child/sub-issues.
 
 **During beta:**
-- If alpha testing passes and product review approves, the coordinator enables the flag in beta.
+- If alpha testing passes and product review approves, the coordinator enables the flag in beta
+  by setting it to `true` in [`beta/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/beta/feature_flags_overrides.textproto).
 - QA testers verify the feature in the beta build.
 
 **Production:**
@@ -124,19 +128,20 @@ develop (flag off) → alpha testing → product review → QA → team lead sig
 **Cleanup (after production enablement):**
 - Once the flag is fully enabled in production and stable for at least one release cycle, remove
   the flag constant, Dagger binding, gating check, and all flag-specific test branches.
-- Removal PR should reference the original tracking issue.
+- Removal PR should reference and close the original tracking issue.
 
-### How feature releases fit into the binary release timeline
+### How feature flag enablement relates to binary releases
 
-Feature flags are enabled in the **Feature Gating Console** independently of binary releases.
-Enabling or disabling a flag does not require a new binary — the app fetches the flag state from
-the Oppia backend at runtime. This means:
+For oppia-android, flag states are controlled by per-flavor textproto override files that are
+compiled into the binary. Enabling or disabling a flag for a specific release stage requires
+modifying the corresponding override file and shipping a new binary for that flavor:
 
-- A flag can be enabled for alpha users the moment the alpha binary is live.
-- A flag can be rolled back instantly if an issue is discovered, without requiring a hotfix release.
+- **Alpha**: [`alpha/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/alpha/feature_flags_overrides.textproto)
+- **Beta**: [`beta/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/beta/feature_flags_overrides.textproto)
+- **Production (GA)**: [`ga/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/ga/feature_flags_overrides.textproto)
 
-For the binary release timeline (branch cut dates, alpha/beta/GA dates), refer to the
-[Release Playbook](Release-Playbook.md).
+This means flag enablement is tied to the binary release cycle. For the binary release timeline
+(branch cut dates, alpha/beta/GA dates), refer to the [Release Playbook](Release-Playbook.md).
 
 ---
 
@@ -156,20 +161,9 @@ Only request production enablement when **all** of the following are true:
 
 ### How to request
 
-Post a comment on your feature's tracking issue with the following information:
-
-```
-**Production enablement request**
-
-- Flag name: `android_enable_<your_flag>` (as defined in FeatureFlagConstants.kt)
-- Tracking issue: #XXXX
-- Beta verification: [link to QA sign-off comment or test report]
-- Product approval: [link to product review approval]
-- Team lead sign-off: [link to sign-off comment]
-- Target release: X.Y (or "next available")
-```
-
-Then assign or ping the **CLaM lead** and the **release coordinator** for the current cycle.
+File a production enablement issue in the product operations tracker, following the requirements
+template at [product-operations-team#46](https://github.com/oppia/product-operations-team/issues/46).
+Then assign or ping the **Tech lead** and the **release coordinator** for the current cycle.
 
 ### Timeline
 

--- a/wiki/Feature-Development-Guide.md
+++ b/wiki/Feature-Development-Guide.md
@@ -1,8 +1,8 @@
 # Feature Development Guide
 
-This guide is for **Android developers** who need to ship a feature safely: gate it behind a
-feature flag, understand how it moves through the release pipeline, and request that it be enabled
-in production.
+This guide is for **Android developers** who need to ship a feature safely. It covers how to gate
+a feature behind a feature flag, how the feature moves through the release pipeline, and how to
+request that it be enabled in production.
 
 **For the technical mechanics of creating a flag** (constants, Dagger wiring, analytics logging),
 see the [Platform Parameters & Feature Flags](Platform-Parameters-&-Feature-Flags.md) wiki.
@@ -87,10 +87,16 @@ Once your flagged feature lands on `develop`, it moves through a defined lifecyc
 reaches production. The lifecycle is:
 
 ```
-develop (flag off) → alpha build (flag on via alpha textproto, if requested)
+develop (flag off) → alpha build (flag on via alpha textproto)
   → product review → beta build (flag on via beta textproto)
   → tech lead sign-off → production (flag on via GA textproto) → cleanup
 ```
+
+> **Alpha enablement is opt-in.** The alpha textproto is only updated when the developer (or
+> coordinator) explicitly requests it — for example, to gather early feedback or validate the
+> feature before beta. If you do not need alpha testing, your feature stays flagged off in the
+> alpha build and first becomes visible in beta. See [§3](#3-requesting-production-enablement) for
+> how to request enablement at any stage.
 
 ### Flag state across release stages
 
@@ -161,9 +167,12 @@ Only request production enablement when **all** of the following are true:
 
 ### How to request
 
-File a production enablement issue in the product operations tracker, following the requirements
-template at [product-operations-team#46](https://github.com/oppia/product-operations-team/issues/46).
-Then assign or ping the **Tech lead** and the **release coordinator** for the current cycle.
+File a production enablement issue using the
+[new launch request template](https://github.com/oppia/product-operations-team/issues/new?template=1_new_launch.yml)
+in the product operations tracker. See
+[product-operations-team#46](https://github.com/oppia/product-operations-team/issues/46) for a
+complete example. Then assign or ping the **Tech lead** and the **release coordinator** for the
+current cycle.
 
 ### Timeline
 

--- a/wiki/Feature-Development-Guide.md
+++ b/wiki/Feature-Development-Guide.md
@@ -92,18 +92,21 @@ develop (flag off) → alpha build (flag on via alpha textproto)
   → tech lead sign-off → production (flag on via GA textproto) → cleanup
 ```
 
-> **Alpha enablement is opt-in.** The alpha textproto is only updated when the developer (or
-> coordinator) explicitly requests it — for example, to gather early feedback or validate the
-> feature before beta. If you do not need alpha testing, your feature stays flagged off in the
-> alpha build and first becomes visible in beta. See [§3](#3-requesting-production-enablement) for
-> how to request enablement at any stage.
+> **Alpha enablement is opt-in.** The alpha textproto is only updated when you explicitly request
+> it — for example, to gather early feedback or validate the feature before product review.
+> If you do not need alpha testing, your feature stays flagged off in the alpha build and first
+> becomes visible in beta.
+>
+> To request alpha enablement, ask the release coordinator to add your flag to
+> [`alpha/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/alpha/feature_flags_overrides.textproto)
+> for the current release branch.
 
 ### Flag state across release stages
 
 | Stage | Where the flag lives | Flag state | Who controls it |
 |---|---|---|---|
 | **Development** | `develop` branch | `false` (default) | Developer |
-| **Alpha** | `release-X.Y` → alpha build | `true` (enabled via [`alpha/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/alpha/feature_flags_overrides.textproto)) | Release coordinator |
+| **Alpha** | `release-X.Y` → alpha build | `false` by default; `true` only if alpha testing was requested (enabled via [`alpha/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/alpha/feature_flags_overrides.textproto)) | Release coordinator |
 | **Beta** | `release-X.Y` → beta build | `true` (enabled via [`beta/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/beta/feature_flags_overrides.textproto), if alpha passed) | Release coordinator |
 | **Production (GA)** | GA rollout | `true` (after QA + product sign-off) | Tech lead / release coordinator |
 | **Cleanup** | Next release cycle | Flag removed entirely | Developer |
@@ -116,11 +119,12 @@ develop (flag off) → alpha build (flag on via alpha textproto)
 - Verify your tracking issue is up to date and linked from all feature PRs that have merged.
 - Add the feature's CUJs to the Android team's CUJ sheet.
 
-**During alpha:**
+**During alpha (only if alpha testing was requested):**
 - The coordinator enables your flag for the alpha build by setting it to `true` in
   [`alpha/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/alpha/feature_flags_overrides.textproto).
 - Participate in alpha testing — verify the feature works end-to-end in a real build.
 - File any regressions as separate issues, linked to the original tracking issue as child/sub-issues.
+- If alpha testing was **not** requested, skip ahead to the beta stage below.
 
 **During beta:**
 - If alpha testing passes and product review approves, the coordinator enables the flag in beta

--- a/wiki/Feature-Development-Guide.md
+++ b/wiki/Feature-Development-Guide.md
@@ -1,0 +1,38 @@
+# Feature Development Guide
+
+This guide is for **Android developers** who need to gate a feature behind a feature flag, understand how that flag progresses through the release pipeline, and request that it be enabled in production.
+
+For a full explanation of the Platform Parameter system and the Dagger wiring required to create flags, see the [Platform Parameters & Feature Flags](Platform-Parameters-&-Feature-Flags) wiki.
+
+## Table of Contents
+
+- [Gating a Feature Behind a Flag](#gating-a-feature-behind-a-flag)
+- [Navigating the Release Process](#navigating-the-release-process)
+- [Requesting Production Enablement](#requesting-production-enablement)
+
+---
+
+## Gating a Feature Behind a Flag
+
+> TODO: Explain the step-by-step process for gating new feature code behind a feature flag:
+> creating the constant in `FeatureFlagConstants.kt`, providing it in `PlatformParameterModule`,
+> injecting and checking it in the feature code, and writing tests with the flag both enabled
+> and disabled.
+
+---
+
+## Navigating the Release Process
+
+> TODO: Explain the lifecycle of a feature flag across releases — how it starts `false` in alpha,
+> what the developer needs to verify during beta testing, and when it is safe to request
+> production enablement. Include a table showing the flag state at each release stage
+> (alpha / beta / GA) and reference the Release Playbook for the release timeline.
+
+---
+
+## Requesting Production Enablement
+
+> TODO: Explain how a developer requests that their feature flag be flipped to `true` in the
+> Feature Gating Console for production. Include: who to contact (CLaM lead / release
+> coordinator), what information to provide (flag name, issue number, verified beta status),
+> and what the expected timeline is relative to the monthly release cycle.

--- a/wiki/Feature-Development-Guide.md
+++ b/wiki/Feature-Development-Guide.md
@@ -128,8 +128,8 @@ develop (flag off) → alpha build (flag on via alpha textproto)
 
 **During beta:**
 - Beta requires **ProdOps approval** before the flag can be enabled, because new features
-  typically come with a public announcement. Request approval by pinging the **tech lead**
-  for the current cycle — they will confirm when ProdOps approval is in place.
+  typically come with a public announcement. Request approval by pinging the **tech lead** —
+  they will confirm when ProdOps approval is in place.
 - Once the tech lead confirms approval, the coordinator enables the flag by setting it to
   `true` in
   [`beta/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/beta/feature_flags_overrides.textproto).

--- a/wiki/Feature-Development-Guide.md
+++ b/wiki/Feature-Development-Guide.md
@@ -92,21 +92,20 @@ develop (flag off) → alpha build (flag on via alpha textproto)
   → tech lead sign-off → production (flag on via GA textproto) → cleanup
 ```
 
-> **Alpha enablement is opt-in.** The alpha textproto is only updated when you explicitly request
-> it — for example, to gather early feedback or validate the feature before product review.
-> If you do not need alpha testing, your feature stays flagged off in the alpha build and first
-> becomes visible in beta.
->
-> To request alpha enablement, ask the release coordinator to add your flag to
-> [`alpha/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/alpha/feature_flags_overrides.textproto)
-> for the current release branch.
+> **Alpha enablement is criteria-based, not automatic.** A flag is enabled in the alpha build
+> when the feature has produced enough output that it can be shown to other stakeholders — QA
+> and product — for early feedback and testing with production assets. The **tech lead** gives the
+> go-ahead to flip the flag for alpha; the release coordinator then updates
+> [`alpha/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/alpha/feature_flags_overrides.textproto).
+> If a feature is not yet at that stage when an alpha build is cut, it stays disabled until the
+> next alpha or until it is ready.
 
 ### Flag state across release stages
 
 | Stage | Where the flag lives | Flag state | Who controls it |
 |---|---|---|---|
 | **Development** | `develop` branch | `false` (default) | Developer |
-| **Alpha** | `release-X.Y` → alpha build | `false` by default; `true` only if alpha testing was requested (enabled via [`alpha/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/alpha/feature_flags_overrides.textproto)) | Release coordinator |
+| **Alpha** | `release-X.Y` → alpha build | `false` by default; `true` when the feature is ready for stakeholder testing (enabled via [`alpha/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/alpha/feature_flags_overrides.textproto)) | Tech lead (approval) + Release coordinator (implementation) |
 | **Beta** | `release-X.Y` → beta build | `true` (enabled via [`beta/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/beta/feature_flags_overrides.textproto), if alpha passed) | Release coordinator |
 | **Production (GA)** | GA rollout | `true` (after QA + product sign-off) | Tech lead / release coordinator |
 | **Cleanup** | Next release cycle | Flag removed entirely | Developer |
@@ -119,16 +118,19 @@ develop (flag off) → alpha build (flag on via alpha textproto)
 - Verify your tracking issue is up to date and linked from all feature PRs that have merged.
 - Add the feature's CUJs to the Android team's CUJ sheet.
 
-**During alpha (only if alpha testing was requested):**
-- The coordinator enables your flag for the alpha build by setting it to `true` in
+**During alpha:**
+- Once the feature has enough output to be shown to QA and product, the tech lead gives the
+  go-ahead to flip the flag.
+- The coordinator enables the flag by setting it to `true` in
   [`alpha/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/alpha/feature_flags_overrides.textproto).
-- Participate in alpha testing — verify the feature works end-to-end in a real build.
-- File any regressions as separate issues, linked to the original tracking issue as child/sub-issues.
-- If alpha testing was **not** requested, skip ahead to the beta stage below.
+- Participate in alpha testing — verify the feature works end-to-end with production assets.
+- File any regressions as separate issues linked to the original tracking issue.
 
 **During beta:**
-- If alpha testing passes and product review approves, the coordinator enables the flag in beta
-  by setting it to `true` in [`beta/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/beta/feature_flags_overrides.textproto).
+- After extensive alpha testing, the coordinator enables the flag in beta by setting it to `true`
+  in [`beta/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/beta/feature_flags_overrides.textproto).
+- Beta requires **ProdOps approval** before the flag is enabled, because new features typically
+  come with a public announcement.
 - QA testers verify the feature in the beta build.
 
 **Production:**

--- a/wiki/Feature-Development-Guide.md
+++ b/wiki/Feature-Development-Guide.md
@@ -127,10 +127,12 @@ develop (flag off) → alpha build (flag on via alpha textproto)
 - File any regressions as separate issues linked to the original tracking issue.
 
 **During beta:**
-- After extensive alpha testing, the coordinator enables the flag in beta by setting it to `true`
-  in [`beta/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/beta/feature_flags_overrides.textproto).
-- Beta requires **ProdOps approval** before the flag is enabled, because new features typically
-  come with a public announcement.
+- Beta requires **ProdOps approval** before the flag can be enabled, because new features
+  typically come with a public announcement. Request approval by pinging the **tech lead**
+  for the current cycle — they will confirm when ProdOps approval is in place.
+- Once the tech lead confirms approval, the coordinator enables the flag by setting it to
+  `true` in
+  [`beta/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/beta/feature_flags_overrides.textproto).
 - QA testers verify the feature in the beta build.
 
 **Production:**

--- a/wiki/Feature-Development-Guide.md
+++ b/wiki/Feature-Development-Guide.md
@@ -106,7 +106,7 @@ develop (flag off) → alpha build (flag on via alpha textproto)
 |---|---|---|---|
 | **Development** | `develop` branch | `false` (default) | Developer |
 | **Alpha** | `release-X.Y` → alpha build | `false` by default; `true` when the feature is ready for stakeholder testing (enabled via [`alpha/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/alpha/feature_flags_overrides.textproto)) | Tech lead (approval) + Release coordinator (implementation) |
-| **Beta** | `release-X.Y` → beta build | `true` (enabled via [`beta/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/beta/feature_flags_overrides.textproto), if alpha passed) | Release coordinator |
+| **Beta** | `release-X.Y` → beta build | `true` (after alpha testing and ProdOps approval, enabled via [`beta/feature_flags_overrides.textproto`](../config/src/java/org/oppia/android/config/platform/featureoverrides/beta/feature_flags_overrides.textproto)) | Release coordinator |
 | **Production (GA)** | GA rollout | `true` (after QA + product sign-off) | Tech lead / release coordinator |
 | **Cleanup** | Next release cycle | Flag removed entirely | Developer |
 


### PR DESCRIPTION
Fixes part of #6106
## Explanation

The existing [Platform Parameters & Feature Flags](wiki/Platform-Parameters-&-Feature-Flags.md) wiki covers the technical mechanics of creating a flag — the constant, Dagger wiring, and test setup. It does not cover what happens after the flag lands: how it moves through alpha, beta, and GA builds; who enables it at each stage; what the developer is responsible for; or how to formally request production enablement.

This PR adds the **Feature Development Guide** wiki page to fill that gap. It is aimed at developers, not release coordinators, and covers three areas:

1. **Gating a feature behind a flag** — concrete code examples showing how to guard every entry point, a table of gating rules (default `false`, every entry point gated, guard is the first line), and the minimum test matrix (flag-disabled and flag-enabled paths).

2. **Navigating the release process** — a table showing flag state at each release stage (development, alpha, beta, GA, cleanup) and what the developer is expected to do at each transition. This is the lifecycle information that currently lives only in informal team knowledge.

3. **Requesting production enablement** — the checklist a developer must satisfy before the coordinator can enable the flag in production (QA sign-off, team lead approval, tracking issue linked).

The guide links to the Platform Parameters & Feature Flags wiki for the low-level Dagger wiring details rather than duplicating them.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage

AI was used for code completion, drafting wiki content, and research.