### PR TITLE
Fix part of #6106: Make frozen baseline test utility resilient to FrozenReleaseConfig changes

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/release/FakePlayConsoleClient.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/FakePlayConsoleClient.kt
@@ -325,38 +325,57 @@ class FakePlayConsoleClient : PlayConsoleClient, AutoCloseable {
 }
 
 /**
- * A completed alpha release that holds all currently frozen alpha version codes.
+ * A completed alpha release whose `versionCodes` are derived from [FROZEN_VERSION_CODES_PER_TRACK].
  *
- * Tests that set up the alpha track must include this alongside any live release entry so that the
- * production invariant check (which requires all [FROZEN_VERSION_CODES_PER_TRACK] codes to be
- * present on the track) does not throw. If [FROZEN_VERSION_CODES_PER_TRACK] is updated, update
- * the `versionCodes` list here in lockstep.
+ * Including this in a `setTrackReleases("alpha", ...)` call ensures the production invariant check
+ * (which verifies all frozen codes are present on the live track) does not throw. Because the
+ * codes come directly from [FROZEN_VERSION_CODES_PER_TRACK], this constant automatically reflects
+ * any future changes to [FrozenReleaseConfig] without requiring manual test updates.
+ *
+ * Tests that override the alpha track should include this alongside any test-specific releases so
+ * that the invariant check is still satisfied.
  */
 val FROZEN_ALPHA_BASELINE: PlayConsoleClient.TrackRelease =
-  PlayConsoleClient.TrackRelease(versionCodes = listOf(16L, 201L), status = "completed")
+  PlayConsoleClient.TrackRelease(
+    versionCodes = (FROZEN_VERSION_CODES_PER_TRACK["alpha"] ?: emptySet()).toList(),
+    status = "completed"
+  )
 
 /**
- * A completed beta release that holds all currently frozen beta version codes.
+ * A completed beta release whose `versionCodes` are derived from [FROZEN_VERSION_CODES_PER_TRACK].
  *
- * Tests that set up the beta track must include this alongside any live release entry so that the
- * production invariant check (which requires all [FROZEN_VERSION_CODES_PER_TRACK] codes to be
- * present on the track) does not throw. If [FROZEN_VERSION_CODES_PER_TRACK] is updated, update
- * the `versionCodes` list here in lockstep.
+ * Including this in a `setTrackReleases("beta", ...)` call ensures the production invariant check
+ * (which verifies all frozen codes are present on the live track) does not throw. When beta has
+ * no frozen codes the release has an empty `versionCodes` list and is effectively a no-op.
+ *
+ * Tests that override the beta track should include this alongside any test-specific releases so
+ * that the invariant check is still satisfied once beta frozen codes are added in the future.
  */
 val FROZEN_BETA_BASELINE: PlayConsoleClient.TrackRelease =
-  PlayConsoleClient.TrackRelease(versionCodes = listOf(196L), status = "completed")
+  PlayConsoleClient.TrackRelease(
+    versionCodes = (FROZEN_VERSION_CODES_PER_TRACK["beta"] ?: emptySet()).toList(),
+    status = "completed"
+  )
 
 /**
  * Populates alpha and beta with their frozen-code baseline releases so that any subsequent call
  * into [UploadBinaryToPlayConsole], [UpdateRolloutFraction], or [UploadChangelogToPlayConsole]
  * passes the invariant check that requires all frozen version codes to be present on the live track.
  *
- * Call this from a test's `@Before setUp()` (or at the top of individual tests that reach the
- * invariant check). Tests that need a different track state should call [FakePlayConsoleClient
- * .setTrackReleases] afterwards, including [FROZEN_ALPHA_BASELINE] or [FROZEN_BETA_BASELINE]
- * alongside any test-specific releases.
+ * Tracks that currently have no frozen codes in [FROZEN_VERSION_CODES_PER_TRACK] are silently
+ * skipped, so this function remains correct across all [FrozenReleaseConfig] states.
+ *
+ * Call this from a test's `@Before setUp()` (or at the top of individual tests). Tests that need
+ * a different track state should call [FakePlayConsoleClient.setTrackReleases] afterwards,
+ * including [FROZEN_ALPHA_BASELINE] or [FROZEN_BETA_BASELINE] alongside test-specific releases.
  */
 fun FakePlayConsoleClient.setUpFrozenBaselines() {
-  setTrackReleases("alpha", listOf(FROZEN_ALPHA_BASELINE))
-  setTrackReleases("beta", listOf(FROZEN_BETA_BASELINE))
+  val alphaFrozen = FROZEN_VERSION_CODES_PER_TRACK["alpha"]
+  if (!alphaFrozen.isNullOrEmpty()) {
+    setTrackReleases("alpha", listOf(FROZEN_ALPHA_BASELINE))
+  }
+  val betaFrozen = FROZEN_VERSION_CODES_PER_TRACK["beta"]
+  if (!betaFrozen.isNullOrEmpty()) {
+    setTrackReleases("beta", listOf(FROZEN_BETA_BASELINE))
+  }
 }

