### PR TITLE
Fix #6413: Add force_sha recovery input

### DIFF
--- a/.github/workflows/auto_release_alpha.yml
+++ b/.github/workflows/auto_release_alpha.yml
@@ -15,7 +15,17 @@ on:
     # Tuesdays at 03:30 UTC. Offset from pull_latest_lesson_versions (Monday 02:30) to avoid
     # Bazel remote cache contention.
     - cron: "30 03 * * 2"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      force_sha:
+        description: |
+          Optional: full commit SHA to build instead of running candidate detection.
+          Use this to recover from a failed dispatch (e.g. after an HTTP 403) when the
+          latest-alpha tag already points to the right commit but no binary was produced.
+          Leave blank to run normal automated candidate detection.
+        required: false
+        type: string
+        default: ""
 
 # Only one auto-release run at a time. cancel-in-progress is false so an in-flight run is
 # never interrupted mid-way through tagging or dispatching.
@@ -71,30 +81,39 @@ jobs:
 
       # FindAlphaCandidate inspects commits newer than the current latest-alpha tag
       # (newest first) and returns the SHA of the first fully-passing commit.
-      # Exits 0 with empty output on NoNewCommits; exits 1 on NoPassingCommit.
+      # Exits 0 in all non-fatal cases (candidate found, no new commits, or no passing commit);
+      # exits 1 only on a fatal API/config error.
+      # If force_sha is set (manual recovery), candidate detection is skipped entirely.
       - name: Find alpha candidate
         id: candidate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Resolve the current latest-alpha tag to a SHA so FindAlphaCandidate only inspects
-          # commits newer than the most recently deployed build. On the very first run (tag doesn't
-          # exist yet), pass "" so all recent commits are inspected.
-          LATEST_ALPHA_SHA=$(git rev-parse refs/tags/latest-alpha 2>/dev/null || echo "")
-          CANDIDATE_SHA=$(bazel run //scripts:find_alpha_candidate -- \
-            "$GITHUB_TOKEN" \
-            "develop" \
-            "$LATEST_ALPHA_SHA")
-          if [[ -z "$CANDIDATE_SHA" ]]; then
-            echo "No new commits since latest-alpha (${LATEST_ALPHA_SHA:0:7}). Nothing to cut."
+          FORCE_SHA="${{ github.event.inputs.force_sha }}"
+          if [[ -n "$FORCE_SHA" ]]; then
+            echo "Manual recovery mode: using force_sha=${FORCE_SHA:0:7} — skipping candidate detection."
+            echo "sha=$FORCE_SHA" >> "$GITHUB_OUTPUT"
           else
-            echo "Alpha candidate: $CANDIDATE_SHA"
+            # Resolve the current latest-alpha tag to a SHA so FindAlphaCandidate only inspects
+            # commits newer than the most recently deployed build. On the very first run (tag doesn't
+            # exist yet), pass "" so all recent commits are inspected.
+            LATEST_ALPHA_SHA=$(git rev-parse refs/tags/latest-alpha 2>/dev/null || echo "")
+            CANDIDATE_SHA=$(bazel run //scripts:find_alpha_candidate -- \
+              "$GITHUB_TOKEN" \
+              "develop" \
+              "$LATEST_ALPHA_SHA")
+            if [[ -z "$CANDIDATE_SHA" ]]; then
+              echo "No new passing candidate found. Nothing to cut this cycle."
+            else
+              echo "Alpha candidate: $CANDIDATE_SHA"
+            fi
+            echo "sha=$CANDIDATE_SHA" >> "$GITHUB_OUTPUT"
           fi
-          echo "sha=$CANDIDATE_SHA" >> "$GITHUB_OUTPUT"
 
       # Force-push the well-known `latest-alpha` tag to the candidate commit.
       # build_and_sign.yml checks out from this tag when source_ref=latest-alpha.
-      # Skipped when FindAlphaCandidate returns NoNewCommits (candidate SHA is empty).
+      # Skipped when no candidate SHA is set (no new commits, no passing commit, or force_sha
+      # already points to the current tag).
       - name: Update latest-alpha tag
         if: steps.candidate.outputs.sha != ''
         run: |
@@ -108,7 +127,8 @@ jobs:
       # Dispatch the build+sign workflow for the alpha flavor. The build_and_sign.yml workflow
       # runs under the oppia-android-release-env environment, so a required reviewer must
       # approve before any job steps execute (provides a human gate before deployment).
-      # Skipped when FindAlphaCandidate returns NoNewCommits (candidate SHA is empty).
+      # Skipped when no candidate SHA is set (no new commits, no passing commit, or manual
+      # force_sha mode was not used).
       - name: Dispatch build-and-sign for alpha
         if: steps.candidate.outputs.sha != ''
         env:

--- a/.github/workflows/auto_release_alpha.yml
+++ b/.github/workflows/auto_release_alpha.yml
@@ -81,8 +81,8 @@ jobs:
 
       # FindAlphaCandidate inspects commits newer than the current latest-alpha tag
       # (newest first) and returns the SHA of the first fully-passing commit.
-      # Exits 0 in all non-fatal cases (candidate found, no new commits, or no passing commit);
-      # exits 1 only on a fatal API/config error.
+      # Exits 0 with empty output on NoNewCommits; exits 1 on NoPassingCommit (intentional —
+      # signals to maintainers that CI is blocking the alpha channel) or on a fatal API error.
       # If force_sha is set (manual recovery), candidate detection is skipped entirely.
       - name: Find alpha candidate
         id: candidate
@@ -103,7 +103,7 @@ jobs:
               "develop" \
               "$LATEST_ALPHA_SHA")
             if [[ -z "$CANDIDATE_SHA" ]]; then
