### PR TITLE
Fix #6441: Fixing spacing issues in list

### DIFF
--- a/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParser.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParser.kt
@@ -11,6 +11,7 @@ import android.text.util.Linkify
 import android.util.Patterns
 import android.view.View
 import android.widget.TextView
+import androidx.core.text.getSpans
 import androidx.core.text.util.LinkifyCompat
 import androidx.core.view.ViewCompat
 import org.oppia.android.util.R
@@ -219,21 +220,36 @@ class HtmlParser private constructor(
    * This is needed since Android's built-in list rendering doesn't match Oppia's (in particular, it
    * renders ordered lists as bullets rather than as numbers).
    */
+
+  private fun String.replaceListTag(
+    originalTag: String,
+    replacementTag: String,
+  ): String {
+    return replace(
+      Regex("""<(/?)$originalTag(?=[\s>])""", RegexOption.IGNORE_CASE),
+      "<$1$replacementTag"
+    )
+  }
   private fun replaceListTags(html: String): String {
-    var adjustedHtml = html
-    if ("<li>" in adjustedHtml) {
-      adjustedHtml = adjustedHtml.replace("<li>", "<$CUSTOM_LIST_LI_TAG>")
-        .replace("</li>", "</$CUSTOM_LIST_LI_TAG>")
-    }
-    if ("<ul>" in adjustedHtml) {
-      adjustedHtml = adjustedHtml.replace("<ul>", "<$CUSTOM_LIST_UL_TAG>")
-        .replace("</ul>", "</$CUSTOM_LIST_UL_TAG>")
-    }
-    if ("<ol>" in adjustedHtml) {
-      adjustedHtml = adjustedHtml.replace("<ol>", "<$CUSTOM_LIST_OL_TAG>")
-        .replace("</ol>", "</$CUSTOM_LIST_OL_TAG>")
-    }
-    return adjustedHtml
+
+    return html
+      .replaceListTag("li", CUSTOM_LIST_LI_TAG)
+      .replaceListTag("ul", CUSTOM_LIST_UL_TAG)
+      .replaceListTag("ol", CUSTOM_LIST_OL_TAG)
+//    var adjustedHtml = html
+//    if ("<li>" in adjustedHtml) {
+//      adjustedHtml = adjustedHtml.replace("<li>", "<$CUSTOM_LIST_LI_TAG>")
+//        .replace("</li>", "</$CUSTOM_LIST_LI_TAG>")
+//    }
+//    if ("<ul>" in adjustedHtml) {
+//      adjustedHtml = adjustedHtml.replace("<ul>", "<$CUSTOM_LIST_UL_TAG>")
+//        .replace("</ul>", "</$CUSTOM_LIST_UL_TAG>")
+//    }
+//    if ("<ol>" in adjustedHtml) {
+//      adjustedHtml = adjustedHtml.replace("<ol>", "<$CUSTOM_LIST_OL_TAG>")
+//        .replace("</ol>", "</$CUSTOM_LIST_OL_TAG>")
+//    }
+//    return adjustedHtml
   }
 
   private fun trimSpannable(spannable: SpannableStringBuilder): SpannableStringBuilder {
@@ -246,6 +262,11 @@ class HtmlParser private constructor(
     // Find the last non-newline from the end.
     var end = text.length
     while (end > start && text[end - 1] == '\n') { end-- }
+
+
+    val lastParagraphSpanEnd = spannable.getSpans(0, spannable.length, android.text.style.ParagraphStyle::class.java)
+      .maxOfOrNull { spannable.getSpanEnd(it) } ?: 0
+    end = maxOf(end, lastParagraphSpanEnd.coerceAtMost(spannable.length))
 
     // Return only the trimmed span.
     return SpannableStringBuilder(spannable.subSequence(start, end))

--- a/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParser.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParser.kt
@@ -249,11 +249,6 @@ class HtmlParser private constructor(
     var end = text.length
     while (end > start && text[end - 1] == '\n') { end-- }
 
-
-    val lastParagraphSpanEnd = spannable.getSpans(0, spannable.length, android.text.style.ParagraphStyle::class.java)
-      .maxOfOrNull { spannable.getSpanEnd(it) } ?: 0
-    end = maxOf(end, lastParagraphSpanEnd.coerceAtMost(spannable.length))
-
     // Return only the trimmed span.
     return SpannableStringBuilder(spannable.subSequence(start, end))
   }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParser.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParser.kt
@@ -220,36 +220,22 @@ class HtmlParser private constructor(
    * This is needed since Android's built-in list rendering doesn't match Oppia's (in particular, it
    * renders ordered lists as bullets rather than as numbers).
    */
+  private fun replaceListTags(html: String): String {
+    return html
+      .replaceListTag(originalTag = "li", replacementTag = CUSTOM_LIST_LI_TAG)
+      .replaceListTag(originalTag = "ul", replacementTag = CUSTOM_LIST_UL_TAG)
+      .replaceListTag(originalTag = "ol", replacementTag = CUSTOM_LIST_OL_TAG)
+  }
 
-  private fun String.replaceListTag(
-    originalTag: String,
-    replacementTag: String,
-  ): String {
+  /**
+   * Replaces opening and closing [originalTag] tags while preserving attributes such as the XHTML
+   * namespace included by Oppia's rich-text editor.
+   */
+  private fun String.replaceListTag(originalTag: String, replacementTag: String): String {
     return replace(
       Regex("""<(/?)$originalTag(?=[\s>])""", RegexOption.IGNORE_CASE),
       "<$1$replacementTag"
     )
-  }
-  private fun replaceListTags(html: String): String {
-
-    return html
-      .replaceListTag("li", CUSTOM_LIST_LI_TAG)
-      .replaceListTag("ul", CUSTOM_LIST_UL_TAG)
-      .replaceListTag("ol", CUSTOM_LIST_OL_TAG)
-//    var adjustedHtml = html
-//    if ("<li>" in adjustedHtml) {
-//      adjustedHtml = adjustedHtml.replace("<li>", "<$CUSTOM_LIST_LI_TAG>")
-//        .replace("</li>", "</$CUSTOM_LIST_LI_TAG>")
-//    }
-//    if ("<ul>" in adjustedHtml) {
-//      adjustedHtml = adjustedHtml.replace("<ul>", "<$CUSTOM_LIST_UL_TAG>")
-//        .replace("</ul>", "</$CUSTOM_LIST_UL_TAG>")
-//    }
-//    if ("<ol>" in adjustedHtml) {
-//      adjustedHtml = adjustedHtml.replace("<ol>", "<$CUSTOM_LIST_OL_TAG>")
-//        .replace("</ol>", "</$CUSTOM_LIST_OL_TAG>")
-//    }
-//    return adjustedHtml
   }
 
   private fun trimSpannable(spannable: SpannableStringBuilder): SpannableStringBuilder {

--- a/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParser.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/HtmlParser.kt
@@ -11,7 +11,6 @@ import android.text.util.Linkify
 import android.util.Patterns
 import android.view.View
 import android.widget.TextView
-import androidx.core.text.getSpans
 import androidx.core.text.util.LinkifyCompat
 import androidx.core.view.ViewCompat
 import org.oppia.android.util.R

--- a/utility/src/main/java/org/oppia/android/util/parser/html/LiTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/LiTagHandler.kt
@@ -46,6 +46,17 @@ class LiTagHandler(
   }
 
   override fun handleOpeningTag(output: Editable, tag: String) {
+
+    if(tag == CUSTOM_LIST_UL_TAG || tag == CUSTOM_LIST_OL_TAG){
+      if(pendingLists.isEmpty()){
+        output.appendNewLine()
+
+        if(output.isNotEmpty() && output.last() == '\n' && (output.length < 2 || output[output.length - 2] != '\n')){
+          output.append('\n')
+        }
+      }
+    }
+
     when (tag) {
       CUSTOM_LIST_UL_TAG -> {
         pendingLists += ListTag.Ul(
@@ -55,12 +66,21 @@ class LiTagHandler(
         )
       }
       CUSTOM_LIST_OL_TAG -> {
-        pendingLists += ListTag.Ol(
-          parentList = latestPendingList, parentMark = latestPendingList?.pendingStartMark
-        )
+        if (pendingLists.isNotEmpty()) {
+          pendingLists += ListTag.Ul(
+            parentList = latestPendingList,
+            parentMark = latestPendingList?.pendingStartMark,
+            indentationLevel = pendingLists.size
+          )
+        } else {
+          pendingLists += ListTag.Ol(
+            parentList = latestPendingList, parentMark = latestPendingList?.pendingStartMark
+          )
+        }
       }
       CUSTOM_LIST_LI_TAG -> latestPendingList?.openItem(output)
     }
+
   }
 
   override fun handleClosingTag(output: Editable, indentation: Int, tag: String) {
@@ -68,6 +88,14 @@ class LiTagHandler(
       CUSTOM_LIST_UL_TAG, CUSTOM_LIST_OL_TAG -> {
         // Actually place the spans only if the root tree has been finished (as the entirety of the
         // tree is needed for analysis).
+        output.appendNewLine()
+
+        if (pendingLists.size == 1) {
+          if (output.isNotEmpty() && output.last() == '\n' && (output.length < 2 || output[output.length - 2] != '\n')) {
+            output.append("\n")
+          }
+        }
+
         val closingList = pendingLists.pop().also { it.recordList() }
         if (pendingLists.isEmpty()) {
           closingList.finishListTree(
@@ -190,6 +218,10 @@ class LiTagHandler(
         checkNotNull(pendingStartMark) { "Cannot close item that hasn't been started." }
       val endingMark = Mark.EndListItem()
       text.appendNewLine()
+
+//      if(text.isNotEmpty() && text.last() == '\n' &&  (text.length < 2 || text[text.length - 2] !='\n')){
+//        text.append('\n')
+//      }
       text.addMark(endingMark)
       markRangesToReplace += MarkedRange(startingMark, endingMark)
       pendingStartMark = null

--- a/utility/src/main/java/org/oppia/android/util/parser/html/LiTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/LiTagHandler.kt
@@ -47,11 +47,11 @@ class LiTagHandler(
 
   override fun handleOpeningTag(output: Editable, tag: String) {
 
-    if(tag == CUSTOM_LIST_UL_TAG || tag == CUSTOM_LIST_OL_TAG){
-      if(pendingLists.isEmpty()){
+    if (tag == CUSTOM_LIST_UL_TAG || tag == CUSTOM_LIST_OL_TAG) {
+      if (pendingLists.isEmpty()) {
         output.appendNewLine()
 
-        if(output.isNotEmpty() && output.last() == '\n' && (output.length < 2 || output[output.length - 2] != '\n')){
+        if (output.isNotEmpty() && output.last() == '\n' && (output.length < 2 || output[output.length - 2] != '\n')) {
           output.append('\n')
         }
       }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/LiTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/LiTagHandler.kt
@@ -51,7 +51,10 @@ class LiTagHandler(
       if (pendingLists.isEmpty()) {
         output.appendNewLine()
 
-        if (output.isNotEmpty() && output.last() == '\n' && (output.length < 2 || output[output.length - 2] != '\n')) {
+        val isSingleNewline = output.isNotEmpty() &&
+          output.last() == '\n' &&
+          (output.length < 2 || output[output.length - 2] != '\n')
+        if (isSingleNewline) {
           output.append('\n')
         }
       }
@@ -72,7 +75,6 @@ class LiTagHandler(
       }
       CUSTOM_LIST_LI_TAG -> latestPendingList?.openItem(output)
     }
-
   }
 
   override fun handleClosingTag(output: Editable, indentation: Int, tag: String) {
@@ -82,7 +84,10 @@ class LiTagHandler(
         // tree is needed for analysis).
         output.appendNewLine()
 
-        if (output.isNotEmpty() && output.last() == '\n' && (output.length < 2 || output[output.length - 2] != '\n')) {
+        val isSingleNewline = output.isNotEmpty() &&
+          output.last() == '\n' &&
+          (output.length < 2 || output[output.length - 2] != '\n')
+        if (isSingleNewline) {
           output.append("\n")
         }
 

--- a/utility/src/main/java/org/oppia/android/util/parser/html/LiTagHandler.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/LiTagHandler.kt
@@ -66,17 +66,9 @@ class LiTagHandler(
         )
       }
       CUSTOM_LIST_OL_TAG -> {
-        if (pendingLists.isNotEmpty()) {
-          pendingLists += ListTag.Ul(
-            parentList = latestPendingList,
-            parentMark = latestPendingList?.pendingStartMark,
-            indentationLevel = pendingLists.size
-          )
-        } else {
-          pendingLists += ListTag.Ol(
-            parentList = latestPendingList, parentMark = latestPendingList?.pendingStartMark
-          )
-        }
+        pendingLists += ListTag.Ol(
+          parentList = latestPendingList, parentMark = latestPendingList?.pendingStartMark
+        )
       }
       CUSTOM_LIST_LI_TAG -> latestPendingList?.openItem(output)
     }
@@ -90,10 +82,8 @@ class LiTagHandler(
         // tree is needed for analysis).
         output.appendNewLine()
 
-        if (pendingLists.size == 1) {
-          if (output.isNotEmpty() && output.last() == '\n' && (output.length < 2 || output[output.length - 2] != '\n')) {
-            output.append("\n")
-          }
+        if (output.isNotEmpty() && output.last() == '\n' && (output.length < 2 || output[output.length - 2] != '\n')) {
+          output.append("\n")
         }
 
         val closingList = pendingLists.pop().also { it.recordList() }
@@ -219,9 +209,6 @@ class LiTagHandler(
       val endingMark = Mark.EndListItem()
       text.appendNewLine()
 
-//      if(text.isNotEmpty() && text.last() == '\n' &&  (text.length < 2 || text[text.length - 2] !='\n')){
-//        text.append('\n')
-//      }
       text.addMark(endingMark)
       markRangesToReplace += MarkedRange(startingMark, endingMark)
       pendingStartMark = null

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ListItemLeadingMarginSpan.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ListItemLeadingMarginSpan.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Rect
-import android.graphics.RectF
 import android.text.Layout
 import android.text.Spanned
 import android.text.TextPaint
@@ -96,34 +95,7 @@ sealed class ListItemLeadingMarginSpan : LeadingMarginSpan {
           maxDrawX - bulletCenterLtrX
         } else bulletCenterLtrX
         val bulletCenterY = (top + bottom) / 2f
-//        when (indentationLevel) {
-//          0 -> {
-//            // A solid circle is used for the outermost bullet.
-//            paint.style = Paint.Style.FILL
-//            canvas.drawCircle(bulletCenterX, bulletCenterY, bulletDrawRadius, paint)
-//          }
-//          1 -> {
-//            // An inner open circle is used for second-level bullets.
-//            paint.style = Paint.Style.STROKE
-//            paint.strokeWidth = 2f
-//            canvas.drawCircle(bulletCenterX, bulletCenterY, bulletDrawRadius, paint)
-//          }
-//          else -> {
-//            // A filled square is used for all subsequent bullets.
-//            paint.style = Paint.Style.FILL
-//            val rectSize = bulletDiameter.toFloat()
-//            canvas.drawRect(
-//              RectF().apply {
-//                left = bulletCenterX
-//                right = left + rectSize
-//                this.top = bulletCenterY - bulletDrawRadius
-//                this.bottom = this.top + rectSize
-//              },
-//              paint
-//            )
-//          }
-//        }
-        paint.style = Paint.Style.FILL // Restore the previously used paint style.
+
         canvas.drawCircle(bulletCenterX, bulletCenterY, bulletDrawRadius, paint)
       }
     }

--- a/utility/src/main/java/org/oppia/android/util/parser/html/ListItemLeadingMarginSpan.kt
+++ b/utility/src/main/java/org/oppia/android/util/parser/html/ListItemLeadingMarginSpan.kt
@@ -83,7 +83,7 @@ sealed class ListItemLeadingMarginSpan : LeadingMarginSpan {
       val isFirstCharacter = startCharOfSpan == start
 
       if (isFirstCharacter) {
-        val previousStyle = paint.style
+//        val previousStyle = paint.style
         val bulletDrawRadius = bulletRadius.toFloat()
 
         val indentedX = parentAbsoluteLeadingMargin + spacingBeforeBullet
@@ -96,34 +96,35 @@ sealed class ListItemLeadingMarginSpan : LeadingMarginSpan {
           maxDrawX - bulletCenterLtrX
         } else bulletCenterLtrX
         val bulletCenterY = (top + bottom) / 2f
-        when (indentationLevel) {
-          0 -> {
-            // A solid circle is used for the outermost bullet.
-            paint.style = Paint.Style.FILL
-            canvas.drawCircle(bulletCenterX, bulletCenterY, bulletDrawRadius, paint)
-          }
-          1 -> {
-            // An inner open circle is used for second-level bullets.
-            paint.style = Paint.Style.STROKE
-            paint.strokeWidth = 2f
-            canvas.drawCircle(bulletCenterX, bulletCenterY, bulletDrawRadius, paint)
-          }
-          else -> {
-            // A filled square is used for all subsequent bullets.
-            paint.style = Paint.Style.FILL
-            val rectSize = bulletDiameter.toFloat()
-            canvas.drawRect(
-              RectF().apply {
-                left = bulletCenterX
-                right = left + rectSize
-                this.top = bulletCenterY - bulletDrawRadius
-                this.bottom = this.top + rectSize
-              },
-              paint
-            )
-          }
-        }
-        paint.style = previousStyle // Restore the previously used paint style.
+//        when (indentationLevel) {
+//          0 -> {
+//            // A solid circle is used for the outermost bullet.
+//            paint.style = Paint.Style.FILL
+//            canvas.drawCircle(bulletCenterX, bulletCenterY, bulletDrawRadius, paint)
+//          }
+//          1 -> {
+//            // An inner open circle is used for second-level bullets.
+//            paint.style = Paint.Style.STROKE
+//            paint.strokeWidth = 2f
+//            canvas.drawCircle(bulletCenterX, bulletCenterY, bulletDrawRadius, paint)
+//          }
+//          else -> {
+//            // A filled square is used for all subsequent bullets.
+//            paint.style = Paint.Style.FILL
+//            val rectSize = bulletDiameter.toFloat()
+//            canvas.drawRect(
+//              RectF().apply {
+//                left = bulletCenterX
+//                right = left + rectSize
+//                this.top = bulletCenterY - bulletDrawRadius
+//                this.bottom = this.top + rectSize
+//              },
+//              paint
+//            )
+//          }
+//        }
+        paint.style = Paint.Style.FILL // Restore the previously used paint style.
+        canvas.drawCircle(bulletCenterX, bulletCenterY, bulletDrawRadius, paint)
       }
     }
 

--- a/utility/src/test/java/org/oppia/android/util/parser/html/LiTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/LiTagHandlerTest.kt
@@ -168,7 +168,9 @@ class LiTagHandlerTest {
   @Test
   fun testCustomListElement_nestedListFollowedByOuterListItem_hasCorrectNewlines() {
     val displayLocale = createDisplayLocaleImpl(US_ENGLISH_CONTEXT)
-    val htmlString = "<oppia-ol><oppia-li>Item 1<oppia-ol><oppia-li>Nested 1</oppia-li></oppia-ol></oppia-li><oppia-li>Item 2</oppia-li></oppia-ol>"
+    val htmlString =
+      "<oppia-ol><oppia-li>Item 1<oppia-ol><oppia-li>Nested 1</oppia-li>" +
+        "</oppia-ol></oppia-li><oppia-li>Item 2</oppia-li></oppia-ol>"
     val liTaghandler = LiTagHandler(context, displayLocale)
     val parsedHtml =
       CustomHtmlContentHandler.fromHtml(

--- a/utility/src/test/java/org/oppia/android/util/parser/html/LiTagHandlerTest.kt
+++ b/utility/src/test/java/org/oppia/android/util/parser/html/LiTagHandlerTest.kt
@@ -165,6 +165,24 @@ class LiTagHandlerTest {
       .hasLength(4)
   }
 
+  @Test
+  fun testCustomListElement_nestedListFollowedByOuterListItem_hasCorrectNewlines() {
+    val displayLocale = createDisplayLocaleImpl(US_ENGLISH_CONTEXT)
+    val htmlString = "<oppia-ol><oppia-li>Item 1<oppia-ol><oppia-li>Nested 1</oppia-li></oppia-ol></oppia-li><oppia-li>Item 2</oppia-li></oppia-ol>"
+    val liTaghandler = LiTagHandler(context, displayLocale)
+    val parsedHtml =
+      CustomHtmlContentHandler.fromHtml(
+        html = htmlString,
+        imageRetriever = mockImageRetriever,
+        customTagHandlers = mapOf(
+          CUSTOM_LIST_LI_TAG to liTaghandler,
+          CUSTOM_LIST_OL_TAG to liTaghandler
+        )
+      )
+
+    assertThat(parsedHtml.toString()).contains("Nested 1\n\nItem 2")
+  }
+
   private fun createDisplayLocaleImpl(context: OppiaLocaleContext): DisplayLocaleImpl {
     val formattingLocale = androidLocaleFactory.createOneOffAndroidLocale(context)
     return DisplayLocaleImpl(context, formattingLocale, machineLocale, formatterFactory)


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->
Fixes #6441 
## Explanation
Previously, the app had inconsistent or missing spacing before and after lists, and incorrectly applied double newlines between every single list item. This caused list items to have huge gaps, and paragraphs to run directly into lists (making them look like links due to missing boundaries).

In the LiTagHandler.kt file , inside the handleOpeningTag, I added logic to prepend a double newline (\n\n) when an outermost list is opened. This ensures the list doesn't bleed into the preceding paragraph.

Between list items, I removed the extra newline that was being forced after every single

I also ensured that as the collaborator commented to fix the issues, i did so and change the logic as well:
-> I updated the nested ordered lists as ListTag.Ol
-> I removed the duplicated method
-> I successfully removed that if (pendingLists.size == 1)  line and replaced it with the correct isSingleNewline logic that runs for all lists (nested or outer). 
-> I removed the unnecessary comments
->As the collaborator requested for fixing of the existing trimming behaviour, now The `trimSpannable` method now simply trims trailing and leading newlines without looking into span layouts, just as he requested...


Before image:                                           After image:
<img width="280" height="600" alt="image" src="https://github.com/user-attachments/assets/1d02e068-5e2b-40bf-ab6c-436c9eb56dc5" />        <img width="280" height="600" alt="image" src="https://github.com/user-attachments/assets/54c3e48c-a712-412e-845b-04d8c87f7d6b" />



## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
<!-- Please answer the following two questions. -->
- **Did you use AI/LLMs when working on this PR?** Type `Yes` or `No`.:Yes
- **If yes, describe the extent AI was used:** e.g. brainstorming, debugging, writing code, writing tests, reviewing code, etc. See https://github.com/oppia/oppia-android/pull/6062 for an example.:AI was used for debugging and reviewing code.

  
## For UI-specific PRs only
<!-- Delete these section if this PR does not include UI-related changes. -->
If your PR includes UI-related changes, then:
- Add screenshots for portrait/landscape for both a tablet & phone of the before & after UI changes
- For the screenshots above, include both English and pseudo-localized (RTL) screenshots (see [RTL guide](https://github.com/oppia/oppia-android/wiki/RTL-Guidelines))
- Add a video showing the full UX flow with a screen reader enabled (see [accessibility guide](https://github.com/oppia/oppia-android/wiki/Accessibility-A11y-Guide))
- For PRs introducing new UI elements or color changes, both light and dark mode screenshots must be included
- Add a screenshot demonstrating that you ran affected Espresso tests locally & that they're passing
