### PR TITLE
Fix #6378: Resetting of reading text size font scale when returning to Topic Page

### DIFF
--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
@@ -415,6 +415,7 @@ class ExplorationActivityPresenter @Inject constructor(
 
   /** Selects the appropriate way to close the activity based on the parent screen. */
   fun backPressActivitySelector() {
+    fontScaleConfigurationUtil.adjustFontScale(activity, ReadingTextSize.MEDIUM_TEXT_SIZE)
     when (parentScreen) {
       ExplorationActivityParams.ParentScreen.TOPIC_SCREEN_LESSONS_TAB,
       ExplorationActivityParams.ParentScreen.STORY_SCREEN -> activity.finish()

--- a/app/src/main/java/org/oppia/android/app/topic/TopicActivity.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicActivity.kt
@@ -63,6 +63,10 @@ class TopicActivity :
     topicActivityPresenter.handleOnCreate(profileId, classroomId, topicId, storyId)
   }
 
+  override fun onRestart() {
+    super.onRestart()
+    topicActivityPresenter.handleOnRestart()
+  }
   override fun routeToQuestionPlayer(skillIdList: ArrayList<String>) {
     startActivity(
       QuestionPlayerActivity.createQuestionPlayerActivityIntent(

--- a/app/src/main/java/org/oppia/android/app/topic/TopicActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/topic/TopicActivityPresenter.kt
@@ -4,10 +4,12 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import org.oppia.android.app.activity.ActivityScope
 import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ReadingTextSize
 import org.oppia.android.app.model.TopicFragmentArguments
 import org.oppia.android.app.spotlight.SpotlightFragment
 import org.oppia.android.app.spotlight.SpotlightManager
 import org.oppia.android.app.ui.R
+import org.oppia.android.app.utility.FontScaleConfigurationUtil
 import org.oppia.android.app.utility.edgetoedge.EdgeToEdgeHelper
 import org.oppia.android.util.extensions.putProto
 import org.oppia.android.util.platformparameter.EnableEdgeToEdge
@@ -22,7 +24,8 @@ const val TOPIC_FRAGMENT_ARGUMENTS_KEY = "TopicFragment.arguments"
 @ActivityScope
 class TopicActivityPresenter @Inject constructor(
   private val activity: AppCompatActivity,
-  @EnableEdgeToEdge private val enableEdgeToEdge: PlatformParameterValue<Boolean>
+  @EnableEdgeToEdge private val enableEdgeToEdge: PlatformParameterValue<Boolean>,
+  private val fontScaleConfigurationUtil: FontScaleConfigurationUtil
 ) {
   private lateinit var classroomId: String
   private lateinit var topicId: String
@@ -33,6 +36,7 @@ class TopicActivityPresenter @Inject constructor(
     topicId: String,
     storyId: String?
   ) {
+    fontScaleConfigurationUtil.adjustFontScale(activity, ReadingTextSize.MEDIUM_TEXT_SIZE)
     this.topicId = topicId
     this.classroomId = classroomId
     if (enableEdgeToEdge.value) {
@@ -68,6 +72,9 @@ class TopicActivityPresenter @Inject constructor(
         SpotlightManager.SPOTLIGHT_FRAGMENT_TAG
       ).commitNow()
     }
+  }
+  fun handleOnRestart() {
+    fontScaleConfigurationUtil.adjustFontScale(activity, ReadingTextSize.MEDIUM_TEXT_SIZE)
   }
 
   private fun getTopicFragment(): TopicFragment? {

--- a/app/src/main/java/org/oppia/android/app/utility/FontScaleConfigurationUtil.kt
+++ b/app/src/main/java/org/oppia/android/app/utility/FontScaleConfigurationUtil.kt
@@ -29,6 +29,7 @@ class FontScaleConfigurationUtil @Inject constructor() {
     metrics.scaledDensity = scaledDensity
     context.createConfigurationContext(configuration)
     context.resources.displayMetrics.setTo(metrics)
+    context.applicationContext?.resources?.displayMetrics?.setTo(metrics)
   }
 
   private fun getReadingTextSizeConfigurationUtil(readingTextSize: ReadingTextSize): Float {

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/TopicActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/TopicActivityTest.kt
@@ -34,6 +34,7 @@ import org.oppia.android.app.application.testing.TestingBuildFlavorModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.model.LegacyProfileId
+import org.oppia.android.app.model.ReadingTextSize
 import org.oppia.android.app.model.ScreenName
 import org.oppia.android.app.model.Spotlight.FeatureCase.FIRST_CHAPTER
 import org.oppia.android.app.model.Spotlight.FeatureCase.TOPIC_LESSON_TAB
@@ -44,6 +45,7 @@ import org.oppia.android.app.test.R
 import org.oppia.android.app.topic.questionplayer.QuestionPlayerActivity
 import org.oppia.android.app.translation.testing.ActivityRecreatorTestModule
 import org.oppia.android.app.utility.EspressoTestsMatchers.hasProtoExtra
+import org.oppia.android.app.utility.FontScaleConfigurationUtil
 import org.oppia.android.data.backends.gae.NetworkConfigProdModule
 import org.oppia.android.data.backends.gae.RetrofitModule
 import org.oppia.android.data.backends.gae.RetrofitServiceModule
@@ -201,6 +203,19 @@ class TopicActivityTest {
       // Verify that the question activity is started with the correct profile ID.
       intended(hasComponent(QuestionPlayerActivity::class.java.name))
       intended(hasProtoExtra(PROFILE_ID_INTENT_DECORATOR, profileId))
+    }
+  }
+  @Test
+  fun testTopicActivity_restarts_resetsFontScaleToMedium() {
+    launchTopicActivity(profileId, TEST_CLASSROOM_ID_1, FRACTIONS_TOPIC_ID).use { scenario ->
+      scenario.onActivity { activity ->
+        val fontScaleConfigUtil = FontScaleConfigurationUtil()
+        fontScaleConfigUtil.adjustFontScale(activity, ReadingTextSize.EXTRA_LARGE_TEXT_SIZE)
+      }
+      scenario.recreate()
+      scenario.onActivity { activity ->
+        assertThat(activity.resources.configuration.fontScale).isEqualTo(1.0f)
+      }
     }
   }
 


### PR DESCRIPTION
## Explanation
Fixes #6378

Ensures that font scale configuration changes applied during lesson explorations do not bleed into non-lesson activities (such as TopicActivity) upon back navigation or activity restarts.

Specifically:

Updated ExplorationActivityPresenter.kt to reset font scale to MEDIUM_TEXT_SIZE (1.0x) in backPressActivitySelector().
Updated TopicActivityPresenter.kt to reset font scale to MEDIUM_TEXT_SIZE (1.0x) in handleOnCreate(), and added a new handleOnRestart() function that performs the same reset when the activity restarts.
Updated TopicActivity.kt to override onRestart() and call topicActivityPresenter.handleOnRestart().
Added unit test in TopicActivityTest.kt (testTopicActivity_restarts_resetsFontScaleToMedium) verifying font scale resets to default 1.0f on activity recreation/restart.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The explanation section above starts with "Fixes #bugnum: " (If this PR fixes part of an issue, use instead: "Fixes part of #bugnum: ...".)
- [x] Any changes to [scripts/assets](https://github.com/oppia/oppia-android/tree/develop/scripts/assets) files have their rationale included in the PR explanation.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia-android/wiki/Coding-style-guide).
- [x] The PR does not contain any unnecessary code changes from Android Studio ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#undo-unnecessary-changes)).
- [x] The PR is made from a branch that's **not** called "develop" and is up-to-date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers ([reference](https://github.com/oppia/oppia-android/wiki/Guidance-on-submitting-a-PR#clarification-regarding-assignees-and-reviewers-section)).

## Disclosure of LLM Usage
- **Did you use AI/LLMs when working on this PR?** Yes
- **If yes, describe the extent AI was used:** Debugging Android font scale configuration lifecycle, writing and unit tests.