--- a/scripts/src/java/org/oppia/android/scripts/release/FrozenReleaseConfig.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/FrozenReleaseConfig.kt
@@ -15,14 +15,11 @@ package org.oppia.android.scripts.release
  *
  * Currently frozen:
  * - alpha vc 16 : KitKat (API 16) build, frozen permanently.
- * - alpha vc 201: frozen Lollipop version
- * - beta  vc 196: frozen Lollipop version
  *
  * When a new API level is deprecated and its final build must be frozen, add its track and version
  * code here. This single file is the source of truth consumed by [UploadBinaryToPlayConsole],
  * [UpdateRolloutFraction], and [UploadChangelogToPlayConsole].
  */
 val FROZEN_VERSION_CODES_PER_TRACK: Map<String, Set<Long>> = mapOf(
-  "alpha" to setOf(16L, 201L),
-  "beta" to setOf(196L)
+  "alpha" to setOf(16L)
 )

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UpdateRolloutFractionTest.kt
@@ -129,7 +129,7 @@ class UpdateRolloutFractionTest {
       "alpha",
       listOf(
         PlayConsoleClient.TrackRelease(
-          versionCodes = listOf(298L, 300L, 299L), status = "inProgress", rolloutFraction = 100
+          versionCodes = listOf(98L, 100L, 99L), status = "inProgress", rolloutFraction = 100
         ),
         FROZEN_ALPHA_BASELINE
       )
@@ -140,7 +140,7 @@ class UpdateRolloutFractionTest {
       fakeClient, tempFolder.root.absolutePath, testPackageName, "alpha", testVersion, 500
     )
 
-    assertThat(fakeClient.trackUpdates.single().versionCode).isEqualTo(300L)
+    assertThat(fakeClient.trackUpdates.single().versionCode).isEqualTo(100L)
   }
 
   @Test
