### PR TITLE
Fix #6375: Download worked examples in lesson assets

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/gae/GaeAndroidEndpointJsonImpl.kt
+++ b/scripts/src/java/org/oppia/android/scripts/gae/GaeAndroidEndpointJsonImpl.kt
@@ -867,6 +867,7 @@ class GaeAndroidEndpointJsonImpl(
       "oppia-noninteractive-image",
       "oppia-noninteractive-math",
       "oppia-noninteractive-skillreview",
+      "oppia-noninteractive-workedexample",
       "oppia-noninteractive-link", // TODO: This shouldn't be present.
       "oppia-noninteractive-tabs", // TODO: This shouldn't be present.
     )

--- a/scripts/src/java/org/oppia/android/scripts/gae/compat/StructureCompatibilityChecker.kt
+++ b/scripts/src/java/org/oppia/android/scripts/gae/compat/StructureCompatibilityChecker.kt
@@ -46,6 +46,7 @@ import org.oppia.android.scripts.gae.json.GaeWrittenTranslation
 import org.oppia.android.scripts.gae.json.GaeWrittenTranslations
 import org.oppia.android.scripts.gae.json.VersionedStructure
 import org.oppia.android.scripts.gae.proto.LocalizationTracker
+import org.oppia.android.scripts.gae.proto.LocalizationTracker.Companion.expandNestedWorkedExampleHtml
 import org.oppia.android.scripts.gae.proto.LocalizationTracker.Companion.extractMathContentsFromHtml
 import org.oppia.android.scripts.gae.proto.LocalizationTracker.Companion.parseColorRgb
 import org.oppia.android.scripts.gae.proto.LocalizationTracker.Companion.resolveLanguageCode
