### PR TITLE
Fix #6360: Exclude frozen version codes from VersionInversionChecker

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/release/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/release/BUILD.bazel
@@ -80,8 +80,12 @@ kt_jvm_library(
     name = "version_inversion_checker",
     srcs = ["VersionInversionChecker.kt"],
     visibility = ["//scripts:oppia_script_library_visibility"],
-    deps = [":play_console_client"],
+    deps = [
+        ":frozen_release_config",
+        ":play_console_client",
+    ],
 )
+
 
 kt_jvm_library(
     name = "pending_release_checker",

--- a/scripts/src/java/org/oppia/android/scripts/release/BUILD.bazel
+++ b/scripts/src/java/org/oppia/android/scripts/release/BUILD.bazel
@@ -86,7 +86,6 @@ kt_jvm_library(
     ],
 )
 
-
 kt_jvm_library(
     name = "pending_release_checker",
     srcs = ["PendingReleaseChecker.kt"],

--- a/scripts/src/java/org/oppia/android/scripts/release/VersionInversionChecker.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/VersionInversionChecker.kt
@@ -131,5 +131,3 @@ class VersionInversionChecker(
     private const val GA_TRACK = "production"
   }
 }
-
-

--- a/scripts/src/java/org/oppia/android/scripts/release/VersionInversionChecker.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/VersionInversionChecker.kt
@@ -11,11 +11,23 @@ package org.oppia.android.scripts.release
  * into the ordering, accounting for both live and pending releases on other tracks (since multiple
  * tracks can be deployed simultaneously).
  *
+ * Frozen OS-specific version codes (see [FROZEN_VERSION_CODES_PER_TRACK]) are excluded from the
+ * ordering constraint. These are permanently active builds for deprecated API levels — they were
+ * assigned low version codes before the current version code scheme and do not represent current
+ * releases that must participate in the cross-track ordering.
+ *
  * Note: Play Console validates version codes within a track but does not enforce the cross-track
  * ordering constraint. This check provides a clearer pre-flight error message and avoids wasting
  * an edit session on a guaranteed API rejection.
+ *
+ * @param client the [PlayConsoleClient] used to query track releases
+ * @param frozenVersionCodesPerTrack version codes to exclude from the inversion check per track;
+ *     defaults to [FROZEN_VERSION_CODES_PER_TRACK]
  */
