### PR TITLE
Fix #6365: Resolve intermittent Android Lint errors in app, testing, and utility

### DIFF
--- a/app/src/main/java/org/oppia/android/app/administratorcontrols/learneranalytics/ControlButtonsViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/administratorcontrols/learneranalytics/ControlButtonsViewModel.kt
@@ -3,7 +3,7 @@ package org.oppia.android.app.administratorcontrols.learneranalytics
 import android.annotation.SuppressLint
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.os.Build
+import android.util.Base64
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -20,7 +20,6 @@ import org.oppia.android.util.logging.SyncStatusManager
 import org.oppia.android.util.logging.SyncStatusManager.SyncStatus
 import java.io.ByteArrayOutputStream
 import java.security.MessageDigest
-import java.util.Base64
 import java.util.zip.GZIPOutputStream
 import javax.inject.Inject
 
@@ -229,11 +228,7 @@ class ControlButtonsViewModel private constructor(
       val compressedMessage = ByteArrayOutputStream().also { byteOutputStream ->
         GZIPOutputStream(byteOutputStream).use(::writeTo)
       }.toByteArray()
-      return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        Base64.getEncoder().encodeToString(compressedMessage)
-      } else {
-        android.util.Base64.encodeToString(compressedMessage, 0)
-      }
+      return Base64.encodeToString(compressedMessage, Base64.NO_WRAP)
     }
 
     private fun String.computeSha1Hash(machineLocale: OppiaLocale.MachineLocale): String {

--- a/testing/src/main/java/org/oppia/android/testing/junit/OppiaParameterizedTestRunner.kt
+++ b/testing/src/main/java/org/oppia/android/testing/junit/OppiaParameterizedTestRunner.kt
@@ -1,7 +1,5 @@
 package org.oppia.android.testing.junit
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import org.junit.runner.Description
 import org.junit.runner.Runner
 import org.junit.runner.manipulation.Filter
@@ -74,7 +72,6 @@ import kotlin.reflect.KClass
  * fields since there's no way to ensure what values those fields will contain (thus they should be
  * treated as undefined outside of tests that specific define their value via [Iteration]).
  */
