### PR TITLE
Fix #6188: Fail test file check for stale test_file_not_required exemptions

### DIFF
--- a/scripts/assets/test_file_exemptions.textproto
+++ b/scripts/assets/test_file_exemptions.textproto
@@ -888,10 +888,7 @@ test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/help/RouteToThirdPartyDependencyListListener.kt"
   test_file_not_required: true
 }
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/help/faq/FAQListActivity.kt"
-  test_file_not_required: true
-}
+
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/help/faq/FAQListActivityPresenter.kt"
   test_file_not_required: true
@@ -1200,10 +1197,7 @@ test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/mydownloads/DownloadsTabFragmentPresenter.kt"
   test_file_not_required: true
 }
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/mydownloads/MyDownloadsActivity.kt"
-  test_file_not_required: true
-}
+
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/mydownloads/MyDownloadsActivityPresenter.kt"
   test_file_not_required: true
@@ -2064,10 +2058,7 @@ test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/profile/PinPasswordViewModel.kt"
   test_file_not_required: true
 }
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/profile/ProfileChooserActivity.kt"
-  test_file_not_required: true
-}
+
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/profile/ProfileChooserActivityPresenter.kt"
   test_file_not_required: true
@@ -2264,10 +2255,7 @@ test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditDialogInterface.kt"
   test_file_not_required: true
 }
-test_file_exemption {
-  exempted_file_path: "app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditFragment.kt"
-  test_file_not_required: true
-}
+
 test_file_exemption {
   exempted_file_path: "app/src/main/java/org/oppia/android/app/settings/profile/ProfileEditFragmentPresenter.kt"
   test_file_not_required: true
@@ -3520,14 +3508,8 @@ test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/classify/rules/continueinteraction/ContinueModule.kt"
   test_file_not_required: true
 }
-test_file_exemption {
-  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputHasElementXAtPositionYClassifierProvider.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputHasElementXBeforeElementYClassifierProvider.kt"
-  test_file_not_required: true
-}
+
+
 test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/classify/rules/dragAndDropSortInput/DragDropSortInputIsEqualToOrderingClassifierProvider.kt"
   source_file_is_incompatible_with_code_coverage: true
@@ -3968,10 +3950,7 @@ test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/oppialogger/logscheduler/MetricLogSchedulerModule.kt"
   source_file_is_incompatible_with_code_coverage: true
 }
-test_file_exemption {
-  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/oppialogger/loguploader/LogReportWorkerModule.kt"
-  test_file_not_required: true
-}
+
 test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/oppialogger/survey/SurveyEventsLogger.kt"
   source_file_is_incompatible_with_code_coverage: true
@@ -4048,10 +4027,7 @@ test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/testing/TestPlatformParameterConfigRetriever.kt"
   test_file_not_required: true
 }
