### PR TITLE
Fix part of #5503: track partial line coverage using branch outcomes

### DIFF
--- a/scripts/src/java/org/oppia/android/scripts/coverage/CoverageRunner.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/CoverageRunner.kt
@@ -91,10 +91,19 @@ class CoverageRunner(
     val linesFound = coverageDataProps["LF"]?.singleOrNull()?.single()?.toInt() ?: 0
     val linesHit = coverageDataProps["LH"]?.singleOrNull()?.single()?.toInt() ?: 0
 
+    val lineBranchOutcomes = coverageDataProps["BRDA"]
+      ?.groupBy(keySelector = { it[0].toInt() }) { it.getOrNull(3).orEmpty() }
+      .orEmpty()
+
     val coveredLines = coverageDataProps["DA"]?.map { (lineNumStr, hitCountStr) ->
+      val lineNumber = lineNumStr.toInt()
+      val hitCount = hitCountStr.toInt()
       CoveredLine.newBuilder().apply {
-        this.lineNumber = lineNumStr.toInt()
-        this.coverage = if (hitCountStr.toInt() > 0) Coverage.FULL else Coverage.NONE
+        this.lineNumber = lineNumber
+        this.coverage = computeLineCoverageStatus(
+          lineHitCount = hitCount,
+          branchOutcomes = lineBranchOutcomes[lineNumber].orEmpty()
+        )
       }.build()
     }.orEmpty()
 
@@ -118,6 +127,24 @@ class CoverageRunner(
       .setDetails(coverageDetails)
       .build()
   }
+}
+
+internal fun computeLineCoverageStatus(
+  lineHitCount: Int,
+  branchOutcomes: List<String>
+): Coverage {
+  if (lineHitCount <= 0) return Coverage.NONE
+  if (branchOutcomes.isEmpty()) return Coverage.FULL
+
+  val normalizedOutcomes = branchOutcomes.map { outcome ->
+    when (outcome) {
+      "-" -> 0
+      else -> outcome.toIntOrNull() ?: 0
+    }
+  }
+  val hasCoveredBranch = normalizedOutcomes.any { it > 0 }
+  val hasMissedBranch = normalizedOutcomes.any { it <= 0 }
+  return if (hasCoveredBranch && hasMissedBranch) Coverage.PARTIAL else Coverage.FULL
 }
 
 private fun generateFailedCoverageReport(

--- a/scripts/src/java/org/oppia/android/scripts/coverage/CoverageRunner.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/CoverageRunner.kt
@@ -129,7 +129,13 @@ class CoverageRunner(
   }
 }
 