-@RequiresApi(Build.VERSION_CODES.N)
 class OppiaParameterizedTestRunner(private val testClass: Class<*>) : Suite(testClass, listOf()) {
   private val parameterizedMethods = computeParameterizedMethods()
   private val selectedRunnerClass by lazy { fetchSelectedRunnerPlatformClass() }
@@ -94,7 +91,6 @@ class OppiaParameterizedTestRunner(private val testClass: Class<*>) : Suite(test
 
   override fun getChildren(): MutableList<Runner> = childrenRunners.toMutableList()
 
-  @RequiresApi(Build.VERSION_CODES.N)
   private fun computeParameterizedMethods(): Map<String, ParameterizedMethod> {
     val fieldsAndParsers = fetchParameterizedFields().map { field ->
       val valueParser = ParameterValue.createParserForField(field)
@@ -184,17 +180,15 @@ class OppiaParameterizedTestRunner(private val testClass: Class<*>) : Suite(test
     }.associateBy { it.methodName }
   }
 
-  @RequiresApi(Build.VERSION_CODES.N)
   private fun fetchParameterizedFields(): List<Field> {
     return testClass.declaredFields.mapNotNull { field ->
-      field.getDeclaredAnnotation(Parameter::class.java)?.let { field }
+      field.getAnnotation(Parameter::class.java)?.let { field }
     }
   }
 
-  @RequiresApi(Build.VERSION_CODES.N)
   private fun fetchParameterizedMethodDeclarations(): List<ParameterizedMethodDeclaration> {
     return testClass.declaredMethods.mapNotNull { method ->
-      method.getDeclaredAnnotationsByType(Iteration::class.java).map { parameters ->
+      method.fetchIterations().map { parameters ->
         parameters.name to parameters.keyValuePairs.toList()
       }.takeIf { it.isNotEmpty() }?.let { rawValues ->
         val groupedValues = rawValues.groupBy({ it.first }, { it.second })
@@ -210,9 +204,25 @@ class OppiaParameterizedTestRunner(private val testClass: Class<*>) : Suite(test
     }
   }
 
-  @RequiresApi(Build.VERSION_CODES.N)
+  private fun Method.fetchIterations(): List<Iteration> {
+    val iterations = mutableListOf<Iteration>()
+    getAnnotation(Iteration::class.java)?.let { iterations.add(it) }
+    declaredAnnotations.forEach { annotation ->
+      try {
+        val valueMethod = annotation.annotationClass.java.getMethod("value")
+        val result = valueMethod.invoke(annotation)
+        val containerIterations = (result as? Array<*>)?.filterIsInstance<Iteration>()
+        if (containerIterations != null) {
+          iterations.addAll(containerIterations)
+        }
+      } catch (ignored: Exception) {
+      }
+    }
+    return iterations.distinct()
+  }
+
   private fun fetchSelectedRunnerPlatformClass(): Class<*> {
-    return checkNotNull(testClass.getDeclaredAnnotation(SelectRunnerPlatform::class.java)) {
+    return checkNotNull(testClass.getAnnotation(SelectRunnerPlatform::class.java)) {
       "All suites using OppiaParameterizedTestRunner must declare their base platform runner" +
         " using SelectRunnerPlatform."
     }.runnerType.java

--- a/testing/src/main/java/org/oppia/android/testing/junit/OppiaParameterizedTestRunner.kt
+++ b/testing/src/main/java/org/oppia/android/testing/junit/OppiaParameterizedTestRunner.kt
@@ -210,7 +210,7 @@ class OppiaParameterizedTestRunner(private val testClass: Class<*>) : Suite(test
     declaredAnnotations.forEach { annotation ->
       val valueMethod = annotation.annotationClass.java.methods.firstOrNull { method ->
         method.name == "value" &&
-          method.parameterCount == 0 &&
+          method.parameterTypes.isEmpty() &&
           method.returnType.isArray &&
           method.returnType.componentType == Iteration::class.java
       }

--- a/testing/src/main/java/org/oppia/android/testing/junit/OppiaParameterizedTestRunner.kt
+++ b/testing/src/main/java/org/oppia/android/testing/junit/OppiaParameterizedTestRunner.kt
@@ -217,6 +217,8 @@ class OppiaParameterizedTestRunner(private val testClass: Class<*>) : Suite(test
       if (valueMethod != null) {
         try {
           val result = valueMethod.invoke(annotation)
+          // The cast is safe: we verified returnType.componentType == Iteration::class.java above.
+          @Suppress("UNCHECKED_CAST")
           val containerIterations = result as? Array<Iteration>
           if (containerIterations != null) {
             iterations.addAll(containerIterations)

--- a/testing/src/main/java/org/oppia/android/testing/junit/OppiaParameterizedTestRunner.kt
+++ b/testing/src/main/java/org/oppia/android/testing/junit/OppiaParameterizedTestRunner.kt
@@ -208,14 +208,22 @@ class OppiaParameterizedTestRunner(private val testClass: Class<*>) : Suite(test
     val iterations = mutableListOf<Iteration>()
     getAnnotation(Iteration::class.java)?.let { iterations.add(it) }
     declaredAnnotations.forEach { annotation ->
-      try {
-        val valueMethod = annotation.annotationClass.java.getMethod("value")
-        val result = valueMethod.invoke(annotation)
-        val containerIterations = (result as? Array<*>)?.filterIsInstance<Iteration>()
-        if (containerIterations != null) {
-          iterations.addAll(containerIterations)
+      val valueMethod = annotation.annotationClass.java.methods.firstOrNull { method ->
+        method.name == "value" &&
+          method.parameterCount == 0 &&
+          method.returnType.isArray &&
+          method.returnType.componentType == Iteration::class.java
+      }
+      if (valueMethod != null) {
+        try {
+          val result = valueMethod.invoke(annotation)
+          val containerIterations = result as? Array<Iteration>
+          if (containerIterations != null) {
+            iterations.addAll(containerIterations)
+          }
+        } catch (ignored: IllegalAccessException) {
+        } catch (ignored: java.lang.reflect.InvocationTargetException) {
         }
-      } catch (ignored: Exception) {
       }
     }
     return iterations.distinct()

--- a/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/MathTagHandler.kt
@@ -178,6 +178,8 @@ private class LatexImageSpan(
         override fun draw(canvas: Canvas) {}
         override fun setAlpha(alpha: Int) {}
         override fun setColorFilter(colorFilter: android.graphics.ColorFilter?) {}
+        // PixelFormat.TRANSPARENT is valid for an empty transparent drawable.
+        @Suppress("WrongConstant")
         override fun getOpacity(): Int = android.graphics.PixelFormat.TRANSPARENT
 
         init {

--- a/utility/src/main/java/org/oppia/android/util/parser/svg/SvgPictureDrawable.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/svg/SvgPictureDrawable.kt
@@ -93,6 +93,7 @@ abstract class SvgPictureDrawable(
 
   override fun setColorFilter(colorFilter: ColorFilter?) { /* Unsupported. */ }
 
+  @Suppress("WrongConstant") // PixelFormat.TRANSLUCENT is valid for SVGs requiring alpha blending.
   override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
 
   /**


### PR DESCRIPTION
## Explanation

Fixes #6365

Android Lint was intermittently failing (and consistently failing in `--mode=full`) due to `NEW_API` and `WRONG_CONSTANT` errors in three files.

### Root Causes & Fixes

**1. `ControlButtonsViewModel.kt` — `NEW_API` (API 26)**

`java.util.Base64.getEncoder().encodeToString()` requires API 26, but minSdk is 21. Replaced with `android.util.Base64.encodeToString(..., Base64.NO_WRAP)` which works on API 1+. `NO_WRAP` produces identical unwrapped output, preserving correct behaviour with the downstream `chunked(80)` logic.

**2. `OppiaParameterizedTestRunner.kt` — `NEW_API` (API 24)**

Three calls required Java 8 / API 24:
- `field.getDeclaredAnnotation(...)` → replaced with `field.getAnnotation(...)` (API 1+)
- `testClass.getDeclaredAnnotation(...)` → replaced with `testClass.getAnnotation(...)` (API 1+)
- `method.getDeclaredAnnotationsByType(Iteration::class.java)` → replaced with a custom `Method.fetchIterations()` extension function using standard Java reflection to handle both direct and repeatable container annotations without any API 24+ calls.

All `@RequiresApi(Build.VERSION_CODES.N)` annotations and unused `Build`/`RequiresApi` imports were removed.

**3. `MathTagHandler.kt` & `SvgPictureDrawable.kt` — `WRONG_CONSTANT` (false positive)**

`PixelFormat.TRANSPARENT` and `PixelFormat.TRANSLUCENT` are valid return values for `getOpacity()` per the Android `Drawable` contract. Android Lint's `WrongConstantDetector` flags these as false positives due to a UAST annotation propagation bug. Added `@Suppress("WrongConstant")` with an explanatory comment in each case to silence the false-positive without masking any real error.

### Verification

- `bazel run //scripts:android_lint_check -- $(pwd) --mode=full` → `Total Issues: 0 — ANDROID LINT CHECK PASSED`
- `bazel run //scripts:android_lint_check -- $(pwd) --checks=NewApi,WrongConstant` → `Total Issues: 0 — ANDROID LINT CHECK PASSED`
- `MathTagHandlerTest` → PASSED (23 tests)
- `ProfileAndDeviceIdFragmentTest` → PASSED (51 tests)
- `ProfileNameValidatorTest` → PASSED (17 tests)

### Before & After Screenshots (for `WRONG_CONSTANT` usage trace)

As requested, here are before/after screenshots confirming that suppressing the `WRONG_CONSTANT` warnings in `MathTagHandler.kt` (LaTeX/math rendering) and `SvgPictureDrawable.kt` (SVG illustrations) causes zero visual regression:

**LaTeX / Math rendering (`MathTagHandler.kt`)**

| Before | After |
|--------|-------|
| ![Before math](https://github.com/user-attachments/assets/03be6ed6-2bea-4290-9fbc-c56c073e9d8a) | ![After math](https://github.com/user-attachments/assets/f868fdb3-7eb0-479a-811c-8c7bae79a4d6) |

**SVG / Vector illustration rendering (`SvgPictureDrawable.kt`)**

| Before | After |
|--------|-------|
| ![Before SVG](https://github.com/user-attachments/assets/a74fd04c-e98d-4d2c-9580-f8125e798869) | ![After SVG](https://github.com/user-attachments/assets/c7590e13-7d18-4838-b947-75b1e1ebff73) |

> **Note:** The UI is intentionally identical before and after — this confirms that `@Suppress("WrongConstant")` is not silencing any real errors, only false-positive lint warnings.



## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: "
- [x] The explanation section above starts with "Fixes #bugnum: "
- [x] Any changes to scripts/assets files have their rationale included in the PR explanation.
- [x] The PR follows the style guide.
- [x] The PR does not contain any unnecessary code changes from Android Studio.
- [x] The PR is made from a branch that's not called "develop" and is up-to-date with "develop".
- [x] The PR is assigned to the appropriate reviewers.

## Disclosure of LLM Usage
- **Did you use AI/LLMs when working on this PR?** Yes
- **If yes, describe the extent AI was used:** Used AI for brainstorming root causes of the intermittent lint failures, writing inline code comments, and writing the PR description.

