### PR TITLE
Fix #6424: Add missing sections to development Study Guide assets

### DIFF
--- a/app/src/sharedTest/java/org/oppia/android/app/topic/studyguide/StudyGuideFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/studyguide/StudyGuideFragmentTest.kt
@@ -241,6 +241,27 @@ class StudyGuideFragmentTest {
   }
 
   @Test
+  fun testStudyGuide_loadJson_fractionsSubtopic2_sectionContentIsDisplayed() {
+    // Reapply both flags together since resetting one platform parameter clears all overrides.
+    TestPlatformParameterModule.reset()
+    TestPlatformParameterModule.forceLoadLessonProtosFromAssets(false)
+    TestPlatformParameterModule.forceEnableWorkedExamples(true)
+    runWithLaunchedActivityAndAddedFragment(
+      FRACTIONS_TOPIC_ID,
+      subtopicIndex = FRACTIONS_SUBTOPIC_TOPIC_ID_1,
+      subtopicListSize = FRACTIONS_SUBTOPIC_LIST_SIZE
+    ) {
+      onView(
+        atPositionOnView(
+          recyclerViewId = R.id.study_guide_section_recycler_view,
+          position = 1,
+          targetViewId = R.id.study_guide_section_content_text
+        )
+      ).check(matches(withText(containsString("Description of subtopic is here."))))
+    }
+  }
+
+  @Test
   fun testStudyGuide_testTopicSubtopic1_secondSectionHeadingIsDisplayed() {
     runWithLaunchedActivityAndAddedFragment(
       TEST_TOPIC_ID_0,

--- a/domain/src/main/assets/dev/GJ2rLXRKD5hw_1.json
+++ b/domain/src/main/assets/dev/GJ2rLXRKD5hw_1.json
@@ -21,6 +21,18 @@
       }
     }
   },
+  "sections": [
+    {
+      "heading": {
+        "content_id": "section_heading_0",
+        "unicode_str": "What is a Fraction?"
+      },
+      "content": {
+        "content_id": "section_content_1",
+        "html": "<p>Description of subtopic is here.</p>.<p>This is sample subtopic with dummy content related to Fractions: <oppia-noninteractive-math render-type=\"inline\" math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;\\\\frac{\\\\frac{1}{6}}{\\\\frac{1}{2}}&amp;quot;}\"></oppia-noninteractive-math> A lot more text that hopefully wraps to the next line in order to see whether the fraction correctly breaks subsequent text lines since we definitely don't want it to overlap since then it would most certainly not be readable in the least.<p>Fractions represent equal parts of a whole or a collection. Fraction of a whole: When we divide a whole into equal parts, each part is a fraction of the whole. A fraction has two parts. The number on the top of the line is called the numerator. It tells how many equal parts of the whole or collection are taken.  The number below the line is called the denominator.  It shows the total divisible number of equal parts the whole into or the total number of equal parts which are there in a collection. Also, here's the equation for a line using in-line LaTeX: <oppia-noninteractive-math render-type=\"inline\" math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;y=mx+b&amp;quot;}\" /><p><oppia-noninteractive-math render-type=\"block\" math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;(x + 1)(x - 2) = \\\\frac{(x ^ {3} + 2x ^ {2} - 5x - 6)}{(x + b)}&amp;quot;}\" /><p><oppia-noninteractive-math render-type=\"block\" math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;y=mx+b&amp;quot;}\" /><p><oppia-noninteractive-math render-type=\"block\" math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;\\\\sqrt{\\\\frac{\\\\frac{\\\\frac{\\\\frac{\\\\frac{\\\\frac{\\\\frac{\\\\frac{1}{2}}{3}}{4}}{5}}{6}}{7}}{8}}{9}}&amp;quot;}\" />"
+      }
+    }
+  ],
   "subtopic_title": "What is a Fraction?",
   "next_subtopic_dict": null
 }

--- a/domain/src/main/assets/dev/GJ2rLXRKD5hw_1.textproto
+++ b/domain/src/main/assets/dev/GJ2rLXRKD5hw_1.textproto
@@ -26,3 +26,13 @@ title {
   html: "What is a Fraction?"
   content_id: "title"
 }
