### PR TITLE
Fix #6416: Increase AndroidLintRunner.kt code coverage

### DIFF
--- a/scripts/src/javatests/org/oppia/android/scripts/lint/AndroidLintRunnerTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/lint/AndroidLintRunnerTest.kt
@@ -506,6 +506,257 @@ class AndroidLintRunnerTest {
   }
 
   @Test
+  fun testLintOrchestrator_execute_invalidMode_errorMessageListsAllValidModes() {
+    val orchestrator = LintOrchestrator(
+      repoRoot = tempFolder.root,
+      commandExecutor = fakeCommandExecutor,
+      scriptBgDispatcher = scriptBgDispatcher
+    )
+
+    val exception = assertThrows<IllegalArgumentException> {
+      orchestrator.execute("nonexistent")
+    }
+
+    // Verify the error message enumerates every valid mode name.
+    assertThat(exception).hasMessageThat().contains("fast")
+    assertThat(exception).hasMessageThat().contains("full")
+    assertThat(exception).hasMessageThat().contains("list-checks")
+    assertThat(exception).hasMessageThat().contains("check-script-consistency")
+  }
+
+  @Test
+  fun testLintOrchestrator_retrieveChangedSourceFiles_withNoChangedFiles_returnsEmptySet() {
+    fakeCommandExecutor.registerHandler("git") { _, args, outputStream, _ ->
+      if (args.contains("merge-base")) {
+        outputStream.print("abc1234567890abcdef")
+      }
+      // All other git calls return empty output → no changed files.
+      0
+    }
+    val orchestrator = LintOrchestrator(
+      repoRoot = tempFolder.root,
+      commandExecutor = fakeCommandExecutor,
+      scriptBgDispatcher = scriptBgDispatcher
+    )
+
+    val changedFiles = orchestrator.retrieveChangedSourceFiles()
+
+    assertThat(changedFiles).isEmpty()
+  }
+
+  @Test
+  fun testLintOrchestrator_execute_withoutTimer_doesNotPrintExecutionTime() {
+    // check-script-consistency completes without bazel infra; exercises timer=null path.
+    val orchestrator = LintOrchestrator(
+      repoRoot = tempFolder.root,
+      commandExecutor = fakeCommandExecutor,
+      scriptBgDispatcher = scriptBgDispatcher,
+      showTimer = false
+    )
+
+    orchestrator.execute("check-script-consistency")
+
+    val output = outputStream.toString()
+    assertThat(output).doesNotContain("Total execution time:")
+  }
+
+  @Test
+  fun testAndroidLintAnalyzer_withGroupByIssueSeverityTrue_reportsGroupedIssues() {
+    setupProjectWithRtlHardCoded()
+    val analyzerGrouped = AndroidLintAnalyzer(
+      commandExecutor = fakeCommandExecutor,
+      workingDirectory = workingDirectory,
+      exemptionProtoPath = "${tempFolder.root}/$pathToProtoBinary",
+      repoRoot = tempFolder.root,
+      reportUnusedEnum = false,
+      groupByIssueSeverity = true,
+      additionalDisabledChecks = LintCheckCatalog.checksAlwaysDisabled
+    )
+
+    val exception = assertThrows<IllegalStateException> {
+      analyzerGrouped.runAnalysis()
+    }
+
+    val output = outputStream.toString()
+    assertThat(output).contains("RTL_HARDCODED")
+    assertThat(exception.message)
+      .contains("${RED}ANDROID LINT CHECK ${BOLD}FAILED$RESET")
+  }
+
+  @Test
+  fun testAndroidLintAnalyzer_withMultipleExplicitChecks_passesAllChecksToLint() {
+    setupProjectStructure()
+    val analyzerMultiCheck = AndroidLintAnalyzer(
+      commandExecutor = fakeCommandExecutor,
+      workingDirectory = workingDirectory,
+      exemptionProtoPath = "${tempFolder.root}/$pathToProtoBinary",
+      repoRoot = tempFolder.root,
+      reportUnusedEnum = false,
+      additionalDisabledChecks = LintCheckCatalog.checksAlwaysDisabled,
+      checks = listOf("HardcodedText", "RtlHardcoded", "NewApi")
+    )
+
+    // Clean project — none of these checks fire.
+    analyzerMultiCheck.runAnalysis()
+
+    val output = outputStream.toString()
+    assertThat(output).contains("${GREEN}ANDROID LINT CHECK ${BOLD}PASSED$RESET")
+  }
+
+  @Test
+  fun testAndroidLintAnalyzer_withNoAdditionalDisabledChecks_detectsNormallySuppressedIssues() {
+    // Exercises the if (suppressLintIssues.isNotEmpty()) false branch in prepareLintArguments.
+    // With an empty set, --disable is NOT added, so checks that are normally suppressed
+    // (e.g. DuplicateStrings) fire on the test project.
+    setupProjectStructure()
+    val analyzerNoDisabled = AndroidLintAnalyzer(
+      commandExecutor = fakeCommandExecutor,
+      workingDirectory = workingDirectory,
+      exemptionProtoPath = "${tempFolder.root}/$pathToProtoBinary",
+      repoRoot = tempFolder.root,
+      reportUnusedEnum = false,
+      additionalDisabledChecks = emptySet()
+    )
+
+    val exception = assertThrows<IllegalStateException> {
+      analyzerNoDisabled.runAnalysis()
+    }
+
+    assertThat(exception.message)
+      .contains("${RED}ANDROID LINT CHECK ${BOLD}FAILED$RESET")
+  }
+
+  @Test
+  fun testAndroidLintAnalyzer_withChangedFilesProvided_includesChangedFilesInDescription() {
+    setupProjectStructure()
+    val changedFile = "app/src/main/java/org/oppia/android/app/AppClass.kt"
+    val analyzerWithChangedFiles = AndroidLintAnalyzer(
+      commandExecutor = fakeCommandExecutor,
+      workingDirectory = workingDirectory,
+      exemptionProtoPath = "${tempFolder.root}/$pathToProtoBinary",
+      repoRoot = tempFolder.root,
+      reportUnusedEnum = false,
+      additionalDisabledChecks = LintCheckCatalog.checksAlwaysDisabled,
+      changedFiles = setOf(changedFile)
+    )
+
+    analyzerWithChangedFiles.runAnalysis()
+
+    val projectDescriptionContent = projectDescriptionFile.readText()
+    assertThat(projectDescriptionContent).contains(changedFile)
+  }
+
+  @Test
+  fun testPrepareJdkEnvironment_nonExistentJdkDirectory_throwsIllegalArgumentException() {
+    setupProjectStructure()
+    val nonExistentJdk = File(tempFolder.root, "non_existent_jdk_directory")
+    fakeCommandExecutor.registerHandler("bazel") { _, args, outputStream, _ ->
+      when {
+        args.contains("info") -> {
+          outputStream.println("output_base: ${tempFolder.root.absolutePath}/bazel-out")
+          outputStream.println("java-home: ${nonExistentJdk.absolutePath}")
+          outputStream.println("java-runtime: OpenJDK Runtime Environment (build 11.0.16+8-post)")
+          0
+        }
+        else -> 0
+      }
+    }
+    val analyzer = AndroidLintAnalyzer(
+      commandExecutor = fakeCommandExecutor,
+      workingDirectory = workingDirectory,
+      exemptionProtoPath = "${tempFolder.root}/$pathToProtoBinary",
+      repoRoot = tempFolder.root,
+      reportUnusedEnum = false,
+      additionalDisabledChecks = LintCheckCatalog.checksAlwaysDisabled,
+      listChecks = true
+    )
+
+    val exception = assertThrows<IllegalArgumentException> {
+      analyzer.runAnalysis()
+    }
+    assertThat(exception)
+      .hasMessageThat()
+      .contains("JDK home path does not exist or is not a directory")
+  }
+
+  @Test
+  fun testPrepareJdkEnvironment_missingReleaseFile_createsReleaseFileFromModuleLayer() {
+    setupProjectStructure()
+    val fakeJdkHome = tempFolder.newFolder("fake_jdk_without_release")
+    val releaseFile = File(fakeJdkHome, "release")
+    assertThat(releaseFile.exists()).isFalse()
+
+    fakeCommandExecutor.registerHandler("bazel") { _, args, outputStream, _ ->
+      when {
+        args.contains("info") -> {
+          outputStream.println("output_base: ${tempFolder.root.absolutePath}/bazel-out")
+          outputStream.println("java-home: ${fakeJdkHome.absolutePath}")
+          outputStream.println("java-runtime: OpenJDK Runtime Environment (build 11.0.16+8-post)")
+          0
+        }
+        else -> 0
+      }
+    }
+    val analyzer = AndroidLintAnalyzer(
+      commandExecutor = fakeCommandExecutor,
+      workingDirectory = workingDirectory,
+      exemptionProtoPath = "${tempFolder.root}/$pathToProtoBinary",
+      repoRoot = tempFolder.root,
+      reportUnusedEnum = false,
+      additionalDisabledChecks = LintCheckCatalog.checksAlwaysDisabled,
+      listChecks = true
+    )
+
+    analyzer.runAnalysis()
+
+    assertThat(releaseFile.exists()).isTrue()
+    assertThat(releaseFile.readText()).contains("MODULES=")
+  }
+
+  @Test
+  fun testLintOrchestrator_execute_fastMode_withProjectStructure_succeeds() {
+    // Unlike testLintOrchestrator_execute_fastMode_printsFastModeDescription (which lacks
+    // project infrastructure and catches an expected exception after printing the mode description),
+    // this test sets up a workspace and exemption proto so that fast mode executes end-to-end and
+    // completes successfully without throwing an exception.
+    setupProjectStructure()
+    fakeCommandExecutor.registerHandler("git") { _, args, outputStream, _ ->
+      if (args.contains("merge-base")) {
+        outputStream.print("abc1234567890abcdef")
+      }
+      0
+    }
+    val orchestrator = LintOrchestrator(
+      repoRoot = tempFolder.root,
+      commandExecutor = fakeCommandExecutor,
+      scriptBgDispatcher = scriptBgDispatcher,
+      exemptionProtoPath = "${tempFolder.root}/$pathToProtoBinary"
+    )
+
+    orchestrator.execute("fast")
+
+    val output = outputStream.toString()
+    assertThat(output).contains("Running linter in 'fast' mode with 0 changed source file(s).")
+  }
+
+  @Test
+  fun testLintOrchestrator_execute_fullMode_withExplicitChecks_succeeds() {
+    setupProjectStructure()
+    val orchestrator = LintOrchestrator(
+      repoRoot = tempFolder.root,
+      commandExecutor = fakeCommandExecutor,
+      scriptBgDispatcher = scriptBgDispatcher,
+      exemptionProtoPath = "${tempFolder.root}/$pathToProtoBinary",
+      explicitChecks = listOf("HardcodedText")
+    )
+
+    orchestrator.execute("full")
+
+    val output = outputStream.toString()
+    assertThat(output).contains("Running linter in 'full' mode with all repository files.")
+  }
+
+  @Test
   fun testAndroidLintAnalyzer_validRootPath_generatesReports() {
     setupProjectStructure()
     androidLintAnalyzerWithFakeExecutor.runAnalysis()


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
Fixes #6416
## Explanation
 Increase AndroidLintRunner.kt code coverage above the required 70% threshold.

Added unit tests covering previously untested branches and execution paths in AndroidLintRunner.kt, including lint modes, JDK environment setup, catalog consistency validation, timer behavior, and changed-file handling.

AndroidLintRunner.kt line coverage increased from 67.32% (239/355 lines) to 79.72% (283/355 lines).

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
<!-- Please answer the following two questions. -->
- **Did you use AI/LLMs when working on this PR?** Type `Yes` or `No`.: Yes
- **If yes, describe the extent AI was used:**: I have used LLM for code-completion, research, debugging and writing unit tests.
  
## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