@@ -666,7 +667,10 @@ class StructureCompatibilityChecker(
       languageType: LanguageType?,
       constraints: CompatibilityConstraints
     ): List<CompatibilityFailure> {
-      val extraTags = html.extractHtmlTags() - constraints.supportedHtmlTags
+      // Worked examples nest HTML inside their attributes, so expand it to ensure the tags and
+      // asset references used there are validated as well.
+      val expandedHtml = expandNestedWorkedExampleHtml(html)
+      val extraTags = expandedHtml.extractHtmlTags() - constraints.supportedHtmlTags
       val tagFailures = if (extraTags.isNotEmpty()) {
         val failure = languageType?.let {
           TranslatedTextHasInvalidTags(contentId, extraTags, it, origin)
@@ -674,8 +678,8 @@ class StructureCompatibilityChecker(
         listOf(failure)
       } else emptyList()
       return tagFailures +
-        html.checkHasValidImageReferences(origin, contentId, constraints) +
-        checkMathTagsForLatex(html, origin, contentId)
+        expandedHtml.checkHasValidImageReferences(origin, contentId, constraints) +
+        checkMathTagsForLatex(expandedHtml, origin, contentId)
     }
 
     private fun String.checkHasValidImageReferences(

--- a/scripts/src/java/org/oppia/android/scripts/gae/compat/TopicPackRepository.kt
+++ b/scripts/src/java/org/oppia/android/scripts/gae/compat/TopicPackRepository.kt
@@ -360,8 +360,9 @@ class TopicPackRepository(
       lastInvalidReference = checkedReference // This structure isn't compatible.
       checkedReference = checkedReference.toPreviousVersion()
       require(--failSafe > 0) {
-        "Didn't find a compatible version in 10 steps--something's probably wrong with the script." +
-          " Structure: $structureId. First failures:\n${firstFailure?.failures?.joinToString("\n") { "- $it" }}"
+        val firstFailures = firstFailure?.failures?.joinToString("\n") { "- $it" }
+        "Didn't find a compatible version in 10 steps--something's probably wrong with the" +
+          " script. Structure: $structureId. First failures:\n$firstFailures"
       }
     }
 

--- a/scripts/src/java/org/oppia/android/scripts/gae/json/GaeInteractionObject.kt
+++ b/scripts/src/java/org/oppia/android/scripts/gae/json/GaeInteractionObject.kt
@@ -139,7 +139,9 @@ sealed class GaeInteractionObject {
               )
             }
             else ->
-              RealWithUnits(checkNotNull(parsableNumberWithUnits.real), parsableNumberWithUnits.units)
+              RealWithUnits(
+                checkNotNull(parsableNumberWithUnits.real), parsableNumberWithUnits.units
+              )
           }
           "fraction" -> {
             FractionWithUnits(

--- a/scripts/src/java/org/oppia/android/scripts/gae/proto/JsonToProtoConverter.kt
+++ b/scripts/src/java/org/oppia/android/scripts/gae/proto/JsonToProtoConverter.kt
@@ -79,9 +79,9 @@ import org.oppia.proto.v1.structure.InteractionInstanceDto.InteractionTypeCase.I
 import org.oppia.proto.v1.structure.InteractionInstanceDto.InteractionTypeCase.ITEM_SELECTION_INPUT
 import org.oppia.proto.v1.structure.InteractionInstanceDto.InteractionTypeCase.MATH_EQUATION_INPUT
 import org.oppia.proto.v1.structure.InteractionInstanceDto.InteractionTypeCase.MULTIPLE_CHOICE_INPUT
+import org.oppia.proto.v1.structure.InteractionInstanceDto.InteractionTypeCase.NUMBER_WITH_UNITS_INPUT
 import org.oppia.proto.v1.structure.InteractionInstanceDto.InteractionTypeCase.NUMERIC_EXPRESSION_INPUT
 import org.oppia.proto.v1.structure.InteractionInstanceDto.InteractionTypeCase.NUMERIC_INPUT
-import org.oppia.proto.v1.structure.InteractionInstanceDto.InteractionTypeCase.NUMBER_WITH_UNITS_INPUT
 import org.oppia.proto.v1.structure.InteractionInstanceDto.InteractionTypeCase.RATIO_EXPRESSION_INPUT
 import org.oppia.proto.v1.structure.InteractionInstanceDto.InteractionTypeCase.TEXT_INPUT
 import org.oppia.proto.v1.structure.ItemSelectionInputInstanceDto

--- a/scripts/src/java/org/oppia/android/scripts/gae/proto/LocalizationTracker.kt
+++ b/scripts/src/java/org/oppia/android/scripts/gae/proto/LocalizationTracker.kt
@@ -469,7 +469,10 @@ class LocalizationTracker private constructor(
     private fun retrieveAssetsForLanguage(language: LanguageType) =
       languages.getOrPut(language) { TrackedAssets(language, downloadConfig = downloadConfig) }
 
-    private fun ensureDefaultLanguageHasContent(contentId: String, languageType: LanguageType? = null) {
+    private fun ensureDefaultLanguageHasContent(
+      contentId: String,
+      languageType: LanguageType? = null
+    ) {
       val expectedExemptionCase = if (id is ContainerId.Exploration) {
         val exemption = downloadConfig.defaultIdExemptionsList.find {
           it.explorationId == id.id && it.contentId == contentId
@@ -481,7 +484,7 @@ class LocalizationTracker private constructor(
       if (contentId !in defaultContentIds) {
         errors +=
           "Attempting to add an asset for a content ID that hasn't been defaulted in container" +
-            " (for language: ${languageType ?: "any"}): $id, content ID: $contentId."
+          " (for language: ${languageType ?: "any"}): $id, content ID: $contentId."
       }
     }
   }

--- a/scripts/src/java/org/oppia/android/scripts/gae/proto/LocalizationTracker.kt
+++ b/scripts/src/java/org/oppia/android/scripts/gae/proto/LocalizationTracker.kt
@@ -632,12 +632,21 @@ class LocalizationTracker private constructor(
     private const val CUSTOM_IMG_FILE_PATH_ATTRIBUTE = "filepath-with-value"
     private const val CUSTOM_MATH_TAG = "oppia-noninteractive-math"
     private const val CUSTOM_MATH_SVG_PATH_ATTRIBUTE = "math_content-with-value"
+    private const val CUSTOM_WORKED_EXAMPLE_QUESTION_ATTRIBUTE = "question-with-value"
+    private const val CUSTOM_WORKED_EXAMPLE_ANSWER_ATTRIBUTE = "answer-with-value"
     private val customImageTagRegex by lazy {
       Regex("<\\s*$CUSTOM_IMG_TAG.+?$CUSTOM_IMG_FILE_PATH_ATTRIBUTE\\s*=\\s*\"(.+?)\"")
     }
     private val customMathTagRegex by lazy {
       Regex(
         "<\\s*$CUSTOM_MATH_TAG.+?$CUSTOM_MATH_SVG_PATH_ATTRIBUTE\\s*=\\s*\"(.+?)\""
+      )
+    }
+    private val customWorkedExampleAttributeRegex by lazy {
+      Regex(
+        "(?:$CUSTOM_WORKED_EXAMPLE_QUESTION_ATTRIBUTE|$CUSTOM_WORKED_EXAMPLE_ANSWER_ATTRIBUTE)" +
+          "\\s*=\\s*\"(.+?)\"",
+        RegexOption.DOT_MATCHES_ALL
       )
     }
     val VALID_LANGUAGE_TYPES = LanguageType.values().filter { it.isValid() }
@@ -683,8 +692,50 @@ class LocalizationTracker private constructor(
       this.durationSecs = this@toProto.durationSecs
     }.build()
 
-    private fun collectAllImageSourcesFromHtml(html: String) =
-      collectImageSourcesFromHtml(html) + collectMathSourcesFromHtml(html)
+    private fun collectAllImageSourcesFromHtml(html: String): Set<String> {
+      // Worked examples nest their own HTML inside tag attributes, so expand it first to ensure any
+      // images/math referenced there are also downloaded.
+      val expandedHtml = expandNestedWorkedExampleHtml(html)
+      return collectImageSourcesFromHtml(expandedHtml) + collectMathSourcesFromHtml(expandedHtml)
+    }
+
+    /**
+     * Returns [html] with the HTML nested inside any worked example question/answer attributes
+     * appended to it.
+     *
+     * Worked example tags store their question and answer as doubly HTML-escaped JSON strings in
+     * attributes, which hides any images or math referenced within them from the tag regexes used
+     * throughout the pipeline. Appending the decoded HTML makes those references discoverable
+     * without needing to change those regexes.
+     *
+     * Note that the result is only suitable for scanning for references: it is deliberately not
+     * well-formed HTML and must never be rendered or written to an asset.
+     */
+    fun expandNestedWorkedExampleHtml(html: String): String {
+      val nestedHtml = customWorkedExampleAttributeRegex.findAll(html)
+        .map { it.destructured }
+        .map { (attributeValue) -> attributeValue.unescapeNestedWorkedExampleHtml() }
+        .toList()
+      return if (nestedHtml.isEmpty()) {
+        html
+      } else nestedHtml.joinToString(separator = "", prefix = html)
+    }
+
+    /**
+     * Decodes a worked example attribute value (which is doubly HTML-escaped, then JSON-encoded)
+     * back into the HTML it represents.
+     */
+    private fun String.unescapeNestedWorkedExampleHtml(): String =
+      unescapeHtmlEntities().unescapeHtmlEntities().replace("\\\"", "\"")
+
+    private fun String.unescapeHtmlEntities(): String {
+      // '&amp;' must be unescaped last, otherwise entities it introduces would be unescaped twice.
+      return replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&amp;", "&")
+    }
 
     private fun collectImageSourcesFromHtml(html: String): Set<String> {
       return customImageTagRegex.findAll(html)

--- a/scripts/src/javatests/org/oppia/android/scripts/gae/proto/LocalizationTrackerTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/gae/proto/LocalizationTrackerTest.kt
@@ -3,6 +3,7 @@ package org.oppia.android.scripts.gae.proto
 import com.google.common.truth.Truth.assertThat
 import java.io.EOFException
 import org.junit.Test
+import org.oppia.android.scripts.gae.proto.LocalizationTracker.Companion.expandNestedWorkedExampleHtml
 import org.oppia.android.scripts.gae.proto.LocalizationTracker.Companion.extractMathContentsFromHtml
 import org.oppia.android.testing.assertThrows
 
@@ -44,5 +45,64 @@ class LocalizationTrackerTest {
     }
 
     assertThat(exception).hasMessageThat().contains("End of input")
+  }
+
+  @Test
+  fun testExpandNestedWorkedExampleHtml_noWorkedExample_returnsHtmlUnchanged() {
+    val html = "<p>plain content</p>"
+
+    val expanded = expandNestedWorkedExampleHtml(html)
+
+    assertThat(expanded).isEqualTo(html)
+  }
+
+  @Test
+  fun testExpandNestedWorkedExampleHtml_workedExample_decodesNestedHtml() {
+    val expanded = expandNestedWorkedExampleHtml(WORKED_EXAMPLE_WITH_NESTED_IMAGE)
+
+    // The original HTML is preserved, with the decoded question/answer HTML appended.
+    assertThat(expanded).startsWith(WORKED_EXAMPLE_WITH_NESTED_IMAGE)
+    assertThat(expanded).contains("<p>Plot 10.67:</p>")
+    assertThat(expanded).contains("<p>It is 10.67.</p>")
+  }
+
+  @Test
+  fun testExpandNestedWorkedExampleHtml_nestedImage_isDiscoverableByImageTagRegex() {
+    val expanded = expandNestedWorkedExampleHtml(WORKED_EXAMPLE_WITH_NESTED_IMAGE)
+
+    // The nested image tag is left in exactly the form the pipeline's own tag regexes expect.
+    assertThat(expanded).contains(
+      "<oppia-noninteractive-image filepath-with-value=\"&amp;quot;img_test.svg&amp;quot;\">"
+    )
+  }
+
+  @Test
+  fun testExpandNestedWorkedExampleHtml_nestedMath_isExtractable() {
+    val html =
+      "<oppia-noninteractive-workedexample answer-with-value=\"" +
+        "&amp;quot;&amp;lt;oppia-noninteractive-math math_content-with-value=" +
+        "\\&amp;quot;{&amp;amp;amp;quot;raw_latex&amp;amp;amp;quot;:&amp;amp;amp;quot;x^2" +
+        "&amp;amp;amp;quot;,&amp;amp;amp;quot;svg_filename&amp;amp;amp;quot;:" +
+        "&amp;amp;amp;quot;nested.svg&amp;amp;amp;quot;}\\&amp;quot;&amp;gt;" +
+        "&amp;lt;/oppia-noninteractive-math&amp;gt;&amp;quot;\">" +
+        "</oppia-noninteractive-workedexample>"
+
+    val values = extractMathContentsFromHtml(expandNestedWorkedExampleHtml(html))
+
+    assertThat(values).hasSize(1)
+    assertThat(values.single().svgFilename).isEqualTo("nested.svg")
+  }
+
+  private companion object {
+    // Mirrors the exact encoding Oppia web produces: the question/answer HTML is doubly
+    // HTML-escaped and JSON-encoded into the worked example tag's attributes.
+    private const val WORKED_EXAMPLE_WITH_NESTED_IMAGE =
+      "<p>Intro</p><oppia-noninteractive-workedexample question-with-value=\"" +
+        "&amp;quot;&amp;lt;p&amp;gt;Plot 10.67:&amp;lt;/p&amp;gt;" +
+        "&amp;lt;oppia-noninteractive-image filepath-with-value=" +
+        "\\&amp;quot;&amp;amp;amp;quot;img_test.svg&amp;amp;amp;quot;\\&amp;quot;&amp;gt;" +
+        "&amp;lt;/oppia-noninteractive-image&amp;gt;&amp;quot;\" answer-with-value=\"" +
+        "&amp;quot;&amp;lt;p&amp;gt;It is 10.67.&amp;lt;/p&amp;gt;&amp;quot;\">" +
+        "</oppia-noninteractive-workedexample>"
   }
 }

--- a/scripts/src/javatests/org/oppia/android/scripts/gae/proto/LocalizationTrackerTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/gae/proto/LocalizationTrackerTest.kt
@@ -1,11 +1,11 @@
 package org.oppia.android.scripts.gae.proto
 
 import com.google.common.truth.Truth.assertThat
-import java.io.EOFException
 import org.junit.Test
 import org.oppia.android.scripts.gae.proto.LocalizationTracker.Companion.expandNestedWorkedExampleHtml
 import org.oppia.android.scripts.gae.proto.LocalizationTracker.Companion.extractMathContentsFromHtml
 import org.oppia.android.testing.assertThrows
+import java.io.EOFException
 
 // Function name: test names are conventionally named with underscores.
 @Suppress("FunctionName")


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fixes #6375

Worked examples never appear in the app because they are never downloaded.

The download script keeps a list of HTML tags it accepts, and `oppia-noninteractive-workedexample` is missing from it. So any study guide containing a worked example fails the compatibility check, and the script falls back to an older version of that lesson, one from before the worked examples were added. That's why the affected subtopics are all pinned at `content_version: 1` and QA still sees the old plain-text "Example 1:/Solution:" paragraphs.

I confirmed this on the alpha build (`0.18-rc02-alpha-ceafafb785`): it contains **zero** worked examples across all 11 topics.

There's a second part to it. A worked example stores its question and answer as escaped HTML inside the tag's own attributes, which makes any image or math inside them invisible to the code that decides which images to download. Just allowing the tag would have shipped worked examples with broken images, 43 images and 16 math SVGs, 42 of which appear nowhere else in their topic.

So this PR does two things:
1. Adds `oppia-noninteractive-workedexample` to the allowed tag list.
2. Adds `LocalizationTracker.expandNestedWorkedExampleHtml`, which decodes those attributes back into the form the existing tag regexes already expect, so nested images and math are downloaded and validated. The decoded string is only ever scanned, never written to an asset.

The second commit fixes 10 pre-existing ktlint errors on this branch. They block the pre-push hook and the Lint Tests CI job for any PR into this branch, and none of them come from my change, I confirmed the same 10 on a clean checkout of the branch tip. It's kept as a separate commit so it's easy to review apart from the fix.


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
<!-- Please answer the following two questions. -->
Yes, LLM was used heavily for this PR. To track the issue and also to resolve the ktlint and other issues that appeared during testing. Most of the work for this PR is done with the help of LLM but I have reviewed it properly.