### PR TITLE
Fix #6395, #6396: Target develop in lesson-versions workflow and exempt PRs from issue checks

### DIFF
--- a/.github/workflows/check_for_fixed_issues_in_pr.yml
+++ b/.github/workflows/check_for_fixed_issues_in_pr.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Scan PR for issues being addressed
         id: step-1
-        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' }}
+        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' && github.event.pull_request.head.ref != 'automated/lesson-versions' }}
         uses: actions/github-script@v8
         with:
           script: |
@@ -37,7 +37,7 @@ jobs:
 
       - name: Find issue assignment(s)
         id: step-2
-        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' && steps.step-1.outputs.failure_message == '' }}
+        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' && github.event.pull_request.head.ref != 'automated/lesson-versions' && steps.step-1.outputs.failure_message == '' }}
         uses: actions/github-script@v8
         env:
           ISSUE_NUMBERS_LIST_JSON: ${{ steps.step-1.outputs.issue_numbers_list_json }}

--- a/.github/workflows/pull_latest_lesson_versions.yml
+++ b/.github/workflows/pull_latest_lesson_versions.yml
@@ -47,13 +47,10 @@ jobs:
           app-id: ${{ secrets.OPPIA_GITHUB_APP_ID }}
           private-key: ${{ secrets.OPPIA_GITHUB_APP_PRIVATE_KEY }}
 
-      - name: Check out introduce-asset-download-script
+      - name: Check out develop
         uses: actions/checkout@v6
         with:
-          # The download_lesson_list Bazel target lives on introduce-asset-download-script,
-          # not on develop (it has not been merged yet). Once introduce-asset-download-script
-          # is merged to develop, this ref should be updated to develop.
-          ref: introduce-asset-download-script
+          ref: develop
           fetch-depth: 1
           # Use the GitHub App token so the push and PR creation trigger CI.
           token: ${{ steps.generate_token.outputs.token }}
@@ -158,7 +155,7 @@ jobs:
             echo "Opening new PR"
             gh pr create \
               --head "$BRANCH" \
-              --base introduce-asset-download-script \
+              --base develop \
               --title "$TITLE" \
               --body "$BODY"
           fi


### PR DESCRIPTION
Fixes #6395
Fixes #6396
## Explanation

**#6395 — Workflow targeting wrong branch**

`pull_latest_lesson_versions.yml` was checking out `introduce-asset-download-script` and also setting that as the base branch for the auto-generated PR. This was a temporary workaround from #6343 (the `download_lesson_list` script lived on that branch before it was merged). Now that the script is on `develop`, both the checkout `ref` and the `--base` argument for `gh pr create` are updated to `develop`.

**#6396 — Auto-generated lesson-version PRs incorrectly marked as draft**

`check_for_fixed_issues_in_pr.yml` requires every PR to contain `Fixes #<issue>` and for the PR author to be assigned to that issue — otherwise the PR is converted to draft. Auto-generated PRs from the `automated/lesson-versions` branch don't have a specific tracking issue, so they were always being marked as draft. This PR adds `automated/lesson-versions` to the exemption condition in both check steps (matching the existing `translatewiki-prs` exemption added in #6150).

## Disclosure of LLM Usage

AI was used for code completion and research.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).