### PR TITLE
Fix #6435: Fix source_ref and dispatch ref in auto_release_alpha workflow

### DIFF
--- a/.github/workflows/auto_release_alpha.yml
+++ b/.github/workflows/auto_release_alpha.yml
@@ -124,19 +124,14 @@ jobs:
           git push --force origin refs/tags/latest-alpha
           echo "Moved latest-alpha → $CANDIDATE_SHA"
 
-      # Dispatch the build+sign workflow for the alpha flavor. The build_and_sign.yml workflow
-      # runs under the oppia-android-release-env environment, so a required reviewer must
-      # approve before any job steps execute (provides a human gate before deployment).
+      # Dispatch build_and_sign.yml for the alpha flavor. It requires reviewer approval
+      # (oppia-android-release-env) before running.
       #
-      # --ref refs/tags/latest-alpha: dispatches on the candidate tag rather than develop HEAD.
-      #   This associates the Build and Sign check run with the candidate commit, not with the
-      #   current HEAD of develop. Without this, a build failure would mark develop HEAD as
-      #   FAILING and cause FindAlphaCandidate to skip it on every subsequent weekly run.
+      # --ref points at the candidate tag, not develop, so a build failure doesn't mark
+      #   develop HEAD as FAILING and get it skipped by future candidate searches.
+      # source_ref must be 'latest-alpha' or 'release-X.Y' — build_and_sign.yml rejects raw SHAs.
       #
-      # --field source_ref=latest-alpha: build_and_sign.yml only accepts 'latest-alpha' or
-      #   'release-X.Y' as source_ref — passing the raw SHA causes input validation to fail.
-      #
-      # Skipped when FindAlphaCandidate returns NoNewCommits (candidate SHA is empty).
+      # Skipped when no candidate was found.
       - name: Dispatch build-and-sign for alpha
         if: steps.candidate.outputs.sha != ''
         env:

--- a/.github/workflows/auto_release_alpha.yml
+++ b/.github/workflows/auto_release_alpha.yml
@@ -108,6 +108,15 @@ jobs:
       # Dispatch the build+sign workflow for the alpha flavor. The build_and_sign.yml workflow
       # runs under the oppia-android-release-env environment, so a required reviewer must
       # approve before any job steps execute (provides a human gate before deployment).
+      #
+      # --ref refs/tags/latest-alpha: dispatches on the candidate tag rather than develop HEAD.
+      #   This associates the Build and Sign check run with the candidate commit, not with the
+      #   current HEAD of develop. Without this, a build failure would mark develop HEAD as
+      #   FAILING and cause FindAlphaCandidate to skip it on every subsequent weekly run.
+      #
+      # --field source_ref=latest-alpha: build_and_sign.yml only accepts 'latest-alpha' or
+      #   'release-X.Y' as source_ref — passing the raw SHA causes input validation to fail.
+      #
       # Skipped when FindAlphaCandidate returns NoNewCommits (candidate SHA is empty).
       - name: Dispatch build-and-sign for alpha
         if: steps.candidate.outputs.sha != ''
@@ -117,12 +126,11 @@ jobs:
           CANDIDATE_SHA="${{ steps.candidate.outputs.sha }}"
           gh workflow run build_and_sign.yml \
             --repo "${{ github.repository }}" \
-            --ref develop \
+            --ref "refs/tags/latest-alpha" \
             --field flavor=alpha \
-            --field source_ref="$CANDIDATE_SHA"
+            --field source_ref="latest-alpha"
           echo "| Step | Result |"
           echo "|---|---|"
-          echo "| Branch | develop |"
           echo "| Candidate SHA | [\`${CANDIDATE_SHA:0:7}\`](${{ github.server_url }}/${{ github.repository }}/commit/${CANDIDATE_SHA}) |"
           echo "| latest-alpha tag | moved and force-pushed |"
-          echo "| build_and_sign.yml | dispatched (flavor=alpha, source_ref=${CANDIDATE_SHA:0:7}) |"
+          echo "| build_and_sign.yml | dispatched (flavor=alpha, source_ref=latest-alpha) |"

--- a/.github/workflows/auto_release_alpha.yml
+++ b/.github/workflows/auto_release_alpha.yml
@@ -150,6 +150,7 @@ jobs:
             --field source_ref="latest-alpha"
           echo "| Step | Result |"
           echo "|---|---|"
+          echo "| Dispatch ref | refs/tags/latest-alpha |"
           echo "| Candidate SHA | [\`${CANDIDATE_SHA:0:7}\`](${{ github.server_url }}/${{ github.repository }}/commit/${CANDIDATE_SHA}) |"
           echo "| latest-alpha tag | moved and force-pushed |"
           echo "| build_and_sign.yml | dispatched (flavor=alpha, source_ref=latest-alpha) |"


### PR DESCRIPTION
Fixes #6435
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

There were two bugs in the 'Dispatch build-and-sign for alpha' step:

1. `source_ref` was passed as the raw candidate SHA `build_and_sign.yml` validates that source_ref must be 'latest-alpha' or match 'release-X.Y'. Passing a 40-char SHA fails this check and exits with code 1. The correct value is 'latest-alpha' — the preceding step already force-pushed the latest-alpha tag to the candidate commit, so build_and_sign.yml will check out the right code via 'ref: latest-alpha'.

2. --ref develop associated the Build and Sign check run with the current HEAD of develop (not the candidate). When that check run failed (because of bug 1 above), the develop HEAD commit appeared FAILING to FindAlphaCandidate on every subsequent weekly run. The result was that the develop HEAD was perpetually skipped and an older commit was returned as the candidate instead.
   Fix: --ref \"refs/tags/latest-alpha\" — dispatches on the candidate tag so the check run is correctly associated with the commit being built, not with unrelated newer commits on develop.

## Disclosure of LLM Usage
AI was used for debugging, code-completion and research.
## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).