### PR TITLE
Fix #6259: Add failure tracking to static_checks.sh

### DIFF
--- a/scripts/static_checks.sh
+++ b/scripts/static_checks.sh
@@ -12,15 +12,16 @@
 
 # LINT CHECKS
 # Run Java lint check
-bash scripts/checkstyle_lint_check.sh
+FAILURES=0
+bash scripts/checkstyle_lint_check.sh || FAILURES=$((FAILURES+1))
 echo ""
 
 # Run Kotlin lint check
-bash scripts/ktlint_lint_check.sh
+bash scripts/ktlint_lint_check.sh || FAILURES=$((FAILURES+1))
 echo ""
 
 # Run protobuf lint checks
-bash scripts/buf_lint_check.sh
+bash scripts/buf_lint_check.sh || FAILURES=$((FAILURES+1))
 echo ""
 
 # Download Buildifier in oppia-android-tools folder (pre-requisite for buildifier checks)
@@ -33,7 +34,7 @@ cd ../oppia-android/
 echo ""
 
 # Run Bazel Build file lint checks (buildifier checks)
-bash scripts/buildifier_lint_check.sh
+bash scripts/buildifier_lint_check.sh || FAILURES=$((FAILURES+1))
 echo ""
 
 
@@ -44,51 +45,50 @@ echo ""
 echo "********************************"
 echo "Running regex pattern checks"
 echo "********************************"
-bazel run //scripts:regex_pattern_validation_check -- $(pwd)
+bazel run //scripts:regex_pattern_validation_check -- $(pwd) || FAILURES=$((FAILURES+1))
 echo ""
 
 # Run XML Syntax check validation
 echo "********************************"
 echo "Running XML Syntax validation checks"
 echo "********************************"
-bazel run //scripts:xml_syntax_check -- $(pwd)
+bazel run //scripts:xml_syntax_check -- $(pwd) || FAILURES=$((FAILURES+1))
 echo ""
 
 # Run TextView Style check
 echo "********************************"
 echo "Running TextView style validation checks"
 echo "********************************"
-bazel run //scripts:check_textview_styles -- $(pwd)
+bazel run //scripts:check_textview_styles -- $(pwd) || FAILURES=$((FAILURES+1))
 echo ""
 
 # Run Testfile Presence Check
 echo "********************************"
 echo "Running Testfile presence checks"
 echo "********************************"
-bazel run //scripts:test_file_check -- $(pwd)
+bazel run //scripts:test_file_check -- $(pwd) || FAILURES=$((FAILURES+1))
 echo ""
 
 # Run Accessibility label Check
 echo "********************************"
 echo "Running Accessibility label checks"
 echo "********************************"
-bazel run //scripts:accessibility_label_check -- $(pwd) scripts/assets/accessibility_label_exemptions.pb app/src/main/AndroidManifest.xml
+bazel run //scripts:accessibility_label_check -- $(pwd) scripts/assets/accessibility_label_exemptions.pb app/src/main/AndroidManifest.xml || FAILURES=$((FAILURES+1))
 echo ""
 
 # Run KDoc Validation Check
 echo "********************************"
 echo "Running KDoc validation checks"
 echo "********************************"
-bazel run //scripts:kdoc_validity_check -- $(pwd) scripts/assets/kdoc_validity_exemptions.pb
+bazel run //scripts:kdoc_validity_check -- $(pwd) scripts/assets/kdoc_validity_exemptions.pb || FAILURES=$((FAILURES+1))
 echo ""
 
 # Run String resource validation check
 echo "********************************"
 echo "Running resource validation checks"
 echo "********************************"
-bazel run //scripts:string_resource_validation_check -- $(pwd)
+bazel run //scripts:string_resource_validation_check -- $(pwd) || FAILURES=$((FAILURES+1))
 echo ""
-
 
 # THIRD PARTY DEPENDENCY CHECKS
 # These are checks for third party dependencies
@@ -97,19 +97,27 @@ echo ""
 echo "********************************"
 echo "Running Maven repin checks"
 echo "********************************"
-REPIN=1 bazel run @unpinned_maven//:pin
+REPIN=1 bazel run @unpinned_maven//:pin || FAILURES=$((FAILURES+1))
 echo ""
 
 # Maven Dependencies Update Check
 echo "********************************"
 echo "Running maven dependencies update checks"
 echo "********************************"
-bazel run //scripts:maven_dependencies_list_check -- $(pwd) third_party/maven_install.json scripts/assets/maven_dependencies.pb
+bazel run //scripts:maven_dependencies_list_check -- $(pwd) third_party/maven_install.json scripts/assets/maven_dependencies.pb || FAILURES=$((FAILURES+1))
 echo ""
 
 # Open issue correctness checks.
 echo "********************************"
 echo "Running TODO correctness checks"
 echo "********************************"
-bazel run //scripts:todo_open_check -- $(pwd) scripts/assets/todo_open_exemptions.pb
+bazel run //scripts:todo_open_check -- $(pwd) scripts/assets/todo_open_exemptions.pb || FAILURES=$((FAILURES+1))
 echo ""
+
+if [ "$FAILURES" -gt 0 ]; then
+    echo "$FAILURES check(s) failed. Please fix the above errors."
+    exit 1
+else
+    echo "All checks passed."
+    exit 0
+fi


### PR DESCRIPTION
Fixes #6259
## Explanation
Previously, `scripts/static_checks.sh` ran each check with a bare `bash`/`bazel run` call, discarding its exit code. This meant that even if one or more checks failed, the script would always exit with code `0`, silently hiding failures.

This PR adds failure tracking by:
- Introducing a `FAILURES` counter initialized to `0` before the first check.
- Appending `|| FAILURES=$((FAILURES+1))` to every check command so that a failing check increments the counter instead of stopping the script, hence allowing **all checks to run to completion** regardless of intermediate failures.
- Adding a final block that prints the total number of failed checks and exits with code `1` if `FAILURES > 0`, or code `0` if all checks passed.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
<!-- Please answer the following two questions. -->
- **Did you use AI/LLMs when working on this PR?** Type `Yes` or `No`.: Yes
- I have used LLM for code-completion, research, and debugging.