### PR TITLE
Fix #6382 and part of #5940: Add edge-to-edge insets to full-screen dialogs

### DIFF
--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsAndSolutionDialogFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsAndSolutionDialogFragment.kt
@@ -151,7 +151,9 @@ class HintsAndSolutionDialogFragment :
 
   override fun onStart() {
     super.onStart()
-    dialog?.window?.setWindowAnimations(R.style.FullScreenHintDialogStyle)
+    val dialog = this.dialog ?: return
+    dialog.window?.setWindowAnimations(R.style.FullScreenHintDialogStyle)
+    hintsAndSolutionDialogFragmentPresenter.applyEdgeToEdgeInsets(dialog)
   }
 
   override fun onSaveInstanceState(outState: Bundle) {

--- a/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsAndSolutionDialogFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/hintsandsolution/HintsAndSolutionDialogFragmentPresenter.kt
@@ -1,5 +1,6 @@
 package org.oppia.android.app.hintsandsolution
 
+import android.app.Dialog
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -18,10 +19,13 @@ import org.oppia.android.app.recyclerview.BindableAdapter
 import org.oppia.android.app.topic.conceptcard.ConceptCardFragment
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.ui.R
+import org.oppia.android.app.utility.edgetoedge.EdgeToEdgeHelper
 import org.oppia.android.util.accessibility.AccessibilityService
 import org.oppia.android.util.gcsresource.DefaultResourceBucketName
 import org.oppia.android.util.parser.html.ExplorationHtmlParserEntityType
 import org.oppia.android.util.parser.html.HtmlParser
+import org.oppia.android.util.platformparameter.EnableEdgeToEdge
+import org.oppia.android.util.platformparameter.PlatformParameterValue
 import javax.inject.Inject
 
 const val TAG_REVEAL_SOLUTION_DIALOG = "REVEAL_SOLUTION_DIALOG"
@@ -36,7 +40,9 @@ class HintsAndSolutionDialogFragmentPresenter @Inject constructor(
   @ExplorationHtmlParserEntityType private val entityType: String,
   private val resourceHandler: AppLanguageResourceHandler,
   private val multiTypeBuilderFactory: BindableAdapter.MultiTypeBuilder.Factory,
-  private val hintsAndSolutionViewModelFactory: HintsAndSolutionViewModel.Factory
+  private val hintsAndSolutionViewModelFactory: HintsAndSolutionViewModel.Factory,
+  @EnableEdgeToEdge
+  private val enableEdgeToEdge: PlatformParameterValue<Boolean>
 ) : HtmlParser.CustomOppiaTagActionListener {
 
   @Inject
@@ -55,6 +61,7 @@ class HintsAndSolutionDialogFragmentPresenter @Inject constructor(
   private lateinit var bindingAdapter: BindableAdapter<HintsAndSolutionItemViewModel>
   private lateinit var explorationId: String
   private lateinit var hintsViewModel: HintsAndSolutionViewModel
+  private lateinit var appBarLayout: View
 
   /**
    * Sets up data binding and toolbar.
@@ -97,6 +104,7 @@ class HintsAndSolutionDialogFragmentPresenter @Inject constructor(
 
     val binding =
       HintsAndSolutionFragmentBinding.inflate(inflater, container, /* attachToRoot= */ false)
+    appBarLayout = binding.hintsAndSolutionAppBarLayout
     binding.hintsAndSolutionToolbar.setNavigationIcon(R.drawable.ic_close_white_24dp)
     binding.hintsAndSolutionToolbar.setNavigationContentDescription(
       R.string.hints_and_solution_close_icon_description
@@ -117,6 +125,21 @@ class HintsAndSolutionDialogFragmentPresenter @Inject constructor(
     }
 
     return binding.root
+  }
+
+  /**
+   * Applies edge-to-edge window insets to the hints and solution [dialog].
+   *
+   * The dialog is shown in its own window, so the insets applied to the host activity don't reach
+   * it and its toolbar would otherwise be drawn underneath the status bar.
+   */
+  fun applyEdgeToEdgeInsets(dialog: Dialog) {
+    if (!enableEdgeToEdge.value) return
+    EdgeToEdgeHelper.applyToDialogTopBar(
+      dialog,
+      appBarLayout,
+      R.color.component_color_shared_hint_dialog_status_bar_color
+    )
   }
 
   private enum class ViewType {

--- a/app/src/main/java/org/oppia/android/app/survey/SurveyOutroDialogFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/survey/SurveyOutroDialogFragment.kt
@@ -49,6 +49,8 @@ class SurveyOutroDialogFragment : InjectableDialogFragment() {
 
   override fun onStart() {
     super.onStart()
-    dialog?.window?.setWindowAnimations(R.style.SurveyOnboardingDialogStyle)
+    val dialog = this.dialog ?: return
+    dialog.window?.setWindowAnimations(R.style.SurveyOnboardingDialogStyle)
+    surveyOutroDialogFragmentPresenter.applyEdgeToEdgeInsets(dialog)
   }
 }

--- a/app/src/main/java/org/oppia/android/app/survey/SurveyOutroDialogFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/survey/SurveyOutroDialogFragmentPresenter.kt
@@ -1,5 +1,6 @@
 package org.oppia.android.app.survey
 
+import android.app.Dialog
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,10 +10,13 @@ import org.oppia.android.app.databinding.databinding.SurveyOutroDialogFragmentBi
 import org.oppia.android.app.fragment.FragmentScope
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.ui.R
+import org.oppia.android.app.utility.edgetoedge.EdgeToEdgeHelper
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.survey.SurveyController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.platformparameter.EnableEdgeToEdge
+import org.oppia.android.util.platformparameter.PlatformParameterValue
 import javax.inject.Inject
 
 const val TAG_SURVEY_OUTRO_DIALOG = "SURVEY_OUTRO_DIALOG"
@@ -24,8 +28,12 @@ class SurveyOutroDialogFragmentPresenter @Inject constructor(
   private val fragment: Fragment,
   private val resourceHandler: AppLanguageResourceHandler,
   private val surveyController: SurveyController,
-  private val oppiaLogger: OppiaLogger
+  private val oppiaLogger: OppiaLogger,
+  @EnableEdgeToEdge
+  private val enableEdgeToEdge: PlatformParameterValue<Boolean>
 ) {
+  private lateinit var rootView: View
+
   /** Sets up data binding. */
   fun handleCreateView(
     inflater: LayoutInflater,
@@ -33,6 +41,7 @@ class SurveyOutroDialogFragmentPresenter @Inject constructor(
   ): View {
     val binding =
       SurveyOutroDialogFragmentBinding.inflate(inflater, container, /* attachToRoot= */ false)
+    rootView = binding.root
 
     binding.lifecycleOwner = fragment
 
@@ -46,6 +55,21 @@ class SurveyOutroDialogFragmentPresenter @Inject constructor(
     }
 
     return binding.root
+  }
+
+  /**
+   * Applies edge-to-edge window insets to the survey outro [dialog].
+   *
+   * The dialog is shown in its own window, so the insets applied to the host activity don't reach
+   * it and its content would otherwise be drawn underneath the status bar.
+   */
+  fun applyEdgeToEdgeInsets(dialog: Dialog) {
+    if (!enableEdgeToEdge.value) return
+    EdgeToEdgeHelper.applyToDialogRootView(
+      dialog,
+      rootView,
+      R.color.component_color_shared_dialogs_secondary_color
+    )
   }
 
   private fun closeSurveyDialogAndActivity() {

--- a/app/src/main/java/org/oppia/android/app/survey/SurveyWelcomeDialogFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/survey/SurveyWelcomeDialogFragment.kt
@@ -101,6 +101,12 @@ class SurveyWelcomeDialogFragment : InjectableDialogFragment() {
     )
   }
 
+  override fun onStart() {
+    super.onStart()
+    val dialog = this.dialog ?: return
+    surveyWelcomeDialogFragmentPresenter.applyEdgeToEdgeInsets(dialog)
+  }
+
   private fun getQuestions(questionNumberList: List<Int>): List<SurveyQuestionName> {
     return questionNumberList.map { number -> SurveyQuestionName.forNumber(number) }
   }

--- a/app/src/main/java/org/oppia/android/app/survey/SurveyWelcomeDialogFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/survey/SurveyWelcomeDialogFragmentPresenter.kt
@@ -1,5 +1,6 @@
 package org.oppia.android.app.survey
 
+import android.app.Dialog
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,12 +10,16 @@ import org.oppia.android.app.databinding.databinding.SurveyWelcomeDialogFragment
 import org.oppia.android.app.fragment.FragmentScope
 import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.model.SurveyQuestionName
+import org.oppia.android.app.ui.R
+import org.oppia.android.app.utility.edgetoedge.EdgeToEdgeHelper
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.oppialogger.analytics.AnalyticsController
 import org.oppia.android.domain.profile.ProfileManagementController
 import org.oppia.android.domain.survey.SurveyController
 import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProviders.Companion.toLiveData
+import org.oppia.android.util.platformparameter.EnableEdgeToEdge
+import org.oppia.android.util.platformparameter.PlatformParameterValue
 import org.oppia.android.util.profile.toProfileIdPreservingZero
 import javax.inject.Inject
 
@@ -28,9 +33,12 @@ class SurveyWelcomeDialogFragmentPresenter @Inject constructor(
   private val surveyController: SurveyController,
   private val oppiaLogger: OppiaLogger,
   private val analyticsController: AnalyticsController,
-  private val profileManagementController: ProfileManagementController
+  private val profileManagementController: ProfileManagementController,
+  @EnableEdgeToEdge
+  private val enableEdgeToEdge: PlatformParameterValue<Boolean>
 ) {
   private lateinit var explorationId: String
+  private lateinit var rootView: View
   private val dismissSurveyListener = activity as DismissSurveyListener
 
   /** Sets up data binding. */
@@ -45,6 +53,7 @@ class SurveyWelcomeDialogFragmentPresenter @Inject constructor(
     this.explorationId = explorationId
     val binding =
       SurveyWelcomeDialogFragmentBinding.inflate(inflater, container, /* attachToRoot= */ false)
+    rootView = binding.root
 
     binding.lifecycleOwner = fragment
 
@@ -63,6 +72,21 @@ class SurveyWelcomeDialogFragmentPresenter @Inject constructor(
     logSurveyPopUpShownEvent(explorationId, topicId, profileId)
 
     return binding.root
+  }
+
+  /**
+   * Applies edge-to-edge window insets to the survey welcome [dialog].
+   *
+   * The dialog is shown in its own window, so the insets applied to the host activity don't reach
+   * it and its content would otherwise be drawn underneath the status bar.
+   */
+  fun applyEdgeToEdgeInsets(dialog: Dialog) {
+    if (!enableEdgeToEdge.value) return
+    EdgeToEdgeHelper.applyToDialogRootView(
+      dialog,
+      rootView,
+      R.color.component_color_shared_dialogs_secondary_color
+    )
   }
 
   private fun startSurveySession(

--- a/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragment.kt
@@ -138,7 +138,9 @@ class ConceptCardFragment : InjectableDialogFragment() {
 
   override fun onStart() {
     super.onStart()
-    dialog?.window?.setWindowAnimations(R.style.FullScreenDialogStyle)
+    val dialog = this.dialog ?: return
+    dialog.window?.setWindowAnimations(R.style.FullScreenDialogStyle)
+    conceptCardFragmentPresenter.applyEdgeToEdgeInsets(dialog)
   }
 
   private fun getSkillId(): String? {

--- a/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentPresenter.kt
@@ -1,14 +1,17 @@
 package org.oppia.android.app.topic.conceptcard
 
+import android.app.Dialog
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import org.oppia.android.app.databinding.databinding.ConceptCardFragmentBinding
 import org.oppia.android.app.fragment.FragmentScope
 import org.oppia.android.app.model.LegacyProfileId
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.ui.R
+import org.oppia.android.app.utility.edgetoedge.EdgeToEdgeHelper
 import org.oppia.android.domain.oppialogger.OppiaLogger
 import org.oppia.android.domain.oppialogger.analytics.AnalyticsController
 import org.oppia.android.domain.translation.TranslationController
@@ -16,6 +19,7 @@ import org.oppia.android.util.gcsresource.DefaultResourceBucketName
 import org.oppia.android.util.parser.html.ConceptCardHtmlParserEntityType
 import org.oppia.android.util.parser.html.HtmlParser
 import org.oppia.android.util.parser.html.WorkedExampleLabels
+import org.oppia.android.util.platformparameter.EnableEdgeToEdge
 import org.oppia.android.util.platformparameter.EnableWorkedExamples
 import org.oppia.android.util.platformparameter.PlatformParameterValue
 import javax.inject.Inject
@@ -33,9 +37,12 @@ class ConceptCardFragmentPresenter @Inject constructor(
   private val translationController: TranslationController,
   private val appLanguageResourceHandler: AppLanguageResourceHandler,
   @EnableWorkedExamples
-  private val enableWorkedExamples: PlatformParameterValue<Boolean>
+  private val enableWorkedExamples: PlatformParameterValue<Boolean>,
+  @EnableEdgeToEdge
+  private val enableEdgeToEdge: PlatformParameterValue<Boolean>
 ) : HtmlParser.CustomOppiaTagActionListener {
   private lateinit var profileId: LegacyProfileId
+  private lateinit var toolbar: Toolbar
 
   /**
    * Sets up data binding and toolbar.
@@ -58,11 +65,12 @@ class ConceptCardFragmentPresenter @Inject constructor(
     conceptCardViewModel.initialize(skillId, profileId)
     logConceptCardEvent(skillId)
 
-    binding.conceptCardToolbar.setNavigationIcon(R.drawable.ic_close_white_24dp)
-    binding.conceptCardToolbar.setNavigationContentDescription(
+    toolbar = binding.conceptCardToolbar
+    toolbar.setNavigationIcon(R.drawable.ic_close_white_24dp)
+    toolbar.setNavigationContentDescription(
       R.string.navigate_up
     )
-    binding.conceptCardToolbar.setNavigationOnClickListener {
+    toolbar.setNavigationOnClickListener {
       (fragment.requireActivity() as? ConceptCardListener)?.dismissConceptCard()
     }
 
@@ -97,6 +105,21 @@ class ConceptCardFragmentPresenter @Inject constructor(
     }
 
     return binding.root
+  }
+
+  /**
+   * Applies edge-to-edge window insets to the concept card's [dialog].
+   *
+   * The concept card is shown in its own window, so the insets applied to the host activity don't
+   * reach it and its toolbar would otherwise be drawn underneath the status bar.
+   */
+  fun applyEdgeToEdgeInsets(dialog: Dialog) {
+    if (!enableEdgeToEdge.value) return
+    EdgeToEdgeHelper.applyToDialogTopBar(
+      dialog,
+      toolbar,
+      R.color.component_color_shared_fragment_status_bar_color
+    )
   }
 
   /**

--- a/app/src/main/java/org/oppia/android/app/utility/edgetoedge/EdgeToEdgeHelper.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/edgetoedge/EdgeToEdgeHelper.kt
@@ -1,9 +1,11 @@
 package org.oppia.android.app.utility.edgetoedge
 
+import android.app.Dialog
 import android.os.Build
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.annotation.ColorRes
@@ -20,8 +22,12 @@ import java.util.WeakHashMap
 
 /**
  * Utility that dispatches edge-to-edge window insets to activity toolbars, navigation drawers,
- * and no-toolbar screens while the `EnableEdgeToEdge` platform parameter gates the Android 15
- * rollout.
+ * no-toolbar screens, and full-screen dialogs while the `EnableEdgeToEdge` platform parameter gates
+ * the Android 15 rollout.
+ *
+ * Every entry point works against a [Window] rather than an activity so that dialogs, which are
+ * shown in their own window and therefore never receive the host activity's insets, can be handled
+ * the same way as the screens hosting them.
  */
 object EdgeToEdgeHelper {
   private const val STATUS_BAR_SPACER_TAG = "oppia_edge_to_edge_status_bar_spacer"
@@ -49,14 +55,15 @@ object EdgeToEdgeHelper {
     toolbar: Toolbar,
     @ColorRes statusBarColorRes: Int
   ) {
+    val window = activity.window
     val parent = toolbar.parent
     if (parent !is LinearLayout) {
-      applyAsTopBar(activity, toolbar, statusBarColorRes)
+      applyAsTopBar(window, toolbar, statusBarColorRes)
       return
     }
     val contentLayout = parent
     val spacer = getOrCreateLinearStatusBarSpacer(
-      activity, contentLayout, statusBarColorRes
+      window, contentLayout, statusBarColorRes
     )
 
     ViewCompat.setOnApplyWindowInsetsListener(spacer) { view, insets ->
@@ -71,7 +78,7 @@ object EdgeToEdgeHelper {
       insets
     }
 
-    disableDecorAncestorFits(activity)
+    disableDecorAncestorFits(window)
     applyRootInsetsIfAvailable(contentLayout) { bars ->
       spacer.layoutParams.height = bars.top
       spacer.requestLayout()
@@ -79,7 +86,7 @@ object EdgeToEdgeHelper {
         bars, applyLeft = true, applyRight = true, applyBottom = true
       )
     }
-    disableNavBarContrast(activity)
+    disableNavBarContrast(window)
   }
 
   /**
@@ -94,14 +101,15 @@ object EdgeToEdgeHelper {
     toolbar: Toolbar,
     @ColorRes statusBarColorRes: Int
   ) {
+    val window = activity.window
     val parent = toolbar.parent
     if (parent !is LinearLayout) {
-      applyAsTopBar(activity, toolbar, statusBarColorRes)
+      applyAsTopBar(window, toolbar, statusBarColorRes)
       return
     }
     val appBarLayout: LinearLayout = parent
-    appBarLayout.setBackgroundColor(ContextCompat.getColor(activity, statusBarColorRes))
-    val contentRoot = activity.findViewById<View>(android.R.id.content)
+    appBarLayout.setBackgroundColor(ContextCompat.getColor(window.context, statusBarColorRes))
+    val contentRoot = window.contentRoot
 
     ViewCompat.setOnApplyWindowInsetsListener(appBarLayout) { view, insets ->
       val bars = insets.systemBarsWithCutout()
@@ -114,14 +122,14 @@ object EdgeToEdgeHelper {
       insets
     }
 
-    disableDecorAncestorFits(activity)
+    disableDecorAncestorFits(window)
     applyRootInsetsIfAvailable(appBarLayout) { bars ->
       appBarLayout.applyInsetPadding(bars, applyTop = true)
       contentRoot.applyInsetPadding(
         bars, applyLeft = true, applyRight = true, applyBottom = true
       )
     }
-    disableNavBarContrast(activity)
+    disableNavBarContrast(window)
   }
 
   /**
@@ -141,7 +149,7 @@ object EdgeToEdgeHelper {
     navigationView.fitsSystemWindows = false
 
     val spacer = getOrCreateLinearStatusBarSpacer(
-      activity, drawerContentLayout, statusBarColorRes
+      activity.window, drawerContentLayout, statusBarColorRes
     )
     ViewCompat.setOnApplyWindowInsetsListener(spacer) { view, insets ->
       val bars = insets.systemBarsWithCutout()
@@ -181,8 +189,9 @@ object EdgeToEdgeHelper {
     @ColorRes statusBarColorRes: Int,
     statusBarLight: Boolean = false
   ): View {
-    val contentRoot = activity.findViewById<View>(android.R.id.content)
-    val spacer = getOrCreateOverlayStatusBarSpacer(activity, contentRoot, statusBarColorRes)
+    val window = activity.window
+    val contentRoot = window.contentRoot
+    val spacer = getOrCreateOverlayStatusBarSpacer(window, contentRoot, statusBarColorRes)
 
     ViewCompat.setOnApplyWindowInsetsListener(spacer) { view, insets ->
       val bars = insets.systemBarsWithCutout()
@@ -202,7 +211,7 @@ object EdgeToEdgeHelper {
       insets
     }
 
-    disableDecorAncestorFits(activity)
+    disableDecorAncestorFits(window)
     applyRootInsetsIfAvailable(rootLayout) { bars ->
       spacer.layoutParams.height = bars.top
       spacer.requestLayout()
@@ -214,9 +223,9 @@ object EdgeToEdgeHelper {
         applyBottom = true
       )
     }
-    WindowCompat.getInsetsController(activity.window, rootLayout)
+    WindowCompat.getInsetsController(window, rootLayout)
       ?.isAppearanceLightStatusBars = statusBarLight
-    disableNavBarContrast(activity)
+    disableNavBarContrast(window)
     ViewCompat.requestApplyInsets(contentRoot)
 
     return spacer
@@ -253,21 +262,42 @@ object EdgeToEdgeHelper {
     )
   }
 
-  // Used when the toolbar's parent is not a LinearLayout. A separate spacer preserves the
-  // toolbar's original color instead of turning the whole toolbar into the status-bar color.
-  private fun applyAsTopBar(
-    activity: AppCompatActivity,
+  /**
+   * Applies edge-to-edge insets to a full-screen [dialog] whose [topBar] (a `Toolbar`, or the
+   * `AppBarLayout` wrapping one) is pinned to the top of the dialog's content.
+   *
+   * A dialog is shown in its own [Window], so the handling applied to the activity behind it never
+   * reaches it: without this the [topBar] is drawn underneath the status bar and its navigation
+   * icon lands in the status bar's touch area, making it untappable. A status-bar spacer colored
+   * with [statusBarColorRes] is inserted above [topBar] so the bar keeps its own color, matching
+   * how toolbar-hosted activities are handled.
+   */
+  fun applyToDialogTopBar(
+    dialog: Dialog,
     topBar: View,
     @ColorRes statusBarColorRes: Int
   ) {
-    val contentRoot = activity.findViewById<View>(android.R.id.content)
+    val window = dialog.window ?: return
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+    applyAsTopBar(window, topBar, statusBarColorRes)
+    ViewCompat.requestApplyInsets(window.contentRoot)
+  }
+
+  // Used when the toolbar's parent is not a LinearLayout. A separate spacer preserves the
+  // toolbar's original color instead of turning the whole toolbar into the status-bar color.
+  private fun applyAsTopBar(
+    window: Window,
+    topBar: View,
+    @ColorRes statusBarColorRes: Int
+  ) {
+    val contentRoot = window.contentRoot
     val topBarParent = topBar.parent
     val spacer = if (topBarParent is ConstraintLayout && topBar.id != View.NO_ID) {
       getOrCreateConstrainedStatusBarSpacer(
-        activity, topBarParent, topBar, statusBarColorRes
+        window, topBarParent, topBar, statusBarColorRes
       )
     } else {
-      getOrCreateOverlayStatusBarSpacer(activity, contentRoot, statusBarColorRes).also {
+      getOrCreateOverlayStatusBarSpacer(window, contentRoot, statusBarColorRes).also {
         initialMargins.getOrPut(topBar) { topBar.captureMargins() }
       }
     }
@@ -287,7 +317,7 @@ object EdgeToEdgeHelper {
       insets
     }
 
-    disableDecorAncestorFits(activity)
+    disableDecorAncestorFits(window)
     applyRootInsetsIfAvailable(spacer) { bars ->
       spacer.layoutParams.height = bars.top
       spacer.requestLayout()
@@ -298,36 +328,36 @@ object EdgeToEdgeHelper {
         bars, applyLeft = true, applyRight = true, applyBottom = true
       )
     }
-    disableNavBarContrast(activity)
+    disableNavBarContrast(window)
   }
 
   private fun getOrCreateLinearStatusBarSpacer(
-    activity: AppCompatActivity,
+    window: Window,
     parent: LinearLayout,
     @ColorRes statusBarColorRes: Int
   ): View {
-    val spacer = parent.findDirectStatusBarSpacer() ?: View(activity).also {
+    val spacer = parent.findDirectStatusBarSpacer() ?: View(window.context).also {
       it.tag = STATUS_BAR_SPACER_TAG
       it.layoutParams = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, 0)
       parent.addView(it, 0)
     }
-    spacer.setBackgroundColor(ContextCompat.getColor(activity, statusBarColorRes))
+    spacer.setBackgroundColor(ContextCompat.getColor(window.context, statusBarColorRes))
     return spacer
   }
 
   private fun getOrCreateConstrainedStatusBarSpacer(
-    activity: AppCompatActivity,
+    window: Window,
     parent: ConstraintLayout,
     topBar: View,
     @ColorRes statusBarColorRes: Int
   ): View {
-    val spacer = parent.findDirectStatusBarSpacer() ?: View(activity).also {
+    val spacer = parent.findDirectStatusBarSpacer() ?: View(window.context).also {
       it.id = View.generateViewId()
       it.tag = STATUS_BAR_SPACER_TAG
       it.layoutParams = ConstraintLayout.LayoutParams(0, 0)
       parent.addView(it)
     }
-    spacer.setBackgroundColor(ContextCompat.getColor(activity, statusBarColorRes))
+    spacer.setBackgroundColor(ContextCompat.getColor(window.context, statusBarColorRes))
 
     val originalMargins = initialMargins.getOrPut(topBar) { topBar.captureMargins() }
     parent.ensureChildrenHaveIds()
@@ -362,12 +392,12 @@ object EdgeToEdgeHelper {
   }
 
   private fun getOrCreateOverlayStatusBarSpacer(
-    activity: AppCompatActivity,
+    window: Window,
     contentRoot: View,
     @ColorRes statusBarColorRes: Int
   ): View {
     val root = contentRoot as ViewGroup
-    val spacer = root.findDirectStatusBarSpacer() ?: View(activity).also {
+    val spacer = root.findDirectStatusBarSpacer() ?: View(window.context).also {
       it.tag = STATUS_BAR_SPACER_TAG
       it.layoutParams = FrameLayout.LayoutParams(
         FrameLayout.LayoutParams.MATCH_PARENT,
@@ -376,9 +406,12 @@ object EdgeToEdgeHelper {
       )
       root.addView(it)
     }
-    spacer.setBackgroundColor(ContextCompat.getColor(activity, statusBarColorRes))
+    spacer.setBackgroundColor(ContextCompat.getColor(window.context, statusBarColorRes))
     return spacer
   }
+
+  private val Window.contentRoot: View
+    get() = findViewById(android.R.id.content)
 
   private fun ViewGroup.findDirectStatusBarSpacer(): View? =
     (0 until childCount)
@@ -392,8 +425,8 @@ object EdgeToEdgeHelper {
   // AppCompat Bridge themes re-apply status-bar top padding via legacy fitsSystemWindows
   // dispatch on ancestors like FitWindowsLinearLayout; clearing those flags avoids double-counting
   // the top inset.
-  private fun disableDecorAncestorFits(activity: AppCompatActivity) {
-    val contentRoot = activity.findViewById<View>(android.R.id.content)
+  private fun disableDecorAncestorFits(window: Window) {
+    val contentRoot = window.contentRoot
     var ancestor: View? = contentRoot.parent as? View
     while (ancestor != null) {
       if (ancestor.fitsSystemWindows) {
@@ -411,9 +444,9 @@ object EdgeToEdgeHelper {
     apply(rootInsets.systemBarsWithCutout())
   }
 
-  private fun disableNavBarContrast(activity: AppCompatActivity) {
+  private fun disableNavBarContrast(window: Window) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      activity.window.isNavigationBarContrastEnforced = false
+      window.isNavigationBarContrastEnforced = false
     }
   }
 

--- a/app/src/main/java/org/oppia/android/app/utility/edgetoedge/EdgeToEdgeHelper.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/edgetoedge/EdgeToEdgeHelper.kt
@@ -188,8 +188,16 @@ object EdgeToEdgeHelper {
     rootLayout: View,
     @ColorRes statusBarColorRes: Int,
     statusBarLight: Boolean = false
+  ): View = applyAsRootView(activity.window, rootLayout, statusBarColorRes, statusBarLight)
+
+  // Shared by the activity and dialog no-toolbar entry points, which only differ in whose window
+  // the insets are dispatched to.
+  private fun applyAsRootView(
+    window: Window,
+    rootLayout: View,
+    @ColorRes statusBarColorRes: Int,
+    statusBarLight: Boolean
   ): View {
-    val window = activity.window
     val contentRoot = window.contentRoot
     val spacer = getOrCreateOverlayStatusBarSpacer(window, contentRoot, statusBarColorRes)
 
@@ -280,7 +288,26 @@ object EdgeToEdgeHelper {
     val window = dialog.window ?: return
     WindowCompat.setDecorFitsSystemWindows(window, false)
     applyAsTopBar(window, topBar, statusBarColorRes)
-    ViewCompat.requestApplyInsets(window.contentRoot)
+  }
+
+  /**
+   * Applies edge-to-edge insets to a full-screen [dialog] that has no top bar, adding a status-bar
+   * spacer colored with [statusBarColorRes] over [rootLayout] and padding [rootLayout] by the
+   * system bars. [statusBarLight] controls whether the status bar uses dark icons.
+   *
+   * This is the dialog counterpart to [applyToRootView]. Without it such a dialog keeps drawing
+   * under a transparent status bar, so the system icons are left on whatever the dialog's window
+   * background happens to be — unreadable when the two are both light.
+   */
+  fun applyToDialogRootView(
+    dialog: Dialog,
+    rootLayout: View,
+    @ColorRes statusBarColorRes: Int,
+    statusBarLight: Boolean = false
+  ) {
+    val window = dialog.window ?: return
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+    applyAsRootView(window, rootLayout, statusBarColorRes, statusBarLight)
   }
 
   // Used when the toolbar's parent is not a LinearLayout. A separate spacer preserves the

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -672,7 +672,9 @@
 
   <!-- Survey On-boarding Dialog -->
   <style name="SurveyOnboardingDialogStyle" parent="Theme.MaterialComponents.Dialog.Bridge">
-    <item name="android:windowNoTitle">false</item>
+    <!-- These dialogs are full-screen, so they have no title bar to show. Leaving one in place
+         puts an empty strip above the content that the status bar then draws over. -->
+    <item name="android:windowNoTitle">true</item>
     <item name="colorPrimaryDark">@color/component_color_shared_dialogs_secondary_color</item>
     <!-- Set this to true if you want Full Screen without status bar -->
     <item name="android:windowFullscreen">false</item>

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/conceptcard/ConceptCardFragmentTest.kt
@@ -10,6 +10,11 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
@@ -161,6 +166,7 @@ class ConceptCardFragmentTest {
   fun setUp() {
     TestPlatformParameterModule.forceLoadLessonProtosFromAssets(true)
     TestPlatformParameterModule.forceEnableWorkedExamples(true)
+    TestPlatformParameterModule.forceEnableEdgeToEdge(true)
     Intents.init()
     setUpTestApplicationComponent()
     testCoroutineDispatchers.registerIdlingResource()
@@ -189,6 +195,27 @@ class ConceptCardFragmentTest {
       testCoroutineDispatchers.runCurrent()
 
       onView(withId(R.id.concept_card_toolbar)).check(doesNotExist())
+    }
+  }
+
+  @Test
+  fun testConceptCardFragment_openCard_toolbarIsPositionedBelowStatusBarInset() {
+    launchTestActivity().use { scenario ->
+      onView(withId(R.id.open_dialog_0)).perform(click())
+      testCoroutineDispatchers.runCurrent()
+
+      scenario.onActivity { activity ->
+        val dialog = checkNotNull(activity.retrieveConceptCardDialogFragment().dialog)
+        val toolbar = dialog.findViewById<Toolbar>(R.id.concept_card_toolbar)
+        val spacerId = (toolbar.layoutParams as ConstraintLayout.LayoutParams).topToBottom
+        // The concept card is shown in its own window, so without the dialog's own inset handling
+        // the toolbar stays pinned to the top of the window & underneath the status bar.
+        assertThat(spacerId).isNotEqualTo(ConstraintLayout.LayoutParams.UNSET)
+
+        val statusBarSpacer = dialog.findViewById<View>(spacerId)
+        ViewCompat.dispatchApplyWindowInsets(statusBarSpacer, TEST_STATUS_BAR_INSETS)
+        assertThat(statusBarSpacer.layoutParams.height).isEqualTo(TEST_STATUS_BAR_HEIGHT)
+      }
     }
   }
 
@@ -590,6 +617,9 @@ class ConceptCardFragmentTest {
     }
   }
 
+  private fun AppCompatActivity.retrieveConceptCardDialogFragment(): ConceptCardFragment =
+    supportFragmentManager.fragments.filterIsInstance<ConceptCardFragment>().single()
+
   private fun launchTestActivity(): ActivityScenario<ConceptCardFragmentTestActivity> {
     val scenario = ActivityScenario.launch<ConceptCardFragmentTestActivity>(
       ConceptCardFragmentTestActivity.createIntent(context, profileId)
@@ -733,6 +763,17 @@ class ConceptCardFragmentTest {
     }
 
     override fun getApplicationInjector(): ApplicationInjector = component
+  }
+
+  private companion object {
+    private const val TEST_STATUS_BAR_HEIGHT = 25
+
+    private val TEST_STATUS_BAR_INSETS: WindowInsetsCompat = WindowInsetsCompat.Builder()
+      .setInsets(
+        WindowInsetsCompat.Type.systemBars(),
+        Insets.of(/* left= */ 0, TEST_STATUS_BAR_HEIGHT, /* right= */ 0, /* bottom= */ 0)
+      )
+      .build()
   }
 }
 

--- a/app/src/test/java/org/oppia/android/app/utility/edgetoedge/EdgeToEdgeHelperTest.kt
+++ b/app/src/test/java/org/oppia/android/app/utility/edgetoedge/EdgeToEdgeHelperTest.kt
@@ -337,6 +337,31 @@ class EdgeToEdgeHelperTest {
   }
 
   @Test
+  fun testApplyToDialogRootView_insetsDialogWindowAndAddsStatusBarSpacer() {
+    launchTestActivity { activity ->
+      val root = ConstraintLayout(activity).apply { setPadding(1, 2, 3, 4) }
+      val dialog = Dialog(activity).also { it.setContentView(root) }
+      val dialogContentRoot = dialog.findViewById<ViewGroup>(android.R.id.content)
+
+      EdgeToEdgeHelper.applyToDialogRootView(dialog, root, STATUS_BAR_COLOR)
+      val spacer = dialogContentRoot.getChildAt(1)
+      dispatchInsets(spacer)
+      dispatchInsets(root)
+
+      // The dialog has no top bar, so the spacer overlays the status bar area of its own window.
+      assertThat(dialogContentRoot.childCount).isEqualTo(2)
+      assertThat(spacer.backgroundColor).isEqualTo(expectedStatusBarColor(activity))
+      assertThat(spacer.layoutParams.height).isEqualTo(25)
+      assertThat(root.paddingLeft).isEqualTo(16)
+      assertThat(root.paddingTop).isEqualTo(27)
+      assertThat(root.paddingRight).isEqualTo(38)
+      assertThat(root.paddingBottom).isEqualTo(44)
+      // The dialog's own window is inset, so the activity behind it is left untouched.
+      assertThat(activity.findViewById<ViewGroup>(android.R.id.content).paddingTop).isEqualTo(0)
+    }
+  }
+
+  @Test
   fun testEnableEdgeToEdgeDispatch_doesNotCrash() {
     launchTestActivity(EdgeToEdgeHelper::enableEdgeToEdgeDispatch)
   }

--- a/app/src/test/java/org/oppia/android/app/utility/edgetoedge/EdgeToEdgeHelperTest.kt
+++ b/app/src/test/java/org/oppia/android/app/utility/edgetoedge/EdgeToEdgeHelperTest.kt
@@ -1,6 +1,7 @@
 package org.oppia.android.app.utility.edgetoedge
 
 import android.app.Application
+import android.app.Dialog
 import android.content.Context
 import android.content.pm.ActivityInfo
 import android.graphics.Color
@@ -294,6 +295,44 @@ class EdgeToEdgeHelperTest {
       assertThat(root.paddingTop).isEqualTo(27)
       assertThat(root.paddingRight).isEqualTo(38)
       assertThat(root.paddingBottom).isEqualTo(44)
+    }
+  }
+
+  @Test
+  fun testApplyToDialogTopBar_insetsDialogWindowAndPreservesTopBarColor() {
+    launchTestActivity { activity ->
+      val root = ConstraintLayout(activity)
+      val toolbar = Toolbar(activity).apply {
+        id = View.generateViewId()
+        setBackgroundColor(Color.RED)
+      }
+      root.addView(toolbar, ConstraintLayout.LayoutParams(0, 56))
+      ConstraintSet().apply {
+        clone(root)
+        connect(toolbar.id, ConstraintSet.TOP, ConstraintSet.PARENT_ID, ConstraintSet.TOP)
+        connect(toolbar.id, ConstraintSet.START, ConstraintSet.PARENT_ID, ConstraintSet.START)
+        connect(toolbar.id, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END)
+        applyTo(root)
+      }
+      val dialog = Dialog(activity).also { it.setContentView(root) }
+      val dialogContentRoot = dialog.findViewById<ViewGroup>(android.R.id.content)
+
+      EdgeToEdgeHelper.applyToDialogTopBar(dialog, toolbar, STATUS_BAR_COLOR)
+      val spacer = root.getChildAt(1)
+      dispatchInsets(spacer)
+      dispatchInsets(dialogContentRoot)
+
+      assertThat(root.childCount).isEqualTo(2)
+      assertThat(toolbar.backgroundColor).isEqualTo(Color.RED)
+      assertThat(spacer.backgroundColor).isEqualTo(expectedStatusBarColor(activity))
+      assertThat(spacer.layoutParams.height).isEqualTo(25)
+      assertThat((toolbar.layoutParams as ConstraintLayout.LayoutParams).topToBottom)
+        .isEqualTo(spacer.id)
+      assertThat(dialogContentRoot.paddingLeft).isEqualTo(15)
+      assertThat(dialogContentRoot.paddingRight).isEqualTo(35)
+      assertThat(dialogContentRoot.paddingBottom).isEqualTo(40)
+      // The dialog's own window is inset, so the activity behind it is left untouched.
+      assertThat(activity.findViewById<ViewGroup>(android.R.id.content).paddingBottom).isEqualTo(0)
     }
   }
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fixes #6382

My earlier edge-to-edge PRs handled activities, but a `DialogFragment` gets its own Window, so none of that reaches it. The concept card's toolbar was drawing at y=0 behind the status bar, and that's also why the close button looked broken, the X was sitting inside the status bar's touch area, so the taps were going to the system instead of the app. The listener wiring was fine all along. The Hints & Solution dialog had exactly the same problem.

I changed `EdgeToEdgeHelper`'s internals to work off a Window instead of an `AppCompatActivity`, so all the existing spacer and padding logic works for dialogs too, and added one entry point (`applyToDialogTopBar`) that reuses the same path the toolbar screens already use. Each dialog applies it in `onStart()` through its presenter, so the `EnableEdgeToEdge` flag check stays where the other ones are.

I also checked every other screen while I was here. All production activities are already covered.

Edit : Fixes the survey welcome and outro dialogs (GL.4 steps F40 and F45), which had the same issue.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
<!-- Please answer the following two questions. -->
- **Did you use AI/LLMs when working on this PR?** Yes but only to write test cases KDoC and PR description.
  
## For UI-specific PRs only

**Concept Card: Before and After**

<img width="360" height="780" alt="conceptcard_BEFORE" src="https://github.com/user-attachments/assets/75dd72d1-3474-4079-a9e1-99c4323ae767" />

<img width="360" height="780" alt="conceptcard_AFTER" src="https://github.com/user-attachments/assets/fed2fdb9-2524-4ed8-9816-6434dfb4b25c" />

**Hints: Before and After**

<img width="360" height="780" alt="hints_BEFORE" src="https://github.com/user-attachments/assets/3326fc68-3c00-4226-81c7-834a79a79618" />
<img width="360" height="780" alt="hints_AFTER" src="https://github.com/user-attachments/assets/00b2bc3c-3c45-4ff1-a9f4-7a7a4256fa78" />

**Welcome: Before and After**

<img width="360" height="780" alt="01-welcome-BEFORE" src="https://github.com/user-attachments/assets/434f20ac-4d69-45af-b8dd-2d0ae275eb61" />
<img width="360" height="780" alt="03-welcome-AFTER" src="https://github.com/user-attachments/assets/788e624d-dada-4809-b264-8b80cfc7a3a9" />

**Outro: Before and After**

<img width="360" height="780" alt="02-outro-BEFORE" src="https://github.com/user-attachments/assets/e8294739-4e49-47fd-a971-d558378f1fd7" />

<img width="360" height="780" alt="04-outro-AFTER" src="https://github.com/user-attachments/assets/cd06684d-de4e-40d4-b959-8dcd7ad07501" />