### PR TITLE
Fix #6430, #6431: Preserve worked example list spacing

### DIFF
--- a/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParser.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParser.kt
@@ -220,20 +220,21 @@ class HtmlParser private constructor(
    * renders ordered lists as bullets rather than as numbers).
    */
   private fun replaceListTags(html: String): String {
-    var adjustedHtml = html
-    if ("<li>" in adjustedHtml) {
-      adjustedHtml = adjustedHtml.replace("<li>", "<$CUSTOM_LIST_LI_TAG>")
-        .replace("</li>", "</$CUSTOM_LIST_LI_TAG>")
-    }
-    if ("<ul>" in adjustedHtml) {
-      adjustedHtml = adjustedHtml.replace("<ul>", "<$CUSTOM_LIST_UL_TAG>")
-        .replace("</ul>", "</$CUSTOM_LIST_UL_TAG>")
-    }
-    if ("<ol>" in adjustedHtml) {
-      adjustedHtml = adjustedHtml.replace("<ol>", "<$CUSTOM_LIST_OL_TAG>")
-        .replace("</ol>", "</$CUSTOM_LIST_OL_TAG>")
-    }
-    return adjustedHtml
+    return html
+      .replaceListTag(originalTag = "li", replacementTag = CUSTOM_LIST_LI_TAG)
+      .replaceListTag(originalTag = "ul", replacementTag = CUSTOM_LIST_UL_TAG)
+      .replaceListTag(originalTag = "ol", replacementTag = CUSTOM_LIST_OL_TAG)
+  }
+
+  /**
+   * Replaces opening and closing [originalTag] tags while preserving attributes such as the XHTML
+   * namespace included by Oppia's rich-text editor.
+   */
+  private fun String.replaceListTag(originalTag: String, replacementTag: String): String {
+    return replace(
+      Regex("""<(/?)$originalTag(?=[\s>])""", RegexOption.IGNORE_CASE),
+      "<$1$replacementTag"
+    )
   }
 
   private fun trimSpannable(spannable: SpannableStringBuilder): SpannableStringBuilder {

--- a/utility/src/main/java/org/oppia/android/util/parser/html/WorkedExampleTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/WorkedExampleTagHandler.kt
@@ -59,6 +59,14 @@ class WorkedExampleTagHandler(
       return
     }
 
+    // Inserting a worked example at the end of a list-item span causes SpannableStringBuilder to
+    // extend that span over the inserted content. This happens when consecutive worked examples
+    // have answers that end in lists, and makes every following example accumulate another list
+    // margin. Remember those spans so their original boundary can be restored after replacement.
+    val precedingListItemSpans = output
+      .getSpans(0, openIndex, ListItemLeadingMarginSpan::class.java)
+      .filter { output.getSpanEnd(it) == openIndex }
+
     val parsedWorkedExample = SpannableStringBuilder().apply {
       // Worked examples are block content, so they're separated from whatever precedes them by a
       // blank line. Existing line breaks count towards that blank line, so an example that follows
@@ -95,6 +103,14 @@ class WorkedExampleTagHandler(
       Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
     )
     output.replace(openIndex, closeIndex, parsedWorkedExample)
+    precedingListItemSpans.forEach { span ->
+      output.setSpan(
+        span,
+        output.getSpanStart(span),
+        openIndex,
+        output.getSpanFlags(span)
+      )
+    }
   }
 
   // Note that this is implemented in addition to getContentDescription since the two are used in

--- a/utility/src/main/java/org/oppia/android/util/parser/html/WorkedExampleTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/WorkedExampleTagHandler.kt
@@ -62,7 +62,7 @@ class WorkedExampleTagHandler(
     // Inserting a worked example at the end of a list-item span causes SpannableStringBuilder to
     // extend that span over the inserted content. This happens when consecutive worked examples
     // have answers that end in lists, and makes every following example accumulate another list
-    // margin. Remember those spans so their original boundary can be restored after replacement.
+    // margin. Remember those spans so their boundary can be restored after replacement.
     val precedingListItemSpans = output
       .getSpans(0, openIndex, ListItemLeadingMarginSpan::class.java)
       .filter { output.getSpanEnd(it) == openIndex }
@@ -103,11 +103,16 @@ class WorkedExampleTagHandler(
       Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
     )
     output.replace(openIndex, closeIndex, parsedWorkedExample)
+    // If the preceding list ended at the end of the original output, its span could validly end
+    // after a non-newline character. The replacement makes that position internal to the output,
+    // where paragraph spans must instead end just after a newline. Include the first separating
+    // newline when one was inserted, while stopping before the worked example begins.
+    val precedingListEnd = openIndex + minOf(workedExampleStart, 1)
     precedingListItemSpans.forEach { span ->
       output.setSpan(
         span,
         output.getSpanStart(span),
-        openIndex,
+        precedingListEnd,
         output.getSpanFlags(span)
       )
     }

--- a/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
@@ -10,6 +10,7 @@ import android.text.style.BulletSpan
 import android.text.style.ClickableSpan
 import android.text.style.ImageSpan
 import android.text.style.LeadingMarginSpan
+import android.text.style.URLSpan
 import android.view.View
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
@@ -30,6 +31,7 @@ import com.google.common.truth.Truth.assertThat
 import dagger.Component
 import org.hamcrest.CoreMatchers
 import org.hamcrest.Matchers.not
+import org.json.JSONObject
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -985,6 +987,68 @@ class HtmlParserTest {
   }
 
   @Test
+  fun testHtmlContent_withWorkedExampleNamespacedList_preservesBlockSpacing() {
+    val htmlParser = htmlParserFactory.create(
+      resourceBucketName,
+      entityType = "",
+      entityId = "",
+      imageCenterAlign = false,
+      displayLocale = appLanguageLocaleHandler.getDisplayLocale()
+    )
+    val textView = TextView(context)
+    val workedExampleMarkup = createWorkedExampleMarkup(
+      questionHtml = "Where should the content be separated?",
+      answerHtml =
+        "<ol xmlns=\"http://www.w3.org/1999/xhtml\"><li>Outer item one:<ul>" +
+          "<li>Inner item one.</li><li>Inner item two.</li></ul></li>" +
+          "<li>Outer item two.</li></ol><p>Following paragraph.</p>"
+    )
+
+    val htmlResult = htmlParser.parseOppiaHtml(
+      workedExampleMarkup,
+      textView,
+      workedExampleLabels = WORKED_EXAMPLE_LABELS
+    )
+
+    assertThat(htmlResult.getSpansFromWholeString(ListItemLeadingMarginSpan.OlSpan::class))
+      .hasLength(2)
+    assertThat(htmlResult.getSpansFromWholeString(ListItemLeadingMarginSpan.UlSpan::class))
+      .hasLength(2)
+    assertThat(htmlResult.toString()).contains("Inner item two.\nOuter item two.")
+    assertThat(htmlResult.toString()).contains("Outer item two.\n\nFollowing paragraph.")
+  }
+
+  @Test
+  fun testHtmlContent_withWorkedExampleNamespacedList_doesNotCreateFalseLinks() {
+    val htmlParser = htmlParserFactory.create(
+      resourceBucketName,
+      entityType = "",
+      entityId = "",
+      imageCenterAlign = false,
+      displayLocale = appLanguageLocaleHandler.getDisplayLocale()
+    )
+    val textView = TextView(context)
+    val workedExampleMarkup = createWorkedExampleMarkup(
+      questionHtml = "Add the decimals.",
+      answerHtml =
+        "<ul xmlns=\"http://www.w3.org/1999/xhtml\">" +
+          "<li>Add a decimal point before the tenths place.</li>" +
+          "<li>Now add the place value digits.</li>" +
+          "<li>The answer is 5.682.</li></ul>"
+    )
+
+    val htmlResult = htmlParser.parseOppiaHtml(
+      workedExampleMarkup,
+      textView,
+      workedExampleLabels = WORKED_EXAMPLE_LABELS
+    )
+
+    assertThat(htmlResult.toString()).contains("place.\nNow")
+    assertThat(htmlResult.toString()).contains("digits.\nThe")
+    assertThat(htmlResult.getSpansFromWholeString(URLSpan::class)).isEmpty()
+  }
+
+  @Test
   fun testHtmlContent_withUrl_hasClickableSpanAndCorrectText() {
     val htmlParser = htmlParserFactory.create(
       gcsResourceName = "", entityType = "", entityId = "", imageCenterAlign = false,
@@ -1428,6 +1492,21 @@ class HtmlParserTest {
   private fun createDisplayLocaleImpl(context: OppiaLocaleContext): DisplayLocaleImpl {
     val formattingLocale = androidLocaleFactory.createOneOffAndroidLocale(context)
     return DisplayLocaleImpl(context, formattingLocale, machineLocale, formatterFactory)
+  }
+
+  private fun createWorkedExampleMarkup(questionHtml: String, answerHtml: String): String {
+    return "<$CUSTOM_WORKED_EXAMPLE_TAG " +
+      "question-with-value=\"${questionHtml.encodeAsWorkedExampleAttribute()}\" " +
+      "answer-with-value=\"${answerHtml.encodeAsWorkedExampleAttribute()}\">" +
+      "</$CUSTOM_WORKED_EXAMPLE_TAG>"
+  }
+
+  private fun String.encodeAsWorkedExampleAttribute(): String {
+    return JSONObject.quote(this)
+      .replace("&", "&amp;amp;")
+      .replace("\"", "&amp;quot;")
+      .replace("<", "&amp;lt;")
+      .replace(">", "&amp;gt;")
   }
 
   private fun Spannable.getTextForSpan(span: Any): String =

--- a/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
@@ -987,6 +987,63 @@ class HtmlParserTest {
   }
 
   @Test
+  fun testHtmlContent_withConsecutiveWorkedExamplesEndingInLists_doesNotAccumulateMargins() {
+    val htmlParser = htmlParserFactory.create(
+      resourceBucketName,
+      entityType = "",
+      entityId = "",
+      imageCenterAlign = false,
+      displayLocale = appLanguageLocaleHandler.getDisplayLocale()
+    )
+    val textView = TextView(context)
+    val firstExample = createWorkedExampleMarkup(
+      questionHtml = "First question",
+      answerHtml =
+        "<ul xmlns=\"http://www.w3.org/1999/xhtml\"><li>First answer</li></ul>"
+    )
+    val secondExample = createWorkedExampleMarkup(
+      questionHtml = "Second question",
+      answerHtml =
+        "<ul xmlns=\"http://www.w3.org/1999/xhtml\"><li>Second answer</li></ul>"
+    )
+    val thirdExample = createWorkedExampleMarkup(
+      questionHtml = "Third question",
+      answerHtml =
+        "<ul xmlns=\"http://www.w3.org/1999/xhtml\"><li>Third answer</li></ul>"
+    )
+
+    val htmlResult = htmlParser.parseOppiaHtml(
+      firstExample + secondExample + thirdExample,
+      textView,
+      workedExampleLabels = WORKED_EXAMPLE_LABELS
+    )
+
+    val questionRanges =
+      listOf("First question", "Second question", "Third question").map { question ->
+        val questionIndex = htmlResult.toString().indexOf(question)
+        questionIndex until questionIndex + question.length
+      }
+    assertThat(
+      questionRanges.map { range ->
+        htmlResult.getSpans(
+          range.first,
+          range.last + 1,
+          LeadingMarginSpan.Standard::class.java
+        ).size
+      }
+    ).containsExactly(1, 1, 1).inOrder()
+    assertThat(
+      questionRanges.map { range ->
+        htmlResult.getSpans(
+          range.first,
+          range.last + 1,
+          ListItemLeadingMarginSpan::class.java
+        ).size
+      }
+    ).containsExactly(0, 0, 0).inOrder()
+  }
+
+  @Test
   fun testHtmlContent_withWorkedExampleNamespacedList_preservesBlockSpacing() {
     val htmlParser = htmlParserFactory.create(
       resourceBucketName,

--- a/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/HtmlParserTest.kt
@@ -6,6 +6,7 @@ import android.app.Instrumentation
 import android.content.Context
 import android.content.Intent
 import android.text.Spannable
+import android.text.SpannableStringBuilder
 import android.text.style.BulletSpan
 import android.text.style.ClickableSpan
 import android.text.style.ImageSpan
@@ -120,6 +121,7 @@ import org.oppia.android.util.locale.DisplayLocaleImpl
 import org.oppia.android.util.locale.LocaleProdModule
 import org.oppia.android.util.locale.OppiaBidiFormatter
 import org.oppia.android.util.locale.OppiaLocale
+import org.oppia.android.util.logging.ConsoleLogger
 import org.oppia.android.util.logging.LoggerModule
 import org.oppia.android.util.logging.SyncStatusModule
 import org.oppia.android.util.networking.NetworkConnectionDebugUtilModule
@@ -128,6 +130,7 @@ import org.oppia.android.util.parser.image.ImageParsingModule
 import org.oppia.android.util.parser.image.TestGlideImageLoader
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
+import org.xml.sax.helpers.AttributesImpl
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.reflect.KClass
@@ -161,6 +164,7 @@ class HtmlParserTest {
   @Inject lateinit var formatterFactory: OppiaBidiFormatter.Factory
   @Inject lateinit var appLanguageLocaleHandler: AppLanguageLocaleHandler
   @Inject lateinit var testGlideImageLoader: TestGlideImageLoader
+  @Inject lateinit var consoleLogger: ConsoleLogger
   @field:[Inject DefaultResourceBucketName] lateinit var resourceBucketName: String
 
   @Before
@@ -1041,6 +1045,82 @@ class HtmlParserTest {
         ).size
       }
     ).containsExactly(0, 0, 0).inOrder()
+  }
+
+  @Test
+  @Config(sdk = [29])
+  fun testHtmlContent_withWorkedExampleAfterList_doesNotCrash() {
+    val htmlParser = htmlParserFactory.create(
+      resourceBucketName,
+      entityType = "",
+      entityId = "",
+      imageCenterAlign = false,
+      displayLocale = appLanguageLocaleHandler.getDisplayLocale()
+    )
+    val textView = TextView(context)
+    val workedExampleMarkup = createWorkedExampleMarkup(
+      questionHtml = "<p xmlns=\"http://www.w3.org/1999/xhtml\">Write 0.15 as a fraction.</p>",
+      answerHtml =
+        "<p xmlns=\"http://www.w3.org/1999/xhtml\">Use these methods.</p>" +
+          "<ol xmlns=\"http://www.w3.org/1999/xhtml\">" +
+          "<li><strong>By place value:</strong><ul><li>The answer is 15/100.</li></ul></li>" +
+          "<li><strong>By multiplication:</strong><ul><li>Multiply by 100.</li></ul></li>" +
+          "<li><strong>By addition:</strong><ul><li>Add the fractions.</li></ul></li></ol>"
+    )
+    val precedingListMarkup =
+      "<ul>\n<li>Read the whole-number part from right to left.</li>\n" +
+        "<li>Read the decimal part from left to right.</li>\n</ul>\n\n"
+
+    val htmlResult = htmlParser.parseOppiaHtml(
+      precedingListMarkup + "<p><br>\n&nbsp;</p>" + workedExampleMarkup,
+      textView,
+      workedExampleLabels = WORKED_EXAMPLE_LABELS
+    )
+
+    assertThat(htmlResult.toString()).contains("Read the decimal part from left to right.")
+    assertThat(htmlResult.toString()).contains("Question:\nWrite 0.15 as a fraction.")
+    assertThat(htmlResult.toString()).contains("The answer is 15/100.")
+  }
+
+  @Test
+  @Config(sdk = [29])
+  fun testWorkedExampleAfterListSpan_endsListSpanAtParagraphBoundary() {
+    val output = SpannableStringBuilder("Previous list item.")
+    val listSpan = ListItemLeadingMarginSpan.UlSpan(
+      parent = null,
+      context = context,
+      indentationLevel = 0,
+      displayLocale = appLanguageLocaleHandler.getDisplayLocale()
+    )
+    output.setSpan(listSpan, 0, output.length, Spannable.SPAN_PARAGRAPH)
+    val openIndex = output.length
+    val attributes = AttributesImpl().apply {
+      addAttribute("", "", "question-with-value", "CDATA", "Question")
+      addAttribute("", "", "answer-with-value", "CDATA", "Answer")
+    }
+    val workedExampleHandler = WorkedExampleTagHandler(
+      consoleLogger,
+      WORKED_EXAMPLE_LABELS,
+      leadingMarginPx = 10,
+      nestedHtmlParser = object : WorkedExampleTagHandler.NestedHtmlParser {
+        override fun parseHtml(html: String): Spannable = SpannableStringBuilder(html)
+
+        override fun parseHtmlForContentDescription(html: String) = html
+      }
+    )
+
+    workedExampleHandler.handleTag(
+      attributes = attributes,
+      openIndex = openIndex,
+      closeIndex = openIndex,
+      output = output,
+      imageRetriever = null
+    )
+
+    val listSpanEnd = output.getSpanEnd(listSpan)
+    assertThat(output.toString()).startsWith("Previous list item.\n\nQuestion:")
+    assertThat(listSpanEnd).isEqualTo(openIndex + 1)
+    assertThat(output[listSpanEnd - 1]).isEqualTo('\n')
   }
 
   @Test


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fixes #6430

Fixes #6431

Worked example lists were not parsed correctly when the list tags had extra attributes. Because of this, spaces between list items and paragraphs were missing. Some joined words were also shown as links.

This PR fixes the list parsing and adds tests for these cases.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
<!-- Please answer the following two questions. -->
- **Did you use AI/LLMs when working on this PR?** `No`