### PR TITLE
Fix #6414: Verify lesson conversion compatibility before pinning lesson versions

### DIFF
--- a/.github/workflows/pull_latest_lesson_versions.yml
+++ b/.github/workflows/pull_latest_lesson_versions.yml
@@ -1,7 +1,7 @@
 # Runs weekly to refresh the pinned lesson version files (config/lessons/*.textproto) by
-# executing download_lesson_list against the live Oppia server, then opens (or force-pushes to)
-# a dedicated PR on the `automated/lesson-versions` branch so the coordinator can
-# review and merge the diff.
+# executing download_lesson_list against the live Oppia server and verifying conversion
+# compatibility via download_lessons, then opens (or force-pushes to) a dedicated PR on
+# the `automated/lesson-versions` branch so the coordinator can review and merge the diff.
 #
 # The workflow runs against latest develop so the textproto diff is always computed relative
 # to the current checked-in state. If the files are already up-to-date the commit step is
@@ -95,9 +95,43 @@ jobs:
             $(pwd)/config/lessons/prod_pinned_lesson_versions.textproto \
             $(pwd)/scripts/assets/prod_download_config.textproto
 
-      - name: Clean up lesson secret
+      # Verify that updated lesson versions are conversion-compatible before committing.
+      # If conversion fails (-Werror triggers exit code 1), the workflow exits early without opening a PR.
+      - name: Download alpha lessons and verify conversion
+        run: |
+          bazel run //scripts:download_lessons -- \
+            https://www.oppia.org \
+            https://storage.googleapis.com \
+            oppiaserver-resources \
+            $(pwd)/prod_server.key \
+            /tmp/verification_assets/alpha \
+            cache_mode=none \
+            /tmp/verification_cache/alpha \
+            $(pwd)/config/lessons/alpha_pinned_lesson_versions.textproto \
+            $(pwd)/scripts/assets/alpha_download_config.textproto \
+            false \
+            -Werror
+
+      - name: Download prod lessons and verify conversion
+        run: |
+          bazel run //scripts:download_lessons -- \
+            https://www.oppia.org \
+            https://storage.googleapis.com \
+            oppiaserver-resources \
+            $(pwd)/prod_server.key \
+            /tmp/verification_assets/prod \
+            cache_mode=none \
+            /tmp/verification_cache/prod \
+            $(pwd)/config/lessons/prod_pinned_lesson_versions.textproto \
+            $(pwd)/scripts/assets/prod_download_config.textproto \
+            false \
+            -Werror
+
+      - name: Clean up lesson secret and verification assets
         if: always()
-        run: rm -f prod_server.key
+        run: |
+          rm -f prod_server.key
+          rm -rf /tmp/verification_assets /tmp/verification_cache
 
       - name: Check for changes
         id: diff


### PR DESCRIPTION
## Explanation
Fixes #6414

The `pull_latest_lesson_versions.yml` workflow previously only ran `//scripts:download_lesson_list` to fetch the latest lesson version numbers and update the pinned textproto files. Because `download_lesson_list` only fetches version numbers and does not download or convert actual lesson assets, it could pin lesson versions that are conversion-incompatible with the current app codebase (which was previously only discovered downstream when `lesson_checks.yml` ran after the PR was already merged).

This PR adds conversion verification steps using `bazel run //scripts:download_lessons` with the `-Werror` flag (following the pattern established in `lesson_checks.yml`) for both alpha and prod lesson configurations immediately after the version lists are fetched:
- **Alpha**: Verified using `config/lessons/alpha_pinned_lesson_versions.textproto` and `scripts/assets/alpha_download_config.textproto`.
- **Prod**: Verified using `config/lessons/prod_pinned_lesson_versions.textproto` and `scripts/assets/prod_download_config.textproto`.
- Output assets and caches are stored in isolated `/tmp` directories (`/tmp/verification_assets` and `/tmp/verification_cache`) so they do not pollute the workspace or interfere with the git diff check.
- Both temporary verification directories and `prod_server.key` are cleaned up in an `if: always()` step.
- When `-Werror` is specified, any conversion failure or asset inconsistency triggers exit code 1 in `DownloadLessons.kt`, halting the workflow early and preventing invalid versions from being committed or proposed in a PR.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
- **Did you use AI/LLMs when working on this PR?** Yes
- **If yes, describe the extent AI was used:** AI was used to examine the workflow step sequence, compare the argument contract against `lesson_checks.yml`, and format the explanation.