-test_file_exemption {
-  exempted_file_path: "domain/src/main/java/org/oppia/android/domain/platformparameter/syncup/PlatformParameterSyncUpWorkerModule.kt"
-  test_file_not_required: true
-}
+
 test_file_exemption {
   exempted_file_path: "domain/src/main/java/org/oppia/android/domain/profile/ProfileManagementController.kt"
   source_file_is_incompatible_with_code_coverage: true
@@ -4260,10 +4236,7 @@ test_file_exemption {
   exempted_file_path: "scripts/src/java/org/oppia/android/scripts/release/GitHubCiClient.kt"
   test_file_not_required: true
 }
-test_file_exemption {
-  exempted_file_path: "scripts/src/java/org/oppia/android/scripts/release/GoogleGitHubCiClient.kt"
-  test_file_not_required: true
-}
+
 test_file_exemption {
   exempted_file_path: "scripts/src/java/org/oppia/android/scripts/release/model/CheckRunsResponse.kt"
   test_file_not_required: true
@@ -4552,10 +4525,7 @@ test_file_exemption {
   exempted_file_path: "utility/src/main/java/org/oppia/android/util/caching/testing/FakeAssetRepository.kt"
   test_file_not_required: true
 }
-test_file_exemption {
-  exempted_file_path: "utility/src/main/java/org/oppia/android/util/data/AsyncDataSubscriptionManager.kt"
-  test_file_not_required: true
-}
+
 test_file_exemption {
   exempted_file_path: "utility/src/main/java/org/oppia/android/util/data/DataProvider.kt"
   test_file_not_required: true
@@ -4680,10 +4650,7 @@ test_file_exemption {
   exempted_file_path: "utility/src/main/java/org/oppia/android/util/logging/firebase/FirestoreInstanceWrapperImpl.kt"
   test_file_not_required: true
 }
-test_file_exemption {
-  exempted_file_path: "utility/src/main/java/org/oppia/android/util/logging/firebase/LogReportingModule.kt"
-  test_file_not_required: true
-}
+
 test_file_exemption {
   exempted_file_path: "utility/src/main/java/org/oppia/android/util/logging/performancemetrics/PerformanceMetricsAssessor.kt"
   test_file_not_required: true
@@ -4692,14 +4659,8 @@ test_file_exemption {
   exempted_file_path: "utility/src/main/java/org/oppia/android/util/logging/performancemetrics/PerformanceMetricsEventLogger.kt"
   test_file_not_required: true
 }
-test_file_exemption {
-  exempted_file_path: "utility/src/main/java/org/oppia/android/util/math/FloatExtensions.kt"
-  test_file_not_required: true
-}
-test_file_exemption {
-  exempted_file_path: "utility/src/main/java/org/oppia/android/util/math/FractionExtensions.kt"
-  test_file_not_required: true
-}
+
+
 test_file_exemption {
   exempted_file_path: "utility/src/main/java/org/oppia/android/util/math/MathExpressionExtensions.kt"
   override_min_coverage_percent_required: 42

--- a/scripts/src/java/org/oppia/android/scripts/testfile/TestFileCheck.kt
+++ b/scripts/src/java/org/oppia/android/scripts/testfile/TestFileCheck.kt
@@ -80,6 +80,14 @@ class TestFileCheck(
       classesWithFailures.filterIsInstance<TestableProdClass.DerivedFromTestFile>()
         .filterNot { it.isExempted(absoluteExemptedTestFilePaths) }
         .sortedBy { it.testFile }
+    // Exemptions that mark a prod file as not requiring a test are only valid while its test file
+    // is absent: once the test exists, the exemption is stale and should be removed.
+    val unnecessaryProdExemptions =
+      testableProdClasses
+        .filterIsInstance<TestableProdClass.DerivedFromProdFile>()
+        .filter { it.isExempted(absoluteExemptedProdFilePaths) }
+        .filter { it.possibleTestFiles.any(File::exists) }
+        .sortedBy { it.prodFile }
 
     if (classesMissingTests.isNotEmpty()) {
       println("========== Classes missing test files: ${classesMissingTests.size} ==========")
@@ -117,6 +125,20 @@ class TestFileCheck(
       println()
     }
 
+    if (unnecessaryProdExemptions.isNotEmpty()) {
+      println(
+        "========== Unnecessary test file exemptions: " +
+          "${unnecessaryProdExemptions.size} =========="
+      )
+      unnecessaryProdExemptions.forEach { testableClass ->
+        println(
+          "- Test file exemption should be removed for " +
+            "${testableClass.prodFile.toRelativeString(repoRoot)}: a test file exists."
+        )
+      }
+      println()
+    }
+
     // Validate that all exemptions exist.
     val allExemptedAbsoluteFilePaths =
       loadTestFileExemptionsProto(testFileExemptionProtoPath)
@@ -141,6 +163,7 @@ class TestFileCheck(
 
     return classesMissingTests.isEmpty() &&
       testsMissingProdClasses.isEmpty() &&
+      unnecessaryProdExemptions.isEmpty() &&
       missingExemptedFiles.isEmpty()
   }
 }

--- a/scripts/src/javatests/org/oppia/android/scripts/testfile/TestFileCheckTest.kt
+++ b/scripts/src/javatests/org/oppia/android/scripts/testfile/TestFileCheckTest.kt
@@ -633,7 +633,7 @@ class TestFileCheckTest {
   }
 
   @Test
-  fun testCheck_exemptions_testFileNotRequired_prodFileWithMainTest_passes() {
+  fun testCheck_exemptions_testFileNotRequired_prodFileWithMainTest_failsWithError() {
     createAppProdFile("demo", "ProdFile.kt").writeText(
       """
       package org.oppia.android.app.demo
@@ -647,8 +647,7 @@ class TestFileCheckTest {
       """.trimIndent()
     )
 
-    // The exemption should be ignored if the test actually exists (this may become a failure in
-    // future changes to the script).
+    // A test_file_not_required exemption is only valid while the test file is missing.
     val checkPassed = runScript(
       TestFileExemption.newBuilder().apply {
         this.exemptedFilePath = "app/src/main/java/org/oppia/android/app/demo/ProdFile.kt"
@@ -656,7 +655,44 @@ class TestFileCheckTest {
       }.build()
     )
 
-    assertThat(checkPassed).isTrue()
+    assertThat(checkPassed).isFalse()
+    val failureMessage =
+      """
+      ========== Unnecessary test file exemptions: 1 ==========
+      - Test file exemption should be removed for app/src/main/java/org/oppia/android/app/demo/ProdFile.kt: a test file exists.
+      """.trimIndent()
+    assertThat(outContent.toString().trim()).isEqualTo(failureMessage)
+  }
+
+  @Test
+  fun testCheck_exemptions_testFileNotRequired_prodFileWithSharedTest_failsWithError() {
+    createAppProdFile("demo", "ProdFile.kt").writeText(
+      """
+      package org.oppia.android.app.demo
+      class ProdFile
+      """.trimIndent()
+    )
+    createAppTestFile("demo", "ProdFileTest.kt", testDir = "sharedTest").writeText(
+      """
+      package org.oppia.android.app.demo
+      class ProdFileTest
+      """.trimIndent()
+    )
+
+    val checkPassed = runScript(
+      TestFileExemption.newBuilder().apply {
+        this.exemptedFilePath = "app/src/main/java/org/oppia/android/app/demo/ProdFile.kt"
+        this.testFileNotRequired = true
+      }.build()
+    )
+
+    assertThat(checkPassed).isFalse()
+    val failureMessage =
+      """
+      ========== Unnecessary test file exemptions: 1 ==========
+      - Test file exemption should be removed for app/src/main/java/org/oppia/android/app/demo/ProdFile.kt: a test file exists.
+      """.trimIndent()
+    assertThat(outContent.toString().trim()).isEqualTo(failureMessage)
   }
 
   @Test


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
## Explanation
Fixes #6188: reject stale `test_file_not_required` exemptions when the corresponding test already exists.

When an existing test is marked with a `test_file_not_required` exemption, `TestFileCheck` silently ignores the exemption (because the test exists) and the check still passes. Stale exemptions accumulate unnoticed and hide the fact that a test now exists.

### Changes
`TestFileCheck` now treats a `test_file_not_required` exemption as a failure when the corresponding test file already exists:
- New `Unnecessary test file exemptions` failure section lists each stale exemption with its prod file path.
- The check returns failure while any stale exemption remains.

The 13 currently stale `test_file_not_required` exemptions (one per file that already has a test in `test/` or `sharedTest/`) are removed from `test_file_exemptions.textproto` so the check passes on the current repo state.

### Verification
- New unit tests: prod file with test in `test/` or `sharedTest/` plus `test_file_not_required` exemption now fails with the expected output; missing-test exemptions and normal test presence still pass.
- Ran the compiled check against the full repository (real exemptions file): `TEST FILE CHECK PASSED`.
- ktlint 0.37.1 (as pinned in CI) passes on the changed Kotlin files.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
<!-- Please answer the following two questions. -->
- **Did you use AI/LLMs when working on this PR?** Type `Yes` or `No`.: Yes
- **If yes, describe the extent AI was used:** e.g. brainstorming, debugging, writing code, writing tests, reviewing code, etc. See https://github.com/oppia/oppia-android/pull/6062 for an example.: AI/LLMs were used for investigating the checker behavior, implementing the fix and regression tests, identifying and removing stale exemptions, running validation, and preparing the PR description.
