### PR TITLE
Fix #6377 :  Prior Reading Text Size Selection Sporadically Persists

### DIFF
--- a/app/src/main/java/org/oppia/android/app/options/ReadingTextSizeFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/options/ReadingTextSizeFragmentPresenter.kt
@@ -27,8 +27,6 @@ class ReadingTextSizeFragmentPresenter @Inject constructor(
       /* attachToRoot= */ false
     )
 
-    updateTextSize(readingTextSize)
-
     binding.viewModel = readingTextSizeSelectionViewModel
     readingTextSizeSelectionViewModel.selectedTextSize = readingTextSize
     binding.textSizeRecyclerView.apply {

--- a/utility/src/main/java/org/oppia/android/util/data/DataProviders.kt
+++ b/utility/src/main/java/org/oppia/android/util/data/DataProviders.kt
@@ -428,7 +428,9 @@ class DataProviders @Inject constructor(
         if (retrievalGeneration == latestRetrievalGeneration.get()) {
           super.postValue(it)
         }
-        runningJob.set(null)
+        kotlin.coroutines.coroutineContext[Job]?.let { currentJob ->
+          runningJob.compareAndSet(currentJob, null)
+        } ?: runningJob.set(null)
       }
     }
 

--- a/utility/src/main/java/org/oppia/android/util/data/DataProviders.kt
+++ b/utility/src/main/java/org/oppia/android/util/data/DataProviders.kt
@@ -15,6 +15,7 @@ import org.oppia.android.util.data.DataProviders.Companion.transform
 import org.oppia.android.util.logging.ExceptionLogger
 import org.oppia.android.util.threading.BackgroundDispatcher
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 
@@ -359,6 +360,11 @@ class DataProviders @Inject constructor(
     private val asyncSubscriber: ObserveAsyncChange = this::handleDataProviderUpdate
     private val isActive = AtomicBoolean(false)
     private val runningJob = AtomicReference<Job?>(null)
+    // A provider notification can start a new retrieval while an earlier retrieval is still
+    // running. AsyncResult timestamps cannot identify which retrieval produced a result because
+    // transforms and combinations create new AsyncResults. Keep the retrieval generation instead
+    // so a completion from an older snapshot cannot overwrite a newer one.
+    private val latestRetrievalGeneration = AtomicLong(0L)
     private var cache: AsyncResult<T>? = null // only accessed on the main thread
 
     override fun onActive() {
@@ -407,6 +413,7 @@ class DataProviders @Inject constructor(
     }
 
     private suspend fun handleDataProviderUpdate() {
+      val retrievalGeneration = latestRetrievalGeneration.incrementAndGet()
       // This doesn't guarantee that retrieveData() is only called when the live data is active
       // (e.g. it can become inactive right after the value is posted & before it's dispatched), but
       // it does guarantee that it won't be called when the live data is currently inactive. This
@@ -415,7 +422,12 @@ class DataProviders @Inject constructor(
       // the override of setValue() above for the adjusted semantics this class requires to ensure
       // its own cache remains up-to-date.
       retrieveFromDataProvider()?.let {
-        super.postValue(it)
+        // Do not enqueue a value from an earlier request after a newer request has started. This
+        // is necessary even though setValue() compares AsyncResult timestamps: a delayed
+        // transformation may construct a stale result with a newer timestamp.
+        if (retrievalGeneration == latestRetrievalGeneration.get()) {
+          super.postValue(it)
+        }
         runningJob.set(null)
       }
     }

--- a/utility/src/test/java/org/oppia/android/util/data/DataProvidersTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/data/DataProvidersTest.kt
@@ -10,6 +10,7 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -179,6 +180,41 @@ class DataProvidersTest {
 
     verify(mockIntLiveDataObserver).onChanged(intResultCaptor.capture())
     assertThat(intResultCaptor.value).isIntSuccessThat().isEqualTo(456)
+  }
+
+  @Test
+  fun testConvertToLiveData_staleRetrievalCompletesAfterNewRetrieval_staleValueIsNotDelivered() {
+    val firstRetrievalStarted = CompletableDeferred<Unit>()
+    val releaseFirstRetrieval = CompletableDeferred<Unit>()
+    var retrievalCount = 0
+    val simpleDataProvider = object : DataProvider<Int>(application) {
+      override fun getId(): Any = "simple_data_provider"
+
+      override suspend fun retrieveData(): AsyncResult<Int> {
+        return when (++retrievalCount) {
+          1 -> {
+            firstRetrievalStarted.complete(Unit)
+            releaseFirstRetrieval.await()
+            AsyncResult.Success(123)
+          }
+          2 -> AsyncResult.Success(456)
+          else -> AsyncResult.Failure(AssertionError("Invalid test case"))
+        }
+      }
+    }
+    simpleDataProvider.toLiveData().observeForever(mockIntLiveDataObserver)
+    testCoroutineDispatchers.runCurrent()
+    assertThat(firstRetrievalStarted.isCompleted).isTrue()
+
+    // This models a store notification while the initial read still holds an older snapshot.
+    asyncDataSubscriptionManager.notifyChangeAsync(simpleDataProvider.getId())
+    testCoroutineDispatchers.runCurrent()
+    releaseFirstRetrieval.complete(Unit)
+    testCoroutineDispatchers.advanceUntilIdle()
+
+    verify(mockIntLiveDataObserver, atLeastOnce()).onChanged(intResultCaptor.capture())
+    assertThat(intResultCaptor.allValues.last()).isIntSuccessThat().isEqualTo(456)
+    assertThat(retrievalCount).isEqualTo(2)
   }
 
   @Test


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixes #6377

Preventing stale DataProvider retrieval results from being delivered to LiveData observers when a newer retrieval has started, which can otherwise cause UI settings (like Reading Text Size) to appear to “flip” between old/new values.
When this PR is merged Reading Text Size Selection appears as selected
  

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
<!-- Please answer the following two questions. -->
- **Did you use AI/LLMs when working on this PR?** 
- Yes
 AI was used for writing tests and also helped me to improve my code quality.
  
## For UI-specific PRs only

https://github.com/user-attachments/assets/8a24108f-ce8b-49d8-908f-4fbe018b5f66


<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
