### PR TITLE
Fix #5809: Ensure fraction horizontal bars in LaTeX expressions are clearly visible

### DIFF
--- a/utility/src/main/java/org/oppia/android/util/parser/math/BUILD.bazel
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/BUILD.bazel
@@ -23,9 +23,13 @@ kt_android_library(
     srcs = [
         "MathBitmapModelLoader.kt",
     ],
-    visibility = ["//utility/src/main/java/org/oppia/android/util/parser/image:__pkg__"],
+    visibility = [
+        "//:oppia_testing_visibility",
+        "//utility/src/main/java/org/oppia/android/util/parser/image:__pkg__",
+    ],
     deps = [
         ":math_latex_model",
+        "//third_party:androidx_annotation_annotation",
         "//third_party:com_github_bumptech_glide_glide",
         "//third_party:io_github_karino2_kotlitex",
         "//utility:resources",

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
@@ -1,7 +1,6 @@
 package org.oppia.android.util.parser.math
 
 import android.app.Application
-import androidx.annotation.VisibleForTesting
 import android.graphics.Bitmap
 import android.graphics.Bitmap.Config.ARGB_8888
 import android.graphics.Canvas
@@ -13,6 +12,7 @@ import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.StaticLayout
 import android.text.TextPaint
+import androidx.annotation.VisibleForTesting
 import com.bumptech.glide.Priority
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.Options

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathBitmapModelLoader.kt
@@ -1,6 +1,7 @@
 package org.oppia.android.util.parser.math
 
 import android.app.Application
+import androidx.annotation.VisibleForTesting
 import android.graphics.Bitmap
 import android.graphics.Bitmap.Config.ARGB_8888
 import android.graphics.Canvas
@@ -141,7 +142,8 @@ class MathBitmapModelLoader private constructor(
         // Estimate the surface necessary for rendering the LaTeX, then compute a tightly-packed
         // bitmap containing rendered pixels. See drawText in BoundsCalculatingSurface and
         // renderAutoSizingBitmap for more details.
-        val surface = BoundsCalculatingSurface()
+        val density = application.resources.displayMetrics.density
+        val surface = BoundsCalculatingSurface(density)
         val totalBounds = surface.also {
           // The x and y are mostly unused by the draw routine.
           span.draw(it, renderableText, x = 0f, y = 0, textPaint)
@@ -149,8 +151,15 @@ class MathBitmapModelLoader private constructor(
         val boundsWidth = totalBounds.width().roundToInt()
         val boundsHeight = totalBounds.height().roundToInt()
         val canvasBitmap =
-          renderToAutoSizingBitmap(estimatedWidth = boundsWidth, estimatedHeight = boundsHeight) {
-            staticTextLayout.draw(it)
+          renderToAutoSizingBitmap(estimatedWidth = boundsWidth, estimatedHeight = boundsHeight) { canvas ->
+            val baseline = staticTextLayout.getLineBaseline(0)
+            canvas.save()
+            if (!span.isError) {
+              canvas.translate(0f, baseline.toFloat())
+            }
+            val mathSurface = MathCanvasSurface(canvas, density)
+            span.draw(mathSurface, renderableText, x = 0f, y = baseline, textPaint)
+            canvas.restore()
           }
 
         val finalWidth =
@@ -186,99 +195,6 @@ class MathBitmapModelLoader private constructor(
 
     // 'Retrieval' is expensive in this case since a rendering operation is needed.
     override fun getDataSource(): DataSource = DataSource.LOCAL
-
-    /**
-     * A [DrawableSurface] which tracks the bounds necessary to draw each constituent part of LaTeX
-     * (rendered by KotliTeX) in order to estimate the bounds necessary to render specific LaTeX.
-     */
-    private class BoundsCalculatingSurface : DrawableSurface {
-      private val initialClipRect =
-        RectF(-Float.MAX_VALUE, -Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE)
-      private var currentClip = initialClipRect
-      private val pastClips = mutableListOf<RectF>()
-      private val currentBounds = RectF()
-
-      /**
-       * Returns the [RectF] encompassing the estimated space required to render the entirety of all
-       * previous render operations called to this surface.
-       *
-       * Note that the returned [RectF] is a copy so changes to it will not change this class's
-       * internal state. Note also that the returned [RectF] is always starting at (0, 0) so its
-       * right and bottom values represent the space's width and height, respectively.
-       */
-      fun computeTotalBounds(): RectF = RectF(currentBounds).apply { offsetTo(0f, 0f) }
-
-      override fun clipRect(rect: RectF) {
-        currentClip = currentClip.intersection(rect)
-      }
-
-      override fun drawLine(x0: Float, y0: Float, x1: Float, y1: Float, paint: Paint) {
-        currentBounds.ensureIncludes(x0, y0)
-        currentBounds.ensureIncludes(x1, y1)
-      }
-
-      override fun drawPath(path: Path, paint: Paint) {
-        val pathBounds = RectF().also {
-          if (android.os.Build.VERSION.SDK_INT >= 36) {
-            path.computeBounds(it)
-          } else {
-            @Suppress("DEPRECATION")
-            path.computeBounds(it, true)
-          }
-        }
-        currentBounds.union(pathBounds.intersection(currentClip))
-      }
-
-      override fun drawRect(rect: RectF, paint: Paint) {
-        currentBounds.union(rect.intersection(currentClip))
-      }
-
-      override fun drawText(text: String, x: Float, y: Float, paint: Paint) {
-        /*
-         * Text is particularly difficult to track size for since it's not obvious to actually get
-         * the dimensions and position of the space that the actual rendered pixels will occupy.
-         * https://stackoverflow.com/a/27631737/3689782 provides context both on how text is laid
-         * out, and provides examples of glyphs that can exceed the expected size of a line.
-         *
-         * This problem is exacerbated by KotliTeX manually positioning glyphs both horizontally and
-         * vertically rather than relying on built-in font kerning, tracking, and other rules (for
-         * a high-level reference on these, see: https://proandroiddev.com/5f06722dd611).
-         *
-         * One way to measure text is by using the Paint object (see
-         * https://stackoverflow.com/a/18260682/3689782), but this doesn't account for the extra
-         * vertical or horizontal space needed for a specific glyph.
-         *
-         * The chosen solution is to approximate vertical alignment by appending a tall character
-         * (such as a parenthesis) on a line below the glyph, then to compute the bounds of the
-         * first line and treat this as the size of the glyph. The use of StaticLayout came as a
-         * suggestion from https://stackoverflow.com/a/7643312/3689782 and
-         * https://stackoverflow.com/a/42091739/3689782. While this still is generally an
-         * under-approximation, it's close to the necessary space and pairs well with rendering to a
-         * larger canvas that can be cropped down.
-         */
-        @Suppress("DEPRECATION") // This call is necessary for the supported min API version.
-        val staticLayout =
-          StaticLayout(
-            "$text\n(",
-            paint as TextPaint,
-            /* width= */ 0,
-            Layout.Alignment.ALIGN_NORMAL,
-            /* spacingmult= */ 1f,
-            /* spacingadd= */ 0f,
-            /* includepad= */ true
-          )
-        val textBounds = staticLayout.getLineBounds().apply { offsetTo(x, y) }
-        currentBounds.union(textBounds.intersection(currentClip))
-      }
-
-      override fun restore() {
-        currentClip = pastClips.removeAt(pastClips.lastIndex)
-      }
-
-      override fun save() {
-        pastClips += currentClip
-      }
-    }
 
     private companion object {
       /**
@@ -349,49 +265,199 @@ class MathBitmapModelLoader private constructor(
           Bitmap.createBitmap(/* width= */ 1, /* height= */ 1, ARGB_8888)
         }
       }
+    }
+  }
 
-      private fun RectF.getActualLeft(): Float = min(left, right)
-      private fun RectF.getActualRight(): Float = max(left, right)
-      private fun RectF.getActualTop(): Float = min(top, bottom)
-      private fun RectF.getActualBottom(): Float = max(top, bottom)
+  /**
+   * A [DrawableSurface] which tracks the bounds necessary to draw each constituent part of LaTeX
+   * (rendered by KotliTeX) in order to estimate the bounds necessary to render specific LaTeX.
+   */
+  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+  class BoundsCalculatingSurface(
+    private val density: Float
+  ) : DrawableSurface {
+    private val initialClipRect =
+      RectF(-Float.MAX_VALUE, -Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE)
+    private var currentClip = initialClipRect
+    private val pastClips = mutableListOf<RectF>()
+    private val currentBounds = RectF()
 
-      private fun RectF.intersection(other: RectF): RectF {
-        // https://stackoverflow.com/a/19754915/3689782 provided a simple approach.
-        val intersectedLeft = max(getActualLeft(), other.getActualLeft())
-        val intersectedTop = max(getActualTop(), other.getActualTop())
-        val intersectedRight = min(getActualRight(), other.getActualRight())
-        val intersectedBottom = min(getActualBottom(), other.getActualBottom())
+    /**
+     * Returns the [RectF] encompassing the estimated space required to render the entirety of all
+     * previous render operations called to this surface.
+     *
+     * Note that the returned [RectF] is a copy so changes to it will not change this class's
+     * internal state. Note also that the returned [RectF] is always starting at (0, 0) so its
+     * right and bottom values represent the space's width and height, respectively.
+     */
+    fun computeTotalBounds(): RectF = RectF(currentBounds).apply { offsetTo(0f, 0f) }
 
-        // Make sure that rectangles which don't at least partially overlap result in a degenerate
-        // rectangle rather than a negative one (which would actually represent the union along
-        // whichever axis doesn't overlap).
-        val (actualLeft, actualRight) = if (intersectedRight < intersectedLeft) {
-          0f to 0f
-        } else intersectedLeft to intersectedRight
-        val (actualTop, actualBottom) = if (intersectedBottom < intersectedTop) {
-          0f to 0f
-        } else intersectedTop to intersectedBottom
-        return RectF(actualLeft, actualTop, actualRight, actualBottom)
+    override fun clipRect(rect: RectF) {
+      currentClip = currentClip.intersection(rect)
+    }
+
+    override fun drawLine(x0: Float, y0: Float, x1: Float, y1: Float, paint: Paint) {
+      val strokeWidth = max(paint.strokeWidth, MIN_FRACTION_BAR_THICKNESS_DP * density)
+      val halfStroke = strokeWidth / 2f
+      currentBounds.ensureIncludes(x0, y0 - halfStroke)
+      currentBounds.ensureIncludes(x1, y1 + halfStroke)
+    }
+
+    override fun drawPath(path: Path, paint: Paint) {
+      val pathBounds = RectF().also {
+        if (android.os.Build.VERSION.SDK_INT >= 36) {
+          path.computeBounds(it)
+        } else {
+          @Suppress("DEPRECATION")
+          path.computeBounds(it, true)
+        }
       }
+      currentBounds.union(pathBounds.intersection(currentClip))
+    }
 
-      private fun RectF.ensureIncludes(x: Float, y: Float) {
-        // Note the '+1' here is necessary since 'right' and 'bottom' are exclusive bounds in the
-        // rectangle class (in order for the 'width' and 'height' computations to operate
-        // correctly).
-        left = min(left, x)
-        right = max(right, x + 1)
-        top = min(top, y)
-        bottom = max(bottom, y + 1)
-      }
+    override fun drawRect(rect: RectF, paint: Paint) {
+      currentBounds.union(rect.intersection(currentClip))
+    }
 
-      private fun StaticLayout.getLineBounds(line: Int = 0): RectF {
-        return RectF(
-          getLineLeft(line),
-          getLineTop(line).toFloat(),
-          getLineRight(line),
-          getLineBottom(line).toFloat()
+    override fun drawText(text: String, x: Float, y: Float, paint: Paint) {
+      /*
+       * Text is particularly difficult to track size for since it's not obvious to actually get
+       * the dimensions and position of the space that the actual rendered pixels will occupy.
+       * https://stackoverflow.com/a/27631737/3689782 provides context both on how text is laid
+       * out, and provides examples of glyphs that can exceed the expected size of a line.
+       *
+       * This problem is exacerbated by KotliTeX manually positioning glyphs both horizontally and
+       * vertically rather than relying on built-in font kerning, tracking, and other rules (for
+       * a high-level reference on these, see: https://proandroiddev.com/5f06722dd611).
+       *
+       * One way to measure text is by using the Paint object (see
+       * https://stackoverflow.com/a/18260682/3689782), but this doesn't account for the extra
+       * vertical or horizontal space needed for a specific glyph.
+       *
+       * The chosen solution is to approximate vertical alignment by appending a tall character
+       * (such as a parenthesis) on a line below the glyph, then to compute the bounds of the
+       * first line and treat this as the size of the glyph. The use of StaticLayout came as a
+       * suggestion from https://stackoverflow.com/a/7643312/3689782 and
+       * https://stackoverflow.com/a/42091739/3689782. While this still is generally an
+       * under-approximation, it's close to the necessary space and pairs well with rendering to a
+       * larger canvas that can be cropped down.
+       */
+      @Suppress("DEPRECATION") // This call is necessary for the supported min API version.
+      val staticLayout =
+        StaticLayout(
+          "$text\n(",
+          paint as TextPaint,
+          /* width= */ 0,
+          Layout.Alignment.ALIGN_NORMAL,
+          /* spacingmult= */ 1f,
+          /* spacingadd= */ 0f,
+          /* includepad= */ true
         )
-      }
+      val textBounds = staticLayout.getLineBounds().apply { offsetTo(x, y) }
+      currentBounds.union(textBounds.intersection(currentClip))
+    }
+
+    override fun restore() {
+      currentClip = pastClips.removeAt(pastClips.lastIndex)
+    }
+
+    override fun save() {
+      pastClips += currentClip
+    }
+  }
+
+  /**
+   * A [DrawableSurface] that renders LaTeX elements to a [Canvas] with enhanced visibility for
+   * horizontal fraction bars by enforcing anti-aliasing and a density-aware minimum stroke width.
+   */
+  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+  class MathCanvasSurface(
+    private val canvas: Canvas,
+    private val density: Float
+  ) : DrawableSurface {
+    override fun save() {
+      canvas.save()
+    }
+
+    override fun restore() {
+      canvas.restore()
+    }
+
+    override fun drawText(text: String, x: Float, y: Float, paint: Paint) {
+      canvas.drawText(text, x, y, paint)
+    }
+
+    override fun clipRect(rect: RectF) {
+      canvas.clipRect(rect)
+    }
+
+    override fun drawRect(rect: RectF, paint: Paint) {
+      canvas.drawRect(rect, paint)
+    }
+
+    override fun drawPath(path: Path, paint: Paint) {
+      canvas.drawPath(path, paint)
+    }
+
+    override fun drawLine(x0: Float, y0: Float, x1: Float, y1: Float, paint: Paint) {
+      paint.isAntiAlias = true
+      val originalStrokeWidth = paint.strokeWidth
+      val minStrokeWidth = MIN_FRACTION_BAR_THICKNESS_DP * density
+      paint.strokeWidth = max(originalStrokeWidth, minStrokeWidth)
+      canvas.drawLine(x0, y0, x1, y1, paint)
+      paint.strokeWidth = originalStrokeWidth
+    }
+  }
+
+  companion object {
+    /**
+     * The minimum thickness (in DP) for fraction horizontal bars to ensure visibility on all
+     * screen densities.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    const val MIN_FRACTION_BAR_THICKNESS_DP = 1.5f
+
+    private fun RectF.getActualLeft(): Float = min(left, right)
+    private fun RectF.getActualRight(): Float = max(left, right)
+    private fun RectF.getActualTop(): Float = min(top, bottom)
+    private fun RectF.getActualBottom(): Float = max(top, bottom)
+
+    private fun RectF.intersection(other: RectF): RectF {
+      // https://stackoverflow.com/a/19754915/3689782 provided a simple approach.
+      val intersectedLeft = max(getActualLeft(), other.getActualLeft())
+      val intersectedTop = max(getActualTop(), other.getActualTop())
+      val intersectedRight = min(getActualRight(), other.getActualRight())
+      val intersectedBottom = min(getActualBottom(), other.getActualBottom())
+
+      // Make sure that rectangles which don't at least partially overlap result in a degenerate
+      // rectangle rather than a negative one (which would actually represent the union along
+      // whichever axis doesn't overlap).
+      val (actualLeft, actualRight) = if (intersectedRight < intersectedLeft) {
+        0f to 0f
+      } else intersectedLeft to intersectedRight
+      val (actualTop, actualBottom) = if (intersectedBottom < intersectedTop) {
+        0f to 0f
+      } else intersectedTop to intersectedBottom
+      return RectF(actualLeft, actualTop, actualRight, actualBottom)
+    }
+
+    private fun RectF.ensureIncludes(x: Float, y: Float) {
+      // Note the '+1' here is necessary since 'right' and 'bottom' are exclusive bounds in the
+      // rectangle class (in order for the 'width' and 'height' computations to operate
+      // correctly).
+      left = min(left, x)
+      right = max(right, x + 1)
+      top = min(top, y)
+      bottom = max(bottom, y + 1)
+    }
+
+    private fun StaticLayout.getLineBounds(line: Int = 0): RectF {
+      return RectF(
+        getLineLeft(line),
+        getLineTop(line).toFloat(),
+        getLineRight(line),
+        getLineBottom(line).toFloat()
+      )
     }
   }
 

--- a/utility/src/main/java/org/oppia/android/util/parser/math/MathModel.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/math/MathModel.kt
@@ -30,12 +30,15 @@ data class MathModel(
    *     [MathModel] (this is used to preserve up to 2 digits of the height, but any past that will
    *     be truncated to reduce cache size for highly reusable cached renders)
    * @property useInlineRendering whether the render is formatted to be displayed in-line with text
+   * @property rendererVersion the version of the math renderer used to invalidate cached bitmaps
+   *     when rendering or styling logic changes
    */
   data class MathModelSignature(
     val rawLatex: String,
     val lineHeightHundredX: Int,
     val useInlineRendering: Boolean,
-    val equationColor: Int
+    val equationColor: Int,
+    val rendererVersion: Int = RENDERER_VERSION
   ) : Key {
     // Impl reference: http://bumptech.github.io/glide/doc/caching.html#custom-cache-invalidation.
 
@@ -46,18 +49,28 @@ data class MathModel(
       val lineHeightBytes = Int.SIZE_BYTES
       val inlineFlagBytes = 1
       val colorBytes = Int.SIZE_BYTES
+      val versionBytes = Int.SIZE_BYTES
 
       messageDigest.update(
-        ByteBuffer.allocate(latexSize + lineHeightBytes + inlineFlagBytes + colorBytes).apply {
+        ByteBuffer.allocate(
+          latexSize + lineHeightBytes + inlineFlagBytes + colorBytes + versionBytes
+        ).apply {
           put(rawLatexBytes)
           putInt(lineHeightHundredX)
           put(if (useInlineRendering) 1 else 0)
           putInt(equationColor)
+          putInt(rendererVersion)
         }.array()
       )
     }
 
     internal companion object {
+      /**
+       * The current version of the math renderer. Increment this version whenever changes are made
+       * to math rendering (such as stroke thickness or styling) to invalidate existing cached bitmaps.
+       */
+      const val RENDERER_VERSION = 1
+
       /** Returns a new [MathModelSignature] for the specified [MathModel] properties. */
       internal fun createSignature(
         rawLatex: String,
@@ -66,7 +79,13 @@ data class MathModel(
         equationColor: Int
       ): MathModelSignature {
         val lineHeightHundredX = (lineHeight * 100f).toInt()
-        return MathModelSignature(rawLatex, lineHeightHundredX, useInlineRendering, equationColor)
+        return MathModelSignature(
+          rawLatex,
+          lineHeightHundredX,
+          useInlineRendering,
+          equationColor,
+          RENDERER_VERSION
+        )
       }
     }
   }

--- a/utility/src/test/java/org/oppia/android/util/parser/math/BUILD.bazel
+++ b/utility/src/test/java/org/oppia/android/util/parser/math/BUILD.bazel
@@ -5,6 +5,36 @@ Tests for the components used to render LaTeX math expressions.
 load("//:oppia_android_test.bzl", "oppia_android_test")
 
 oppia_android_test(
+    name = "MathBitmapModelLoaderTest",
+    srcs = ["MathBitmapModelLoaderTest.kt"],
+    custom_package = "org.oppia.android.util.parser.math",
+    test_class = "org.oppia.android.util.parser.math.MathBitmapModelLoaderTest",
+    test_manifest = "//utility:test_manifest",
+    deps = [
+        "//:dagger",
+        "//testing/src/main/java/org/oppia/android/testing/robolectric:test_module",
+        "//testing/src/main/java/org/oppia/android/testing/threading:test_module",
+        "//testing/src/main/java/org/oppia/android/testing/time:test_module",
+        "//third_party:androidx_test_core",
+        "//third_party:androidx_test_ext_junit",
+        "//third_party:com_github_bumptech_glide_glide",
+        "//third_party:com_google_truth_truth",
+        "//third_party:junit_junit",
+        "//third_party:org_mockito_mockito-core",
+        "//third_party:org_robolectric_robolectric",
+        "//third_party:robolectric_android-all",
+        "//utility/src/main/java/org/oppia/android/util/locale:prod_module",
+        "//utility/src/main/java/org/oppia/android/util/logging:console_logger_injector",
+        "//utility/src/main/java/org/oppia/android/util/logging:console_logger_injector_provider",
+        "//utility/src/main/java/org/oppia/android/util/logging:prod_module",
+        "//utility/src/main/java/org/oppia/android/util/parser/math:math_bitmap_model_loader",
+        "//utility/src/main/java/org/oppia/android/util/parser/math:math_latex_model",
+        "//utility/src/main/java/org/oppia/android/util/threading:dispatcher_injector",
+        "//utility/src/main/java/org/oppia/android/util/threading:dispatcher_injector_provider",
+    ],
+)
+
+oppia_android_test(
     name = "MathModelTest",
     srcs = ["MathModelTest.kt"],
     custom_package = "org.oppia.android.util.parser.math",
@@ -17,3 +47,4 @@ oppia_android_test(
         "//utility/src/main/java/org/oppia/android/util/parser/math:math_latex_model",
     ],
 )
+

--- a/utility/src/test/java/org/oppia/android/util/parser/math/MathBitmapModelLoaderTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/math/MathBitmapModelLoaderTest.kt
@@ -1,0 +1,285 @@
+package org.oppia.android.util.parser.math
+
+import android.app.Application
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RectF
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.model.MultiModelLoaderFactory
+import com.google.common.truth.Truth.assertThat
+import dagger.Binds
+import dagger.BindsInstance
+import dagger.Component
+import dagger.Module
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyFloat
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnit
+import org.mockito.junit.MockitoRule
+import org.oppia.android.testing.robolectric.RobolectricModule
+import org.oppia.android.testing.threading.TestDispatcherModule
+import org.oppia.android.testing.time.FakeOppiaClockModule
+import org.oppia.android.util.locale.LocaleProdModule
+import org.oppia.android.util.logging.ConsoleLoggerInjector
+import org.oppia.android.util.logging.ConsoleLoggerInjectorProvider
+import org.oppia.android.util.logging.LoggerModule
+import org.oppia.android.util.threading.DispatcherInjector
+import org.oppia.android.util.threading.DispatcherInjectorProvider
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import javax.inject.Singleton
+
+/** Tests for [MathBitmapModelLoader]. */
+// FunctionName: test names are conventionally named with underscores.
+@Suppress("FunctionName")
+@RunWith(AndroidJUnit4::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+@Config(application = MathBitmapModelLoaderTest.TestApplication::class)
+class MathBitmapModelLoaderTest {
+  @Rule
+  @JvmField
+  val mockitoRule: MockitoRule = MockitoJUnit.rule()
+
+  private lateinit var application: Application
+
+  @Before
+  fun setUp() {
+    application = ApplicationProvider.getApplicationContext()
+  }
+
+  @Test
+  fun testMathCanvasSurface_drawLine_setsAntiAliasToTrue() {
+    val canvas = mock(Canvas::class.java)
+    val mathCanvasSurface = MathBitmapModelLoader.MathCanvasSurface(canvas, density = 1.0f)
+    val paint = Paint().apply { isAntiAlias = false }
+
+    mathCanvasSurface.drawLine(0f, 0f, 10f, 0f, paint)
+
+    assertThat(paint.isAntiAlias).isTrue()
+  }
+
+  @Test
+  fun testMathCanvasSurface_drawLine_thinStroke_enforcesMinimumStrokeWidth() {
+    val canvas = mock(Canvas::class.java)
+    val density = 2.0f
+    val mathCanvasSurface = MathBitmapModelLoader.MathCanvasSurface(canvas, density)
+    val paint = Paint().apply { strokeWidth = 0.5f }
+    var strokeWidthDuringDraw = 0f
+
+    doAnswer {
+      val paintArg = it.getArgument<Paint>(4)
+      strokeWidthDuringDraw = paintArg.strokeWidth
+      null
+    }.`when`(canvas).drawLine(
+      anyFloat(), anyFloat(), anyFloat(), anyFloat(), any(Paint::class.java)
+    )
+
+    mathCanvasSurface.drawLine(0f, 10f, 20f, 10f, paint)
+
+    val expectedMinStrokeWidth = MathBitmapModelLoader.MIN_FRACTION_BAR_THICKNESS_DP * density
+    assertThat(strokeWidthDuringDraw).isEqualTo(expectedMinStrokeWidth)
+    // Original paint's stroke width is restored after drawLine completes.
+    assertThat(paint.strokeWidth).isEqualTo(0.5f)
+  }
+
+  @Test
+  fun testMathCanvasSurface_drawLine_thickStroke_preservesLargerStrokeWidth() {
+    val canvas = mock(Canvas::class.java)
+    val density = 2.0f
+    val mathCanvasSurface = MathBitmapModelLoader.MathCanvasSurface(canvas, density)
+    val paint = Paint().apply { strokeWidth = 5.0f }
+    var strokeWidthDuringDraw = 0f
+
+    doAnswer {
+      val paintArg = it.getArgument<Paint>(4)
+      strokeWidthDuringDraw = paintArg.strokeWidth
+      null
+    }.`when`(canvas).drawLine(
+      anyFloat(), anyFloat(), anyFloat(), anyFloat(), any(Paint::class.java)
+    )
+
+    mathCanvasSurface.drawLine(0f, 10f, 20f, 10f, paint)
+
+    assertThat(strokeWidthDuringDraw).isEqualTo(5.0f)
+    assertThat(paint.strokeWidth).isEqualTo(5.0f)
+  }
+
+  @Test
+  fun testMathCanvasSurface_delegatesOtherMethodsToCanvas() {
+    val canvas = mock(Canvas::class.java)
+    val mathCanvasSurface = MathBitmapModelLoader.MathCanvasSurface(canvas, density = 1.0f)
+    val paint = Paint()
+    val rect = RectF(0f, 0f, 10f, 10f)
+    val path = Path()
+
+    mathCanvasSurface.save()
+    verify(canvas).save()
+
+    mathCanvasSurface.restore()
+    verify(canvas).restore()
+
+    mathCanvasSurface.clipRect(rect)
+    verify(canvas).clipRect(rect)
+
+    mathCanvasSurface.drawRect(rect, paint)
+    verify(canvas).drawRect(rect, paint)
+
+    mathCanvasSurface.drawPath(path, paint)
+    verify(canvas).drawPath(path, paint)
+
+    mathCanvasSurface.drawText("test", 5f, 5f, paint)
+    verify(canvas).drawText("test", 5f, 5f, paint)
+  }
+
+  @Test
+  fun testBoundsCalculatingSurface_drawLine_accountsForMinStrokeWidthExpansion() {
+    val density = 2.0f
+    val surface = MathBitmapModelLoader.BoundsCalculatingSurface(density)
+    val paint = Paint().apply { strokeWidth = 0.5f }
+
+    // Draw along baseline (y = 0f) where math elements are aligned.
+    surface.drawLine(0f, 0f, 30f, 0f, paint)
+
+    val bounds = surface.computeTotalBounds()
+    val expectedMinStrokeWidth = MathBitmapModelLoader.MIN_FRACTION_BAR_THICKNESS_DP * density
+    val expectedHalfStroke = expectedMinStrokeWidth / 2f
+
+    // Total bounds is offset to (0, 0), so width is right and height is bottom.
+    // X goes from 0 to 30 -> width with +1 offset is 30 - 0 + 1 = 31
+    assertThat(bounds.left).isEqualTo(0f)
+    assertThat(bounds.top).isEqualTo(0f)
+    assertThat(bounds.width()).isEqualTo(31f)
+    // Height should accommodate the top and bottom vertical extensions (+1 for inclusive right/bottom):
+    // y0 - halfStroke to y1 + halfStroke = 0 - 1.5 to 0 + 1.5 = -1.5 to 1.5 -> span = 3.0 + 1 = 4.0
+    val expectedHeight = (expectedHalfStroke * 2f) + 1f
+    assertThat(bounds.height()).isEqualTo(expectedHeight)
+  }
+
+  @Test
+  fun testBoundsCalculatingSurface_clipRect_restrictsBounds() {
+    val surface = MathBitmapModelLoader.BoundsCalculatingSurface(density = 1.0f)
+    val paint = Paint()
+
+    surface.clipRect(RectF(0f, 0f, 50f, 50f))
+    surface.drawRect(RectF(10f, 10f, 100f, 100f), paint)
+
+    val bounds = surface.computeTotalBounds()
+    assertThat(bounds.width()).isAtMost(51f)
+    assertThat(bounds.height()).isAtMost(51f)
+  }
+
+  @Test
+  fun testBoundsCalculatingSurface_saveAndRestore_restoresPreviousClip() {
+    val surface = MathBitmapModelLoader.BoundsCalculatingSurface(density = 1.0f)
+    val paint = Paint()
+
+    surface.save()
+    surface.clipRect(RectF(0f, 0f, 10f, 10f))
+    surface.restore()
+
+    surface.drawRect(RectF(0f, 0f, 50f, 50f), paint)
+
+    val bounds = surface.computeTotalBounds()
+    assertThat(bounds.width()).isGreaterThan(10f)
+  }
+
+  @Test
+  fun testFactory_build_createsModelLoader() {
+    val factory = MathBitmapModelLoader.Factory(application)
+    val mockMultiFactory = mock(MultiModelLoaderFactory::class.java)
+
+    val modelLoader = factory.build(mockMultiFactory)
+
+    assertThat(modelLoader).isNotNull()
+    assertThat(modelLoader).isInstanceOf(MathBitmapModelLoader::class.java)
+  }
+
+  @Test
+  fun testModelLoader_handles_returnsTrue() {
+    val factory = MathBitmapModelLoader.Factory(application)
+    val mockMultiFactory = mock(MultiModelLoaderFactory::class.java)
+    val modelLoader = factory.build(mockMultiFactory)
+    val model = MathModel(
+      rawLatex = "\\frac{1}{7}",
+      lineHeight = 20f,
+      useInlineRendering = true,
+      equationColor = Color.BLACK
+    )
+
+    assertThat(modelLoader.handles(model)).isTrue()
+  }
+
+  @Test
+  fun testModelLoader_buildLoadData_returnsExpectedKeySignature() {
+    val factory = MathBitmapModelLoader.Factory(application)
+    val mockMultiFactory = mock(MultiModelLoaderFactory::class.java)
+    val modelLoader = factory.build(mockMultiFactory)
+    val model = MathModel(
+      rawLatex = "\\frac{1}{7}",
+      lineHeight = 20f,
+      useInlineRendering = true,
+      equationColor = Color.BLACK
+    )
+
+    val loadData = modelLoader.buildLoadData(model, /* width= */ 100, /* height= */ 100, Options())
+
+    assertThat(loadData).isNotNull()
+    assertThat(loadData?.sourceKey).isEqualTo(model.toKeySignature())
+  }
+
+  @Module
+  interface TestModule {
+    @Binds
+    fun provideContext(application: Application): Context
+  }
+
+  @Singleton
+  @Component(
+    modules = [
+      TestDispatcherModule::class,
+      LoggerModule::class,
+      FakeOppiaClockModule::class,
+      RobolectricModule::class,
+      LocaleProdModule::class,
+      TestModule::class
+    ]
+  )
+  interface TestApplicationComponent : DispatcherInjector, ConsoleLoggerInjector {
+    @Component.Builder
+    interface Builder {
+      @BindsInstance
+      fun setApplication(application: Application): Builder
+      fun build(): TestApplicationComponent
+    }
+
+    fun inject(test: MathBitmapModelLoaderTest)
+  }
+
+  class TestApplication :
+    Application(), DispatcherInjectorProvider, ConsoleLoggerInjectorProvider {
+    private val component: TestApplicationComponent by lazy {
+      DaggerMathBitmapModelLoaderTest_TestApplicationComponent.builder()
+        .setApplication(this)
+        .build()
+    }
+
+    fun inject(test: MathBitmapModelLoaderTest) {
+      component.inject(test)
+    }
+
+    override fun getDispatcherInjector(): DispatcherInjector = component
+
+    override fun getConsoleLoggerInjector(): ConsoleLoggerInjector = component
+  }
+}

--- a/utility/src/test/java/org/oppia/android/util/parser/math/MathBitmapModelLoaderTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/math/MathBitmapModelLoaderTest.kt
@@ -2,6 +2,7 @@ package org.oppia.android.util.parser.math
 
 import android.app.Application
 import android.content.Context
+import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
@@ -9,7 +10,9 @@ import android.graphics.Path
 import android.graphics.RectF
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.bumptech.glide.Priority
 import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.data.DataFetcher
 import com.bumptech.glide.load.model.MultiModelLoaderFactory
 import com.google.common.truth.Truth.assertThat
 import dagger.Binds
@@ -20,6 +23,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyFloat
 import org.mockito.Mockito.doAnswer
@@ -28,6 +32,7 @@ import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoRule
 import org.oppia.android.testing.robolectric.RobolectricModule
+import org.oppia.android.testing.threading.TestCoroutineDispatchers
 import org.oppia.android.testing.threading.TestDispatcherModule
 import org.oppia.android.testing.time.FakeOppiaClockModule
 import org.oppia.android.util.locale.LocaleProdModule
@@ -38,6 +43,8 @@ import org.oppia.android.util.threading.DispatcherInjector
 import org.oppia.android.util.threading.DispatcherInjectorProvider
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
+import java.nio.ByteBuffer
+import javax.inject.Inject
 import javax.inject.Singleton
 
 /** Tests for [MathBitmapModelLoader]. */
@@ -51,11 +58,15 @@ class MathBitmapModelLoaderTest {
   @JvmField
   val mockitoRule: MockitoRule = MockitoJUnit.rule()
 
+  @Inject
+  lateinit var testCoroutineDispatchers: TestCoroutineDispatchers
+
   private lateinit var application: Application
 
   @Before
   fun setUp() {
     application = ApplicationProvider.getApplicationContext()
+    (application as TestApplication).inject(this)
   }
 
   @Test
@@ -236,6 +247,37 @@ class MathBitmapModelLoaderTest {
 
     assertThat(loadData).isNotNull()
     assertThat(loadData?.sourceKey).isEqualTo(model.toKeySignature())
+  }
+
+  @Test
+  fun testModelLoader_loadData_withFraction_rendersValidBitmap() {
+    val factory = MathBitmapModelLoader.Factory(application)
+    val mockMultiFactory = mock(MultiModelLoaderFactory::class.java)
+    val modelLoader = factory.build(mockMultiFactory)
+    val model = MathModel(
+      rawLatex = "\\frac{1}{7}",
+      lineHeight = 20f,
+      useInlineRendering = true,
+      equationColor = Color.BLACK
+    )
+
+    val loadData = modelLoader.buildLoadData(model, /* width= */ 100, /* height= */ 100, Options())
+    @Suppress("UNCHECKED_CAST")
+    val callback: DataFetcher.DataCallback<ByteBuffer> =
+      mock(DataFetcher.DataCallback::class.java) as DataFetcher.DataCallback<ByteBuffer>
+    val byteBufferCaptor = ArgumentCaptor.forClass(ByteBuffer::class.java)
+
+    loadData?.fetcher?.loadData(Priority.NORMAL, callback)
+    testCoroutineDispatchers.runCurrent()
+
+    verify(callback).onDataReady(byteBufferCaptor.capture())
+    val byteBuffer = byteBufferCaptor.value
+    assertThat(byteBuffer).isNotNull()
+    val bytes = ByteArray(byteBuffer.remaining()).also { byteBuffer.get(it) }
+    val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+    assertThat(bitmap).isNotNull()
+    assertThat(bitmap.width).isGreaterThan(0)
+    assertThat(bitmap.height).isGreaterThan(0)
   }
 
   @Module

--- a/utility/src/test/java/org/oppia/android/util/parser/math/MathModelTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/math/MathModelTest.kt
@@ -226,4 +226,32 @@ class MathModelTest {
     assertThat(digest1.digest()).isNotEqualTo(digest2.digest())
     assertThat(model1).isNotEqualTo(model2)
   }
+
+  @Test
+  fun testToKeySignature_differentRendererVersion_returnsDifferentKeyWithDifferentDigest() {
+    val key1 = MathModel.MathModelSignature(
+      rawLatex = "\\frac{2}{6}",
+      lineHeightHundredX = 2150,
+      useInlineRendering = true,
+      equationColor = Color.BLACK,
+      rendererVersion = 1
+    )
+    val key2 = MathModel.MathModelSignature(
+      rawLatex = "\\frac{2}{6}",
+      lineHeightHundredX = 2150,
+      useInlineRendering = true,
+      equationColor = Color.BLACK,
+      rendererVersion = 2
+    )
+
+    val digest1 = MessageDigest.getInstance("SHA-256")
+    val digest2 = MessageDigest.getInstance("SHA-256")
+
+    key1.updateDiskCacheKey(digest1)
+    key2.updateDiskCacheKey(digest2)
+
+    assertThat(key1).isNotEqualTo(key2)
+    assertThat(key1.hashCode()).isNotEqualTo(key2.hashCode())
+    assertThat(digest1.digest()).isNotEqualTo(digest2.digest())
+  }
 }


### PR DESCRIPTION
## Explanation


Fixes #5809
This PR fixes an issue where horizontal fraction division bars in LaTeX expressions were rendered too thin or faint on high-density screens across both light and dark themes.

In JLaTeXMath, fraction division bars are rendered with a default rule thickness of 0.04em, which evaluates to a hairline width at inline text sizes. In addition, the paint used for drawing lines lacked anti-aliasing, causing these lines to appear broken or nearly invisible on mobile displays.

To resolve this, `MathBitmapModelLoader` was updated to enforce a density-aware minimum stroke width of 1.5dp and enable anti-aliasing when drawing lines. The bounds calculation was also updated to account for the stroke thickness to prevent clipping, and unit tests were added in `MathBitmapModelLoaderTest` to verify the behavior.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage

- **Did you use AI/LLMs when working on this PR?** Type `Yes` or `No`.
  Yes
- **If yes, describe the extent AI was used:**
  AI was used for brainstorming the targeted canvas rendering approach in `MathBitmapModelLoader`, writing unit tests in `MathBitmapModelLoaderTest`, and troubleshooting Bazel test targets.

## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->

### Phone (Portrait) - "What is a Fraction?" Revision Card

| Light Theme | Dark Theme |
| :---: | :---: |
| <img width="576" height="1280" alt="oppia issue 5809 light" src="https://github.com/user-attachments/assets/059cb155-a599-40b5-af7d-907f283de9b1" />  | <img width="576" height="1280" alt="oppia issue 5809 dark" src="https://github.com/user-attachments/assets/1c57b19b-00a7-4a03-8b09-1195bf5d9b82" />|

- Tested on physical device (Android 16, 420 dpi).
- Fraction bars in both inline and block LaTeX expressions are crisp, solid, and clearly visible in both light and dark themes.
