### PR TITLE
Fix #6436: Exempt automated/lesson-versions from force-push close and CLA check

### DIFF
--- a/.github/workflows/check_for_forced_push_prs.yml
+++ b/.github/workflows/check_for_forced_push_prs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Detect and close (on change)
-        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' && github.event.action == 'synchronize' }}
+        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' && github.event.pull_request.head.ref != 'automated/lesson-versions' && github.event.action == 'synchronize' }}
         uses: actions/github-script@v8
         with:
           script: |
@@ -30,7 +30,7 @@ jobs:
             } else core.info(`Standard push detected. Commit history status: ${status}. No action taken.`);
 
       - name: Detect and close reopened force-pushed PRs
-        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' && github.event.action == 'reopened' }}
+        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' && github.event.pull_request.head.ref != 'automated/lesson-versions' && github.event.action == 'reopened' }}
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/check_for_forced_push_prs.yml
+++ b/.github/workflows/check_for_forced_push_prs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Detect and close (on change)
-        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' && github.event.pull_request.head.ref != 'automated/lesson-versions' && github.event.action == 'synchronize' }}
+        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' && !(github.event.pull_request.head.ref == 'automated/lesson-versions' && github.event.pull_request.head.repo.full_name == github.repository) && github.event.action == 'synchronize' }}
         uses: actions/github-script@v8
         with:
           script: |
@@ -30,7 +30,7 @@ jobs:
             } else core.info(`Standard push detected. Commit history status: ${status}. No action taken.`);
 
       - name: Detect and close reopened force-pushed PRs
-        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' && github.event.pull_request.head.ref != 'automated/lesson-versions' && github.event.action == 'reopened' }}
+        if: ${{ github.event.pull_request.head.ref != 'translatewiki-prs' && !(github.event.pull_request.head.ref == 'automated/lesson-versions' && github.event.pull_request.head.repo.full_name == github.repository) && github.event.action == 'reopened' }}
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/oppiabot.yml
+++ b/.github/workflows/oppiabot.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   oppiabot:
     runs-on: ubuntu-24.04
+    # Skip CLA and bot checks for automated PRs — oppia-github-app[bot] cannot sign the CLA
+    # and the commit history is always a single clean machine-generated commit.
+    if: ${{ github.event.pull_request.head.ref != 'automated/lesson-versions' }}
     steps:
       - uses: actions/checkout@v6
       - name: CLA Check

--- a/.github/workflows/oppiabot.yml
+++ b/.github/workflows/oppiabot.yml
@@ -15,7 +15,11 @@ jobs:
     runs-on: ubuntu-24.04
     # Skip CLA and bot checks for automated PRs — oppia-github-app[bot] cannot sign the CLA
     # and the commit history is always a single clean machine-generated commit.
-    if: ${{ github.event.pull_request.head.ref != 'automated/lesson-versions' }}
+    if: >-
+      ${{
+        !(github.event.pull_request.head.ref == 'automated/lesson-versions' &&
+          github.event.pull_request.head.repo.full_name == github.repository)
+      }}
     steps:
       - uses: actions/checkout@v6
       - name: CLA Check


### PR DESCRIPTION
Fixes #6436
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

The pull_latest_lesson_versions workflow intentionally force-pushes a single clean commit to the automated/lesson-versions branch each week. This caused two failures:

1. `check_for_forced_push_prs.yml` auto-closed the PR because only `translatewiki-prs` was exempted from the force-push detection logic. Fix: add automated/lesson-versions to the exemption condition on both the 'synchronize' and 'reopened' steps.

2. `oppiabot.yml` failed the CLA check because the PR author is `oppia-github-app[bot]`, a GitHub App that cannot sign the CLA. Fix: skip the oppiabot job for `automated/lesson-versions` PRs via a job-level if condition.

This matches the existing translatewiki-prs exemption pattern.

## Disclosure of LLM Usage
AI was used for debugging, code-completion and research.
## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).