### PR TITLE
Fix #6391: Pass download_config to download_lesson_list script

### DIFF
--- a/.github/workflows/pull_latest_lesson_versions.yml
+++ b/.github/workflows/pull_latest_lesson_versions.yml
@@ -82,7 +82,8 @@ jobs:
             https://storage.googleapis.com \
             oppiaserver-resources \
             $(pwd)/prod_server.key \
-            $(pwd)/config/lessons/alpha_pinned_lesson_versions.textproto
+            $(pwd)/config/lessons/alpha_pinned_lesson_versions.textproto \
+            $(pwd)/scripts/assets/alpha_download_config.textproto
 
       - name: Download prod pinned lesson versions
         run: |
@@ -91,7 +92,8 @@ jobs:
             https://storage.googleapis.com \
             oppiaserver-resources \
             $(pwd)/prod_server.key \
-            $(pwd)/config/lessons/prod_pinned_lesson_versions.textproto
+            $(pwd)/config/lessons/prod_pinned_lesson_versions.textproto \
+            $(pwd)/scripts/assets/prod_download_config.textproto
 
       - name: Clean up lesson secret
         if: always()


### PR DESCRIPTION
Fixes #6391 
## Explanation

`DownloadLessonList.kt` requires 6–7 arguments, the 6th being a `DownloadConfig` proto file path, enforced by a `check(args.size in 6..7)` at startup. The workflow was only passing 5, causing an `IllegalStateException` on every run.

This commit adds the missing argument to both download steps:
- Alpha step: `scripts/assets/alpha_download_config.textproto`
- Prod step: `scripts/assets/prod_download_config.textproto`


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage

AI was used for code completion and research.