### PR TITLE
Fix #6310 : fix alpha langauge selection

### DIFF
--- a/app/src/main/java/org/oppia/android/app/options/AppLanguageFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AppLanguageFragmentPresenter.kt
@@ -12,7 +12,6 @@ import org.oppia.android.app.databinding.databinding.AppLanguageSelectionFragmen
 import org.oppia.android.app.model.AppLanguageFragmentStateBundle
 import org.oppia.android.app.model.AppLanguageSelection
 import org.oppia.android.app.model.LegacyProfileId
-import org.oppia.android.app.model.OnboardingFragmentStateBundle
 import org.oppia.android.app.model.OppiaLanguage
 import org.oppia.android.app.onboarding.AppLanguageViewModel
 import org.oppia.android.app.options.AudioLanguageFragment.Companion.FRAGMENT_SAVED_STATE_KEY
@@ -58,8 +57,8 @@ class AppLanguageFragmentPresenter @Inject constructor(
 
     val savedSelectedLanguage = outState?.getProto(
       FRAGMENT_SAVED_STATE_KEY,
-      OnboardingFragmentStateBundle.getDefaultInstance()
-    )?.selectedLanguage
+      AppLanguageFragmentStateBundle.getDefaultInstance()
+    )?.oppiaLanguage
 
     selectedLanguage = savedSelectedLanguage ?: currentSelection
 
@@ -150,6 +149,16 @@ class AppLanguageFragmentPresenter @Inject constructor(
   private fun updateSelectedLanguage(selectedLanguage: OppiaLanguage) {
     val selection = AppLanguageSelection.newBuilder().setSelectedLanguage(selectedLanguage).build()
     translationController.updateAppLanguage(profileId.toProfileIdPreservingZero(), selection)
+      .toLiveData()
+      .observe(fragment) { result ->
+        if (result is AsyncResult.Failure) {
+          oppiaLogger.e(
+            "AppLanguageFragment",
+            "Failed to update app language to: $selectedLanguage.",
+            result.error
+          )
+        }
+      }
   }
 
   private fun updateAppLanguage(appLanguage: OppiaLanguage) {

--- a/app/src/sharedTest/java/org/oppia/android/app/options/AppLanguageFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/options/AppLanguageFragmentTest.kt
@@ -44,6 +44,7 @@ import org.oppia.android.app.application.testing.TestingBuildFlavorModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.model.OppiaLanguage
+import org.oppia.android.app.model.ProfileId
 import org.oppia.android.app.options.AppLanguageFragment.Companion.retrieveLanguageFromArguments
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
@@ -82,11 +83,13 @@ import org.oppia.android.domain.oppialogger.logscheduler.MetricLogSchedulerModul
 import org.oppia.android.domain.oppialogger.loguploader.LogReportWorkerModule
 import org.oppia.android.domain.platformparameter.PlatformParameterSingletonModule
 import org.oppia.android.domain.question.QuestionModule
+import org.oppia.android.domain.translation.TranslationController
 import org.oppia.android.domain.workmanager.WorkManagerConfigurationModule
 import org.oppia.android.testing.OppiaTestRule
 import org.oppia.android.testing.RunOn
 import org.oppia.android.testing.TestLogReportingModule
 import org.oppia.android.testing.TestPlatform
+import org.oppia.android.testing.data.DataProviderTestMonitor
 import org.oppia.android.testing.firebase.TestAuthenticationModule
 import org.oppia.android.testing.junit.DefineAppLanguageLocaleContext
 import org.oppia.android.testing.junit.InitializeDefaultLocaleRule
@@ -122,6 +125,7 @@ import javax.inject.Singleton
 class AppLanguageFragmentTest {
 
   private companion object {
+    private const val ADMIN_PROFILE_ID = 0
     private const val ENGLISH_BUTTON_INDEX = 0
     private const val KISWAHILI_BUTTON_INDEX = 1
     private const val PORTUGUESE_BUTTON_INDEX = 3
@@ -146,6 +150,12 @@ class AppLanguageFragmentTest {
 
   @Inject
   lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
+
+  @Inject
+  lateinit var monitorFactory: DataProviderTestMonitor.Factory
+
+  @Inject
+  lateinit var translationController: TranslationController
 
   @Inject
   lateinit var appLanguageLocaleHandler: AppLanguageLocaleHandler
@@ -481,7 +491,11 @@ class AppLanguageFragmentTest {
   @Test
   fun testFragment_onboardingV2_portugueseSelected_languageDropdownTextIsUpdated() {
     setUpTestWithOnboardingV2Enabled()
-    launch(AppLanguageActivity::class.java).use { scenario ->
+    launch<AppLanguageActivity>(
+      AppLanguageActivity.createAppLanguageActivityIntent(
+        context, OppiaLanguage.ENGLISH, ADMIN_PROFILE_ID
+      )
+    ).use { scenario ->
       testCoroutineDispatchers.runCurrent()
 
       scenario.onActivity { activity ->
@@ -500,6 +514,13 @@ class AppLanguageFragmentTest {
         onView(withId(R.id.onboarding_language_dropdown)).check(
           matches(withText(R.string.brazilian_portuguese_localized_language_name))
         )
+        val selection = monitorFactory.waitForNextSuccessfulResult(
+          translationController.getAppLanguageSelection(
+            ProfileId.newBuilder().setInternalId(ADMIN_PROFILE_ID).build()
+          )
+        )
+        assertThat(selection.selectedLanguage)
+          .isEqualTo(OppiaLanguage.BRAZILIAN_PORTUGUESE)
       }
     }
   }


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
Fixes #6310 

## Explanation

Previously, the update operation was never observed, so its lazy data provider did not execute.
As a result, the dropdown appeared updated but the saved preference remained English. When this PR is merged this will be fixed.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
<!-- Please answer the following two questions. -->
- **Did you use AI/LLMs when working on this PR?** 
Yes, AI is used for writing test
  
## For UI-specific PRs only

https://github.com/user-attachments/assets/7641b5ab-d65c-4b4a-a585-8c8f03d0745f


<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
