### PR TITLE
Fix #6411: pass download config to lesson_checks download_lesson_list

### DIFF
--- a/.github/workflows/lesson_checks.yml
+++ b/.github/workflows/lesson_checks.yml
@@ -42,7 +42,8 @@ jobs:
             https://storage.googleapis.com \
             oppiaserver-resources \
             $(pwd)/prod_server.key \
-            $(pwd)/release_assets/pinned_versions.textproto
+            $(pwd)/release_assets/pinned_versions.textproto \
+            $(pwd)/scripts/assets/prod_download_config.textproto
 
       - name: Download lessons and verify conversion
         run: |


### PR DESCRIPTION
## Explanation
Fixes #6411: `lesson_checks.yml` still called `//scripts:download_lesson_list` with 5 arguments after the script started requiring a 6th path to a download-config textproto (`allowed_classrooms`, `allowed_topic_ids`, `allowed_interaction_ids`).

`pull_latest_lesson_versions.yml` already passes that 6th argument for prod as `scripts/assets/prod_download_config.textproto`. This PR updates the "Download lesson version list" step in `lesson_checks.yml` to pass the same prod config path so the Monday cron job can populate `pinned_versions.textproto` and continue to the conversion check.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
- **Did you use AI/LLMs when working on this PR?** Yes
- **If yes, describe the extent AI was used:** Assisted with locating the matching invocation in `pull_latest_lesson_versions.yml`, applying the one-line workflow fix, and drafting this PR description. The change was manually verified against the working prod download step.


Made with [Cursor](https://cursor.com)