-              echo "No new passing candidate found. Nothing to cut this cycle."
+              echo "No new passing candidate found since ${LATEST_ALPHA_SHA:0:7}. Nothing to cut this cycle."
             else
               echo "Alpha candidate: $CANDIDATE_SHA"
             fi

--- a/scripts/src/java/org/oppia/android/scripts/release/FindAlphaCandidate.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/FindAlphaCandidate.kt
@@ -25,9 +25,9 @@ sealed class AlphaCandidateResult {
  * whose GitHub CI check runs are all passing — the "alpha deployment candidate".
  *
  * Exit codes:
- *   0 – candidate found (SHA printed to stdout), no new commits since latest-alpha, or no passing
- *       commit found among the inspected commits (all three are "nothing to do" outcomes)
- *   1 – fatal error (e.g. API failure); reason printed to stderr
+ *   0 – candidate found (SHA printed to stdout) OR no new commits since latest-alpha (nothing to do)
+ *   1 – no passing candidate found (CI is blocking the alpha channel — surface to maintainers)
+ *       OR fatal error (e.g. API failure); reason printed to stderr
  *
  * Usage:
  *   bazel run //scripts:find_alpha_candidate -- <github_token> [branch]
@@ -73,10 +73,9 @@ fun main(args: Array<String>) {
       is AlphaCandidateResult.NoPassingCommit -> {
         System.err.println(
           "No passing candidate found in the last ${result.commitsChecked} commit(s) on " +
-            "'$branch'. CI may still be running — no new release will be cut this cycle."
+            "'$branch'. CI is blocking the alpha channel — surface this to repository maintainers."
         )
-        // Exit 0 — not a failure. The calling workflow checks for an empty candidate SHA
-        // and skips the tag-push and dispatch steps automatically.
+        System.exit(1)
       }
     }
   } catch (e: IllegalStateException) {

--- a/scripts/src/java/org/oppia/android/scripts/release/FindAlphaCandidate.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/FindAlphaCandidate.kt
@@ -26,8 +26,8 @@ sealed class AlphaCandidateResult {
  *
  * Exit codes:
  *   0 – candidate found (SHA printed to stdout) OR no new commits since latest-alpha (nothing to do)
- *   1 – no passing candidate found (CI is blocking the alpha channel — surface to maintainers)
- *       OR fatal error (e.g. API failure); reason printed to stderr
+ *   1 – no passing candidate found — prints error to surface to maintainers that CI has
+ *       an issue. OR fatal error (e.g. API failure); reason printed to stderr
  *
  * Usage:
  *   bazel run //scripts:find_alpha_candidate -- <github_token> [branch]
@@ -73,7 +73,7 @@ fun main(args: Array<String>) {
       is AlphaCandidateResult.NoPassingCommit -> {
         System.err.println(
           "No passing candidate found in the last ${result.commitsChecked} commit(s) on " +
-            "'$branch'. CI is blocking the alpha channel — surface this to repository maintainers."
+            "'$branch'. Please investigate the CI failures."
         )
         System.exit(1)
       }

--- a/scripts/src/java/org/oppia/android/scripts/release/FindAlphaCandidate.kt
+++ b/scripts/src/java/org/oppia/android/scripts/release/FindAlphaCandidate.kt
@@ -25,8 +25,9 @@ sealed class AlphaCandidateResult {
  * whose GitHub CI check runs are all passing — the "alpha deployment candidate".
  *
  * Exit codes:
- *   0 – candidate found (SHA printed to stdout) OR no new commits since latest-alpha (nothing to do)
- *   1 – no passing candidate found; reason printed to stderr
+ *   0 – candidate found (SHA printed to stdout), no new commits since latest-alpha, or no passing
+ *       commit found among the inspected commits (all three are "nothing to do" outcomes)
+ *   1 – fatal error (e.g. API failure); reason printed to stderr
  *
  * Usage:
  *   bazel run //scripts:find_alpha_candidate -- <github_token> [branch]
@@ -72,9 +73,10 @@ fun main(args: Array<String>) {
       is AlphaCandidateResult.NoPassingCommit -> {
         System.err.println(
           "No passing candidate found in the last ${result.commitsChecked} commit(s) on " +
-            "'$branch'. Ensure CI has completed for recent commits and retry."
+            "'$branch'. CI may still be running — no new release will be cut this cycle."
         )
-        System.exit(1)
+        // Exit 0 — not a failure. The calling workflow checks for an empty candidate SHA
+        // and skips the tag-push and dispatch steps automatically.
       }
     }
   } catch (e: IllegalStateException) {


### PR DESCRIPTION
Fixes #6413
## Explanation

This PR fixes two issues discovered after `auto_release_alpha.yml` (#6348) ran for the first time:

**1. `FindAlphaCandidate` exits 1 on `NoPassingCommit` (bug)**
When new commits exist since `latest-alpha` but none have fully-green CI, the script previously exited with code 1. GitHub Actions treats any non-zero exit as a step failure, causing the workflow to show as failed — even though this is expected, non-error behavior (no release should be cut). The fix changes `NoPassingCommit` to exit 0, matching the existing behavior for `NoNewCommits`. Only genuine fatal errors (API failures, config errors) now exit 1.

**2. No recovery path when the dispatch itself fails (missing feature)**
If `build_and_sign.yml` dispatch fails (e.g. HTTP 403 from a missing App permission), `latest-alpha` is already tagged at the right commit but no binary is produced. The next cron run sees no new passing commits and correctly skips — but the tagged SHA is never built. This PR adds an optional `force_sha` input to `workflow_dispatch`. When provided, candidate detection is skipped entirely and the specified SHA is used directly, allowing the release manager to manually recover without touching git tags or waiting for the next weekly run.

## Disclosure of LLM Usage
AI was used for debugging, code-completion and research.
## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).