### PR TITLE
Fix #6020: Introduce API for surfacing supported audio languages

### DIFF
--- a/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/options/AudioLanguageSelectionViewModel.kt
@@ -54,10 +54,9 @@ class AudioLanguageSelectionViewModel @Inject constructor(
   val selectedLanguage = MutableLiveData<AudioLanguage>()
 
   /** Sets the list of audio languages supported by the app based on [OppiaLanguage]. */
-  // TODO(#6020): Replace getSupportedAppLanguages with an audio languages specific API.
   val supportedOppiaLanguagesLiveData: LiveData<List<OppiaLanguage>> =
     Transformations.map(
-      translationController.getSupportedAppLanguages().toLiveData()
+      translationController.getSupportedAudioLanguages().toLiveData()
     ) { supportedLanguagesResult ->
       when (supportedLanguagesResult) {
         is AsyncResult.Failure -> {

--- a/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
@@ -53,7 +53,7 @@ private const val AUDIO_TRANSLATION_CONTENT_LANG_RES_DATA_PROVIDER_ID =
   "audio_translation_content_language_resolution"
 private const val AUDIO_TRANSLATION_CONTENT_SELECTION_DATA_PROVIDER_ID =
   "audio_translation_content_selection"
-private const val SUPPORTED_AUDIO_LANGUAGES_COMBINATION_ID = "supported_audio_languages"
+private const val SUPPORTED_AUDIO_LANGUAGES_DATA_PROVIDER_ID = "supported_audio_languages"
 private const val SUPPORTED_AUDIO_LANGUAGES_LIST_DATA_PROVIDER_ID =
   "supported_audio_languages_list"
 private const val UPDATE_AUDIO_TRANSLATION_CONTENT_DATA_PROVIDER_ID =
@@ -332,7 +332,7 @@ class TranslationController @Inject constructor(
   ): DataProvider<OppiaLocale.ContentLocale> {
     val resolvedLanguageProvider =
       getAudioTranslationContentLanguageSelection(profileId).combineWith(
-        getSupportedAudioLanguages(), SUPPORTED_AUDIO_LANGUAGES_COMBINATION_ID
+        getSupportedAudioLanguages(), SUPPORTED_AUDIO_LANGUAGES_DATA_PROVIDER_ID
       ) { audioLanguageSelection, supportedAudioLanguages ->
         // Before a profile sets an audio language, LANGUAGE_UNSPECIFIED is always returned.
         // In some cases, a language might not be supported but has a fallback configured.

--- a/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
@@ -53,7 +53,7 @@ private const val AUDIO_TRANSLATION_CONTENT_LANG_RES_DATA_PROVIDER_ID =
   "audio_translation_content_language_resolution"
 private const val AUDIO_TRANSLATION_CONTENT_SELECTION_DATA_PROVIDER_ID =
   "audio_translation_content_selection"
-private const val SUPPORTED_AUDIO_LANGUAGES_DATA_PROVIDER_ID = "supported_audio_languages"
+private const val SUPPORTED_AUDIO_LANGUAGES_COMBINATION_ID = "supported_audio_languages"
 private const val SUPPORTED_AUDIO_LANGUAGES_LIST_DATA_PROVIDER_ID =
   "supported_audio_languages_list"
 private const val UPDATE_AUDIO_TRANSLATION_CONTENT_DATA_PROVIDER_ID =
@@ -332,11 +332,11 @@ class TranslationController @Inject constructor(
   ): DataProvider<OppiaLocale.ContentLocale> {
     val resolvedLanguageProvider =
       getAudioTranslationContentLanguageSelection(profileId).combineWith(
-        getSupportedAudioLanguages(), SUPPORTED_AUDIO_LANGUAGES_DATA_PROVIDER_ID
-      ) { audioLanguageSelection, supportedAppLanguages ->
+        getSupportedAudioLanguages(), SUPPORTED_AUDIO_LANGUAGES_COMBINATION_ID
+      ) { audioLanguageSelection, supportedAudioLanguages ->
         // Before a profile sets an audio language, LANGUAGE_UNSPECIFIED is always returned.
         // In some cases, a language might not be supported but has a fallback configured.
-        if (audioLanguageSelection.selectedLanguage in supportedAppLanguages ||
+        if (audioLanguageSelection.selectedLanguage in supportedAudioLanguages ||
           audioLanguageSelection.selectionTypeCase == SelectionTypeCase.USE_APP_LANGUAGE ||
           audioLanguageSelection.selectedLanguage == OppiaLanguage.LANGUAGE_UNSPECIFIED
         ) {

--- a/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/translation/TranslationController.kt
@@ -54,6 +54,8 @@ private const val AUDIO_TRANSLATION_CONTENT_LANG_RES_DATA_PROVIDER_ID =
 private const val AUDIO_TRANSLATION_CONTENT_SELECTION_DATA_PROVIDER_ID =
   "audio_translation_content_selection"
 private const val SUPPORTED_AUDIO_LANGUAGES_DATA_PROVIDER_ID = "supported_audio_languages"
+private const val SUPPORTED_AUDIO_LANGUAGES_LIST_DATA_PROVIDER_ID =
+  "supported_audio_languages_list"
 private const val UPDATE_AUDIO_TRANSLATION_CONTENT_DATA_PROVIDER_ID =
   "update_audio_translation_content"
 private const val PROFILE_AUDIO_LANGUAGE_PROVIDER_ID = "profile_audio_language"
@@ -129,6 +131,23 @@ class TranslationController @Inject constructor(
     return dataProviders.createInMemoryDataProvider(RETRIEVED_CONTENT_LANGUAGE_DATA_PROVIDER_ID) {
       languageConfigRetriever.loadSupportedLanguages().languageDefinitionsList.filter {
         it.hasAppStringId()
+      }.map { it.language }
+    }
+  }
+
+  /**
+   * Returns a data provider for a list of [OppiaLanguage] which can be passed to
+   * [updateAudioTranslationContentLanguage].
+   *
+   * Note that this list may differ from [getSupportedAppLanguages] since some languages support
+   * audio voiceovers but not app strings (e.g. Hinglish).
+   */
+  fun getSupportedAudioLanguages(): DataProvider<List<OppiaLanguage>> {
+    return dataProviders.createInMemoryDataProvider(
+      SUPPORTED_AUDIO_LANGUAGES_LIST_DATA_PROVIDER_ID
+    ) {
+      languageConfigRetriever.loadSupportedLanguages().languageDefinitionsList.filter {
+        it.hasAudioTranslationId()
       }.map { it.language }
     }
   }
@@ -311,10 +330,9 @@ class TranslationController @Inject constructor(
   fun getAudioTranslationContentLocale(
     profileId: ProfileId
   ): DataProvider<OppiaLocale.ContentLocale> {
-    // TODO(#6020): Replace getSupportedAppLanguages with an audio languages specific API.
     val resolvedLanguageProvider =
       getAudioTranslationContentLanguageSelection(profileId).combineWith(
-        getSupportedAppLanguages(), SUPPORTED_AUDIO_LANGUAGES_DATA_PROVIDER_ID
+        getSupportedAudioLanguages(), SUPPORTED_AUDIO_LANGUAGES_DATA_PROVIDER_ID
       ) { audioLanguageSelection, supportedAppLanguages ->
         // Before a profile sets an audio language, LANGUAGE_UNSPECIFIED is always returned.
         // In some cases, a language might not be supported but has a fallback configured.

--- a/domain/src/test/java/org/oppia/android/domain/translation/TranslationControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/translation/TranslationControllerTest.kt
@@ -1178,7 +1178,7 @@ class TranslationControllerTest {
   }
 
   @Test
-  fun testGetAudioLocale_updateLanguageToHinglish_returnsEnglishLocale() {
+  fun testGetAudioLocale_updateLanguageToHinglish_returnsHinglishLocale() {
     forceDefaultLocale(Locale.ROOT)
     ensureAudioTranslationsLanguageIsUpdatedTo(PROFILE_ID_0, HINGLISH)
 
@@ -1187,7 +1187,9 @@ class TranslationControllerTest {
     val locale = monitorFactory.waitForNextSuccessfulResult(localeProvider)
     val context = locale.localeContext
     assertThat(context.usageMode).isEqualTo(AUDIO_TRANSLATIONS)
-    assertThat(context.languageDefinition.language).isEqualTo(ENGLISH)
+    // HINGLISH is now a supported audio language (it has audio_translation_id), so it correctly
+    // resolves to HINGLISH rather than falling back to ENGLISH.
+    assertThat(context.languageDefinition.language).isEqualTo(HINGLISH)
     // This region comes from the default locale.
     assertThat(context.regionDefinition.region).isEqualTo(REGION_UNSPECIFIED)
   }
@@ -2034,6 +2036,20 @@ class TranslationControllerTest {
     // the language selection system provides exactly the list of intended languages.
     assertThat(languageListData)
       .containsExactly(ARABIC, ENGLISH, HINDI, BRAZILIAN_PORTUGUESE, SWAHILI, NIGERIAN_PIDGIN)
+  }
+
+  @Test
+  fun testGetSupportedAudioLanguages_returnsAudioLanguageDefinitions() {
+    val languageListProvider = translationController.getSupportedAudioLanguages()
+    val languageListData = monitorFactory.waitForNextSuccessfulResult(languageListProvider)
+
+    // Audio languages include HINGLISH which has an audio_translation_id but no app_string_id,
+    // so it correctly appears here but not in getSupportedAppLanguages(). This is a change
+    // detector test to ensure the audio language selection system provides exactly the list of
+    // intended languages.
+    assertThat(languageListData).containsExactly(
+      ARABIC, ENGLISH, HINDI, HINGLISH, BRAZILIAN_PORTUGUESE, SWAHILI, NIGERIAN_PIDGIN
+    )
   }
 
   private fun setUpTestApplicationComponent() {

--- a/domain/src/test/java/org/oppia/android/domain/translation/TranslationControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/translation/TranslationControllerTest.kt
@@ -1195,6 +1195,23 @@ class TranslationControllerTest {
   }
 
   @Test
+  fun testGetAudioLocale_updateLanguageToPortuguese_returnsEnglishLocale() {
+    forceDefaultLocale(Locale.ROOT)
+    ensureAudioTranslationsLanguageIsUpdatedTo(PROFILE_ID_0, PORTUGUESE)
+
+    val localeProvider = translationController.getAudioTranslationContentLocale(PROFILE_ID_0)
+
+    val locale = monitorFactory.waitForNextSuccessfulResult(localeProvider)
+    val context = locale.localeContext
+    assertThat(context.usageMode).isEqualTo(AUDIO_TRANSLATIONS)
+    // PORTUGUESE does not have an audio_translation_id, so it is unsupported for audio translations.
+    // Therefore, it should fall back to ENGLISH.
+    assertThat(context.languageDefinition.language).isEqualTo(ENGLISH)
+    // This region comes from the default locale.
+    assertThat(context.regionDefinition.region).isEqualTo(REGION_UNSPECIFIED)
+  }
+
+  @Test
   fun testGetAudioLocale_updateLanguageToUseApp_returnsAppLanguage() {
     // First, initialize the language to Hindi before overwriting to use the app language.
     ensureAudioTranslationsLanguageIsUpdatedTo(PROFILE_ID_0, HINDI)

--- a/domain/src/test/java/org/oppia/android/domain/translation/TranslationControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/translation/TranslationControllerTest.kt
@@ -1187,10 +1187,7 @@ class TranslationControllerTest {
     val locale = monitorFactory.waitForNextSuccessfulResult(localeProvider)
     val context = locale.localeContext
     assertThat(context.usageMode).isEqualTo(AUDIO_TRANSLATIONS)
-    // HINGLISH is now a supported audio language (it has audio_translation_id), so it correctly
-    // resolves to HINGLISH rather than falling back to ENGLISH.
     assertThat(context.languageDefinition.language).isEqualTo(HINGLISH)
-    // This region comes from the default locale.
     assertThat(context.regionDefinition.region).isEqualTo(REGION_UNSPECIFIED)
   }
 


### PR DESCRIPTION
## Explanation

Fixes #6020
Introduces a `getSupportedAudioLanguages()` API in `TranslationController` to correctly surface the list of languages that support audio voiceovers.

**Problem:** `getAudioTranslationContentLocale()` and `AudioLanguageSelectionViewModel` were both using `getSupportedAppLanguages()` (which filters by `hasAppStringId()`) to validate audio language selections. This was incorrect — languages like Hinglish have an `audio_translation_id` but no `app_string_id`, so they were incorrectly excluded from the supported audio language list and falling back to English.

**Changes:**
- Added `getSupportedAudioLanguages()` to `TranslationController` filtering by `hasAudioTranslationId()`.
- Updated `getAudioTranslationContentLocale()` to use the new API, resolving `TODO(#6020)`.
- Updated `AudioLanguageSelectionViewModel` to use `getSupportedAudioLanguages()`, resolving `TODO(#6020)`.
- Updated existing test `testGetAudioLocale_updateLanguageToHinglish` to expect `HINGLISH` locale (correct behavior) instead of `ENGLISH` fallback.
- Added change-detector test verifying HINGLISH is included in the audio language list.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
- **Did you use AI/LLMs when working on this PR?** Yes
- **If yes, describe the extent AI was used:** Used AI for brainstorming the approach, identifying `hasAudioTranslationId()` as the correct filter, debugging the existing HINGLISH fallback test failure, and code review assistance.
