### PR TITLE
Fix #6400 and Fix #5338: Survey not showing consistently and Flaky tests in SurveyProgressControllerTest

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/StateFragmentPresenter.kt
@@ -505,9 +505,28 @@ class StateFragmentPresenter @Inject constructor(
       oppiaClock.getCurrentTimeMs()
     ).toLiveData()
 
-    // Only check gating result when the previous operation has completed because gating depends on
-    // result of saving the time spent in the exploration, at the end of the exploration.
-    markStoryCompletedLivedata.observe(fragment, { maybeShowSurveyDialog(profileId, topicId) })
+    // Wait for chapter recording to finish before checking eligibility. Survey gating separately
+    // flushes the current learning time since the exploration is still active on this exit path.
+    markStoryCompletedLivedata.observe(
+      fragment,
+      object : Observer<AsyncResult<Any?>> {
+        override fun onChanged(result: AsyncResult<Any?>?) {
+          when (result) {
+            null, is AsyncResult.Pending -> Unit
+            is AsyncResult.Failure -> {
+              markStoryCompletedLivedata.removeObserver(this)
+              oppiaLogger.e("StateFragment", "Failed to record completed chapter", result.error)
+              (activity as StopStatePlayingSessionWithSavedProgressListener)
+                .deleteCurrentProgressAndStopSession(isCompletion = true)
+            }
+            is AsyncResult.Success -> {
+              markStoryCompletedLivedata.removeObserver(this)
+              maybeShowSurveyDialog(profileId, topicId)
+            }
+          }
+        }
+      }
+    )
   }
 
   private fun showHintsAndSolutions(helpIndex: HelpIndex, isCurrentStatePendingState: Boolean) {

--- a/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
+++ b/app/src/test/java/org/oppia/android/app/player/exploration/ExplorationActivityLocalTest.kt
@@ -67,6 +67,7 @@ import org.oppia.android.domain.classify.rules.numericinput.NumericInputRuleModu
 import org.oppia.android.domain.classify.rules.ratioinput.RatioInputModule
 import org.oppia.android.domain.classify.rules.textinput.TextInputRuleModule
 import org.oppia.android.domain.classroom.TEST_CLASSROOM_ID_0
+import org.oppia.android.domain.exploration.ExplorationActiveTimeController
 import org.oppia.android.domain.exploration.ExplorationDataController
 import org.oppia.android.domain.exploration.ExplorationProgressModule
 import org.oppia.android.domain.exploration.ExplorationStorageModule
@@ -139,6 +140,9 @@ class ExplorationActivityLocalTest {
 
   @Inject
   lateinit var profileManagementController: ProfileManagementController
+
+  @Inject
+  lateinit var explorationActiveTimeController: ExplorationActiveTimeController
 
   private lateinit var networkConnectionUtil: NetworkConnectionUtil
   private lateinit var explorationDataController: ExplorationDataController
@@ -466,6 +470,9 @@ class ExplorationActivityLocalTest {
   private fun setUpTestWithNpsEnabled() {
     TestPlatformParameterModule.forceEnableNpsSurvey(true)
     setUpTestApplicationComponent()
+    // TestApplication does not register Oppia's application lifecycle observer. Explicitly mark
+    // this simulated foreground session so its lesson time is included in survey eligibility.
+    explorationActiveTimeController.onAppInForeground()
   }
 
   private fun markAllSpotlightsSeen() {

--- a/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationActiveTimeController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/exploration/ExplorationActiveTimeController.kt
@@ -39,6 +39,7 @@ private const val BEGIN_SESSION_TIMER_PROVIDER_ID =
   "begin_session_timer_provider_id"
 private const val STOP_SESSION_TIMER_PROVIDER_ID =
   "stop_session_timer_provider_id"
+private const val FLUSH_LEARNING_TIME_PROVIDER_ID = "flush_learning_time_provider_id"
 private const val PAUSE_SESSION_TIMER_PROVIDER_ID =
   "pause_session_timer_provider_id"
 private const val RESUME_SESSION_TIMER_PROVIDER_ID =
@@ -68,6 +69,9 @@ class ExplorationActiveTimeController @Inject constructor(
   private var explorationStarted: Boolean = false
 
   private var mostRecentCommandQueue: SendChannel<ControllerMessage<*>>? = null
+
+  private var mostRecentStopResultFlow =
+    MutableStateFlow<AsyncResult<Any?>>(AsyncResult.Success(null))
 
   private var mostRecentSessionId = MutableStateFlow<String?>(null)
   private val activeSessionId: String
@@ -138,6 +142,7 @@ class ExplorationActiveTimeController @Inject constructor(
     topicId: String
   ): DataProvider<Any?> {
     val sessionId = UUID.randomUUID().toString().also {
+      mostRecentSessionId.value = it
       mostRecentCommandQueue = createControllerCommandActor()
     }
     val beginSessionTimerResultFlow = createAsyncResultStateFlow<Any?>()
@@ -163,7 +168,9 @@ class ExplorationActiveTimeController @Inject constructor(
    * executing, or when the app goes to the background during an active exploration session.
    */
   private fun stopSessionTimerAsync(isExplorationStarted: Boolean): DataProvider<Any?> {
-    val stopTimerResultFlow = createAsyncResultStateFlow<Any?>()
+    val stopTimerResultFlow = createAsyncResultStateFlow<Any?>().also {
+      mostRecentStopResultFlow = it
+    }
     val message = ControllerMessage.StopSessionTimer(
       sessionId = activeSessionId,
       callbackFlow = stopTimerResultFlow,
@@ -180,6 +187,26 @@ class ExplorationActiveTimeController @Inject constructor(
       mostRecentSessionId.value = null
       mostRecentCommandQueue = null
     }
+  }
+
+  /**
+   * Saves current foreground learning time before checking survey eligibility.
+   *
+   * If the exploration has just ended, waits for its queued timer stop and save instead. The
+   * returned provider stays pending until persistence completes, so callers cannot decide using
+   * the previous session's aggregate. An active timer continues from the saved timestamp.
+   */
+  fun flushLearningTime(): DataProvider<Any?> {
+    val resultFlow = if (mostRecentCommandQueue == null) {
+      mostRecentStopResultFlow
+    } else {
+      createAsyncResultStateFlow<Any?>().also { flow ->
+        sendCommandForOperation(ControllerMessage.FlushLearningTime(activeSessionId, flow)) {
+          "Failed to schedule saving current learning time."
+        }
+      }
+    }
+    return resultFlow.convertToSessionProvider(FLUSH_LEARNING_TIME_PROVIDER_ID)
   }
 
   /**
@@ -258,6 +285,11 @@ class ExplorationActiveTimeController @Inject constructor(
                 message.isExplorationStarted
               )
             }
+            is ControllerMessage.FlushLearningTime -> {
+              controllerState.tryOperation(message.callbackFlow) {
+                saveCurrentLearningTime()
+              }
+            }
             is ControllerMessage.StopSessionTimer -> {
               try {
                 controllerState.stopTimerImpl(
@@ -310,14 +342,8 @@ class ExplorationActiveTimeController @Inject constructor(
         "Expected an exploration to have been started."
       }
 
+      saveCurrentLearningTime()
       timerSessionState.isExplorationStarted = isExplorationStarted
-
-      val sessionDuration = (oppiaClock.getCurrentTimeMs() - timerSessionState.sessionStartTime)
-      recordAggregateTopicLearningTime(
-        profileId = timerSessionState.currentProfileId,
-        topicId = timerSessionState.currentTopicId,
-        sessionDuration = sessionDuration
-      )
     }
   }
 
@@ -330,14 +356,24 @@ class ExplorationActiveTimeController @Inject constructor(
         "Expected app to be in the foreground and an exploration to be started."
       }
 
+      saveCurrentLearningTime()
       timerSessionState.isAppInForeground = isAppInForeground
+    }
+  }
 
-      val sessionDuration = (oppiaClock.getCurrentTimeMs() - timerSessionState.sessionStartTime)
-      recordAggregateTopicLearningTime(
+  private suspend fun ControllerState.saveCurrentLearningTime() {
+    if (timerSessionState.isAppInForeground && timerSessionState.isExplorationStarted) {
+      val currentTimeMs = oppiaClock.getCurrentTimeMs()
+      val result = recordAggregateTopicLearningTime(
         profileId = timerSessionState.currentProfileId,
         topicId = timerSessionState.currentTopicId,
-        sessionDuration = sessionDuration
-      )
+        sessionDuration = currentTimeMs - timerSessionState.sessionStartTime
+      ).retrieveData()
+      when (result) {
+        is AsyncResult.Success -> timerSessionState.sessionStartTime = currentTimeMs
+        is AsyncResult.Failure -> throw result.error
+        is AsyncResult.Pending -> error("Expected learning time persistence to have completed.")
+      }
     }
   }
 
@@ -397,6 +433,12 @@ class ExplorationActiveTimeController @Inject constructor(
       val isExplorationStarted: Boolean,
       val profileId: ProfileId,
       val topicId: String,
+      override val sessionId: String,
+      override val callbackFlow: MutableStateFlow<AsyncResult<Any?>>
+    ) : ControllerMessage<Any?>()
+
+    /** [ControllerMessage] for saving learning time while keeping the timer active. */
+    data class FlushLearningTime(
       override val sessionId: String,
       override val callbackFlow: MutableStateFlow<AsyncResult<Any?>>
     ) : ControllerMessage<Any?>()

--- a/domain/src/main/java/org/oppia/android/domain/survey/SurveyGatingController.kt
+++ b/domain/src/main/java/org/oppia/android/domain/survey/SurveyGatingController.kt
@@ -18,6 +18,7 @@ import javax.inject.Inject
 
 private const val GET_TOPIC_LEARNING_TIME_PROVIDER_ID =
   "get_topic_learning_time_provider_id"
+private const val READY_LEARNING_TIME_PROVIDER_ID = "ready_learning_time_provider_id"
 private const val GATING_RESULT_PROVIDER_ID =
   "gating_result_provider_id"
 
@@ -44,7 +45,11 @@ class SurveyGatingController @Inject constructor(
    */
   fun maybeShowSurvey(profileId: LegacyProfileId, topicId: String): DataProvider<Boolean> {
     val lastShownDateProvider = retrieveSurveyLastShownDate(profileId)
-    val learningTimeProvider = retrieveAggregateLearningTime(profileId, topicId)
+    // Both early exit (timer stop queued) and completion (timer still running) must include
+    // the current session before making a gating decision.
+    val learningTimeProvider = activeTimeController.flushLearningTime().combineWith(
+      retrieveAggregateLearningTime(profileId, topicId), READY_LEARNING_TIME_PROVIDER_ID
+    ) { _, learningTimeMs -> learningTimeMs }
     return lastShownDateProvider.combineWith(
       learningTimeProvider, GATING_RESULT_PROVIDER_ID
     ) { lastShownTimestampMs, learningTimeMs ->

--- a/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationActiveTimeControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/exploration/ExplorationActiveTimeControllerTest.kt
@@ -488,6 +488,84 @@ class ExplorationActiveTimeControllerTest {
     assertThat(secondTestProfileAggregateTime.topicLearningTimeMs).isEqualTo(SESSION_LENGTH_2)
   }
 
+  @Test
+  fun testFlushLearningTime_noSession_completesSuccessfully() {
+    setUpTestApplicationComponent()
+
+    monitorFactory.waitForNextSuccessfulResult(explorationActiveTimeController.flushLearningTime())
+  }
+
+  @Test
+  fun testFlushLearningTime_stopQueued_savesTimeBeforeCompleting() {
+    setUpTestApplicationComponent()
+    oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_UPTIME_MILLIS)
+    explorationActiveTimeController.onAppInForeground()
+    explorationActiveTimeController.onExplorationStarted(firstTestProfile, TEST_TOPIC_ID_0)
+    testCoroutineDispatchers.runCurrent()
+    testCoroutineDispatchers.advanceTimeBy(SESSION_LENGTH_1)
+    explorationActiveTimeController.onExplorationEnded()
+
+    val flushProvider = explorationActiveTimeController.flushLearningTime()
+    monitorFactory.waitForNextSuccessfulResult(flushProvider)
+    val learningTime = monitorFactory.waitForNextSuccessfulResult(
+      explorationActiveTimeController.retrieveAggregateTopicLearningTimeDataProvider(
+        firstTestProfile, TEST_TOPIC_ID_0
+      )
+    )
+    assertThat(learningTime.topicLearningTimeMs).isEqualTo(SESSION_LENGTH_1)
+  }
+
+  @Test
+  fun testFlushLearningTime_activeSessionThenStop_doesNotCountSavedTimeTwice() {
+    setUpTestApplicationComponent()
+    oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_UPTIME_MILLIS)
+    explorationActiveTimeController.onAppInForeground()
+    explorationActiveTimeController.onExplorationStarted(firstTestProfile, TEST_TOPIC_ID_0)
+    testCoroutineDispatchers.runCurrent()
+    testCoroutineDispatchers.advanceTimeBy(SESSION_LENGTH_1)
+
+    monitorFactory.waitForNextSuccessfulResult(explorationActiveTimeController.flushLearningTime())
+    testCoroutineDispatchers.advanceTimeBy(SESSION_LENGTH_3)
+    explorationActiveTimeController.onExplorationEnded()
+    monitorFactory.waitForNextSuccessfulResult(explorationActiveTimeController.flushLearningTime())
+
+    val learningTime = monitorFactory.waitForNextSuccessfulResult(
+      explorationActiveTimeController.retrieveAggregateTopicLearningTimeDataProvider(
+        firstTestProfile, TEST_TOPIC_ID_0
+      )
+    )
+    assertThat(learningTime.topicLearningTimeMs).isEqualTo(SESSION_LENGTH_1 + SESSION_LENGTH_3)
+  }
+
+  @Test
+  fun testFlushLearningTime_backgroundThenResume_onlyCountsForegroundTime() {
+    setUpTestApplicationComponent()
+    oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_UPTIME_MILLIS)
+    explorationActiveTimeController.onAppInForeground()
+    explorationActiveTimeController.onExplorationStarted(firstTestProfile, TEST_TOPIC_ID_0)
+    testCoroutineDispatchers.runCurrent()
+    testCoroutineDispatchers.advanceTimeBy(SESSION_LENGTH_1)
+    monitorFactory.waitForNextSuccessfulResult(explorationActiveTimeController.flushLearningTime())
+    explorationActiveTimeController.onAppInBackground()
+    // Process the pause before advancing fake time so background time is excluded.
+    testCoroutineDispatchers.runCurrent()
+    testCoroutineDispatchers.advanceTimeBy(SESSION_LENGTH_2)
+    monitorFactory.waitForNextSuccessfulResult(explorationActiveTimeController.flushLearningTime())
+    explorationActiveTimeController.onAppInForeground()
+    // Initialize the resumed session before advancing fake time again.
+    testCoroutineDispatchers.runCurrent()
+    testCoroutineDispatchers.advanceTimeBy(SESSION_LENGTH_3)
+    explorationActiveTimeController.onExplorationEnded()
+    monitorFactory.waitForNextSuccessfulResult(explorationActiveTimeController.flushLearningTime())
+
+    val learningTime = monitorFactory.waitForNextSuccessfulResult(
+      explorationActiveTimeController.retrieveAggregateTopicLearningTimeDataProvider(
+        firstTestProfile, TEST_TOPIC_ID_0
+      )
+    )
+    assertThat(learningTime.topicLearningTimeMs).isEqualTo(SESSION_LENGTH_1 + SESSION_LENGTH_3)
+  }
+
   private fun startPlayingNewExploration(
     classroomId: String,
     topicId: String,

--- a/domain/src/test/java/org/oppia/android/domain/survey/SurveyGatingControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/survey/SurveyGatingControllerTest.kt
@@ -33,6 +33,7 @@ import org.oppia.android.testing.threading.TestDispatcherModule
 import org.oppia.android.testing.time.FakeOppiaClock
 import org.oppia.android.testing.time.FakeOppiaClockModule
 import org.oppia.android.util.caching.AssetModule
+import org.oppia.android.util.data.AsyncResult
 import org.oppia.android.util.data.DataProvidersInjector
 import org.oppia.android.util.data.DataProvidersInjectorProvider
 import org.oppia.android.util.locale.LocaleProdModule
@@ -631,6 +632,82 @@ class SurveyGatingControllerTest {
     val result = monitorFactory.waitForNextSuccessfulResult(gatingProvider)
 
     assertThat(result).isTrue()
+  }
+
+  @Test
+  fun testGating_activeSessionAtMinimumTime_noPreviousTime_returnsTrue() {
+    startActiveSessionAtMinimumTime(PROFILE_ID_1)
+
+    val results = monitorFactory.waitForAllNextResults {
+      surveyGatingController.maybeShowSurvey(PROFILE_ID_1, TEST_TOPIC_ID_0)
+    }
+
+    assertThat(results.last()).isEqualTo(AsyncResult.Success(true))
+    assertThat(results).doesNotContain(AsyncResult.Success(false))
+  }
+
+  @Test
+  fun testGating_stopJustQueued_atMinimumTime_doesNotEmitFalseBeforeSave() {
+    startActiveSessionAtMinimumTime(PROFILE_ID_1)
+    explorationActiveTimeController.onExplorationEnded()
+    // Do not drain the timer stop or persistence work before requesting eligibility.
+
+    val results = monitorFactory.waitForAllNextResults {
+      surveyGatingController.maybeShowSurvey(PROFILE_ID_1, TEST_TOPIC_ID_0)
+    }
+
+    assertThat(results.last()).isEqualTo(AsyncResult.Success(true))
+    assertThat(results).doesNotContain(AsyncResult.Success(false))
+  }
+
+  @Test
+  fun testGating_firstProfileShownSurvey_secondProfileActiveSameTopic_isIndependentlyEligible() {
+    startActiveSessionAtMinimumTime(PROFILE_ID_0)
+    assertThat(
+      monitorFactory.waitForNextSuccessfulResult(
+        surveyGatingController.maybeShowSurvey(PROFILE_ID_0, TEST_TOPIC_ID_0)
+      )
+    ).isTrue()
+    // Showing the welcome dialog records this timestamp, including when the survey is submitted.
+    monitorFactory.waitForNextSuccessfulResult(
+      profileManagementController.updateSurveyLastShownTimestamp(
+        PROFILE_ID_0.toProfileIdPreservingZero()
+      )
+    )
+    explorationActiveTimeController.onExplorationEnded()
+    testCoroutineDispatchers.runCurrent()
+    monitorFactory.waitForNextSuccessfulResult(
+      profileManagementController.loginToProfile(PROFILE_ID_1.toProfileIdPreservingZero())
+    )
+    startActiveSessionAtMinimumTime(PROFILE_ID_1)
+
+    val secondProfileResult = monitorFactory.waitForNextSuccessfulResult(
+      surveyGatingController.maybeShowSurvey(PROFILE_ID_1, TEST_TOPIC_ID_0)
+    )
+    val firstProfileResult = monitorFactory.waitForNextSuccessfulResult(
+      surveyGatingController.maybeShowSurvey(PROFILE_ID_0, TEST_TOPIC_ID_0)
+    )
+
+    assertThat(secondProfileResult).isTrue()
+    assertThat(firstProfileResult).isFalse()
+    assertThat(
+      monitorFactory.waitForNextSuccessfulResult(
+        profileManagementController.retrieveSurveyLastShownTimestamp(
+          PROFILE_ID_1.toProfileIdPreservingZero()
+        )
+      )
+    ).isEqualTo(0L)
+  }
+
+  private fun startActiveSessionAtMinimumTime(profileId: LegacyProfileId) {
+    oppiaClock.setFakeTimeMode(FakeOppiaClock.FakeTimeMode.MODE_FIXED_FAKE_TIME)
+    oppiaClock.setCurrentTimeMs(EVENING_UTC_TIMESTAMP_MILLIS)
+    explorationActiveTimeController.onAppInForeground()
+    explorationActiveTimeController.onExplorationStarted(
+      profileId.toProfileIdPreservingZero(), TEST_TOPIC_ID_0
+    )
+    testCoroutineDispatchers.runCurrent()
+    oppiaClock.setCurrentTimeMs(EVENING_UTC_TIMESTAMP_MILLIS + SESSION_LENGTH_MINIMUM)
   }
 
   private fun startAndEndExplorationSession(

--- a/domain/src/test/java/org/oppia/android/domain/survey/SurveyProgressControllerTest.kt
+++ b/domain/src/test/java/org/oppia/android/domain/survey/SurveyProgressControllerTest.kt
@@ -36,6 +36,8 @@ import org.oppia.android.testing.threading.TestCoroutineDispatchers
 import org.oppia.android.testing.threading.TestDispatcherModule
 import org.oppia.android.testing.time.FakeOppiaClockModule
 import org.oppia.android.util.caching.AssetModule
+import org.oppia.android.util.data.AsyncResult
+import org.oppia.android.util.data.DataProvider
 import org.oppia.android.util.data.DataProvidersInjector
 import org.oppia.android.util.data.DataProvidersInjectorProvider
 import org.oppia.android.util.locale.LocaleProdModule
@@ -95,7 +97,7 @@ class SurveyProgressControllerTest {
     val surveyDataProvider =
       surveyController.startSurveySession(questions, profileId = profileId)
 
-    monitorFactory.waitForNextSuccessfulResult(surveyDataProvider)
+    waitForSuccessfulResult(surveyDataProvider)
   }
 
   @Test
@@ -164,7 +166,7 @@ class SurveyProgressControllerTest {
     val result = surveyProgressController.submitAnswer(createUserTypeAnswer(UserTypeAnswer.PARENT))
 
     // Verify that the answer submission was successful.
-    monitorFactory.waitForNextSuccessfulResult(result)
+    waitForSuccessfulResult(result)
   }
 
   @Test
@@ -177,7 +179,7 @@ class SurveyProgressControllerTest {
       surveyProgressController.submitAnswer(
         createMarketFitAnswer(MarketFitAnswer.VERY_DISAPPOINTED)
       )
-    monitorFactory.waitForNextSuccessfulResult(result)
+    waitForSuccessfulResult(result)
   }
 
   @Test
@@ -189,7 +191,7 @@ class SurveyProgressControllerTest {
 
     val result =
       surveyProgressController.submitAnswer(createNpsAnswer(9))
-    monitorFactory.waitForNextSuccessfulResult(result)
+    waitForSuccessfulResult(result)
   }
 
   @Test
@@ -208,7 +210,7 @@ class SurveyProgressControllerTest {
         )
       )
 
-    monitorFactory.waitForNextSuccessfulResult(result)
+    waitForSuccessfulResult(result)
   }
 
   @Test
@@ -323,7 +325,7 @@ class SurveyProgressControllerTest {
       surveyProgressController.submitAnswer(createMarketFitAnswer(MarketFitAnswer.NOT_DISAPPOINTED))
 
     // New answer is submitted successfully
-    monitorFactory.waitForNextSuccessfulResult(submitAnswerProvider)
+    waitForSuccessfulResult(submitAnswerProvider)
   }
 
   @Test
@@ -342,7 +344,7 @@ class SurveyProgressControllerTest {
     startSuccessfulSurveySession()
     waitForGetCurrentQuestionSuccessfulLoad()
     val stopProvider = surveyController.stopSurveySession(surveyCompleted = false)
-    monitorFactory.waitForNextSuccessfulResult(stopProvider)
+    waitForSuccessfulResult(stopProvider)
   }
 
   @Test
@@ -431,34 +433,49 @@ class SurveyProgressControllerTest {
 
   private fun stopSurveySession(surveyCompleted: Boolean) {
     val stopProvider = surveyController.stopSurveySession(surveyCompleted)
-    monitorFactory.waitForNextSuccessfulResult(stopProvider)
+    waitForSuccessfulResult(stopProvider)
   }
 
   private fun startSuccessfulSurveySession() {
-    monitorFactory.waitForNextSuccessfulResult(
+    waitForSuccessfulResult(
       surveyController.startSurveySession(questions, profileId = profileId)
     )
   }
 
   private fun waitForGetCurrentQuestionSuccessfulLoad(): EphemeralSurveyQuestion {
-    return monitorFactory.waitForNextSuccessfulResult(
+    return waitForSuccessfulResult(
       surveyProgressController.getCurrentQuestion()
     )
   }
 
   private fun moveToPreviousQuestion(): EphemeralSurveyQuestion {
-    // This operation might fail for some tests.
-    monitorFactory.ensureDataProviderExecutes(
-      surveyProgressController.moveToPreviousQuestion()
-    )
+    waitForSuccessfulResult(surveyProgressController.moveToPreviousQuestion())
     return waitForGetCurrentQuestionSuccessfulLoad()
   }
 
   private fun submitAnswer(answer: SurveySelectedAnswer): EphemeralSurveyQuestion {
-    monitorFactory.waitForNextSuccessfulResult(
+    waitForSuccessfulResult(
       surveyProgressController.submitAnswer(answer)
     )
     return waitForGetCurrentQuestionSuccessfulLoad()
+  }
+
+  /** Awaits the terminal success, ignoring the provider's expected initial Pending emission. */
+  private fun <T> waitForSuccessfulResult(dataProvider: DataProvider<T>): T {
+    val deadlineNanos = System.nanoTime() + SUCCESS_RESULT_TIMEOUT_NANOS
+    var latestResult: AsyncResult<T> = AsyncResult.Pending()
+    while (System.nanoTime() < deadlineNanos) {
+      latestResult = monitorFactory.waitForAllNextResults { dataProvider }.lastOrNull()
+        ?: continue
+      when (latestResult) {
+        is AsyncResult.Success -> return latestResult.value
+        is AsyncResult.Failure -> throw AssertionError(
+          "Expected a successful result", latestResult.error
+        )
+        is AsyncResult.Pending -> Unit
+      }
+    }
+    error("Timed out waiting for a terminal successful result; latest result: $latestResult")
   }
 
   private fun submitUserTypeAnswer(answer: UserTypeAnswer): EphemeralSurveyQuestion {
@@ -606,6 +623,7 @@ class SurveyProgressControllerTest {
   }
 
   companion object {
+    private const val SUCCESS_RESULT_TIMEOUT_NANOS = 5_000_000_000L
     private const val TEXT_ANSWER = "Some text answer"
     private val questions = listOf(
       SurveyQuestionName.USER_TYPE,


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation

Fixes #6400 

Fixes #5338

Survey eligibility could be checked before the current lesson’s learning time was saved. This prevented another learner from seeing a survey after reaching the minimum aggregate time, even though learning time and survey history were already stored per profile.

- Toolbar and back-button exits queued an asynchronous timer stop, allowing survey gating to read stale learning time before persistence finished.
- “Return to topic” checked eligibility while the exploration was still active, leaving the current session’s time unsaved.
- The lesson-completion observer triggered survey gating on intermediate results instead of waiting for successful completion.

### This PR:
- Added an awaitable learning-time flush before evaluating survey eligibility. It saves an active session’s elapsed time or waits for an already queued stop to finish saving.
- Reused the same saving logic for flush, pause, and stop. Successful saves advance the accounting timestamp, preventing double counting, and only foreground time is recorded.
- Retained the generated active-session ID for subsequent timer operations.
- Updated lesson completion to handle terminal results once and check survey eligibility after successful chapter-progress recording.
Existing per-profile cooldowns and eligibility thresholds remain unchanged.

### Test changes
- Added domain coverage for active-session eligibility, eligibility immediately after a queued stop, and independent eligibility for a second learner playing the same topic.
- Added timer coverage for flushing without a session, saving before stop completion, avoiding duplicate time, and excluding background time.
- Updated lifecycle timing tests to process queued events before advancing the fake clock.
- Added a local five-second timeout for survey-progress success assertions to tolerate transient Pending results without changing the shared test monitor.
- Updated ExplorationActivityLocalTest to explicitly mark the simulated app as foreground because its test application does not register the production lifecycle observer.

Verified the tests in `SurveyProgressControllerTest` are no longer flaky by running them 1000x:

```php
BazelelTestRunner exiting with a return value of 0
JVM shutdown hooks (if any) will run now.
The JVM will exit once they complete.

-- JVM shutdown starting at 2026-09-09 01:32:39 --

================================================================================
INFO: From Testing //domain/src/test/java/org/oppia/android/domain/survey:SurveyProgressControllerTest (run 928 of 1000):
==================== Test output for //domain/src/test/java/org/oppia/android/domain/survey:SurveyProgressControllerTest (run 928 of 1000):
JUnit4 Test Runner
.resources.arsc in APK '/private/var/tmp/_bazel_adhiambo/02ee010362edf64cf4a14fbac48cd5cf/sandbox/darwin-sandbox/2293/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/domain/src/test/java/org/oppia/android/domain/survey/SurveyProgressControllerTest.runfiles/__main__/../robolectric/bazel/../../org_robolectric_android_all_instrumented_11_robolectric_6757853_i2/android-all-instrumented-11-robolectric-6757853-i2.jar' is compressed.
.......................
Time: 4.188

OK (24 tests)


BazelTestRunner exiting with a return value of 0
JVM shutdown hooks (if any) will run now.
The JVM will exit once they complete.

-- JVM shutdown starting at 2026-09-09 01:32:39 --

================================================================================
Target //domain/src/test/java/org/oppia/android/domain/survey:SurveyProgressControllerTest up-to-date:
  bazel-bin/domain/src/test/java/org/oppia/android/domain/survey/SurveyProgressControllerTest.jar
  bazel-bin/domain/src/test/java/org/oppia/android/domain/survey/SurveyProgressControllerTest
INFO: Elapsed time: 741.458s, Critical Path: 14.50s
INFO: 1008 processes: 1 internal, 1003 darwin-sandbox, 4 worker.
INFO: Build completed successfully, 1008 total actions
//domain/src/test/java/org/oppia/android/domain/survey:SurveyProgressControllerTest PASSED in 12.7s
  Stats over 1000 runs: max = 12.7s, min = 5.5s, avg = 10.1s, dev = 0.7s

Executed 1 out of 1 test: 1 test passes.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
<!-- Please answer the following two questions. -->
- **Did you use AI/LLMs when working on this PR?** Type `Yes` or `No`. Yes
- **If yes, describe the extent AI was used:** e.g. brainstorming, debugging, writing code, writing tests, reviewing code, etc. See https://github.com/oppia/oppia-android/pull/6062 for an example.
The root cause analysis and actual code generation was done in Codex, with prompts and feedback from me. I refactored the generated code to ensure that it meets Oppia's code quality standards.
  
## For UI-specific PRs only

For the purposes of recording 1 video, I modified the default value of `NPS_SURVEY_MINIMUM_AGGREGATE_LEARNING_TIME_IN_A_TOPIC_IN_MINUTES` to be 1 minute.

https://drive.google.com/file/d/1uX9RANNNI4dNEU88hSEIqHkVmPTzB3C9/view?usp=drive_link

