### PR TITLE
Fix #6388: show locked-chapter prerequisite micro-tooltip on tap

### DIFF
--- a/app/src/main/java/org/oppia/android/app/topic/lessons/ChapterSummaryViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/ChapterSummaryViewModel.kt
@@ -1,12 +1,12 @@
 package org.oppia.android.app.topic.lessons
 
-import androidx.lifecycle.ViewModel
+import androidx.databinding.ObservableBoolean
 import org.oppia.android.app.model.ChapterPlayState
 import org.oppia.android.app.translation.AppLanguageResourceHandler
 import org.oppia.android.app.view.models.R
 import org.oppia.android.app.viewmodel.ObservableViewModel
 
-/** [ViewModel] for displaying a chapter summary. */
+/** [ObservableViewModel] for displaying a chapter summary. */
 class ChapterSummaryViewModel(
   val chapterPlayState: ChapterPlayState,
   val explorationId: String,
@@ -16,13 +16,53 @@ class ChapterSummaryViewModel(
   private val index: Int,
   private val chapterSummarySelector: ChapterSummarySelector,
   private val resourceHandler: AppLanguageResourceHandler,
-  val storyIndex: Int
+  val storyIndex: Int,
+  private val lockedChapterTooltipCoordinator: LockedChapterTooltipCoordinator? = null
 ) : ObservableViewModel() {
 
+  /**
+   * Whether the locked-chapter micro-tooltip (prerequisite message) is currently visible.
+   *
+   * Only meaningful when [chapterPlayState] is
+   * [ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES]. Toggled by [onClick].
+   */
+  val isPrerequisiteTooltipVisible = ObservableBoolean(false)
+
+  /** True when this chapter cannot be played until a prior chapter is completed. */
+  val isLocked: Boolean
+    get() = chapterPlayState == ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES
+
+  /**
+   * Handles a chapter row click.
+   *
+   * Locked chapters toggle a micro-tooltip that explains which prior chapter must be
+   * completed. Playable chapters route through [ChapterSummarySelector].
+   */
   fun onClick(explorationId: String) {
+    if (isLocked) {
+      val willShow = !isPrerequisiteTooltipVisible.get()
+      if (willShow) {
+        lockedChapterTooltipCoordinator?.onLockedChapterTooltipRequested(this)
+      }
+      isPrerequisiteTooltipVisible.set(willShow)
+      return
+    }
+    // Hide any leftover tooltip state before navigating away.
+    isPrerequisiteTooltipVisible.set(false)
     chapterSummarySelector.selectChapterSummary(storyId, explorationId, chapterPlayState)
   }
 
+  /** Hides the locked-chapter micro-tooltip if it is showing. */
+  fun hidePrerequisiteTooltip() {
+    if (isPrerequisiteTooltipVisible.get()) {
+      isPrerequisiteTooltipVisible.set(false)
+    }
+  }
+
+  /**
+   * Returns the micro-tooltip / accessibility text explaining why this chapter is locked,
+   * or why it is completed / in progress for non-locked states.
+   */
   fun computeChapterPlayStateIconContentDescription(): String {
     return when (chapterPlayState) {
       ChapterPlayState.COMPLETED -> {
@@ -30,21 +70,7 @@ class ChapterSummaryViewModel(
           R.string.chapter_completed, (index + 1).toString(), chapterTitle
         )
       }
-      ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES -> {
-        if (previousChapterTitle != null) {
-          resourceHandler.getStringInLocaleWithWrapping(
-            R.string.chapter_locked_prerequisite_title_label,
-            (index + 1).toString(),
-            chapterTitle,
-            index.toString(),
-            previousChapterTitle
-          )
-        } else {
-          resourceHandler.getStringInLocaleWithWrapping(
-            R.string.chapter_prerequisite_title_label_without_chapter_title
-          )
-        }
-      }
+      ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES -> computeLockedPrerequisiteMessage()
       else -> {
         resourceHandler.getStringInLocaleWithWrapping(
           R.string.chapter_in_progress, (index + 1).toString(), chapterTitle
@@ -53,9 +79,37 @@ class ChapterSummaryViewModel(
     }
   }
 
+  /**
+   * Returns the learner-facing prerequisite message shown in the locked-chapter
+   * micro-tooltip.
+   */
+  fun computePrerequisiteTooltipText(): String = computeLockedPrerequisiteMessage()
+
   fun computePlayChapterIndexText(): String {
     return resourceHandler.getStringInLocaleWithWrapping(
       R.string.topic_play_chapter_index, (index + 1).toString()
     )
+  }
+
+  private fun computeLockedPrerequisiteMessage(): String {
+    return if (previousChapterTitle != null) {
+      resourceHandler.getStringInLocaleWithWrapping(
+        R.string.chapter_locked_prerequisite_title_label,
+        (index + 1).toString(),
+        chapterTitle,
+        index.toString(),
+        previousChapterTitle
+      )
+    } else {
+      resourceHandler.getStringInLocaleWithWrapping(
+        R.string.chapter_prerequisite_title_label_without_chapter_title
+      )
+    }
+  }
+
+  /** Coordinates exclusive visibility of locked-chapter micro-tooltips within a story. */
+  interface LockedChapterTooltipCoordinator {
+    /** Called before [source] shows its tooltip so siblings can hide theirs. */
+    fun onLockedChapterTooltipRequested(source: ChapterSummaryViewModel)
   }
 }

--- a/app/src/main/java/org/oppia/android/app/topic/lessons/StorySummaryViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/StorySummaryViewModel.kt
@@ -69,26 +69,42 @@ class StorySummaryViewModel(
   }
 
   private fun computeChapterSummaryItemList(): List<ChapterSummaryViewModel> {
-    return ephemeralStorySummary.chaptersList.mapIndexed { index, ephemeralChapterSummary ->
-      ChapterSummaryViewModel(
-        chapterPlayState = ephemeralChapterSummary.chapterSummary.chapterPlayState,
-        explorationId = ephemeralChapterSummary.chapterSummary.explorationId,
-        chapterTitle = translationController.extractString(
-          ephemeralChapterSummary.chapterSummary.title,
-          ephemeralChapterSummary.writtenTranslationContext
-        ),
-        previousChapterTitle = if (index > 0) {
-          translationController.extractString(
-            ephemeralStorySummary.chaptersList[index - 1].chapterSummary.title,
-            ephemeralStorySummary.chaptersList[index - 1].writtenTranslationContext
-          )
-        } else null,
-        storyId = storySummary.storyId,
-        index = index,
-        chapterSummarySelector = chapterSummarySelector,
-        resourceHandler = resourceHandler,
-        storyIndex = storyIndex
+    val chapterViewModels = mutableListOf<ChapterSummaryViewModel>()
+    val tooltipCoordinator =
+      object : ChapterSummaryViewModel.LockedChapterTooltipCoordinator {
+        override fun onLockedChapterTooltipRequested(source: ChapterSummaryViewModel) {
+          chapterViewModels.forEach { sibling ->
+            if (sibling !== source) {
+              sibling.hidePrerequisiteTooltip()
+            }
+          }
+        }
+      }
+
+    ephemeralStorySummary.chaptersList.forEachIndexed { index, ephemeralChapterSummary ->
+      chapterViewModels.add(
+        ChapterSummaryViewModel(
+          chapterPlayState = ephemeralChapterSummary.chapterSummary.chapterPlayState,
+          explorationId = ephemeralChapterSummary.chapterSummary.explorationId,
+          chapterTitle = translationController.extractString(
+            ephemeralChapterSummary.chapterSummary.title,
+            ephemeralChapterSummary.writtenTranslationContext
+          ),
+          previousChapterTitle = if (index > 0) {
+            translationController.extractString(
+              ephemeralStorySummary.chaptersList[index - 1].chapterSummary.title,
+              ephemeralStorySummary.chaptersList[index - 1].writtenTranslationContext
+            )
+          } else null,
+          storyId = storySummary.storyId,
+          index = index,
+          chapterSummarySelector = chapterSummarySelector,
+          resourceHandler = resourceHandler,
+          storyIndex = storyIndex,
+          lockedChapterTooltipCoordinator = tooltipCoordinator
+        )
       )
     }
+    return chapterViewModels
   }
 }

--- a/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentPresenter.kt
@@ -286,13 +286,24 @@ class TopicLessonsFragmentPresenter @Inject constructor(
     explorationId: String,
     chapterPlayState: ChapterPlayState
   ) {
+    // Locked chapters are handled entirely in ChapterSummaryViewModel (micro-tooltip).
+    // Never attempt to start or replay a lesson that is missing prerequisites.
+    if (chapterPlayState == ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES) {
+      oppiaLogger.d(
+        "TopicLessonsFragment",
+        "Ignoring navigation for locked chapter explorationId=$explorationId"
+      )
+      return
+    }
+
     val canHavePartialProgressSaved =
       when (chapterPlayState) {
         ChapterPlayState.IN_PROGRESS_SAVED, ChapterPlayState.IN_PROGRESS_NOT_SAVED,
         ChapterPlayState.STARTED_NOT_COMPLETED, ChapterPlayState.NOT_STARTED -> true
         ChapterPlayState.COMPLETION_STATUS_UNSPECIFIED,
-        ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES, ChapterPlayState.UNRECOGNIZED,
+        ChapterPlayState.UNRECOGNIZED,
         ChapterPlayState.COMPLETED -> false
+        ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES -> false
       }
 
     when (chapterPlayState) {
@@ -342,6 +353,9 @@ class TopicLessonsFragmentPresenter @Inject constructor(
           canHavePartialProgressSaved,
           hadProgress = true
         )
+      }
+      ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES -> {
+        // Defensive: locked chapters must not reach playExploration.
       }
       else -> {
         playExploration(

--- a/app/src/main/res/layout/lessons_locked_chapter_view.xml
+++ b/app/src/main/res/layout/lessons_locked_chapter_view.xml
@@ -18,12 +18,19 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
+    <!--
+      Locked chapters must remain clickable so learners can tap to reveal the
+      prerequisite micro-tooltip. This layout is only bound for
+      NOT_PLAYABLE_MISSING_PREREQUISITES rows.
+    -->
     <LinearLayout
       android:id="@+id/locked_chapter_container"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:background="@color/component_color_lessons_tab_activity_lessons_locked_chapter_container_background_color"
-      android:clickable="@{viewModel.chapterPlayState != ChapterPlayState.NOT_PLAYABLE_MISSING_PREREQUISITES ? true : false}"
+      android:clickable="true"
+      android:contentDescription="@{viewModel.computeChapterPlayStateIconContentDescription()}"
+      android:focusable="true"
       android:minHeight="48dp"
       android:onClick="@{() -> viewModel.onClick(viewModel.explorationId)}"
       android:orientation="horizontal">
@@ -73,6 +80,27 @@
         android:textColor="@color/component_color_lessons_tab_activity_lessons_locked_chapter_name_text_color"
         android:textSize="14sp" />
     </LinearLayout>
+
+    <!-- Micro-tooltip: shown when the locked chapter row is tapped. -->
+    <TextView
+      android:id="@+id/locked_chapter_prerequisite_tooltip"
+      style="@style/TextViewStart"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="8dp"
+      android:layout_marginTop="4dp"
+      android:layout_marginEnd="8dp"
+      android:layout_marginBottom="8dp"
+      android:background="@drawable/spotlight_hint_text_background"
+      android:fontFamily="sans-serif"
+      android:paddingStart="12dp"
+      android:paddingTop="8dp"
+      android:paddingEnd="12dp"
+      android:paddingBottom="8dp"
+      android:text="@{viewModel.computePrerequisiteTooltipText()}"
+      android:textColor="@color/component_color_shared_secondary_5_text_color"
+      android:textSize="14sp"
+      android:visibility="@{viewModel.isPrerequisiteTooltipVisible ? View.VISIBLE : View.GONE}" />
 
     <View
       android:id="@+id/divider"

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/lessons/TopicLessonsFragmentTest.kt
@@ -15,6 +15,7 @@ import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.times
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.ViewMatchers.hasContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
@@ -461,6 +462,112 @@ class TopicLessonsFragmentTest {
             )
           )
         )
+    }
+  }
+
+  @Test
+  fun testLessonsPlayFragment_loadRatiosTopic_lockedChapter_isClickable() {
+    launch<TopicActivity>(
+      createTopicActivityIntent(
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+      )
+    ).use {
+      clickLessonTab()
+      clickStoryItem(position = 1, targetViewId = R.id.chapter_list_drop_down_icon)
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.chapter_recycler_view,
+          position = 1,
+          targetViewId = R.id.locked_chapter_container
+        )
+      ).check(matches(isDisplayed()))
+        .check(matches(isClickable()))
+    }
+  }
+
+  @Test
+  fun testLessonsPlayFragment_loadRatiosTopic_clickLockedChapter_showsPrerequisiteTooltip() {
+    launch<TopicActivity>(
+      createTopicActivityIntent(
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+      )
+    ).use {
+      clickLessonTab()
+      clickStoryItem(position = 1, targetViewId = R.id.chapter_list_drop_down_icon)
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.chapter_recycler_view,
+          position = 1,
+          targetViewId = R.id.locked_chapter_prerequisite_tooltip
+        )
+      ).check(matches(not(isDisplayed())))
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.chapter_recycler_view,
+          position = 1,
+          targetViewId = R.id.locked_chapter_container
+        )
+      ).perform(click())
+      testCoroutineDispatchers.runCurrent()
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.chapter_recycler_view,
+          position = 1,
+          targetViewId = R.id.locked_chapter_prerequisite_tooltip
+        )
+      ).check(matches(isDisplayed()))
+        .check(
+          matches(
+            withText(
+              "Chapter 2: Order is important is currently locked. Please complete chapter 1: " +
+                "What is a Ratio? to unlock this chapter."
+            )
+          )
+        )
+      // Locked chapter must not navigate into ExplorationActivity.
+      intended(hasComponent(ExplorationActivity::class.java.name), times(0))
+    }
+  }
+
+  @Test
+  fun testLessonsPlayFragment_loadRatiosTopic_clickLockedChapterTwice_hidesPrerequisiteTooltip() {
+    launch<TopicActivity>(
+      createTopicActivityIntent(
+        profileId, TEST_CLASSROOM_ID_1, RATIOS_TOPIC_ID
+      )
+    ).use {
+      clickLessonTab()
+      clickStoryItem(position = 1, targetViewId = R.id.chapter_list_drop_down_icon)
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.chapter_recycler_view,
+          position = 1,
+          targetViewId = R.id.locked_chapter_container
+        )
+      ).perform(click())
+      testCoroutineDispatchers.runCurrent()
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.chapter_recycler_view,
+          position = 1,
+          targetViewId = R.id.locked_chapter_prerequisite_tooltip
+        )
+      ).check(matches(isDisplayed()))
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.chapter_recycler_view,
+          position = 1,
+          targetViewId = R.id.locked_chapter_container
+        )
+      ).perform(click())
+      testCoroutineDispatchers.runCurrent()
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.chapter_recycler_view,
+          position = 1,
+          targetViewId = R.id.locked_chapter_prerequisite_tooltip
+        )
+      ).check(matches(not(isDisplayed())))
     }
   }
 


