### PR TITLE
Fix #6395: Fix lesson checkout

### DIFF
--- a/.github/workflows/pull_latest_lesson_versions.yml
+++ b/.github/workflows/pull_latest_lesson_versions.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Check out introduce-asset-download-script
         uses: actions/checkout@v6
         with:
-          # The download_lesson_list Bazel target lives on introduce-asset-download-script,
-          # not on develop (it has not been merged yet). Once introduce-asset-download-script
-          # is merged to develop, this ref should be updated to develop.
+          # The download_lesson_list Bazel target lives on introduce-asset-download-script
+          # (not yet merged to develop). The PR opened later still targets develop — only
+          # the build step needs this branch, matching the pattern used by lesson_checks.yml.
           ref: introduce-asset-download-script
           fetch-depth: 1
           # Use the GitHub App token so the push and PR creation trigger CI.

--- a/.github/workflows/pull_latest_lesson_versions.yml
+++ b/.github/workflows/pull_latest_lesson_versions.yml
@@ -47,7 +47,7 @@ jobs:
           app-id: ${{ secrets.OPPIA_GITHUB_APP_ID }}
           private-key: ${{ secrets.OPPIA_GITHUB_APP_PRIVATE_KEY }}
 
-      - name: Check out develop
+      - name: Check out introduce-asset-download-script
         uses: actions/checkout@v6
         with:
           # The download_lesson_list Bazel target lives on introduce-asset-download-script
@@ -102,13 +102,17 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
-          if git diff --quiet config/lessons/; then
+          # Compare the downloaded textprotos against develop's baseline, not against
+          # introduce-asset-download-script's baseline (which may differ). This ensures the
+          # change-detection and the PR diff are both measuring the same thing.
+          git fetch origin develop --depth=1
+          if git diff --quiet origin/develop -- config/lessons/; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No changes detected in config/lessons/ — skipping PR update."
+            echo "No changes detected in config/lessons/ relative to develop — skipping PR update."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Changes detected:"
-            git diff --stat config/lessons/
+            echo "Changes detected relative to develop:"
+            git diff --stat origin/develop -- config/lessons/
           fi
 
       - name: Commit and push to dedicated branch
@@ -165,7 +169,7 @@ jobs:
 
           if [ -n "$PR_NUMBER" ]; then
             echo "Updating existing PR #$PR_NUMBER"
-            gh pr edit "$PR_NUMBER" --title "$TITLE" --body "$BODY"
+            gh pr edit "$PR_NUMBER" --base develop --title "$TITLE" --body "$BODY"
           else
             echo "Opening new PR"
             gh pr create \

--- a/.github/workflows/pull_latest_lesson_versions.yml
+++ b/.github/workflows/pull_latest_lesson_versions.yml
@@ -129,6 +129,9 @@ jobs:
           cp config/lessons/alpha_pinned_lesson_versions.textproto /tmp/alpha_pinned.textproto
           cp config/lessons/prod_pinned_lesson_versions.textproto /tmp/prod_pinned.textproto
 
+          # Discard working tree changes so git checkout can proceed without conflicts.
+          git checkout -- config/lessons/
+
           # Fetch develop and reset the dedicated branch to its HEAD.
           git fetch origin develop --depth=1
           git checkout -B "$BRANCH" origin/develop

--- a/.github/workflows/pull_latest_lesson_versions.yml
+++ b/.github/workflows/pull_latest_lesson_versions.yml
@@ -117,9 +117,19 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Always reset the dedicated branch to the current develop HEAD so the diff
-          # in the PR is always exactly the textproto update and nothing else.
-          git checkout -B "$BRANCH"
+          # Stash the downloaded textprotos before switching branches. We checked out
+          # introduce-asset-download-script for the Bazel build, but the PR must be
+          # rooted on develop so its diff is exactly the textproto update and nothing else.
+          cp config/lessons/alpha_pinned_lesson_versions.textproto /tmp/alpha_pinned.textproto
+          cp config/lessons/prod_pinned_lesson_versions.textproto /tmp/prod_pinned.textproto
+
+          # Fetch develop and reset the dedicated branch to its HEAD.
+          git fetch origin develop --depth=1
+          git checkout -B "$BRANCH" origin/develop
+
+          # Restore the downloaded textprotos on top of develop.
+          cp /tmp/alpha_pinned.textproto config/lessons/alpha_pinned_lesson_versions.textproto
+          cp /tmp/prod_pinned.textproto config/lessons/prod_pinned_lesson_versions.textproto
 
           git add config/lessons/alpha_pinned_lesson_versions.textproto \
                   config/lessons/prod_pinned_lesson_versions.textproto


### PR DESCRIPTION
Fixes #6395
## Explanation

`pull_latest_lesson_versions.yml` failed at the "Download alpha pinned lesson versions" step with:

```
ERROR: no such target '//scripts:download_lesson_list'
```

**Root cause (two bugs):**

**1.** PR #6398 changed the checkout `ref` from `introduce-asset-download-script` to `develop` to fix the PR base branch. But `//scripts:download_lesson_list` only exists on `introduce-asset-download-script` — it hasn't been merged to `develop` yet. So the Bazel build step could never find the target on `develop`.

**2.** Even before #6398, the commit step had a separate bug: `git checkout -B "$BRANCH"` was creating `automated/lesson-versions` from `introduce-asset-download-script` HEAD rather than `develop` HEAD. This means the generated PR would include all commits from that entire branch, not just the textproto update — making it an incorrectly scoped PR.

**Fix:**

- Reverts the checkout `ref` back to `introduce-asset-download-script` (matching the pattern used by `lesson_checks.yml`) so the Bazel build step can find the target.
- Fixes the commit step to explicitly `git fetch origin develop --depth=1` and use `git checkout -B "$BRANCH" origin/develop` as the start point, so `automated/lesson-versions` is always rooted on `develop` HEAD.
- Stashes the downloaded textprotos to `/tmp` before the branch switch and restores them on top of `develop`, ensuring the PR diff is exactly the textproto update relative to `develop` and nothing else.
- The `--base develop` in `gh pr create` is unchanged — the PR still targets `develop`.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage

AI was used for code completion.