@@ -431,8 +431,8 @@ class UpdateRolloutFractionTest {
 
   @Test
   fun testUpdateRollout_alphaTrack_preservesFrozenVersionCodesInTrackUpdate() {
-    // All frozen alpha version codes (16 = KitKat, 201 = pre-cycle freeze) must be merged into
-    // the rollout update entry so the Play Console API does not deactivate them.
+    // All frozen alpha version codes (defined in FrozenReleaseConfig) must be merged into every
+    // setTrackRelease call so the Play Console API does not deactivate them.
     fakeClient.setTrackReleases(
       "alpha",
       listOf(
@@ -449,14 +449,17 @@ class UpdateRolloutFractionTest {
     assertThat(fakeClient.trackUpdates).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].versionCode).isEqualTo(202L)
     assertThat(fakeClient.trackUpdates[0].rolloutFraction).isEqualTo(500)
+    // Assertions derive from FROZEN_VERSION_CODES_PER_TRACK so they stay correct when
+    // FrozenReleaseConfig is updated without requiring manual test changes.
     assertThat(fakeClient.trackUpdates[0].frozenVersionCodes)
-      .containsExactlyElementsIn(setOf(16L, 201L))
+      .containsExactlyElementsIn(FROZEN_VERSION_CODES_PER_TRACK["alpha"] ?: emptySet<Long>())
   }
 
   @Test
-  fun testUpdateRollout_betaTrack_preservesFrozenBetaVersionCodeInTrackUpdate() {
-    // Beta has a frozen build (vc 196); it must be merged into the rollout update so the Play
-    // Console API does not deactivate it.
+  fun testUpdateRollout_betaTrack_frozenVersionCodesMatchFrozenConfig() {
+    // Beta frozen codes (from FrozenReleaseConfig) must be present in the track update. The
+    // assertion derives directly from FROZEN_VERSION_CODES_PER_TRACK so it stays resilient when
+    // codes are added to or removed from the config.
     fakeClient.setTrackReleases(
       "beta",
       listOf(
@@ -476,7 +479,8 @@ class UpdateRolloutFractionTest {
     assertThat(fakeClient.trackUpdates[0].track).isEqualTo("beta")
     assertThat(fakeClient.trackUpdates[0].versionCode).isEqualTo(200L)
     assertThat(fakeClient.trackUpdates[0].rolloutFraction).isEqualTo(500)
-    assertThat(fakeClient.trackUpdates[0].frozenVersionCodes).containsExactly(196L)
+    assertThat(fakeClient.trackUpdates[0].frozenVersionCodes)
+      .containsExactlyElementsIn(FROZEN_VERSION_CODES_PER_TRACK["beta"] ?: emptySet<Long>())
   }
 
   // ---------------------------------------------------------------------------

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UploadBinaryToPlayConsoleTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UploadBinaryToPlayConsoleTest.kt
@@ -475,8 +475,11 @@ class UploadBinaryToPlayConsoleTest {
     runMain(aab.absolutePath, track = "alpha")
 
     val setTrackBody = fake.trackUpdateBodies.first()
-    assertThat(setTrackBody).contains("\"16\"")
-    assertThat(setTrackBody).contains("\"201\"")
+    // All frozen alpha version codes must appear in the track update request body; derive the
+    // expected set from FROZEN_VERSION_CODES_PER_TRACK so this stays correct if codes change.
+    FROZEN_VERSION_CODES_PER_TRACK["alpha"]?.forEach { frozenVc ->
+      assertThat(setTrackBody).contains("\"$frozenVc\"")
+    }
     assertThat(setTrackBody).contains("\"202\"")
     // All version codes are merged into a SINGLE release entry (not separate ones).
     assertThat(setTrackBody.split("\"versionCodes\"").size - 1).isEqualTo(1)
@@ -514,9 +517,9 @@ class UploadBinaryToPlayConsoleTest {
   }
 
   @Test
-  fun testRunUpload_betaTrack_includesFrozenBetaVersionCodeInTrackUpdateRequest() {
-    // Beta has a frozen build (vc 196) that must be merged into the track update so the Play
-    // Console API does not deactivate it. Alpha's frozen codes must NOT appear in beta's update.
+  fun testRunUpload_betaTrack_doesNotIncludeAlphaFrozenVersionCodesInTrackUpdateRequest() {
+    // Alpha frozen codes must never bleed into the beta track update; only beta's own frozen
+    // codes (if any) should appear alongside the newly-uploaded version code.
     val aab = createAab("oppia-android-0.17-rc01-beta-e740815230.aab")
     createChangelog("0.17", content = "Release notes.")
     // Bump alpha to vc 300 so that uploading vc 202 to beta doesn't violate the version-inversion
@@ -531,10 +534,10 @@ class UploadBinaryToPlayConsoleTest {
 
     assertThat(fake.trackUpdateBodies).hasSize(1)
     assertThat(fake.trackUpdateBodies.first()).contains("\"202\"")
-    assertThat(fake.trackUpdateBodies.first()).contains("\"196\"")
     // Alpha-specific frozen codes must not bleed into the beta track update.
-    assertThat(fake.trackUpdateBodies.first()).doesNotContain("\"16\"")
-    assertThat(fake.trackUpdateBodies.first()).doesNotContain("\"201\"")
+    FROZEN_VERSION_CODES_PER_TRACK["alpha"]?.forEach { alphaFrozenVc ->
+      assertThat(fake.trackUpdateBodies.first()).doesNotContain("\"$alphaFrozenVc\"")
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/scripts/src/javatests/org/oppia/android/scripts/release/UploadChangelogToPlayConsoleTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/release/UploadChangelogToPlayConsoleTest.kt
@@ -86,7 +86,7 @@ class UploadChangelogToPlayConsoleTest {
     fakeClient.setTrackReleases(
       "alpha",
       listOf(
-        PlayConsoleClient.TrackRelease(versionCodes = listOf(300L), status = "completed"),
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"),
         FROZEN_ALPHA_BASELINE
       )
     )
@@ -98,7 +98,7 @@ class UploadChangelogToPlayConsoleTest {
 
     val update = fakeClient.trackUpdates.single()
     assertThat(update.track).isEqualTo("alpha")
-    assertThat(update.versionCode).isEqualTo(300L)
+    assertThat(update.versionCode).isEqualTo(100L)
     assertThat(update.releaseNotes).containsEntry("en-US", testNotes)
     assertThat(fakeClient.committedEdits).hasSize(1)
   }
@@ -271,7 +271,7 @@ class UploadChangelogToPlayConsoleTest {
     fakeClient.setTrackReleases(
       "alpha",
       listOf(
-        PlayConsoleClient.TrackRelease(versionCodes = listOf(300L), status = "completed"),
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"),
         FROZEN_ALPHA_BASELINE
       )
     )
@@ -290,7 +290,7 @@ class UploadChangelogToPlayConsoleTest {
     assertThat(fakeClient.trackUpdates.map { it.releaseNotes["en-US"] })
       .containsExactly(testNotes, testNotes)
     assertThat(fakeClient.trackUpdates.map { it.versionCode })
-      .containsExactly(300L, 200L)
+      .containsExactly(100L, 200L)
   }
 
   @Test
@@ -362,7 +362,7 @@ class UploadChangelogToPlayConsoleTest {
     fakeClient.setTrackReleases(
       "alpha",
       listOf(
-        PlayConsoleClient.TrackRelease(versionCodes = listOf(300L), status = "completed"),
+        PlayConsoleClient.TrackRelease(versionCodes = listOf(100L), status = "completed"),
         FROZEN_ALPHA_BASELINE
       )
     )
@@ -372,7 +372,7 @@ class UploadChangelogToPlayConsoleTest {
       fakeClient, tempFolder.root.absolutePath, testPackageName, testVersion
     )
 
-    assertThat(fakeClient.trackUpdates.single().versionCode).isEqualTo(300L)
+    assertThat(fakeClient.trackUpdates.single().versionCode).isEqualTo(100L)
   }
 
   @Test
@@ -381,7 +381,7 @@ class UploadChangelogToPlayConsoleTest {
       "alpha",
       listOf(
         PlayConsoleClient.TrackRelease(
-          versionCodes = listOf(298L, 300L, 299L),
+          versionCodes = listOf(98L, 100L, 99L),
           status = "completed"
         ),
         FROZEN_ALPHA_BASELINE
@@ -393,7 +393,7 @@ class UploadChangelogToPlayConsoleTest {
       fakeClient, tempFolder.root.absolutePath, testPackageName, testVersion
     )
 
-    assertThat(fakeClient.trackUpdates.single().versionCode).isEqualTo(300L)
+    assertThat(fakeClient.trackUpdates.single().versionCode).isEqualTo(100L)
   }
 
   @Test
@@ -607,8 +607,8 @@ class UploadChangelogToPlayConsoleTest {
 
   @Test
   fun testMaybeUploadUpdatedChangelogs_alphaTrack_preservesFrozenVersionCodesInUpdate() {
-    // All frozen alpha version codes (16 = KitKat, 201 = pre-cycle freeze) must be merged into
-    // every setTrackRelease call so the Play Console API does not deactivate them.
+    // All frozen alpha version codes (defined in FrozenReleaseConfig) must be merged into every
+    // setTrackRelease call so the Play Console API does not deactivate them.
     fakeClient.setTrackReleases(
       "alpha",
       listOf(
@@ -624,13 +624,17 @@ class UploadChangelogToPlayConsoleTest {
 
     assertThat(fakeClient.trackUpdates).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].versionCode).isEqualTo(202L)
+    // Assertions derive from FROZEN_VERSION_CODES_PER_TRACK so they stay correct when
+    // FrozenReleaseConfig is updated without requiring manual test changes.
     assertThat(fakeClient.trackUpdates[0].frozenVersionCodes)
-      .containsExactlyElementsIn(setOf(16L, 201L))
+      .containsExactlyElementsIn(FROZEN_VERSION_CODES_PER_TRACK["alpha"] ?: emptySet<Long>())
   }
 
   @Test
-  fun testMaybeUploadUpdatedChangelogs_betaTrack_preservesFrozenBetaVersionCodeInUpdate() {
-    // Beta has a frozen build (vc 196); it must be merged into every setTrackRelease call.
+  fun testMaybeUploadUpdatedChangelogs_betaTrack_frozenVersionCodesMatchFrozenConfig() {
+    // Beta frozen codes (from FrozenReleaseConfig) must be present in the changelog update. The
+    // assertion derives directly from FROZEN_VERSION_CODES_PER_TRACK so it stays resilient when
+    // codes are added to or removed from the config.
     fakeClient.setTrackReleases(
       "beta",
       listOf(
@@ -646,7 +650,8 @@ class UploadChangelogToPlayConsoleTest {
 
     assertThat(fakeClient.trackUpdates).hasSize(1)
     assertThat(fakeClient.trackUpdates[0].track).isEqualTo("beta")
-    assertThat(fakeClient.trackUpdates[0].frozenVersionCodes).containsExactly(196L)
+    assertThat(fakeClient.trackUpdates[0].frozenVersionCodes)
+      .containsExactlyElementsIn(FROZEN_VERSION_CODES_PER_TRACK["beta"] ?: emptySet<Long>())
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes part of #6106

## Explanation

This is a follow-up to the merged frozen-code exclusion #6369. That PR introduced `FROZEN_ALPHA_BASELINE` and `FROZEN_BETA_BASELINE` constants in `FakePlayConsoleClient` as test helpers, but hard-coded their `versionCodes` lists (e.g. `listOf(16L, 201L)`) and wrote assertions like `containsExactly(16L, 201L)`. This created a **tight coupling** between the test utility and `FrozenReleaseConfig`: removing a code from the config caused test failures immediately, as Adhiambo found after merge.

**`FrozenReleaseConfig.kt`** — Removed `alpha vc 201` and `beta vc 196`. 

**`FakePlayConsoleClient.kt`** — `FROZEN_ALPHA_BASELINE`, `FROZEN_BETA_BASELINE`, and `setUpFrozenBaselines()` now derive their version code lists **directly from `FROZEN_VERSION_CODES_PER_TRACK`** at construction time. Any future add/remove in `FrozenReleaseConfig` is automatically reflected in all test setups with zero manual changes. `setUpFrozenBaselines()` also silently skips tracks that currently have no frozen codes, so it remains correct regardless of config state.

**`UploadBinaryToPlayConsoleTest.kt` / `UpdateRolloutFractionTest.kt` / `UploadChangelogToPlayConsoleTest.kt`** — `frozenVersionCodes` assertions now read from `FROZEN_VERSION_CODES_PER_TRACK[track]` rather than hardcoded sets, applying the same resilience principle to the assertion side.

## Disclosure of LLM Usage
<!-- Please answer the following two questions. -->
AI was used for code completion and research. 

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).