-class VersionInversionChecker(private val client: PlayConsoleClient) {
+class VersionInversionChecker(
+  private val client: PlayConsoleClient,
+  private val frozenVersionCodesPerTrack: Map<String, Set<Long>> = FROZEN_VERSION_CODES_PER_TRACK
+) {
 
   /**
    * Verifies that [newVersionCode] satisfies the cross-track ordering constraint when deploying
@@ -24,8 +36,9 @@ class VersionInversionChecker(private val client: PlayConsoleClient) {
    * Specifically:
    * - Deploying to **alpha**: new vc must be greater than the highest version code on beta and ga
    * - Deploying to **beta**: new vc must be greater than the highest on ga, and less than the
-   *   lowest pending/live alpha version code
-   * - Deploying to **production**: new vc must be less than the lowest beta and alpha version codes
+   *   lowest non-frozen alpha version code
+   * - Deploying to **production**: new vc must be less than the lowest non-frozen beta and alpha
+   *   version codes
    *
    * @param packageName the application package name (e.g. "org.oppia.android")
    * @param targetTrack the Play Console track being deployed to ("alpha", "beta", or "production")
@@ -39,10 +52,18 @@ class VersionInversionChecker(private val client: PlayConsoleClient) {
     newVersionCode: Long,
     existingEditId: String
   ) {
+    val frozenAlpha = frozenVersionCodesPerTrack[ALPHA_TRACK] ?: emptySet()
+    val frozenBeta = frozenVersionCodesPerTrack[BETA_TRACK] ?: emptySet()
+
+    // Exclude frozen version codes before computing min/max so that permanently-active
+    // OS-specific builds (e.g. the KitKat VC 16 on alpha) do not participate in the
+    // cross-track ordering constraint.
     val alphaVersionCodes = client.getTrackReleases(packageName, ALPHA_TRACK, existingEditId)
       .flatMap { it.versionCodes }
+      .filterNot { it in frozenAlpha }
     val betaVersionCodes = client.getTrackReleases(packageName, BETA_TRACK, existingEditId)
       .flatMap { it.versionCodes }
+      .filterNot { it in frozenBeta }
     val gaVersionCodes = client.getTrackReleases(packageName, GA_TRACK, existingEditId)
       .flatMap { it.versionCodes }
 
@@ -110,3 +131,5 @@ class VersionInversionChecker(private val client: PlayConsoleClient) {
     private const val GA_TRACK = "production"
   }
 }
+
+

--- a/scripts/src/javatests/org/oppia/android/scripts/release/VersionInversionCheckerTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/VersionInversionCheckerTest.kt
@@ -431,7 +431,7 @@ class VersionInversionCheckerTest {
     fakeClient.setTrackReleases(
       "alpha",
       listOf(
-        PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(16L)),   // frozen
+        PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(16L)), // frozen
         PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(40000L)) // live
       )
     )
@@ -472,8 +472,8 @@ class VersionInversionCheckerTest {
     fakeClient.setTrackReleases(
       "alpha",
       listOf(
-        PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(16L)),  // frozen
-        PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(100L))  // live
+        PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(16L)), // frozen
+        PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(100L)) // live
       )
     )
     val frozenCodes = mapOf("alpha" to setOf(16L))
@@ -497,7 +497,7 @@ class VersionInversionCheckerTest {
     fakeClient.setTrackReleases(
       "beta",
       listOf(
-        PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(16L)),   // frozen
+        PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(16L)), // frozen
         PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(40000L)) // live
       )
     )
@@ -513,4 +513,3 @@ class VersionInversionCheckerTest {
     )
   }
 }
-

--- a/scripts/src/javatests/org/oppia/android/scripts/release/VersionInversionCheckerTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/VersionInversionCheckerTest.kt
@@ -418,4 +418,99 @@ class VersionInversionCheckerTest {
       "upload-edit-42", "upload-edit-42", "upload-edit-42"
     )
   }
+
+  // ---------------------------------------------------------------------------
+  // Frozen version code exclusion
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun testVerify_beta_frozenAlphaVcLowerThanNewBeta_passes() {
+    // Regression test for https://github.com/oppia/oppia-android/issues/6360:
+    // deploying VC 37301 to beta was failing because frozen alpha VC 16 was included in the
+    // inversion check (minAlpha = 16, and 37301 < 16 is false → crash).
+    fakeClient.setTrackReleases(
+      "alpha",
+      listOf(
+        PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(16L)),   // frozen
+        PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(40000L)) // live
+      )
+    )
+    val frozenCodes = mapOf("alpha" to setOf(16L))
+    val checkerWithFrozen = VersionInversionChecker(fakeClient, frozenCodes)
+
+    // Should pass: 37301 < 40000 (frozen VC 16 is excluded from the check).
+    checkerWithFrozen.verify(
+      "org.oppia.android",
+      "beta",
+      newVersionCode = 37301L,
+      existingEditId = "test-edit"
+    )
+  }
+
+  @Test
+  fun testVerify_beta_frozenAlphaVcOnlyAlphaRelease_treatsAlphaAsEmpty_passes() {
+    // If ALL alpha releases are frozen, the non-frozen alpha set is empty → no inversion
+    // constraint applies (minAlpha == null). Any beta VC should pass.
+    fakeClient.setTrackReleases(
+      "alpha",
+      listOf(PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(16L)))
+    )
+    val frozenCodes = mapOf("alpha" to setOf(16L))
+    val checkerWithFrozen = VersionInversionChecker(fakeClient, frozenCodes)
+
+    checkerWithFrozen.verify(
+      "org.oppia.android",
+      "beta",
+      newVersionCode = 37301L,
+      existingEditId = "test-edit"
+    )
+  }
+
+  @Test
+  fun testVerify_beta_nonFrozenAlphaVcLowerThanNewBeta_stillFails() {
+    // The exclusion must NOT suppress a genuine inversion on a non-frozen alpha release.
+    fakeClient.setTrackReleases(
+      "alpha",
+      listOf(
+        PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(16L)),  // frozen
+        PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(100L))  // live
+      )
+    )
+    val frozenCodes = mapOf("alpha" to setOf(16L))
+    val checkerWithFrozen = VersionInversionChecker(fakeClient, frozenCodes)
+
+    // 200 > 100 (non-frozen minAlpha) → inversion; must fail.
+    val exception = assertThrows<IllegalStateException>() {
+      checkerWithFrozen.verify(
+        "org.oppia.android",
+        "beta",
+        newVersionCode = 200L,
+        existingEditId = "test-edit"
+      )
+    }
+    assertThat(exception).hasMessageThat().contains("100")
+  }
+
+  @Test
+  fun testVerify_ga_frozenBetaVcLowerThanNewGa_passes() {
+    // Same pattern on the GA → beta constraint.
+    fakeClient.setTrackReleases(
+      "beta",
+      listOf(
+        PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(16L)),   // frozen
+        PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(40000L)) // live
+      )
+    )
+    val frozenCodes = mapOf("beta" to setOf(16L))
+    val checkerWithFrozen = VersionInversionChecker(fakeClient, frozenCodes)
+
+    // 37000 < 40000 (non-frozen minBeta); should pass.
+    checkerWithFrozen.verify(
+      "org.oppia.android",
+      "production",
+      newVersionCode = 37000L,
+      existingEditId = "test-edit"
+    )
+  }
 }
+

--- a/scripts/src/javatests/org/oppia/android/scripts/release/VersionInversionCheckerTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/VersionInversionCheckerTest.kt
@@ -419,7 +419,6 @@ class VersionInversionCheckerTest {
     )
   }
 
-
   @Test
   fun testVerify_beta_frozenAlphaVcLowerThanNewBeta_passes() {
     fakeClient.setTrackReleases(

--- a/scripts/src/javatests/org/oppia/android/scripts/release/VersionInversionCheckerTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/VersionInversionCheckerTest.kt
@@ -419,15 +419,9 @@ class VersionInversionCheckerTest {
     )
   }
 
-  // ---------------------------------------------------------------------------
-  // Frozen version code exclusion
-  // ---------------------------------------------------------------------------
 
   @Test
   fun testVerify_beta_frozenAlphaVcLowerThanNewBeta_passes() {
-    // Regression test for https://github.com/oppia/oppia-android/issues/6360:
-    // deploying VC 37301 to beta was failing because frozen alpha VC 16 was included in the
-    // inversion check (minAlpha = 16, and 37301 < 16 is false → crash).
     fakeClient.setTrackReleases(
       "alpha",
       listOf(
@@ -436,10 +430,9 @@ class VersionInversionCheckerTest {
       )
     )
     val frozenCodes = mapOf("alpha" to setOf(16L))
-    val checkerWithFrozen = VersionInversionChecker(fakeClient, frozenCodes)
+    val checkerWithFrozenCodes = VersionInversionChecker(fakeClient, frozenCodes)
 
-    // Should pass: 37301 < 40000 (frozen VC 16 is excluded from the check).
-    checkerWithFrozen.verify(
+    checkerWithFrozenCodes.verify(
       "org.oppia.android",
       "beta",
       newVersionCode = 37301L,
@@ -449,16 +442,14 @@ class VersionInversionCheckerTest {
 
   @Test
   fun testVerify_beta_frozenAlphaVcOnlyAlphaRelease_treatsAlphaAsEmpty_passes() {
-    // If ALL alpha releases are frozen, the non-frozen alpha set is empty → no inversion
-    // constraint applies (minAlpha == null). Any beta VC should pass.
     fakeClient.setTrackReleases(
       "alpha",
       listOf(PlayConsoleClient.TrackRelease(status = "completed", versionCodes = listOf(16L)))
     )
     val frozenCodes = mapOf("alpha" to setOf(16L))
-    val checkerWithFrozen = VersionInversionChecker(fakeClient, frozenCodes)
+    val checkerWithFrozenCodes = VersionInversionChecker(fakeClient, frozenCodes)
 
-    checkerWithFrozen.verify(
+    checkerWithFrozenCodes.verify(
       "org.oppia.android",
       "beta",
       newVersionCode = 37301L,
@@ -477,23 +468,24 @@ class VersionInversionCheckerTest {
       )
     )
     val frozenCodes = mapOf("alpha" to setOf(16L))
-    val checkerWithFrozen = VersionInversionChecker(fakeClient, frozenCodes)
+    val checkerWithFrozenCodes = VersionInversionChecker(fakeClient, frozenCodes)
 
-    // 200 > 100 (non-frozen minAlpha) → inversion; must fail.
     val exception = assertThrows<IllegalStateException>() {
-      checkerWithFrozen.verify(
+      checkerWithFrozenCodes.verify(
         "org.oppia.android",
         "beta",
         newVersionCode = 200L,
         existingEditId = "test-edit"
       )
     }
-    assertThat(exception).hasMessageThat().contains("100")
+    assertThat(exception).hasMessageThat().isEqualTo(
+      "Version inversion: deploying 200 to beta but alpha has a release at version code 100." +
+        " Beta must be strictly less than all alpha version codes."
+    )
   }
 
   @Test
   fun testVerify_ga_frozenBetaVcLowerThanNewGa_passes() {
-    // Same pattern on the GA → beta constraint.
     fakeClient.setTrackReleases(
       "beta",
       listOf(
@@ -502,10 +494,9 @@ class VersionInversionCheckerTest {
       )
     )
     val frozenCodes = mapOf("beta" to setOf(16L))
-    val checkerWithFrozen = VersionInversionChecker(fakeClient, frozenCodes)
+    val checkerWithFrozenCodes = VersionInversionChecker(fakeClient, frozenCodes)
 
-    // 37000 < 40000 (non-frozen minBeta); should pass.
-    checkerWithFrozen.verify(
+    checkerWithFrozenCodes.verify(
       "org.oppia.android",
       "production",
       newVersionCode = 37000L,


### PR DESCRIPTION
Fixes #6360
## Explanation
Deploying to beta was failing with a version inversion error:

```
Version inversion: deploying 37301 to beta but alpha has a release at version code 16.
Beta must be strictly less than all alpha version codes.
```

The frozen KitKat build (VC 16 on alpha, permanently active for API 16 devices) was being included in the cross-track ordering check. Since 16 is the `minAlpha`, the check `newVersionCode < minAlpha` (i.e. `37301 < 16`) always fails for any modern beta deployment.

`VersionInversionChecker.verify()` queried all alpha version codes, including frozen ones, to compute `minAlpha`. Frozen OS-specific builds were deployed before the current version code scheme and do not represent "current" alpha releases; they must not participate in the ordering constraint.

`VersionInversionChecker` now accepts a `frozenVersionCodesPerTrack` parameter (defaulting to `FROZEN_VERSION_CODES_PER_TRACK` from `FrozenReleaseConfig.kt`) and filters frozen codes out of each track's version codes before computing `min`/`max`. The call site in `UploadBinaryToPlayConsole.kt` requires no changes.

## Disclosure of LLM Usage

AI was used for code completion.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).