-internal fun computeLineCoverageStatus(
+/**
+ * Classifies a source line from LCOV `DA` hit count and `BRDA` branch outcomes.
+ *
+ * A hit line with no branch records is fully covered. A hit line is partial when at least one
+ * tracked branch executed and at least one did not (`0` or `-`).
+ */
+fun computeLineCoverageStatus(
   lineHitCount: Int,
   branchOutcomes: List<String>
 ): Coverage {

--- a/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/RunCoverage.kt
@@ -264,7 +264,11 @@ class RunCoverage(
     coverageReports: List<CoverageReport>
   ): CoverageReport {
     fun aggregateCoverage(coverages: List<Coverage>): Coverage {
-      return coverages.find { it == Coverage.FULL } ?: Coverage.NONE
+      return when {
+        coverages.any { it == Coverage.FULL } -> Coverage.FULL
+        coverages.any { it == Coverage.PARTIAL } -> Coverage.PARTIAL
+        else -> Coverage.NONE
+      }
     }
 
     val groupedCoverageReports = coverageReports.groupBy {

--- a/scripts/src/java/org/oppia/android/scripts/coverage/reporter/CoverageReporter.kt
+++ b/scripts/src/java/org/oppia/android/scripts/coverage/reporter/CoverageReporter.kt
@@ -170,11 +170,14 @@ class CoverageReporter(
                     .source-code-col {
                       width: 96%;
                     }
-                    .covered-line, .not-covered-line, .uncovered-line {
+                    .covered-line, .partially-covered-line, .not-covered-line, .uncovered-line {
                       white-space: pre-wrap;
                     }
                     .covered-line {
                       background-color: #c8e6c9; /* Light green */
+                    }
+                    .partially-covered-line {
+                      background-color: #fff9c4; /* Light yellow */
                     }
                     .not-covered-line {
                       background-color: #ffcdd2; /* Light red */
@@ -226,6 +229,10 @@ class CoverageReporter(
                       margin-left: 4px;
                       background-color: #ffcdd2; /* Light red */
                     }
+                    .legend .partially-covered {
+                      margin-left: 4px;
+                      background-color: #fff9c4; /* Light yellow */
+                    }
                     @media screen and (max-width: 768px) {
                       body {
                         padding: 10px;
@@ -244,6 +251,8 @@ class CoverageReporter(
                       <div class="legend">
                         <div class="legend-item covered"></div>
                         <span>Covered</span>
+                        <div class="legend-item partially-covered"></div>
+                        <span>Partial</span>
                         <div class="legend-item not-covered"></div>
                         <span>Uncovered</span>
                       </div>
@@ -271,6 +280,7 @@ class CoverageReporter(
               val lineNumber = index + 1
               val lineClass = when (coverageMap[lineNumber]?.coverage) {
                 Coverage.FULL -> "covered-line"
+                Coverage.PARTIAL -> "partially-covered-line"
                 Coverage.NONE -> "not-covered-line"
                 else -> "uncovered-line"
               }

--- a/scripts/src/java/org/oppia/android/scripts/proto/coverage.proto
+++ b/scripts/src/java/org/oppia/android/scripts/proto/coverage.proto
@@ -76,4 +76,6 @@ enum Coverage {
   FULL = 1;
   // The line is not covered at all, that is, it was never executed during a test.
   NONE = 2;
+  // The line is partially covered: some instructions/branches executed, some missed.
+  PARTIAL = 3;
 }

--- a/scripts/src/javatests/org/oppia/android/scripts/coverage/CoverageRunnerTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/coverage/CoverageRunnerTest.kt
@@ -256,6 +256,37 @@ class CoverageRunnerTest {
     assertThat(results[0]).isEqualTo(expectedResult)
   }
 
+  @Test
+  fun testComputeLineCoverageStatus_lineNotHit_returnsNone() {
+    val coverage = computeLineCoverageStatus(lineHitCount = 0, branchOutcomes = listOf("1", "0"))
+
+    assertThat(coverage).isEqualTo(Coverage.NONE)
+  }
+
+  @Test
+  fun testComputeLineCoverageStatus_lineHitWithoutBranches_returnsFull() {
+    val coverage = computeLineCoverageStatus(lineHitCount = 1, branchOutcomes = emptyList())
+
+    assertThat(coverage).isEqualTo(Coverage.FULL)
+  }
+
+  @Test
+  fun testComputeLineCoverageStatus_lineHitWithPartialBranches_returnsPartial() {
+    val coverage = computeLineCoverageStatus(
+      lineHitCount = 1,
+      branchOutcomes = listOf("1", "0", "-")
+    )
+
+    assertThat(coverage).isEqualTo(Coverage.PARTIAL)
+  }
+
+  @Test
+  fun testComputeLineCoverageStatus_lineHitWithAllCoveredBranches_returnsFull() {
+    val coverage = computeLineCoverageStatus(lineHitCount = 1, branchOutcomes = listOf("1", "2"))
+
+    assertThat(coverage).isEqualTo(Coverage.FULL)
+  }
+
   private fun initializeCommandExecutorWithLongProcessWaitTime(): CommandExecutorImpl {
     return CommandExecutorImpl(
       scriptBgDispatcher, processTimeout = 5, processTimeoutUnit = TimeUnit.MINUTES

--- a/scripts/src/javatests/org/oppia/android/scripts/coverage/reporter/CoverageReporterTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/coverage/reporter/CoverageReporterTest.kt
@@ -571,11 +571,14 @@ class CoverageReporterTest {
         .source-code-col {
           width: 96%;
         }
-        .covered-line, .not-covered-line, .uncovered-line {
+        .covered-line, .partially-covered-line, .not-covered-line, .uncovered-line {
           white-space: pre-wrap;
         }
         .covered-line {
           background-color: #c8e6c9; /* Light green */
+        }
+        .partially-covered-line {
+          background-color: #fff9c4; /* Light yellow */
         }
         .not-covered-line {
           background-color: #ffcdd2; /* Light red */
@@ -627,6 +630,10 @@ class CoverageReporterTest {
           margin-left: 4px;
           background-color: #ffcdd2; /* Light red */
         }
+        .legend .partially-covered {
+          margin-left: 4px;
+          background-color: #fff9c4; /* Light yellow */
+        }
         @media screen and (max-width: 768px) {
           body {
             padding: 10px;
@@ -645,6 +652,8 @@ class CoverageReporterTest {
           <div class="legend">
             <div class="legend-item covered"></div>
             <span>Covered</span>
+            <div class="legend-item partially-covered"></div>
+            <span>Partial</span>
             <div class="legend-item not-covered"></div>
             <span>Uncovered</span>
           </div>


### PR DESCRIPTION
## Explanation

Fixes part of #5503

The coverage script currently marks a line as fully covered whenever LCOV `DA` reports the line was hit at least once. This can over-report coverage when a single source line contains multiple branches and only some are executed.

This change introduces explicit `PARTIAL` line coverage classification using LCOV `BRDA` branch outcomes:
- `FULL`: line executed and all tracked branches covered
- `PARTIAL`: line executed, but at least one branch missed
- `NONE`: line not executed

It then propagates that state through aggregation and HTML reporting.

### What changed

1. Added `PARTIAL` to the coverage proto enum in `scripts/src/java/org/oppia/android/scripts/proto/coverage.proto`.
2. Updated `CoverageRunner` to parse `BRDA` data and classify per-line coverage via `computeLineCoverageStatus(...)`.
3. Updated aggregation in `RunCoverage` to preserve `PARTIAL` when no `FULL` coverage is present for a line.
4. Updated HTML report rendering in `CoverageReporter` to include a yellow `partially-covered-line` style and legend item.
5. Added regression tests for the line-state classifier in `CoverageRunnerTest`.
6. Updated HTML reporter test expectations in `CoverageReporterTest`.

### Verification

- Attempted: `bazel test //scripts/src/javatests/org/oppia/android/scripts/coverage:CoverageRunnerTest //scripts/src/javatests/org/oppia/android/scripts/coverage/reporter:CoverageReporterTest --test_output=errors`
- Blocker in local environment: Bazel Android SDK toolchain resolution failure (`No matching toolchains found for types @bazel_tools//tools/android:sdk_toolchain_type`).

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (or "Fix part of #bugnum: " when partial)
- [x] The explanation section above starts with "Fixes #bugnum: " (or "Fixes part of #bugnum: ")
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio.
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [ ] The PR is **assigned** to the appropriate reviewers.

## Disclosure of LLM Usage
- **Did you use AI/LLMs when working on this PR?** Yes
- **If yes, describe the extent AI was used:** Used for codebase search/navigation, implementing scoped refactors in coverage scripts, and drafting tests/PR text. All code changes were reviewed and validated manually.