### PR DESCRIPTION
## Explanation
Fixes #6388: On the Topic Lessons tab, tapping a locked chapter did nothing — `lessons_locked_chapter_view.xml` only binds `NOT_PLAYABLE_MISSING_PREREQUISITES` rows, but `android:clickable` was inverted so those rows were never clickable. Even if they were, `selectChapterSummary` fell through to `playExploration` for locked chapters.

This PR:
1. Makes locked chapter rows clickable/focusable and attaches an accessibility content description on the container.
2. Adds a micro-tooltip (`locked_chapter_prerequisite_tooltip`) that toggles on tap with the existing prerequisite copy (`chapter_locked_prerequisite_title_label`).
3. Coordinates sibling tooltips so only one locked-chapter tip is visible at a time within a story.
4. Short-circuits navigation in `TopicLessonsFragmentPresenter` for locked chapters.
5. Adds Espresso coverage for clickability, tooltip show/hide, and no exploration navigation.

Note: Replaces closed PR #6419 (auto-closed after a force-push; this branch has a clean history).

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
- **Did you use AI/LLMs when working on this PR?** Yes
- **If yes, describe the extent AI was used:** Assisted with root-cause analysis of the inverted clickable binding, implementing the tooltip ViewModel/layout/presenter changes and Espresso tests, and drafting this description. Changes were reviewed manually; `ktlint` was run locally on all touched Kotlin files.

## Test plan
- [x] `ktlint --android` on all changed `.kt` files (pass)
- [ ] `bazel test //app:topic_lessons_fragment_test` (or CI) for the new Espresso cases
- [ ] Manual: Topic → Lessons → expand a story with locked chapters → tap lock row → tip appears; tap again → tip hides; no lesson launch


Made with [Cursor](https://cursor.com)