+sections {
+  heading {
+    unicode_str: "What is a Fraction?"
+    content_id: "section_heading_0"
+  }
+  content {
+    html: "<p>Description of subtopic is here.</p>.<p>This is sample subtopic with dummy content related to Fractions: <oppia-noninteractive-math render-type=\"inline\" math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;\\\\frac{\\\\frac{1}{6}}{\\\\frac{1}{2}}&amp;quot;}\"></oppia-noninteractive-math> A lot more text that hopefully wraps to the next line in order to see whether the fraction correctly breaks subsequent text lines since we definitely don't want it to overlap since then it would most certainly not be readable in the least.<p>Fractions represent equal parts of a whole or a collection. Fraction of a whole: When we divide a whole into equal parts, each part is a fraction of the whole. A fraction has two parts. The number on the top of the line is called the numerator. It tells how many equal parts of the whole or collection are taken.  The number below the line is called the denominator.  It shows the total divisible number of equal parts the whole into or the total number of equal parts which are there in a collection. Also, here's the equation for a line using in-line LaTeX: <oppia-noninteractive-math render-type=\"inline\" math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;y=mx+b&amp;quot;}\" /><p><oppia-noninteractive-math render-type=\"block\" math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;(x + 1)(x - 2) = \\\\frac{(x ^ {3} + 2x ^ {2} - 5x - 6)}{(x + b)}&amp;quot;}\" /><p><oppia-noninteractive-math render-type=\"block\" math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;y=mx+b&amp;quot;}\" /><p><oppia-noninteractive-math render-type=\"block\" math_content-with-value=\"{&amp;quot;raw_latex&amp;quot;:&amp;quot;\\\\sqrt{\\\\frac{\\\\frac{\\\\frac{\\\\frac{\\\\frac{\\\\frac{\\\\frac{\\\\frac{1}{2}}{3}}{4}}{5}}{6}}{7}}{8}}{9}}&amp;quot;}\" />"
+    content_id: "section_content_1"
+  }
+}

--- a/domain/src/main/assets/dev/GJ2rLXRKD5hw_2.json
+++ b/domain/src/main/assets/dev/GJ2rLXRKD5hw_2.json
@@ -21,6 +21,18 @@
       }
     }
   },
+  "sections": [
+    {
+      "heading": {
+        "content_id": "section_heading_0",
+        "unicode_str": "Fractions of a group"
+      },
+      "content": {
+        "content_id": "section_content_1",
+        "html": "<p>Description of subtopic is here. <oppia-noninteractive-skillreview skill_id-with-value=\"&amp;quot;5RM9KPfQxobH&amp;quot;\" text-with-value=\"&amp;quot;This concept card demonstrates overall concept card functionality.&amp;quot;\"></oppia-noninteractive-skillreview></p>"
+      }
+    }
+  ],
   "subtopic_title": "Fractions of a group",
   "next_subtopic_dict": null
 }

--- a/domain/src/main/assets/dev/GJ2rLXRKD5hw_2.textproto
+++ b/domain/src/main/assets/dev/GJ2rLXRKD5hw_2.textproto
@@ -26,3 +26,13 @@ title {
   html: "Fractions of a group"
   content_id: "title"
 }
+sections {
+  heading {
+    unicode_str: "Fractions of a group"
+    content_id: "section_heading_0"
+  }
+  content {
+    html: "<p>Description of subtopic is here. <oppia-noninteractive-skillreview skill_id-with-value=\"&amp;quot;5RM9KPfQxobH&amp;quot;\" text-with-value=\"&amp;quot;This concept card demonstrates overall concept card functionality.&amp;quot;\"></oppia-noninteractive-skillreview></p>"
+    content_id: "section_content_1"
+  }
+}

--- a/domain/src/main/assets/dev/GJ2rLXRKD5hw_3.json
+++ b/domain/src/main/assets/dev/GJ2rLXRKD5hw_3.json
@@ -21,6 +21,18 @@
       }
     }
   },
+  "sections": [
+    {
+      "heading": {
+        "content_id": "section_heading_0",
+        "unicode_str": "Mixed Numbers"
+      },
+      "content": {
+        "content_id": "section_content_1",
+        "html": "<p>Description of subtopic is here.</p>"
+      }
+    }
+  ],
   "subtopic_title": "Mixed Numbers",
   "next_subtopic_dict": null
 }

--- a/domain/src/main/assets/dev/GJ2rLXRKD5hw_3.textproto
+++ b/domain/src/main/assets/dev/GJ2rLXRKD5hw_3.textproto
@@ -26,3 +26,13 @@ title {
   html: "Mixed Numbers"
   content_id: "title"
 }
+sections {
+  heading {
+    unicode_str: "Mixed Numbers"
+    content_id: "section_heading_0"
+  }
+  content {
+    html: "<p>Description of subtopic is here.</p>"
+    content_id: "section_content_1"
+  }
+}

--- a/domain/src/main/assets/dev/GJ2rLXRKD5hw_4.json
+++ b/domain/src/main/assets/dev/GJ2rLXRKD5hw_4.json
@@ -21,6 +21,18 @@
       }
     }
   },
+  "sections": [
+    {
+      "heading": {
+        "content_id": "section_heading_0",
+        "unicode_str": "Adding Fractions"
+      },
+      "content": {
+        "content_id": "section_content_1",
+        "html": "<p>Description of subtopic is here.</p>"
+      }
+    }
+  ],
   "subtopic_title": "Adding Fractions",
   "next_subtopic_dict": null
 }

--- a/domain/src/main/assets/dev/GJ2rLXRKD5hw_4.textproto
+++ b/domain/src/main/assets/dev/GJ2rLXRKD5hw_4.textproto
@@ -27,3 +27,13 @@ title {
   html: "Adding Fractions"
   content_id: "title"
 }
+sections {
+  heading {
+    unicode_str: "Adding Fractions"
+    content_id: "section_heading_0"
+  }
+  content {
+    html: "<p>Description of subtopic is here.</p>"
+    content_id: "section_content_1"
+  }
+}

--- a/domain/src/main/assets/dev/omzF4oqgeTXd_1.json
+++ b/domain/src/main/assets/dev/omzF4oqgeTXd_1.json
@@ -21,6 +21,18 @@
       }
     }
   },
+  "sections": [
+    {
+      "heading": {
+        "content_id": "section_heading_0",
+        "unicode_str": "What is a Ratio?"
+      },
+      "content": {
+        "content_id": "section_content_1",
+        "html": "In mathematics, a ratio indicates how many times one number contains another. For example, if there are eight oranges and six lemons in a bowl of fruit, then the ratio of oranges to lemons is eight to six. Similarly, the ratio of lemons to oranges is 6∶8 and the ratio of oranges to the total amount of fruit is 8∶14."
+      }
+    }
+  ],
   "subtopic_title": "What is a Ratio?",
   "next_subtopic_dict": null
 }

--- a/domain/src/main/assets/dev/omzF4oqgeTXd_1.textproto
+++ b/domain/src/main/assets/dev/omzF4oqgeTXd_1.textproto
@@ -25,3 +25,13 @@ title {
   html: "What is a Ratio?"
   content_id: "title"
 }
+sections {
+  heading {
+    unicode_str: "What is a Ratio?"
+    content_id: "section_heading_0"
+  }
+  content {
+    html: "In mathematics, a ratio indicates how many times one number contains another. For example, if there are eight oranges and six lemons in a bowl of fruit, then the ratio of oranges to lemons is eight to six. Similarly, the ratio of lemons to oranges is 6∶8 and the ratio of oranges to the total amount of fruit is 8∶14."
+    content_id: "section_content_1"
+  }
+}

--- a/domain/src/test/java/org/oppia/android/domain/topic/TopicControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/topic/TopicControllerTest.kt
@@ -1151,14 +1151,14 @@ class TopicControllerTest {
   }
 
   @Test
-  fun testGetStudyGuide_fractionsSubtopic2_legacyRecord_hasNoSections() {
-    // A subtopic record that predates study guide support has no sections. It still loads as a
-    // study guide, but with an empty sections list and its subtopic title preserved.
+  fun testGetStudyGuide_fractionsSubtopic2_hasSectionContent() {
     val studyGuideProvider =
       topicController.getStudyGuide(profileId1, FRACTIONS_TOPIC_ID, SUBTOPIC_TOPIC_ID_2)
 
     val ephemeralStudyGuide = monitorFactory.waitForNextSuccessfulResult(studyGuideProvider)
-    assertThat(ephemeralStudyGuide.studyGuide.sectionsList).isEmpty()
+    val section = ephemeralStudyGuide.studyGuide.sectionsList.single()
+    assertThat(section.heading.unicodeStr).isEqualTo("Fractions of a group")
+    assertThat(section.content.html).contains("Description of subtopic is here.")
     assertThat(ephemeralStudyGuide.studyGuide.subtopicTitle.html).isEqualTo("Fractions of a group")
   }
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fixes #6424

This happened because the development lesson files had the old `page_contents` data, but the new Study Guide screen reads from `sections`. This PR adds the missing `sections` to the five development Study Guides. I updated both the JSON and textproto files because the app can load either format. I kept the old `page_contents` data so Revision Cards will still work when Study Guides are disabled. I also added tests to make sure the content loads correctly from both JSON and textproto files.


## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
<!-- Please answer the following two questions. -->
Yes, I used an LLM as making all these repetitive changes manually would have taken me several hours for a small fix. I personally reviewed everything and verified the fix.

### Before and After

| Before | After |
| --- | --- |
| <img width="360" alt="Before: Study Guide content is blank" src="https://github.com/user-attachments/assets/bc0f725b-49d9-46bf-a774-3976a15b5779" /> | <img width="360" alt="After: Study Guide content is displayed" src="https://github.com/user-attachments/assets/a4c7fba0-16aa-4448-a68e-4ee73efd85e9" /> |